### PR TITLE
feat(modules): stub out serial and model for now

### DIFF
--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -440,7 +440,7 @@ void ramp_temp_after_change_temp()
             tc_timer.reset();
             break;
           case Gcode::get_device_info:
-            gcode.device_info_response(device_serial, device_model, device_version);
+            gcode.device_info_response("dummySerial", "dummyModel", device_version);
             break;
           case Gcode::dfu:
             break;

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -440,7 +440,7 @@ void ramp_temp_after_change_temp()
             tc_timer.reset();
             break;
           case Gcode::get_device_info:
-            gcode.device_info_response("dummySerial", "dummyModel", device_version);
+            gcode.device_info_response(device_serial, device_model, device_version);
             break;
           case Gcode::dfu:
             break;

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -88,8 +88,8 @@ bool cover_should_be_hot = false;
 
 /********* DEVICE INFO **********/
 
-String device_serial = "";  // leave empty, this value is read from eeprom during setup()
-String device_model = "";   // leave empty, this value is read from eeprom during setup()
+String device_serial = "dummySerial";  // TODO: remove stub, later leave empty, this value is read from eeprom during setup()
+String device_model = "dummyModel";   // TODO: remove stub, later leave empty, this value is read from eeprom during setup()
 String device_version = "v1.0.1";
 
 /********* MISC GLOBALS *********/


### PR DESCRIPTION
Until there is a static place for serial number and model, let's stub them out for downstream
development in the meantime.