### PR TITLE
feat(modules): add pause and resume to timer and gcodes

### DIFF
--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
@@ -21,6 +21,7 @@
   GCODE_DEF(set_ramp_rate, M566),   \
   GCODE_DEF(edit_pid_params, M301), \
   GCODE_DEF(pause, M76),            \
+  GCODE_DEF(resume, M77),            \
   GCODE_DEF(deactivate_all, M18),   \
   GCODE_DEF(get_device_info, M115), \
   GCODE_DEF(dfu, dfu),              \

--- a/modules/thermo-cycler/thermo-cycler-arduino/tc_timer.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/tc_timer.cpp
@@ -17,10 +17,31 @@ bool TC_Timer::start()
   {
     return false;
   }
-    _total_hold_time_millis = total_hold_time * 1000;
-    _hold_start_timestamp = millis();
-    _status = Timer_status::running;
-    return true;
+  _total_hold_time_millis = total_hold_time * 1000;
+  _hold_start_timestamp = millis();
+  _status = Timer_status::running;
+  return true;
+}
+
+bool TC_Timer::pause()
+{
+  if(_status != Timer_status::running)
+  {
+    return false;
+  }
+  _status = Timer_status::paused;
+  return true;
+}
+
+bool TC_Timer::resume()
+{
+  if(_status != Timer_status::paused)
+  {
+    return false;
+  }
+  _hold_start_timestamp = _hold_start_timestamp + ((millis() - _hold_start_timestamp) - _elapsed_time);
+  _status = Timer_status::running;
+  return true;
 }
 
 unsigned int TC_Timer::time_left()

--- a/modules/thermo-cycler/thermo-cycler-arduino/tc_timer.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/tc_timer.cpp
@@ -47,7 +47,7 @@ bool TC_Timer::resume()
 unsigned int TC_Timer::time_left()
 {
   update();
-  if(_status == Timer_status::running)
+  if(_status == Timer_status::running || _status == Timer_status::paused)
   {
     return (_total_hold_time_millis - _elapsed_time) / 1000;
   }

--- a/modules/thermo-cycler/thermo-cycler-arduino/tc_timer.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/tc_timer.h
@@ -5,6 +5,7 @@ enum class Timer_status
 {
   idle,
   running,
+  paused,
   complete
 };
 
@@ -15,6 +16,8 @@ class TC_Timer
     TC_Timer();
     void reset();
     bool start();
+    bool pause();
+    bool resume();
     unsigned int time_left();
     Timer_status status();
     void update();

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -429,11 +429,11 @@ void ramp_temp_after_change_temp()
             break;
           case Gcode::pause:
             tc_timer.pause();
-            // TODO: hold temp in addition to pausing timer
+            // TODO: BC: 2019-03-25 hold temp in addition to pausing timer
             break;
           case Gcode::resume:
             tc_timer.resume();
-            // TODO: continue ramping in addition to resuming timer
+            // TODO: BC: 2019-03-25 continue ramping in addition to resuming timer
             break;
           case Gcode::deactivate_all:
             heat_pad_off();

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -428,8 +428,12 @@ void ramp_temp_after_change_temp()
             }
             break;
           case Gcode::pause:
-            // Flush out details about how to resume and what happens to the timer
-            // when paused
+            tc_timer.pause();
+            // TODO: hold temp in addition to pausing timer
+            break;
+          case Gcode::resume:
+            tc_timer.resume();
+            // TODO: continue ramping in addition to resuming timer
             break;
           case Gcode::deactivate_all:
             heat_pad_off();


### PR DESCRIPTION
Add gcodes for pause and resume function that map to according timer control calls.

This only controls the timer and doesn't effect the holding temperature.  The desired functionality is that a received "pause" gcode should hold at current temp and a sequential "resume" gcode should continue the ramp toward the target.  In place of the temperature-effect logic, I've placed TODO comments.