### PR TITLE
feat(modules): add thermocycler lid position detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,12 +77,13 @@ setup:
 .PHONY: build
 build: build-magdeck build-tempdeck build-thermocycler
 
+DUMMY_BOARD := false
+
 .PHONY: build-magdeck
 build-magdeck:
 	$(ARDUINO) --verify --board Opentrons:avr:magdeck32u4cat $(MODULES_DIR)/mag-deck/mag-deck-arduino/mag-deck-arduino.ino --verbose-build
 	mkdir -p $(BUILDS_DIR)/mag-deck
 	cp $(BUILDS_DIR)/tmp/mag-deck-arduino.ino.hex $(BUILDS_DIR)/mag-deck/
-
 
 .PHONY: build-tempdeck
 build-tempdeck:
@@ -92,6 +93,7 @@ build-tempdeck:
 
 .PHONY: build-thermocycler
 build-thermocycler:
+	echo "compiler.cpp.extra_flags=-DDUMMY_BOARD=$(DUMMY_BOARD)" > $(ARDUINO15_LOC)/packages/adafruit/hardware/samd/1.3.0/platform.local.txt
 	$(ARDUINO) --verify --board adafruit:samd:adafruit_feather_m0 $(MODULES_DIR)/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino --verbose-build
 	mkdir -p $(BUILDS_DIR)/thermo-cycler
 	cp $(BUILDS_DIR)/tmp/thermo-cycler-arduino.ino.bin $(BUILDS_DIR)/thermo-cycler/

--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.h
@@ -4,8 +4,10 @@
 #include "Arduino.h"
 #include <Wire.h>
 
-#define PIN_COVER_OPEN_SWITCH       8
-#define PIN_COVER_CLOSED_SWITCH     9
+#define DUMMY_BOARD true  // To be used for internal dev only
+
+#define PIN_COVER_SWITCH      8
+#define PIN_BOTTOM_SWITCH     9
 
 #define PIN_SOLENOID                A1
 
@@ -40,10 +42,22 @@
 #define STEPS_PER_MM 15  // full-stepping
 #define PULSE_HIGH_MICROSECONDS 2
 
+#define TO_INT(an_enum) static_cast<int>(an_enum)
+
+/* The TC has two switches to detect lid positions: one inside the lid (PIN_COVER_SWITCH)
+ * that is engaged when the lid fully opens and the other in the main
+ * boards assembly (PIN_BOTTOM_SWITCH) which is engaged when the lid is closed
+ * and locked. These are N.O. switches and the pins read HIGH when not engaged.
+ * When neither of the switch is engaged, the lid is assumed to be 'in_between'
+ * 'open' and 'closed' status. When both switches read LOW (which should never happen),
+ * the lid is in 'error' state.
+ */
 #define STATUS_TABLE \
-          STATUS(unknown),  \
+          STATUS(in_between),  \
           STATUS(closed),   \
-          STATUS(open)
+          STATUS(open),   \
+          STATUS(error),  \
+          STATUS(max)
 
 #define STATUS(_status) _status
 
@@ -71,12 +85,13 @@ class Lid
     void set_speed(float mm_per_sec);
     void set_acceleration(float mm_per_sec_per_sec);
     void set_current(float current);
-    void move_millimeters(float mm, bool top_switch, bool bottom_switch);
-    static const char * LID_STATUS_STRINGS[3];
+    bool move_millimeters(float mm);
+    void switch_poller();
+    static const char * LID_STATUS_STRINGS[TO_INT(Lid_status::max)+1];
 
   private:
-    bool _is_open_switch_pressed();
-    bool _is_closed_switch_pressed();
+    bool _is_cover_switch_pressed;
+    bool _is_bottom_switch_pressed;
     void _setup_digipot();
     void _save_current();
     void _i2c_write(byte address, byte value);
@@ -84,12 +99,20 @@ class Lid
     void _calculate_step_delay();
     void _update_acceleration();
     void _motor_step(uint8_t dir);
+    void _update_status();
 
     double _step_delay_microseconds = 1000000 / (STEPS_PER_MM * 10);  // default 10mm/sec
     double _mm_per_sec = 20;
     double _acceleration = 300;  // mm/sec/sec
     const double _start_mm_per_sec = 1;
     double _active_mm_per_sec;
+    Lid_status _status;
+    enum class _Lid_switch {
+      cover_switch,
+      bottom_switch,
+      max
+    };
+    uint16_t _debounce_state[TO_INT(_Lid_switch::max)] = {0};
 };
 
 #endif

--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.h
@@ -4,9 +4,11 @@
 #include "Arduino.h"
 #include <Wire.h>
 
-#define DUMMY_BOARD true  // To be used for internal dev only
-
-#define PIN_COVER_SWITCH      8
+#if DUMMY_BOARD
+  #define PIN_COVER_SWITCH PIN_SPI_MOSI
+#else
+  #define PIN_COVER_SWITCH      8
+#endif
 #define PIN_BOTTOM_SWITCH     9
 
 #define PIN_SOLENOID                A1
@@ -40,6 +42,7 @@
 #define DIRECTION_UP HIGH
 
 #define STEPS_PER_MM 15  // full-stepping
+#define LID_MOTOR_RANGE_MM  300 // The max distance in mm the motor should move between open to close positions
 #define PULSE_HIGH_MICROSECONDS 2
 
 #define TO_INT(an_enum) static_cast<int>(an_enum)
@@ -86,12 +89,12 @@ class Lid
     void set_acceleration(float mm_per_sec_per_sec);
     void set_current(float current);
     bool move_millimeters(float mm);
-    void switch_poller();
+    void check_switches();
     static const char * LID_STATUS_STRINGS[TO_INT(Lid_status::max)+1];
 
   private:
-    bool _is_cover_switch_pressed;
     bool _is_bottom_switch_pressed;
+    bool _is_cover_switch_pressed;
     void _setup_digipot();
     void _save_current();
     void _i2c_write(byte address, byte value);


### PR DESCRIPTION
Closes [#2951](https://github.com/Opentrons/opentrons/issues/2951)

## overview 
This PR adds lid status detection by adding a timer interrupt mechanism that polls the lid's end switches. It's a non blocking mechanism that always knows the status of the lid and hence makes it easy to detect any unexpected behavior.

## changes
Added:
- timer interrupt setup
- timer ISR
- `Lid::switch_poller()`

Changed the pin names to match those in schematic

## review requests
Check for code sanity. 
Also test on a TC board. If using a dummy board, comment out lines 791-198 in the .ino file and make sure DUMMY_BOARD in `lid.h` is true. 
To test, pull the `PIN_COVER_SWITCH`(pin 8) and `PIN_BOTTOM_SWITCH`(pin 9) pins to GND to simulate a button press. On the dummy board, pin D8- the `PIN_COVER_SWITCH` isn't exposed, so you can change line 9 to `#define PIN_COVER_SWITCH PIN_SPI_MOSI` and use the pin labelled MOSI instead. 

## updated behavior after addressing comments
- lid detection is switched to a hardware interrupt with a debounce check
- DUMMY_BOARD macro is now enabled via make command eg `make build-thermocycler DUMMY_BOARD=true`