### PR TITLE
feat(modules): add lid heat control via gcodes and some cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,9 @@ setup:
 .PHONY: build
 build: build-magdeck build-tempdeck build-thermocycler
 
-DUMMY_BOARD := false
-USE_GCODES := true
-LID_WARNING := true
+DUMMY_BOARD ?= false
+USE_GCODES ?= true
+LID_WARNING ?= true
 
 .PHONY: build-magdeck
 build-magdeck:

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,8 @@ setup:
 build: build-magdeck build-tempdeck build-thermocycler
 
 DUMMY_BOARD := false
+USE_GCODES := true
+LID_WARNING := true
 
 .PHONY: build-magdeck
 build-magdeck:
@@ -93,7 +95,8 @@ build-tempdeck:
 
 .PHONY: build-thermocycler
 build-thermocycler:
-	echo "compiler.cpp.extra_flags=-DDUMMY_BOARD=$(DUMMY_BOARD)" > $(ARDUINO15_LOC)/packages/adafruit/hardware/samd/1.3.0/platform.local.txt
+	echo "compiler.cpp.extra_flags=-DDUMMY_BOARD=$(DUMMY_BOARD) -DUSE_GCODES=$(USE_GCODES) -DLID_WARNING=$(LID_WARNING)" \
+	> $(ARDUINO15_LOC)/packages/adafruit/hardware/samd/1.3.0/platform.local.txt
 	$(ARDUINO) --verify --board adafruit:samd:adafruit_feather_m0 $(MODULES_DIR)/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino --verbose-build
 	mkdir -p $(BUILDS_DIR)/thermo-cycler
 	cp $(BUILDS_DIR)/tmp/thermo-cycler-arduino.ino.bin $(BUILDS_DIR)/thermo-cycler/

--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.cpp
@@ -172,6 +172,15 @@ void GcodeHandler::targetting_temperature_response(float target_temp,
   Serial.println((unsigned int)time_remaining);
 }
 
+void GcodeHandler::targetting_temperature_response(float target_temp,
+                                                   float current_temp)
+{
+  Serial.print(F("T:"));
+  Serial.print(target_temp, SERIAL_DIGITS_IN_RESPONSE);
+  Serial.print(F(" C:"));
+  Serial.println(current_temp, SERIAL_DIGITS_IN_RESPONSE);
+}
+
 void GcodeHandler::idle_temperature_response(float current_temp)
 {
   Serial.print(F("T:none"));
@@ -180,10 +189,16 @@ void GcodeHandler::idle_temperature_response(float current_temp)
   Serial.println(F(" H:none"));
 }
 
+void GcodeHandler::idle_lid_temperature_response(float current_temp)
+{
+  Serial.print(F("T:none"));
+  Serial.print(F(" C:"));
+  Serial.println(current_temp, SERIAL_DIGITS_IN_RESPONSE);
+}
 void GcodeHandler::response(String param, String msg)
 {
   Serial.print(param);
-  Serial.print(":");
+  Serial.print(F(":"));
   response(msg);
 }
 
@@ -192,11 +207,12 @@ void GcodeHandler::response(String msg)
   Serial.println(msg);
 }
 
-void GcodeHandler::response(String param, float val)
+void GcodeHandler::add_debug_response(String param, float val)
 {
   Serial.print(param);
-  Serial.print(":");
-  Serial.println(val);
+  Serial.print(F(":"));
+  Serial.print(val);
+  Serial.print(F(" "));
 }
 
 /* Use in .ino setup() with the baudrate to enable

--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
@@ -15,6 +15,7 @@
   GCODE_DEF(open_lid, M126),        \
   GCODE_DEF(close_lid, M127),       \
   GCODE_DEF(set_lid_temp, M140),    \
+  GCODE_DEF(get_lid_temp, M141),    \
   GCODE_DEF(deactivate_lid_heating, M108),  \
   GCODE_DEF(set_plate_temp, M104),  \
   GCODE_DEF(get_plate_temp, M105),  \
@@ -61,14 +62,16 @@ class GcodeHandler
       void send_ack();
       bool buffer_empty();
       void device_info_response(String serial, String model, String version);
+      void targetting_temperature_response(float target_temp, float current_temp);
       void targetting_temperature_response(float target_temp,
                                            float current_temp, float time_left);
       void idle_temperature_response(float current_temp);
+      void idle_lid_temperature_response(float current_temp);
       float popped_arg();
       bool pop_arg(char key);
       void response(String msg);
       void response(String param, String msg);
-      void response(String param, float val);
+      void add_debug_response(String param, float val);
 
     private:
       struct

--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.cpp
@@ -17,7 +17,7 @@ void Lid::_i2c_write(byte address, byte value)
   byte error = Wire.endTransmission();
   if (error)
   {
-    Serial.print("Digipot I2C Error: "); Serial.println(error);
+    // Serial.print("Digipot I2C Error: "); Serial.println(error);
   }
 }
 
@@ -76,7 +76,7 @@ void Lid::_update_status()
       _status = Lid_status::open;
       break;
     default:
-      _status = Lid_status::error;
+      _status = Lid_status::unknown;
       break;
   }
 }

--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.h
@@ -50,9 +50,9 @@
 /* The TC has two switches to detect lid positions: one inside the lid (PIN_COVER_SWITCH)
  * that is engaged when the lid fully opens and the other in the main
  * boards assembly (PIN_BOTTOM_SWITCH) which is engaged when the lid is closed
- * and locked. These are N.O. switches and the pins read HIGH when not engaged.
+ * and locked. These are N.C. switches and the pins read LOW when not engaged.
  * When neither of the switch is engaged, the lid is assumed to be 'in_between'
- * 'open' and 'closed' status. When both switches read LOW (which should never happen),
+ * 'open' and 'closed' status. When both switches read HIGH (which should never happen),
  * the lid is in 'error' state.
  */
 #define STATUS_TABLE \
@@ -77,7 +77,7 @@ class Lid
   public:
 
     Lid();
-    void setup();
+    bool setup();
     void open_cover();
     void close_cover();
     Lid_status status();
@@ -87,7 +87,6 @@ class Lid
     void motor_on();
     void set_speed(float mm_per_sec);
     void set_acceleration(float mm_per_sec_per_sec);
-    void set_current(float current);
     bool move_millimeters(float mm);
     void check_switches();
     static const char * LID_STATUS_STRINGS[TO_INT(Lid_status::max)+1];
@@ -95,9 +94,10 @@ class Lid
   private:
     bool _is_bottom_switch_pressed;
     bool _is_cover_switch_pressed;
-    void _setup_digipot();
-    void _save_current();
-    void _i2c_write(byte address, byte value);
+    bool _setup_digipot();
+    bool _save_current();
+    bool _set_current(float current);
+    bool _i2c_write(byte address, byte value);
     void _reset_acceleration();
     void _calculate_step_delay();
     void _update_acceleration();

--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.h
@@ -59,7 +59,7 @@
           STATUS(in_between),  \
           STATUS(closed),   \
           STATUS(open),   \
-          STATUS(error),  \
+          STATUS(unknown),  \
           STATUS(max)
 
 #define STATUS(_status) _status

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -97,7 +97,6 @@ String device_version = "v1.0.1";
 
 /********* MISC GLOBALS *********/
 
-#define USE_GCODES true
 unsigned long plotter_timestamp = 0;
 const int plotter_interval = 500;
 bool running_from_script = false;


### PR DESCRIPTION
## overview
This PR adds the gcode logic for controlling the lid's heat pad.
Also changes the format of the debug responses in order to be easy to parse.

Also added USE_GCODES and LID_WARNING (required for science testing since the prototype doesn't have lid movement control enabled) to compiler flags.

For science testing, compile thus:
```  make build-thermocycler DUMMY_BOARD=false USE_GCODES=true LID_WARNING=false ```