### PR TITLE
fix(thermocycler): correct thermistor lookup table

### DIFF
--- a/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
@@ -106,28 +106,28 @@ int ThermistorsADC::_read_adc(int index) {
 }
 
 float ThermistorsADC::_adc_to_celsius(int _adc) {
-  if (_adc < TABLE[ADC_TABLE_SIZE-1][0]) {
-    return TABLE[ADC_TABLE_SIZE-1][1];
+  if (_adc < TABLE[ADC_TABLE_SIZE-1].adc_reading) {
+    return TABLE[ADC_TABLE_SIZE-1].celsius;
   }
-  else if (_adc > TABLE[0][0]){
-    return TABLE[0][1];
+  else if (_adc > TABLE[0].adc_reading){
+    return TABLE[0].celsius;
   }
   else {
     int ADC_LOW, ADC_HIGH;
     for (int i=0;i<ADC_TABLE_SIZE - 1;i++){
-      ADC_HIGH = TABLE[i][0];
-      ADC_LOW = TABLE[i+1][0];
+      ADC_HIGH = TABLE[i].adc_reading;
+      ADC_LOW = TABLE[i+1].adc_reading;
       if (_adc >= ADC_LOW && _adc <= ADC_HIGH){
         float p = float(abs(ADC_HIGH - _adc)) / abs(ADC_HIGH - ADC_LOW);
-        p *= float(abs(TABLE[i+1][1] - TABLE[i][1]));
-        p += float(TABLE[i][1]);
+        p *= float(abs(TABLE[i+1].celsius - TABLE[i].celsius));
+        p += float(TABLE[i].celsius);
         return p;
       }
     }
   }
 }
 
-const int ThermistorsADC::TABLE[][2] = {
+const AdcToCelsius ThermistorsADC::TABLE[] = {
       // ADC, Celsius
       {21758, -20},
       {21638, -19},

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.h
@@ -34,6 +34,12 @@
 #define TOTAL_THERMISTORS              8
 #define TOTAL_PLATE_THERMISTORS        6
 
+typedef struct
+{
+  int adc_reading;
+  float celsius;
+}AdcToCelsius;
+
 class ThermistorsADC{
       public:
 
@@ -91,7 +97,7 @@ class ThermistorsADC{
             // lookup table provided for thermistor PN: KS103J2
             // ADC values calculated for when powering 1.5 volts into
             // a 10k ohm resistor, followed by the thermistor leading to GND
-            static const int TABLE[ADC_TABLE_SIZE][2];
+            static const AdcToCelsius TABLE[ADC_TABLE_SIZE];
 };
 
 #endif


### PR DESCRIPTION
## overview ##
This PR corrects the thermistor adc values lookup table.
This table contains fractional values but was previously declared as an `int` array. This PR changes it to an array of a `struct` containing an integer adc value and a float celsius value