### PR TITLE
feat(thermocycler): add lid movement and lid test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ LID_WARNING ?= true
 HFQ_PWM ?= false
 OLD_PID_INTERVAL ?= true
 HW_VERSION ?= 3
+LID_TESTING ?= false
 
 .PHONY: build-magdeck
 build-magdeck:
@@ -98,7 +99,7 @@ build-tempdeck:
 
 .PHONY: build-thermocycler
 build-thermocycler:
-	echo "compiler.cpp.extra_flags=-DDUMMY_BOARD=$(DUMMY_BOARD) -DUSE_GCODES=$(USE_GCODES) -DLID_WARNING=$(LID_WARNING) -DHFQ_PWM=$(HFQ_PWM) -DOLD_PID_INTERVAL=$(OLD_PID_INTERVAL) -DHW_VERSION=$(HW_VERSION)" \
+	echo "compiler.cpp.extra_flags=-DDUMMY_BOARD=$(DUMMY_BOARD) -DUSE_GCODES=$(USE_GCODES) -DLID_WARNING=$(LID_WARNING) -DHFQ_PWM=$(HFQ_PWM) -DOLD_PID_INTERVAL=$(OLD_PID_INTERVAL) -DHW_VERSION=$(HW_VERSION) -DLID_TESTING=$(LID_TESTING)" \
 	> $(ARDUINO15_LOC)/packages/Opentrons/hardware/samd/$(OPENTRONS_SAMD_BOARDS_VER)/platform.local.txt
 	$(ARDUINO) --verify --board Opentrons:samd:thermocycler_m0 $(MODULES_DIR)/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino --verbose-build
 	mkdir -p $(BUILDS_DIR)/thermo-cycler

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ HFQ_PWM ?= false
 OLD_PID_INTERVAL ?= true
 HW_VERSION ?= 3
 LID_TESTING ?= false
+RGBW_NEO ?= true
 
 .PHONY: build-magdeck
 build-magdeck:
@@ -99,7 +100,7 @@ build-tempdeck:
 
 .PHONY: build-thermocycler
 build-thermocycler:
-	echo "compiler.cpp.extra_flags=-DDUMMY_BOARD=$(DUMMY_BOARD) -DUSE_GCODES=$(USE_GCODES) -DLID_WARNING=$(LID_WARNING) -DHFQ_PWM=$(HFQ_PWM) -DOLD_PID_INTERVAL=$(OLD_PID_INTERVAL) -DHW_VERSION=$(HW_VERSION) -DLID_TESTING=$(LID_TESTING)" \
+	echo "compiler.cpp.extra_flags=-DDUMMY_BOARD=$(DUMMY_BOARD) -DUSE_GCODES=$(USE_GCODES) -DLID_WARNING=$(LID_WARNING) -DHFQ_PWM=$(HFQ_PWM) -DOLD_PID_INTERVAL=$(OLD_PID_INTERVAL) -DHW_VERSION=$(HW_VERSION) -DLID_TESTING=$(LID_TESTING) -DRGBW_NEO=$(RGBW_NEO)" \
 	> $(ARDUINO15_LOC)/packages/Opentrons/hardware/samd/$(OPENTRONS_SAMD_BOARDS_VER)/platform.local.txt
 	$(ARDUINO) --verify --board Opentrons:samd:thermocycler_m0 $(MODULES_DIR)/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino --verbose-build
 	mkdir -p $(BUILDS_DIR)/thermo-cycler

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ in the build directory under its module name eg. `../build/thermo-cycler/thermo-
 Use Arduino IDE to compile:
 Select the correct board file for your project from _Tools->board_ (Opentrons Thermocycler M0/ Opentrons Magdeck/ Opentrons Tempdeck)
 
-* NOTE: For Opentrons Thermocycler M0, you will have to set the appropriate flags in the `platform.local.txt` file: Find this file in your Arduino15 folder at `../packages/Opentrons/hardware/samd/1.0.1`. Paste this line in the file above: `compiler.cpp.extra_flags=-DDUMMY_BOARD=false -DUSE_GCODES=true -DLID_WARNING=false -DHFQ_PWM=false -DOLD_PID_INTERVAL=true -DHW_VERSION=3` (set appropriate flag values)
+* NOTE: For Opentrons Thermocycler M0, you will have to set the appropriate flags in the `platform.local.txt` file: Find this file in your Arduino15 folder at `../packages/Opentrons/hardware/samd/1.0.1`. Paste this line in the file above: `compiler.cpp.extra_flags=-DDUMMY_BOARD=false -DUSE_GCODES=true -DLID_WARNING=false -DHFQ_PWM=false -DOLD_PID_INTERVAL=true -DHW_VERSION=3 -DLID_TESTING=false -DRGBW_NEO=true` (set appropriate flag values)
 
 Then select _Sketch->Compile_.
 

--- a/modules/thermo-cycler/QC/lid_testing/TC_lid_tester.py
+++ b/modules/thermo-cycler/QC/lid_testing/TC_lid_tester.py
@@ -1,0 +1,81 @@
+import serial
+import csv
+import time
+import threading
+from argparse import ArgumentParser
+
+SLEEP_TIME = 17 #seconds
+TEST_ROUNDS = 1000
+BAUDRATE = 115200
+SERIAL_ACK = '\r\n'
+GCODES = {
+    'OPEN_LID': 'M126',
+    'CLOSE_LID': 'M127',
+    'GET_LID_STATUS': 'M119',
+    'SET_LID_TEMP': 'M140',
+    'GET_LID_TEMP': 'M141',
+    'DEACTIVATE_LID_HEATING': 'M108',
+    'EDIT_PID_PARAMS': 'M301',
+    'SET_PLATE_TEMP': 'M104',
+    'GET_PLATE_TEMP': 'M105',
+    'SET_RAMP_RATE': 'M566',
+    'DEACTIVATE': 'M18',
+    'DEVICE_INFO': 'M115'
+}
+
+OPEN_CMD = '{}{}'.format(GCODES['OPEN_LID'], SERIAL_ACK)
+CLOSE_CMD = '{}{}'.format(GCODES['CLOSE_LID'], SERIAL_ACK)
+
+def build_arg_parser():
+	arg_parser = ArgumentParser(
+		description="Thermocycler temperature data logger")
+	arg_parser.add_argument("-P", "--module_port", required=True)
+	arg_parser.add_argument("-F", "--csv_file_name", required=True)
+	return arg_parser
+
+def record_status(filename, ser, lock):
+	while True:
+		with lock:
+			serial_line = ser.readline()
+		if serial_line:
+			print("Received a serial line")
+			status_list = serial_line.decode().split(",")
+			status_list = list(map(lambda x: x.strip(), status_list))
+			for i, item in enumerate(status_list):
+				if item.isdigit():
+					status_list[i] = int(item)
+			print("{}".format(status_list))
+			with open('{}.csv'.format(filename), mode='a') as data_file:
+				data_writer = csv.writer(data_file, delimiter=',', quoting=csv.QUOTE_NONNUMERIC)
+				data_writer.writerow(status_list)
+		time.sleep(1);
+
+def _send(ser, lock, cmd):
+	print("Sending: {}".format(cmd))
+	ser.write(cmd.encode())
+
+def open_close_lid(ser, lock):
+	for i in range(TEST_ROUNDS):
+		with lock:
+			_send(ser, lock, OPEN_CMD);
+			time.sleep(SLEEP_TIME);
+			_send(ser,lock, CLOSE_CMD);
+			time.sleep(SLEEP_TIME);
+		time.sleep(2)
+
+if __name__ == '__main__':
+	arg_parser = build_arg_parser()
+	args = arg_parser.parse_args()
+	ser = serial.Serial(args.module_port, baudrate=BAUDRATE, timeout=1)
+	print("Serial: {}".format(ser))
+	time.sleep(1)
+	filename = args.csv_file_name
+	with open('{}.csv'.format(filename), mode='w') as data_file:
+	    data_writer = csv.writer(data_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_NONNUMERIC)
+	    data_writer.writerow(["Action", "End status", "Duration (msec)", "Action", "End status", "Duration (msec)"])
+	lock = threading.Lock()
+	recorder = threading.Thread(target=record_status, args=(filename, ser, lock), daemon=True)
+	lid_tester = threading.Thread(target=open_close_lid, args=(ser, lock))
+	recorder.start()
+	lid_tester.start()
+	lid_tester.join()

--- a/modules/thermo-cycler/QC/lid_testing/readme.md
+++ b/modules/thermo-cycler/QC/lid_testing/readme.md
@@ -1,0 +1,30 @@
+Lid Testing Instructions- WINDOWS OS
+-------------------------------------
+*Pulling latest changes on branch from git:*
+1. Open Git Bash
+2. Navigate to firmware directory:
+`cd Documents\opentrons\opentrons-modules`
+3. Check you branch name (should show up in parentheses next to the current path). If you need to switch to a different branch, do `git checkout branch_name`
+4. Make sure you don't have any uncommitted changes by checking with `git status`
+5 Pull with `git pull`
+
+*Uploading firmware:*
+1. Open Arduino
+2. Open the thermocycler sketch (if not already open) from File->sketchbook->modules->thermo-cycler->thermo-cycler-arduino
+3. Go to Tools->Board and select 'Adafruit Feather M0'
+4. Go to Tools->Port and select the thermocycler port (should show up as a COM port with description- 'Adafruit Feather M0')
+5. Upload the firmware by clicking the arrow button below the menu items or from Sketch->Upload
+
+*Running the python script:*
+To run the script we need to know the COM port that the thermocycler's connected to.
+You can find it out from Arduino (Tools->Port) or from Device manager->Ports
+1. Open Command Prompt (cmd)
+2. cd into the script directory: `Documents\opentrons\opentrons-modules\modules\thermo-cycler\QC\lid_testing`
+3. The script, TC_lid_tester.py, takes 2 arguments to successfully run:
+       -P: COM port of thermocycler
+       -F: filename to save data into
+So, eg command to run the script:
+`python TC_lid_tester.py -P COM3 -F lid_test_data`
+
+*The script will run until 1000 rounds of Open+Close are complete.
+To stop the script before that, use Ctrl+Pause/Brk in the cmd window*

--- a/modules/thermo-cycler/QC/lid_testing/readme.md
+++ b/modules/thermo-cycler/QC/lid_testing/readme.md
@@ -11,8 +11,8 @@ Lid Testing Instructions- WINDOWS OS
 *Uploading firmware:*
 1. Open Arduino
 2. Open the thermocycler sketch (if not already open) from File->sketchbook->modules->thermo-cycler->thermo-cycler-arduino
-3. Go to Tools->Board and select 'Adafruit Feather M0'
-4. Go to Tools->Port and select the thermocycler port (should show up as a COM port with description- 'Adafruit Feather M0')
+3. Go to Tools->Board and select 'Opentrons Thermocycler M0'
+4. Go to Tools->Port and select the thermocycler port (should show up as a COM port with description- 'Opentrons Thermocycler M0')
 5. Upload the firmware by clicking the arrow button below the menu items or from Sketch->Upload
 
 *Running the python script:*
@@ -27,4 +27,5 @@ So, eg command to run the script:
 `python TC_lid_tester.py -P COM3 -F lid_test_data`
 
 *The script will run until 1000 rounds of Open+Close are complete.
-To stop the script before that, use Ctrl+Pause/Brk in the cmd window*
+To change the number of rounds, see TC_lid_tester.py, line 8.
+To stop the script before that, use Ctrl+Pause/Break in the cmd window.*

--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.cpp
@@ -198,35 +198,6 @@ void Lid::reset_motor_driver()
   digitalWrite(PIN_MOTOR_RST, HIGH);
 #endif
 }
-void Lid::set_speed(float mm_per_sec)
-{
-  _mm_per_sec = mm_per_sec;
-}
-
-void Lid::set_acceleration(float mm_per_sec_per_sec)
-{
-  _acceleration = mm_per_sec_per_sec;
-}
-
-void Lid::_reset_acceleration()
-{
-  _active_mm_per_sec = _start_mm_per_sec;
-  _calculate_step_delay();
-}
-
-void Lid::_calculate_step_delay()
-{
-  _step_delay_microseconds = 1000000 / (STEPS_PER_MM * _active_mm_per_sec);
-  _step_delay_microseconds -= PULSE_HIGH_MICROSECONDS;
-}
-
-void Lid::_update_acceleration()
-{
-  // take the time since the last step, and calculate how much to adjust mm/sec
-  _active_mm_per_sec += ((_step_delay_microseconds + PULSE_HIGH_MICROSECONDS) / 1000000) * _acceleration;
-  _active_mm_per_sec = min(_active_mm_per_sec, _mm_per_sec);
-  _calculate_step_delay();
-}
 
 bool Lid::move_millimeters(float mm)
 {
@@ -234,7 +205,6 @@ bool Lid::move_millimeters(float mm)
   if (mm < 0) dir = DIRECTION_DOWN;
   unsigned long steps = abs(mm) * float(STEPS_PER_MM);
 
-  _reset_acceleration();
   for (unsigned long i=0;i<steps;i++)
   {
     _motor_step(dir);

--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.cpp
@@ -294,7 +294,7 @@ bool Lid::close_cover()
   motor_on();
   bool res = move_millimeters(-LID_MOTOR_RANGE_MM);
   solenoid_off();
-  delay(500);
+  delay(700);
   motor_off();
   return res;
 }
@@ -328,15 +328,13 @@ bool Lid::setup()
   bool status = true;
 	pinMode(PIN_SOLENOID, OUTPUT);
 	solenoid_off();
-#if HW_VERSION >= 3
-  pinMode(PIN_MOTOR_FAULT, INPUT_PULLUP);
-  pinMode(PIN_MOTOR_RST, OUTPUT);
-  digitalWrite(PIN_MOTOR_RST, HIGH);
-#endif
 	pinMode(PIN_STEPPER_STEP, OUTPUT);
 	pinMode(PIN_STEPPER_DIR, OUTPUT);
 	pinMode(PIN_STEPPER_ENABLE, OUTPUT);
 #if HW_VERSION >= 3
+  pinMode(PIN_MOTOR_FAULT, INPUT_PULLUP);
+  pinMode(PIN_MOTOR_RST, OUTPUT);
+  digitalWrite(PIN_MOTOR_RST, HIGH);
   attachInterrupt(digitalPinToInterrupt(PIN_MOTOR_FAULT), _motor_fault_callback, FALLING);
   // Use DAC to set Vref for motor current limit
   analogWriteResolution(10);

--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.h
@@ -105,8 +105,6 @@ class Lid
     void solenoid_off();
     void motor_off();
     void motor_on();
-    void set_speed(float mm_per_sec);
-    void set_acceleration(float mm_per_sec_per_sec);
     bool move_millimeters(float mm);
     void check_switches();
     void reset_motor_driver();
@@ -121,19 +119,11 @@ class Lid
     bool _save_current();
     bool _set_current(uint8_t current_data);
     bool _i2c_write(byte address, byte value);
-    void _reset_acceleration();
-    void _calculate_step_delay();
-    void _update_acceleration();
     void _motor_step(uint8_t dir);
     void _update_status();
     byte _i2c_read();
     uint16_t _to_dac_out(float driver_vref);
 
-    double _step_delay_microseconds = 1000000 / (STEPS_PER_MM * 10);  // default 10mm/sec
-    double _mm_per_sec = 20;
-    double _acceleration = 300;  // mm/sec/sec
-    const double _start_mm_per_sec = 1;
-    double _active_mm_per_sec;
     Lid_status _status;
     enum class _Lid_switch {
       cover_switch,

--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.h
@@ -63,7 +63,7 @@
 #define LID_MOTOR_RANGE_MM  390 // The max distance in mm the motor should move between open to close positions
 #define PULSE_HIGH_MICROSECONDS 2
 #define MOTOR_STEP_DELAY 60
-#define LID_CLOSE_BACKTRACK_STEPS 3600
+#define LID_CLOSE_BACKTRACK_STEPS 3200
 
 #define TO_INT(an_enum) static_cast<int>(an_enum)
 

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -9,7 +9,11 @@ Peltiers peltiers;
 Fan cover_fan;
 Fan heatsink_fan;
 
+#if RGBW_NEO
 Adafruit_NeoPixel_ZeroDMA strip(NUM_PIXELS, NEO_PIN, NEO_RGBW);
+#else
+Adafruit_NeoPixel_ZeroDMA strip(NUM_PIXELS, NEO_PIN, NEO_GRB + NEO_KHZ800);
+#endif
 
 // Left Peltier -> Peltier::pel_3
 PID PID_left_pel(
@@ -681,10 +685,14 @@ void read_from_serial() {
           Serial.read();
           if (Serial.peek() == '1')
           {
+            empty_serial_buffer();
+            Serial.println("Opening cover");
             lid.open_cover();
           }
           else
           {
+            empty_serial_buffer();
+            Serial.println("Closing cover");
             lid.close_cover();
           }
         }
@@ -701,7 +709,11 @@ void set_leds_white()
 {
   for(int i=0; i<strip.numPixels(); i++)
   {
+  #if RGBW_NEO
     strip.setPixelColor(i, 0, 0, 0, 255); // strip.setPixelColor(n, red, green, blue, white);
+  #else
+    strip.setPixelColor(i, 220, 220, 200);
+  #endif
     strip.show();
     delay(30);
   }
@@ -766,6 +778,10 @@ void setup()
   strip.setBrightness(50);
   strip.show();
   set_leds_white();
+
+  pinMode(PIN_FRONT_BUTTON_SW, INPUT);
+  analogWrite(PIN_FRONT_BUTTON_LED, LED_BRIGHTNESS);
+
 }
 
 void loop()

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -315,10 +315,42 @@ void update_fans_from_state()
             gcode.response("Lid", lid.LID_STATUS_STRINGS[static_cast<int>(lid.status())]);
             break;
           case Gcode::open_lid:
+          #if LID_TESTING
+            gcode_rec_timestamp = millis();
+            Serial.print("Opening, ");
+            if (lid.open_cover())
+            {
+              Serial.print("Opened, ");
+              Serial.print(millis() - gcode_rec_timestamp);
+              Serial.print(", ");
+            }
+            else
+            {
+              Serial.print("Errored, ");
+              Serial.print(millis() - gcode_rec_timestamp);
+              Serial.print(", ");
+            }
+          #else
             lid.open_cover();
+          #endif
             break;
           case Gcode::close_lid:
+          #if LID_TESTING
+            gcode_rec_timestamp = millis();
+            Serial.print("Closing, ");
+            if (lid.close_cover())
+            {
+              Serial.print("Closed, ");
+              Serial.println(millis() - gcode_rec_timestamp);
+            }
+            else
+            {
+              Serial.print("Errored:");
+              Serial.println(millis() - gcode_rec_timestamp);
+            }
+          #else
             lid.close_cover();
+          #endif
             break;
           case Gcode::set_lid_temp:
             if (!gcode.pop_arg('S'))
@@ -459,7 +491,9 @@ void update_fans_from_state()
             break;
         }
       }
+    #if !LID_TESTING
       gcode.send_ack();
+    #endif
     }
   }
 #else

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -133,5 +133,8 @@ bool debug_print_mode = true;
 bool gcode_debug_mode = false;  // Debug mode is not compatible with API
 bool running_graph = false;
 bool zoom_mode = false;
+#if LID_TESTING
+unsigned long gcode_rec_timestamp;
+#endif
 /***************************************/
 #endif

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -122,6 +122,7 @@ String device_version = "v1.0.1";
 #if HW_VERSION >= 3
   #define PIN_FRONT_BUTTON_SW   23
   #define PIN_FRONT_BUTTON_LED  24
+  #define LED_BRIGHTNESS        150
 #endif
 
 /********* MISC GLOBALS *********/


### PR DESCRIPTION
## overview ##

This PR enables the thermocycler to be able to Open and Close its lid/ cover. 
Also adds a lid testing script and thermocycler mode (flag: LID_TESTING)

Closes [#3399](https://github.com/Opentrons/opentrons/issues/3399)
## changes ##

- Switched to a driver current limit of 1.2A by changing digipot Vref. The current and step delay values have been decided after checking for values that provide sufficient torque at a reasonable speed (documentation here:  https://docs.google.com/spreadsheets/d/1K8WGy_3ngbcmAN21cRjCk-YtJ_DRXSawmVblKG8OU0k/edit?usp=sharing). The i2c values to set Vref are calculated from the datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/AD5110_5112_5114.pdf
- Added digipot tolerance check function
- added lid movement 'choreography' so it latches and unlatches properly
- small LED handling changes
- added lid testing script that opens and closes the lid continuously while recording the timestamps.
Sample recording:
```
"Action","End status","Duration (msec)","Action","End status","Duration (msec)"
"Opening","Opened",12894,"Closing","Closed",13543
"Opening","Opened",12890,"Closing","Closed",13545
"Opening","Opened",12893,"Closing","Closed",13547
"Opening","Opened",12885,"Closing","Closed",13548
"Opening","Opened",12886,"Closing","Closed",13549
"Opening","Opened",12393,"Closing","Closed",13551
"Opening","Opened",12890,"Closing","Closed",13552
```
( The second to last line shows that it took a much lesser time to open the lid. That means the lid was not closed properly in the line above)


