### PR TITLE
tests(thermocycler): add thermistor life test, NGS prep test

### DIFF
--- a/modules/thermo-cycler/QC/NGS_test/readme.md
+++ b/modules/thermo-cycler/QC/NGS_test/readme.md
@@ -1,0 +1,30 @@
+################## NGS test script ######################
+
+This is the script for controlling a Thermocycler to go through a set number of
+1- hour PCR cycles. In the 1 hour, the thermocycler will cycle through multiple
+temperatures defined in the script.
+
+To run the script:
+1. Upload firmware from `TC_lifetime_test` branch onto the thermocycler.
+2. In a terminal/ commandline window, navigate to this directory (`/opentrons-modules/modules/thermo-cycler/QC/NGS_test`)
+3. Run the script with the following command:
+`python NGS_test_protocol.py -P port_name -F a_filename`
+Write the actual port name and specify a file name. The script will create a new
+csv file with this name.
+
+For example:
+  `python TC_datalogger.py -P /dev/cu.usbmodem1421 -F lifetimeTest_TC_1`
+or
+  `python TC_datalogger.py -P COM10 -F lifetimeTest_TC_2`
+
+To stop/ abort the script, enter Ctrl+C in the terminal/command line window.
+You can then use Arduino serial monitor to deactivate the thermocycler by entering
+the gcode `M18`
+
+---------------------------
+TROUBLESHOOTING TIPS:
+---------------------------
+If you get errors while running the script:
+1. If you get an error saying 'serial not recognized' then you will need to install pyserial module by typing in commandline- `python3 -m pip install pyserial`. Once the module is installed, run the script again
+
+2. If you get syntax errors, make sure you are running python3. You can check your version by typing `python --version` in the commandline window. Usually the default for most systems is python 2 but you will mostly already have python3 on your computer. You can check this with `python3 --version`. If you see a python3 version, then run the script by typing `python 3 NGS_test_protocol.py ....` instead of just `python`.

--- a/modules/thermo-cycler/QC/lifetime_test/TC_datalogger.py
+++ b/modules/thermo-cycler/QC/lifetime_test/TC_datalogger.py
@@ -1,0 +1,196 @@
+import serial
+import csv
+import time
+import threading
+from argparse import ArgumentParser
+
+#---------------------------------------#
+TOTAL_RUNS = 250
+GCODES = True
+TC_GCODE_ROUNDING_PRECISION = 2
+
+COVER_TEMP = 105
+PLATE_TEMP_PRE = 10
+PLATE_TEMP_HOLD_1 = (94, 180)
+# Following temp durations have been increased by 10 sec to accommodate for ramp time
+PLATE_TEMP_REPEAT = [(94, 20), (70, 40), (72, 40)]
+PLATE_TEMP_HOLD_2 = (72, 300)
+PLATE_TEMP_POST = 4
+CYCLES = 29
+#---------------------------------------#
+
+BAUDRATE = 115200
+GCODES = {
+    'OPEN_LID': 'M126',
+    'CLOSE_LID': 'M127',
+    'GET_LID_STATUS': 'M119',
+    'SET_LID_TEMP': 'M140',
+    'GET_LID_TEMP': 'M141',
+    'DEACTIVATE_LID_HEATING': 'M108',
+    'EDIT_PID_PARAMS': 'M301',
+    'SET_PLATE_TEMP': 'M104',
+    'GET_PLATE_TEMP': 'M105',
+    'SET_RAMP_RATE': 'M566',
+    'DEACTIVATE': 'M18',
+    'DEVICE_INFO': 'M115'
+}
+
+NO_GCODES = {
+	'OPEN_LID': '',
+    'CLOSE_LID': '',
+    'GET_LID_STATUS': '',
+    'SET_LID_TEMP': 'c1',
+    'GET_LID_TEMP': '',
+    'DEACTIVATE_LID_HEATING': 'c0',
+    'EDIT_PID_PARAMS': '',
+    'SET_PLATE_TEMP': 't',
+    'GET_PLATE_TEMP': '',
+    'SET_RAMP_RATE': '',
+    'DEACTIVATE': 'x',
+    'DEVICE_INFO': ''
+}
+SERIAL_ACK = '\r\n'
+
+if GCODES:
+	PROTOCOL_STEPS = [
+		'{} S{}{}'.format(GCODES['SET_PLATE_TEMP'], PLATE_TEMP_PRE, SERIAL_ACK),	# 0
+		'{} S{}{}'.format(GCODES['SET_LID_TEMP'], COVER_TEMP, SERIAL_ACK),		# 1
+		'{} S{} H{}{}'.format(GCODES['SET_PLATE_TEMP'], PLATE_TEMP_HOLD_1[0], PLATE_TEMP_HOLD_1[1], SERIAL_ACK),		# 2
+		'{} S{} H{}{}'.format(GCODES['SET_PLATE_TEMP'], PLATE_TEMP_REPEAT[0][0], PLATE_TEMP_REPEAT[0][1], SERIAL_ACK),# 3
+		'{} S{} H{}{}'.format(GCODES['SET_PLATE_TEMP'], PLATE_TEMP_REPEAT[1][0], PLATE_TEMP_REPEAT[1][1], SERIAL_ACK),# 4
+		'{} S{} H{}{}'.format(GCODES['SET_PLATE_TEMP'], PLATE_TEMP_REPEAT[2][0], PLATE_TEMP_REPEAT[2][1], SERIAL_ACK),# 5
+		'{} S{} H{}{}'.format(GCODES['SET_PLATE_TEMP'], PLATE_TEMP_HOLD_2[0], PLATE_TEMP_HOLD_2[1], SERIAL_ACK),		# 6
+		'{}{}'.format(GCODES['DEACTIVATE_LID_HEATING'], SERIAL_ACK),				# 7
+		'{} S{}{}'.format(GCODES['SET_PLATE_TEMP'], PLATE_TEMP_POST, SERIAL_ACK)	# 8
+		]
+	GCODE_DEBUG_PRINT_MODE = 'M111 cont{}'.format(SERIAL_ACK)
+	GET_STAT = 'stat{}'.format(SERIAL_ACK)
+	DEACTIVATE = '{}{}'.format(GCODES['DEACTIVATE'], SERIAL_ACK)
+else:
+	PROTOCOL_STEPS = [
+		'{}{}{}'.format(NO_GCODES['SET_PLATE_TEMP'], PLATE_TEMP_PRE, SERIAL_ACK),	# 0
+		'{}{}'.format(NO_GCODES['SET_LID_TEMP'], COVER_TEMP, SERIAL_ACK),		# 1
+		'{}{}{}'.format(NO_GCODES['SET_PLATE_TEMP'], PLATE_TEMP_HOLD_1[0], PLATE_TEMP_HOLD_1[1], SERIAL_ACK),		# 2
+		'{}{}{}'.format(NO_GCODES['SET_PLATE_TEMP'], PLATE_TEMP_REPEAT[0][0], PLATE_TEMP_REPEAT[0][1], SERIAL_ACK),# 3
+		'{}{}{}'.format(NO_GCODES['SET_PLATE_TEMP'], PLATE_TEMP_REPEAT[1][0], PLATE_TEMP_REPEAT[1][1], SERIAL_ACK),# 4
+		'{}{}{}'.format(NO_GCODES['SET_PLATE_TEMP'], PLATE_TEMP_REPEAT[2][0], PLATE_TEMP_REPEAT[2][1], SERIAL_ACK),# 5
+		'{}{}{}'.format(NO_GCODES['SET_PLATE_TEMP'], PLATE_TEMP_HOLD_2[0], PLATE_TEMP_HOLD_2[1], SERIAL_ACK),		# 6
+		'{}{}'.format(NO_GCODES['DEACTIVATE_LID_HEATING'], SERIAL_ACK),				# 7
+		'{}{}{}'.format(NO_GCODES['SET_PLATE_TEMP'], PLATE_TEMP_POST, SERIAL_ACK)	# 8
+		]
+
+def build_arg_parser():
+	arg_parser = ArgumentParser(
+		description="Thermocycler temperature data logger")
+	arg_parser.add_argument("-P", "--module_port", required=True)
+	arg_parser.add_argument("-F", "--csv_file_name", required=True)
+	return arg_parser
+
+def _send(ser, lock, cmd):
+	with lock:
+		print("Sending: {}".format(cmd))
+		ser.write(cmd.encode())
+
+def parse_number_from_substring(substring, rounding_val):
+	'''
+	Returns the number in the expected string "N:12.3", where "N" is the
+	key, and "12.3" is a floating point value
+
+	For the temp-deck or thermocycler's temperature response, one expected
+	input is something like "T:none", where "none" should return a None value
+	'''
+	try:
+		value = substring.split(':')[1]
+		if value.strip().lower() == 'none':
+			return None
+		return round(float(value), rounding_val)
+	except (ValueError, IndexError, TypeError, AttributeError):
+		print('Unexpected argument to parse_number_from_substring:')
+		raise Exception(
+			'Unexpected argument to parse_number_from_substring: {}'.format(substring))
+
+
+def parse_key_from_substring(substring) -> str:
+	'''
+	Returns the axis in the expected string "N:12.3", where "N" is the
+	key, and "12.3" is a floating point value
+	'''
+	try:
+		return substring.split(':')[0]
+	except (ValueError, IndexError, TypeError, AttributeError):
+		print('Unexpected argument to parse_key_from_substring:')
+		raise Exception(
+			'Unexpected argument to parse_key_from_substring: {}'.format(substring))
+
+
+def run_protocol(ser, lock):
+	for run_x in range(TOTAL_RUNS):
+		print("****** Run #{} *******".format(run_x))
+		_send(ser, lock, PROTOCOL_STEPS[0])	# Plate PRE
+		_send(ser, lock, PROTOCOL_STEPS[1])	# Lid temp
+		time.sleep(150)	 # Takes approx 5 minutes for lid to heat
+		_send(ser, lock, PROTOCOL_STEPS[2])	# First point
+		time.sleep(PLATE_TEMP_HOLD_1[1])
+		for i in range(CYCLES):
+			_send(ser, lock, PROTOCOL_STEPS[3])	# First repeat
+			time.sleep(PLATE_TEMP_REPEAT[0][1])
+			_send(ser, lock, PROTOCOL_STEPS[4])	# Second repeat
+			time.sleep(PLATE_TEMP_REPEAT[1][1])
+			_send(ser, lock, PROTOCOL_STEPS[5])	# Last repeat
+			time.sleep(PLATE_TEMP_REPEAT[2][1])
+		_send(ser, lock, PROTOCOL_STEPS[6])	# Rest step
+		time.sleep(PLATE_TEMP_HOLD_2[1])
+		_send(ser, lock, PROTOCOL_STEPS[7])	# Lid stop
+		_send(ser, lock, PROTOCOL_STEPS[8])	# incubate
+		time.sleep(200)
+		print("******* Run #{} Completed *******".format(run_x))
+	_send(ser, lock, DEACTIVATE)
+
+
+def record_status(filename, ser, lock):
+	_send(ser, lock, GCODE_DEBUG_PRINT_MODE)
+	time.sleep(0.5)
+	ser.readline()
+	ser.readline()
+	while True:
+		with lock:
+			serial_line = ser.readline()
+		if serial_line:
+			serial_list = serial_line.decode().split("\t")
+			serial_list = list(map(lambda x: x.strip(), serial_list))
+			data_res = {}
+			for substr in serial_list:
+				if substr == '':
+					continue
+				print(substr,end ="\t"),
+				key = parse_key_from_substring(substr)
+				value = parse_number_from_substring(substr, TC_GCODE_ROUNDING_PRECISION)
+				data_res[key] = value
+			print()
+			print("---------------------")
+			status_list = []
+			for key, val in data_res.items():
+				status_list.append(val)
+			with open('{}.csv'.format(filename), mode='a') as data_file:
+				data_writer = csv.writer(data_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
+				data_writer.writerow(status_list)
+		time.sleep(0.1)
+
+if __name__ == '__main__':
+	arg_parser = build_arg_parser()
+	args = arg_parser.parse_args()
+	ser = serial.Serial(args.module_port, baudrate=BAUDRATE, timeout=1)
+	print("Serial: {}".format(ser))
+	time.sleep(1)
+	filename = args.csv_file_name
+	with open('{}.csv'.format(filename), mode='w') as data_file:
+	    data_writer = csv.writer(data_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
+	    data_writer.writerow(["Millis", "Plate target", "Cover target", "hold time", "therm1", "therm2", "therm3", "therm4", "therm5", "therm6", "heatsink", "loop duration", "fan", "lid temp", "motor fault"])
+	lock = threading.Lock()
+	recorder = threading.Thread(target=record_status, args=(filename, ser, lock), daemon=True)
+	protocol_writer = threading.Thread(target=run_protocol, args=(ser, lock))
+	recorder.start()
+	time.sleep(5)	# Just to record pre-protocol data
+	print("Starting protocol writer")
+	protocol_writer.start()
+	protocol_writer.join()

--- a/modules/thermo-cycler/QC/lifetime_test/readme.md
+++ b/modules/thermo-cycler/QC/lifetime_test/readme.md
@@ -1,0 +1,23 @@
+################## Lifetime test TC_datalogger script ######################
+
+This is the script for controlling a Thermocycler to go through a set number of
+1- hour PCR cycles. In the 1 hour, the thermocycler will cycle through multiple
+temperatures defined in the script.
+
+To run the script:
+1. Upload firmware from `TC_lifetime_test` branch onto the thermocycler.
+2. In a terminal/ commandline window, navigate to this directory (`/opentrons-modules/modules/thermo-cycler/QC/lieftime_test`)
+3. Run the script with the following command:
+`python TC_datalogger.py -P port_name -F a_filename`
+Write the actual port name and specify a file name. The script will create a new
+csv file with this name.
+
+For example:
+  `python TC_datalogger.py -P /dev/cu.usbmodem1421 -F lifetimeTest_TC_1`
+or
+  `python TC_datalogger.py -P COM10 -F lifetimeTest_TC_2`
+
+The script will deactivate the thermocycler when all the runs are completed.
+To stop/ abort the script, enter Ctrl+C in the terminal/command line window.
+You can then use Arduino serial monitor to deactivate the thermocycler by entering
+the gcode `M18`

--- a/modules/thermo-cycler/thermo-cycler-arduino/fan.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/fan.h
@@ -18,6 +18,7 @@ class Fan
     void enable();
     void disable();
     float current_power;
+    float manual_power;
 
   private:
     uint8_t _pwm_pin;

--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.cpp
@@ -210,8 +210,15 @@ void GcodeHandler::response(String msg)
 void GcodeHandler::add_debug_response(String param, float val)
 {
   Serial.print(param);
-  Serial.print(F(":"));
+  Serial.print(F(": "));
   Serial.print(val);
+  Serial.print(F("\t"));
+}
+
+void GcodeHandler::add_debug_timestamp()
+{
+  Serial.print(F("millis: "));
+  Serial.print(millis());
   Serial.print(F("\t"));
 }
 

--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
@@ -24,8 +24,8 @@
   GCODE_DEF(pause, M76),            \
   GCODE_DEF(deactivate_all, M18),   \
   GCODE_DEF(get_device_info, M115), \
-  GCODE_DEF(heatsink_fan_on, M106), \
-  GCODE_DEF(heatsink_fan_off, M107),\
+  GCODE_DEF(heatsink_fan_pwr_manual, M106), \
+  GCODE_DEF(heatsink_fan_auto_on, M107),  \
   GCODE_DEF(dfu, dfu),              \
   GCODE_DEF(motor_reset, mrst),     \
   GCODE_DEF(debug_mode, M111),      \

--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
@@ -30,6 +30,7 @@
   GCODE_DEF(motor_reset, mrst),     \
   GCODE_DEF(debug_mode, M111),      \
   GCODE_DEF(print_debug_stat, stat),\
+  GCODE_DEF(continous_debug_stat, cont),\
   GCODE_DEF(max, -)
 
 #define GCODE_DEF(name, _) name
@@ -73,6 +74,7 @@ class GcodeHandler
       void response(String msg);
       void response(String param, String msg);
       void add_debug_response(String param, float val);
+      void add_debug_timestamp();
 
     private:
       struct

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
@@ -18,6 +18,9 @@ void ThermistorsADC::setup(float voltage) {
 
   adc_a->begin();
   adc_b->begin();
+
+  adc_a->setSPS(ADS1115_DR_860SPS);   // Sample rate 860 per sec
+  adc_b->setSPS(ADS1115_DR_860SPS);   // Sample rate 860 per sec
 }
 
 bool ThermistorsADC::update() {

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -243,6 +243,17 @@ void update_fans_from_state()
 
   if (millis() - last_checked > 100)
   {
+    if (!auto_fan)
+    { // Heatsink safety threshold overrides manual operation
+      if (temp_probes.heat_sink_temperature() > 55)
+      {
+        // Fan speed proportional to temperature
+        float pwr = temp_probes.heat_sink_temperature() / 100;
+        pwr = max(pwr, heatsink_fan.manual_power);
+        heatsink_fan.set_percentage(pwr);
+      }
+      return;
+    }
     last_checked = millis();
     if (master_set_a_target)
     {
@@ -253,33 +264,38 @@ void update_fans_from_state()
       }
       else if (is_ramping_down())
       {
-        heatsink_fan.set_percentage(0.5);
+        heatsink_fan.set_percentage(0.55);
         return;
       }
-      else if (is_ramping_up())
+      // else if (is_ramping_up())
+      // {
+      //   heatsink_fan.set_percentage(0.2);
+      //   return;
+      // }
+      else if (temp_probes.heat_sink_temperature() > 38)
       {
         heatsink_fan.set_percentage(0.2);
-        return;
       }
     }
-    if (temp_probes.heat_sink_temperature() > 45)
+    if (temp_probes.heat_sink_temperature() > 55)
     {
-      // Fan speed propertional to temperature
-      heatsink_fan.set_percentage((temp_probes.heat_sink_temperature() * 0.8) / 100);
+      // Fan speed proportional to temperature
+      heatsink_fan.set_percentage(temp_probes.heat_sink_temperature() / 100);
     }
-    else if(temp_probes.heat_sink_temperature() < 38)
+    else if(temp_probes.heat_sink_temperature() < 36)
     {
       heatsink_fan.disable();
     }
 
-    if (cover_should_be_hot)
-    {
-      cover_fan.enable();
-    }
-    else
-    {
-      cover_fan.disable();
-    }
+    // TODO: decide what to do about cover fan
+    // if (cover_should_be_hot)
+    // {
+    //   cover_fan.enable();
+    // }
+    // else
+    // {
+    //   cover_fan.disable();
+    // }
   }
 }
 
@@ -324,6 +340,7 @@ void deactivate_all()
     gcode.add_debug_response("loop_time", float(timeStamp)/1000);
     // Fan power:
     gcode.add_debug_response("Fan", heatsink_fan.current_power);
+    gcode.add_debug_response("Fan auto?", auto_fan);
     // Cover temperature:
     gcode.add_debug_response("T.Lid", temp_probes.cover_temperature());
     // Motor status:
@@ -468,17 +485,22 @@ void deactivate_all()
               }
             }
             break;
-          case Gcode::heatsink_fan_on:
+          case Gcode::heatsink_fan_pwr_manual:
+            // Control fan power manually. Arg is specified with 'S' and should be
+            // a fractional value. If heatsink temperature exceeds safe limit
+            // then manual power is overridden by a higher value power proportional
+            // to heatsink temperature.
             auto_fan = false;
             heatsink_fan.enable();
             if (gcode.pop_arg('S'))
             {
-              heatsink_fan.set_percentage(gcode.popped_arg());
+              heatsink_fan.manual_power = gcode.popped_arg();
+              heatsink_fan.set_percentage(heatsink_fan.manual_power);
             }
             break;
-          case Gcode::heatsink_fan_off:
-            auto_fan = false;
-            heatsink_fan.disable();
+          case Gcode::heatsink_fan_auto_on:
+            heatsink_fan.manual_power = 0;
+            auto_fan = true;
             break;
           case Gcode::pause:
             // Flush out details about how to resume and what happens to the timer
@@ -850,9 +872,28 @@ void setup()
 #endif
 }
 
+void temp_safety_check()
+{
+  if (temp_probes.heat_sink_temperature() >= 70
+      || (temp_probes.back_left_temperature() > 100
+          || temp_probes.back_center_temperature() > 100
+          || temp_probes.back_right_temperature() > 100
+          || temp_probes.front_left_temperature() > 100
+          || temp_probes.front_center_temperature() > 100
+          || temp_probes.front_right_temperature() > 100
+        )
+      )
+  {
+    gcode.response("System too hot! Deactivating.");
+    deactivate_all();
+  }
+}
+
 void loop()
 {
+  temp_safety_check();
   lid.check_switches();
+
 #if USE_GCODES
   /* Check if gcode(s) available on Serial */
   read_gcode();
@@ -879,10 +920,8 @@ void loop()
     current_temperature_cover = temp_probes.cover_temperature();
   }
 #endif
-  if (auto_fan)
-  {
-    update_fans_from_state();
-  }
+
+  update_fans_from_state();
 
   if (master_set_a_target && tc_timer.status() == Timer_status::idle && is_at_target())
   {

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -286,16 +286,6 @@ void update_fans_from_state()
     {
       heatsink_fan.disable();
     }
-
-    // TODO: decide what to do about cover fan
-    // if (cover_should_be_hot)
-    // {
-    //   cover_fan.enable();
-    // }
-    // else
-    // {
-    //   cover_fan.disable();
-    // }
   }
 }
 
@@ -878,13 +868,13 @@ void temp_safety_check()
   {
     return;
   }
-  if (temp_probes.heat_sink_temperature() >= 70
-      || (temp_probes.back_left_temperature() > 100
-          || temp_probes.back_center_temperature() > 100
-          || temp_probes.back_right_temperature() > 100
-          || temp_probes.front_left_temperature() > 100
-          || temp_probes.front_center_temperature() > 100
-          || temp_probes.front_right_temperature() > 100
+  if (temp_probes.heat_sink_temperature() >= HEATSINK_SAFE_TEMP_LIMIT
+      || (temp_probes.back_left_temperature() > PELTIER_SAFE_TEMP_LIMIT
+          || temp_probes.back_center_temperature() > PELTIER_SAFE_TEMP_LIMIT
+          || temp_probes.back_right_temperature() > PELTIER_SAFE_TEMP_LIMIT
+          || temp_probes.front_left_temperature() > PELTIER_SAFE_TEMP_LIMIT
+          || temp_probes.front_center_temperature() > PELTIER_SAFE_TEMP_LIMIT
+          || temp_probes.front_right_temperature() > PELTIER_SAFE_TEMP_LIMIT
         )
       )
   {

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -874,6 +874,10 @@ void setup()
 
 void temp_safety_check()
 {
+  if (!master_set_a_target)
+  {
+    return;
+  }
   if (temp_probes.heat_sink_temperature() >= 70
       || (temp_probes.back_left_temperature() > 100
           || temp_probes.back_center_temperature() > 100

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -245,10 +245,10 @@ void update_fans_from_state()
   {
     if (!auto_fan)
     { // Heatsink safety threshold overrides manual operation
-      if (temp_probes.heat_sink_temperature() > 55)
+      if (temp_probes.heat_sink_temperature() > HEATSINK_FAN_HI_TEMP)
       {
         // Fan speed proportional to temperature
-        float pwr = temp_probes.heat_sink_temperature() / 100;
+        float pwr = HEATSINK_P_CONSTANT * temp_probes.heat_sink_temperature() / 100.0;
         pwr = max(pwr, heatsink_fan.manual_power);
         heatsink_fan.set_percentage(pwr);
       }
@@ -259,12 +259,12 @@ void update_fans_from_state()
     {
       if (is_target_cold())
       {
-        heatsink_fan.set_percentage(0.7);
+        heatsink_fan.set_percentage(FAN_PWR_COLD_TARGET);
         return;
       }
       else if (is_ramping_down())
       {
-        heatsink_fan.set_percentage(0.55);
+        heatsink_fan.set_percentage(FAN_PWR_RAMPING_DOWN);
         return;
       }
       // else if (is_ramping_up())
@@ -272,17 +272,17 @@ void update_fans_from_state()
       //   heatsink_fan.set_percentage(0.2);
       //   return;
       // }
-      else if (temp_probes.heat_sink_temperature() > 38)
+      else if (temp_probes.heat_sink_temperature() > HEATSINK_FAN_LO_TEMP)
       {
-        heatsink_fan.set_percentage(0.2);
+        heatsink_fan.set_percentage(FAN_POWER_LOW);
       }
     }
-    if (temp_probes.heat_sink_temperature() > 55)
+    if (temp_probes.heat_sink_temperature() > HEATSINK_FAN_HI_TEMP)
     {
       // Fan speed proportional to temperature
-      heatsink_fan.set_percentage(temp_probes.heat_sink_temperature() / 100);
+      heatsink_fan.set_percentage(HEATSINK_P_CONSTANT * temp_probes.heat_sink_temperature() / 100.0);
     }
-    else if(temp_probes.heat_sink_temperature() < 36)
+    else if(temp_probes.heat_sink_temperature() < HEATSINK_FAN_OFF_TEMP)
     {
       heatsink_fan.disable();
     }

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -42,13 +42,19 @@
 #define PIN_FAN_SINK_ENABLE         2    // Heat sink fan
 #define FAN_POWER_HIGH              0.8
 #define FAN_POWER_LOW               0.2
+#define FAN_PWR_COLD_TARGET         0.7
+#define FAN_PWR_RAMPING_DOWN        0.55
+#define HEATSINK_P_CONSTANT         1.0
 
 /********* TEMPERATURE PREDEFS *********/
 
-#define TEMPERATURE_ROOM 23
-#define TEMPERATURE_COVER_HOT 105
-#define PELTIER_SAFE_TEMP_LIMIT 105
-#define HEATSINK_SAFE_TEMP_LIMIT 75
+#define TEMPERATURE_ROOM          23
+#define TEMPERATURE_COVER_HOT     105
+#define PELTIER_SAFE_TEMP_LIMIT   105
+#define HEATSINK_SAFE_TEMP_LIMIT  75
+#define HEATSINK_FAN_LO_TEMP      38
+#define HEATSINK_FAN_HI_TEMP      55
+#define HEATSINK_FAN_OFF_TEMP     36
 
 /********* PID: PLATE PELTIERS *********/
 // NOTE: temp_probes.update takes 136-137ms while rest of the loop takes 0-1ms.

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -45,7 +45,7 @@
 
 /********* TEMPERATURE PREDEFS *********/
 
-#define TEMPERATURE_ROOM 23
+#define TEMPERATURE_ROOM 26
 #define TEMPERATURE_COVER_HOT 105
 
 /********* PID: PLATE PELTIERS *********/

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -47,6 +47,8 @@
 
 #define TEMPERATURE_ROOM 23
 #define TEMPERATURE_COVER_HOT 105
+#define PELTIER_SAFE_TEMP_LIMIT 105
+#define HEATSINK_SAFE_TEMP_LIMIT 75
 
 /********* PID: PLATE PELTIERS *********/
 // NOTE: temp_probes.update takes 136-137ms while rest of the loop takes 0-1ms.

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -45,7 +45,7 @@
 
 /********* TEMPERATURE PREDEFS *********/
 
-#define TEMPERATURE_ROOM 26
+#define TEMPERATURE_ROOM 23
 #define TEMPERATURE_COVER_HOT 105
 
 /********* PID: PLATE PELTIERS *********/

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -127,6 +127,7 @@ String device_version = "v1.0.1";
 
 /********* MISC GLOBALS *********/
 
+#define DEBUG_PRINT_INTERVAL 2000  // millisec
 unsigned long plotter_timestamp = 0;
 const int plotter_interval = 500;
 bool front_button_pressed = false;
@@ -134,6 +135,7 @@ unsigned long front_button_pressed_at = 0;
 bool running_from_script = false;
 bool debug_print_mode = true;
 bool gcode_debug_mode = false;  // Debug mode is not compatible with API
+bool continuous_debug_stat_mode = false;
 bool running_graph = false;
 bool zoom_mode = false;
 #if LID_TESTING


### PR DESCRIPTION
## overview ##

**NGS Prep test**: A python script runs an NGS prep sequence of 29 temperature cycles while recording the device status to a csv file.

**Thermistor life test:** A python script runs the above NGS protocol continuously 250 times. This is to check how much the thermistors drift during its lifetime. This test will last ~10 days and will be repeated thrice.

The two tests are very similar but are saved separately since they could each have future changes that the other would not want.

## changes ##

1. Main change in the thermocycler firmware is the addition of temperature safety check and making the manual fan control mode a semi-manual one. Previously, when a user entered manual fan control mode, there were no checks being made or warnings given if the system was heating up beyond the safety limits. This led scenarios where a thermocycler that's in manual fan control mode would have the fan turned off or set to a very low value and then being issued a command to go to a value (usually lower than room temperature) that required a lot of heat to be displaced out of the device. But since the fan was set to an insufficient speed, and the code was not controlling the fan anymore, that heat would keep building inside the device, making it rise to levels high enough to damage the board. 

The semi manual mode allows the user to set the fan speed manually as long as it is sufficient to keep the system temperatures within the safety limit.

2. added a safety check that will deactivate the thermocycler if the system crosses safe temperature levels.
3. removed cover fan control since we are getting rid of those fans. They aren't needed as the cover doesn't heat up much.
4. added a continuous status print mode and reformatted the status parameters.

NOTE: the fan control thresholds and speed values will be revisited in [#3643](https://github.com/Opentrons/opentrons/issues/3643)