### PR TITLE
fix(thermocycler): add pause on bottom switch during lid open

### DIFF
--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.cpp
@@ -240,15 +240,20 @@ bool Lid::open_cover()
      return true;
   }
   motor_on();
-  if(move_angle(-5))  // move down a bit
+  bool res;
+  if(move_angle(LID_OPEN_SWITCH_PROBE_ANGLE))  // move down to reach bottom switch
   {
     // lid hit bottom switch
     solenoid_on();
     delay(400);
     move_angle(10);     // move up a bit
     solenoid_off();
+    res = move_angle(LID_MOTOR_RANGE_DEG);
   }
-  bool res = move_angle(LID_MOTOR_RANGE_DEG);
+  else
+  {
+    res = false;
+  }
   motor_off();
   return res;
 }
@@ -259,11 +264,14 @@ bool Lid::close_cover()
   {
     return true;
   }
-  // solenoid_on();
   motor_on();
   bool res = move_angle(-LID_MOTOR_RANGE_DEG);
-  // solenoid_off();
-  delay(700);
+  delay(500);
+  if (res)
+  {
+    move_angle(LID_CLOSE_BACKTRACK_ANGLE);
+  }
+  delay(250);
   motor_off();
   return res;
 }

--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.cpp
@@ -226,12 +226,6 @@ bool Lid::move_angle(float deg)
     {
       if (_is_bottom_switch_pressed)
       {
-        delay(50);
-        for (int j = 0; j < LID_CLOSE_BACKTRACK_STEPS; j++)
-        {
-          // Backtrack a bit
-          _motor_step(DIRECTION_UP);
-        }
         return true;
       }
     }
@@ -246,11 +240,14 @@ bool Lid::open_cover()
      return true;
   }
   motor_on();
-  move_angle(-1);    // move down a bit
-  solenoid_on();
-  delay(100);
-  move_angle(5);     // move up a bit
-  solenoid_off();
+  if(move_angle(-5))  // move down a bit
+  {
+    // lid hit bottom switch
+    solenoid_on();
+    delay(400);
+    move_angle(10);     // move up a bit
+    solenoid_off();
+  }
   bool res = move_angle(LID_MOTOR_RANGE_DEG);
   motor_off();
   return res;
@@ -265,7 +262,7 @@ bool Lid::close_cover()
   // solenoid_on();
   motor_on();
   bool res = move_angle(-LID_MOTOR_RANGE_DEG);
-  solenoid_off();
+  // solenoid_off();
   delay(700);
   motor_off();
   return res;

--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.h
@@ -73,7 +73,7 @@
 #define LID_MOTOR_RANGE_DEG 100 // Max angle the lid motor can move
 #define PULSE_HIGH_MICROSECONDS 2
 #define MOTOR_STEP_DELAY 60   // microseconds
-#define LID_CLOSE_BACKTRACK_ANGLE 1.5
+#define LID_CLOSE_BACKTRACK_ANGLE 3.0
 #define LID_OPEN_SWITCH_PROBE_ANGLE -30
 
 #define TO_INT(an_enum) static_cast<int>(an_enum)

--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.h
@@ -73,7 +73,8 @@
 #define LID_MOTOR_RANGE_DEG 100 // Max angle the lid motor can move
 #define PULSE_HIGH_MICROSECONDS 2
 #define MOTOR_STEP_DELAY 60   // microseconds
-#define LID_CLOSE_BACKTRACK_STEPS 2500
+#define LID_CLOSE_BACKTRACK_ANGLE 1.5
+#define LID_OPEN_SWITCH_PROBE_ANGLE -30
 
 #define TO_INT(an_enum) static_cast<int>(an_enum)
 


### PR DESCRIPTION
Previously, the thermocycler lid had a frequent issue of not being able to open properly. This was because in closed position, the lid was staying hooked onto the latch. When made to open, the lid was supposed to move down a little in order to free the latch so it could open, but this downward movement distance was different for different thermocyclers and also changed depending on the labware used and whether the thermocycer had a lid seal.

This PR changes the lid open movement so the lid moves down enough and precisely, by moving down until it hits the bottom switch, to let the solenoid open the latch easily. This eliminates the variability of downward distance and allows the lid to open more reliably.