### PR TITLE
feat(thermocycler): detect and report thermistor failure

### DIFF
--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
@@ -26,6 +26,7 @@
   GCODE_DEF(get_device_info, M115), \
   GCODE_DEF(heatsink_fan_pwr_manual, M106), \
   GCODE_DEF(heatsink_fan_auto_on, M107),  \
+  GCODE_DEF(get_device_state, M78), \
   GCODE_DEF(dfu, dfu),              \
   GCODE_DEF(motor_reset, mrst),     \
   GCODE_DEF(debug_mode, M111),      \

--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
@@ -26,7 +26,6 @@
   GCODE_DEF(get_device_info, M115), \
   GCODE_DEF(heatsink_fan_pwr_manual, M106), \
   GCODE_DEF(heatsink_fan_auto_on, M107),  \
-  GCODE_DEF(get_device_state, M78), \
   GCODE_DEF(dfu, dfu),              \
   GCODE_DEF(motor_reset, mrst),     \
   GCODE_DEF(debug_mode, M111),      \

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
@@ -50,13 +50,14 @@ void ThermistorsADC::update(ThermistorPair n) {
   delay(inter_temp_read_interval);
   if (!is_in_range(probe_temps[therm_index1]) || !is_in_range(probe_temps[therm_index2]))
   {
+    // Once set to true, will need system reset to clear
     detected_invalid_val = true;
   }
 }
 
-bool is_in_range(double celsius)
+bool ThermistorsADC::is_in_range(double celsius)
 {
-  return (celsius < THERMISTOR_ERROR_VAL_HI && celsius > THERMISTOR_ERROR_VAL_LOW)
+  return (celsius < THERMISTOR_ERROR_VAL_HI && celsius > THERMISTOR_ERROR_VAL_LOW);
 }
 
 float ThermistorsADC::average_plate_temperature() {
@@ -66,9 +67,7 @@ float ThermistorsADC::average_plate_temperature() {
     front_right_temperature() +
     back_left_temperature() +
     back_center_temperature() +
-    back_right_temperature() +
-    //heat_sink_temperature() +
-    0.0
+    back_right_temperature()
   ) / TOTAL_PLATE_THERMISTORS;
 }
 

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
@@ -48,6 +48,15 @@ void ThermistorsADC::update(ThermistorPair n) {
   delay(inter_temp_read_interval);
   probe_temps[therm_index2] = _adc_to_celsius(_read_adc(therm_index2));
   delay(inter_temp_read_interval);
+  if (!is_in_range(probe_temps[therm_index1]) || !is_in_range(probe_temps[therm_index2]))
+  {
+    detected_invalid_val = true;
+  }
+}
+
+bool is_in_range(double celsius)
+{
+  return (celsius < THERMISTOR_ERROR_VAL_HI && celsius > THERMISTOR_ERROR_VAL_LOW)
 }
 
 float ThermistorsADC::average_plate_temperature() {

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.h
@@ -79,6 +79,7 @@ class ThermistorsADC{
             float back_right_temperature();
             float cover_temperature();
             float heat_sink_temperature();
+            bool detected_invalid_val;
 
       private:
 

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.h
@@ -46,6 +46,11 @@
 #define TOTAL_THERMISTORS              8
 #define TOTAL_PLATE_THERMISTORS        6
 
+// When thermistor is disconnected, the value at open ckt = -20
+// But we don't want to reach low -ve or  high +ve values either..
+#define THERMISTOR_ERROR_VAL_LOW  -10
+#define THERMISTOR_ERROR_VAL_HI   120
+
 enum class ThermistorPair
 {
     left=0,
@@ -88,6 +93,7 @@ class ThermistorsADC{
 
             uint16_t _read_adc(int index);
             float _adc_to_celsius(uint16_t _adc);
+            bool is_in_range(double celsius);
 
             double probe_temps[TOTAL_THERMISTORS] = {0, };
             double sum_probe_temps[TOTAL_THERMISTORS] = {0, };

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -342,6 +342,8 @@ void debug_status_prints()
   gcode.add_debug_response("Fan auto?", auto_fan);
   // Cover temperature:
   gcode.add_debug_response("T.Lid", temp_probes.cover_temperature());
+  // Thermistor status:
+  gcode.add_debug_response("T_error", int(thermistor_failure));
   // Motor status:
 #if HW_VERSION >= 3
   gcode.add_debug_response("Motor_fault", int(lid.is_driver_faulted()));
@@ -510,6 +512,16 @@ void read_gcode()
           break;
         case Gcode::get_device_info:
           gcode.device_info_response(device_serial, device_model, device_version);
+          break;
+        case Gcode::get_device_state:
+          if (temp_probes.detected_invalid_val)
+          {
+            gcode.response("Device Error");
+          }
+          else
+          {
+            gcode.response("All OK");
+          }
           break;
         case Gcode::dfu:
           break;
@@ -824,8 +836,13 @@ void therm_pid_peltier_update()
 void loop()
 {
   timeStamp = micros();
-  temp_safety_check();
   therm_pid_peltier_update();
+  if (temp_probes.detected_invalid_val)
+  {
+    gcode.response("");
+    deactivate_all();
+  }
+  temp_safety_check();
   // temp_plot();
   lid.check_switches();
   #if LID_WARNING

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -832,7 +832,6 @@ void loop()
     if (millis() - last_error_print > ERROR_PRINT_INTERVAL)
     {
       gcode.response("ERROR", "Invalid thermistor value");
-      gcode.send_ack();
       last_error_print = millis();
     }
     deactivate_all();
@@ -847,7 +846,6 @@ void loop()
       if (millis() - last_error_print > ERROR_PRINT_INTERVAL)
       {
         gcode.response("WARNING", "Lid Open");
-        gcode.send_ack();
         last_error_print = millis();
       }
     }

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -55,6 +55,8 @@
 #define HEATSINK_FAN_LO_TEMP      38
 #define HEATSINK_FAN_HI_TEMP      55
 #define HEATSINK_FAN_OFF_TEMP     36
+#define THERMISTOR_ERROR_VAL_LOW  -10
+#define THERMISTOR_ERROR_VAL_HI   120
 
 /********* PID: PLATE PELTIERS *********/
 // NOTE: temp_probes.update takes 136-137ms while rest of the loop takes 0-1ms.

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -55,8 +55,6 @@
 #define HEATSINK_FAN_LO_TEMP      38
 #define HEATSINK_FAN_HI_TEMP      55
 #define HEATSINK_FAN_OFF_TEMP     36
-#define THERMISTOR_ERROR_VAL_LOW  -10
-#define THERMISTOR_ERROR_VAL_HI   120
 
 /********* PID: PLATE PELTIERS *********/
 // NOTE: temp_probes.update takes 136-137ms while rest of the loop takes 0-1ms.
@@ -138,18 +136,14 @@ String device_version = "v1.0.1";
 /********* MISC GLOBALS *********/
 
 #define DEBUG_PRINT_INTERVAL 2000  // millisec
-unsigned long plotter_timestamp = 0;
-const int plotter_interval = 500;
+#define ERROR_PRINT_INTERVAL  2000  //ms
+unsigned long last_error_print = 0;
 bool front_button_pressed = false;
 unsigned long front_button_pressed_at = 0;
 bool timer_interrupted = false;
 uint8_t therm_read_state = 0;
-bool running_from_script = false;
-bool debug_print_mode = true;
-bool gcode_debug_mode = false;  // Debug mode is not compatible with API
-bool continuous_debug_stat_mode = false;
-bool running_graph = false;
-bool zoom_mode = false;
+bool gcode_debug_mode = false;
+bool continuous_debug_stat_mode = false; // continuous_debug_stat_mode is not compatible with API
 #if LID_TESTING
 unsigned long gcode_rec_timestamp;
 #endif


### PR DESCRIPTION
## overview

Closes [#3772](https://github.com/Opentrons/opentrons/issues/3772)
This PR adds a safety feature that would allow the module to deactivate if any of the thermistors gets disconnected since it would otherwise cause the PID computation to go haywire (This is also a compliance requirement) 
It also sends error warning through serial. The warning will be repeated every 2 seconds until the thermistor connection is repaired and system rebooted.
