### PR TITLE
 fix(tempdeck): fix model v4 fan control, LED pins & gcode args check

### DIFF
--- a/modules/temp-deck/temp-deck-arduino/gcode.cpp
+++ b/modules/temp-deck/temp-deck-arduino/gcode.cpp
@@ -120,7 +120,6 @@ void Gcode::setup(int baudrate) {
   COMMAND_CODES[GCODE_DEVICE_INFO] =  "M115";
   COMMAND_CODES[GCODE_DISENGAGE] =    "M18";
   COMMAND_CODES[GCODE_DFU] =          "dfu";
-  COMMAND_CODES[GCODE_FAN] =          "M106";
   Serial.begin(baudrate);
   Serial.setTimeout(3);
 }

--- a/modules/temp-deck/temp-deck-arduino/gcode.cpp
+++ b/modules/temp-deck/temp-deck-arduino/gcode.cpp
@@ -76,14 +76,12 @@ bool Gcode::read_number(char key) {
         break;
       }
     }
-    if (number_string) {
+    if (number_string.length() > 0) {
       parsed_number = number_string.toFloat();
       return true;
     }
-    else {
-      return false;
-    }
   }
+  return false;
 }
 
 void Gcode::print_device_info(String serial, String model, String version) {

--- a/modules/temp-deck/temp-deck-arduino/gcode.cpp
+++ b/modules/temp-deck/temp-deck-arduino/gcode.cpp
@@ -120,6 +120,7 @@ void Gcode::setup(int baudrate) {
   COMMAND_CODES[GCODE_DEVICE_INFO] =  "M115";
   COMMAND_CODES[GCODE_DISENGAGE] =    "M18";
   COMMAND_CODES[GCODE_DFU] =          "dfu";
+  COMMAND_CODES[GCODE_FAN] =          "M106";
   Serial.begin(baudrate);
   Serial.setTimeout(3);
 }

--- a/modules/temp-deck/temp-deck-arduino/gcode.h
+++ b/modules/temp-deck/temp-deck-arduino/gcode.h
@@ -15,7 +15,8 @@
 #define GCODE_DISENGAGE             2
 #define GCODE_DEVICE_INFO           3
 #define GCODE_DFU                   4
-#define TOTAL_GCODE_COMMAND_CODES   5
+#define GCODE_FAN                   5
+#define TOTAL_GCODE_COMMAND_CODES   6
 
 class Gcode{
 

--- a/modules/temp-deck/temp-deck-arduino/gcode.h
+++ b/modules/temp-deck/temp-deck-arduino/gcode.h
@@ -15,8 +15,7 @@
 #define GCODE_DISENGAGE             2
 #define GCODE_DEVICE_INFO           3
 #define GCODE_DFU                   4
-#define GCODE_FAN                   5
-#define TOTAL_GCODE_COMMAND_CODES   6
+#define TOTAL_GCODE_COMMAND_CODES   5
 
 class Gcode{
 

--- a/modules/temp-deck/temp-deck-arduino/lights.cpp
+++ b/modules/temp-deck/temp-deck-arduino/lights.cpp
@@ -168,7 +168,17 @@ void Lights::startup_animation(int target_number, int transition_time) {
   set_color_bar(0, 0, 0, 1);
 }
 
-void Lights::setup_lights() {
+void Lights::setup_lights(bool is_blue_pin_5) {
+  if (is_blue_pin_5)
+  {
+    blue_led = 5;
+    red_led = 6;
+  }
+  else
+  {
+    blue_led = 6;
+    red_led = 5;
+  }
   pinMode(red_led, OUTPUT);
   pinMode(blue_led, OUTPUT);
   Wire.setClock(400000);

--- a/modules/temp-deck/temp-deck-arduino/lights.cpp
+++ b/modules/temp-deck/temp-deck-arduino/lights.cpp
@@ -7,6 +7,10 @@ Lights::Lights(){
   https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library
 */
   pwm = Adafruit_PWMServoDriver();
+
+  // Default led pins
+  blue_led = 6;
+  red_led = 5;
 }
 
 void Lights::set_pwm_pin(int pin, float val) {

--- a/modules/temp-deck/temp-deck-arduino/lights.h
+++ b/modules/temp-deck/temp-deck-arduino/lights.h
@@ -31,7 +31,7 @@ class Lights{
   public:
 
     Lights();
-    void setup_lights(bool blue_is_pin_5);
+    void setup_lights(bool is_blue_pin_5);
     void startup_animation(int target_number, int transition_time);
     void display_number(int number, bool debounce=true);
     void set_color_bar(float red, float green, float blue, float white);

--- a/modules/temp-deck/temp-deck-arduino/lights.h
+++ b/modules/temp-deck/temp-deck-arduino/lights.h
@@ -14,9 +14,6 @@
 */
 #include <Adafruit_PWMServoDriver.h>
 
-#define red_led 5
-#define blue_led 6
-
 #define NUM_DIGITS 2
 #define NUM_SEGMENTS 7
 
@@ -34,7 +31,7 @@ class Lights{
   public:
 
     Lights();
-    void setup_lights();
+    void setup_lights(bool blue_is_pin_5);
     void startup_animation(int target_number, int transition_time);
     void display_number(int number, bool debounce=true);
     void set_color_bar(float red, float green, float blue, float white);
@@ -44,7 +41,7 @@ class Lights{
     void flash_off();
 
   private:
-
+    uint8_t red_led, blue_led;
     Adafruit_PWMServoDriver pwm;
     const uint8_t segments_pin_mapping[NUM_DIGITS][NUM_SEGMENTS] = {
       {10, 11, 4, 5, 6, 9, 8},

--- a/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
+++ b/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
@@ -26,6 +26,10 @@
 #include "gcode.h"
 
 #define device_version "v2.0.0"
+#define MODEL_VER_TEMPLATE "temp_deck_v"
+#define MODEL_VER_TEMPLATE_LEN sizeof(MODEL_VER_TEMPLATE) - 1
+#define SERIAL_VER_TEMPLATE "TDV03P2018"
+#define SERIAL_VER_TEMPLATE_LEN sizeof(SERIAL_VER_TEMPLATE) - 1
 
 #define PIN_BUZZER 11  // a piezo buzzer we can use tone() with
 #define PIN_FAN 9      // blower-fan controlled by simple PWM analogWrite()
@@ -532,9 +536,7 @@ void setup() {
 
   memory.read_serial(device_serial);
   memory.read_model(device_model);
-
-  const String model_ver_template= "temp_deck_v";
-  String ver = device_model.substring(model_ver_template.length());
+  String ver = device_model.substring(MODEL_VER_TEMPLATE_LEN);
   model_version = ver.toInt();
 
   if (model_version == 3 || model_version == 4)
@@ -543,12 +545,12 @@ void setup() {
     if (model_version == 3)
     {
       // V3 tempdecks produced after Oct 15 have different LED pin configuration
-      const String serial_ver_template = "TDV03P2018"; // example serial-TDV03P20181008A01
-      const uint8_t date_length = 4;
+      // serial number has the production date. eg. TDV03P*20181008*A01
+      const uint8_t date_length = 4;  // MMDD
       String serial_date = device_serial.substring(
-        serial_ver_template.length(), serial_ver_template.length() + date_length);
+        SERIAL_VER_TEMPLATE_LEN, SERIAL_VER_TEMPLATE_LEN + date_length);
       int v3_date = serial_date.toInt();
-      if (v3_date > 1019)
+      if (v3_date > 1015)
       {
         is_blue_pin_5 = true;
       }

--- a/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
+++ b/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
@@ -71,8 +71,8 @@ unsigned long fan_timestamp = 0;
 bool is_fan_on = false;
 bool is_v3_v4_fan = false;
 
-// LED pins for model versions 3 & 4: red = 6, blue = 5
-// LED pins for model versions < 3  : red = 5, blue = 6
+// LED pins for model versions 3 (post 2018.10.15) & 4: red = 6, blue = 5
+// LED pins for model versions < 3 & 3.0 (pre- 2018.10.15) : red = 5, blue = 6
 bool is_blue_pin_5 = false;
 
 // the "Kd" of the PID never changes in our setup
@@ -486,12 +486,6 @@ void read_gcode(){
           break;
         case GCODE_DEVICE_INFO:
           gcode.print_device_info(device_serial, device_model, device_version);
-          break;
-        case GCODE_FAN:
-          if (gcode.read_number('S'))
-          {
-              set_fan_power(gcode.parsed_number);
-          }
           break;
         case GCODE_DFU:
           gcode.send_ack(); // Send ack here since we not reaching the end of the loop

--- a/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
+++ b/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
@@ -133,12 +133,21 @@ void set_fan_power(float percentage){
 }
 
 void fan_v3_v4_on() {
-  digitalWrite(PIN_FAN, HIGH);
+  if (is_fan_on_high())
+  {
+    analogWrite(PIN_FAN, FAN_V3_V4_HI_PWR);
+  }
+  else
+  { // If it's a PWM fan, it'll be powered down to the low power value.
+    // If it's not a PWM fan, low pwm will still turn its driver ON as long as
+    // it's above a threshold.
+    analogWrite(PIN_FAN, FAN_V3_V4_LOW_PWR);
+  }
   is_fan_on = true;
 }
 
 void fan_v3_v4_off() {
-  digitalWrite(PIN_FAN, LOW);
+  analogWrite(PIN_FAN, LOW);
   is_fan_on = false;
 }
 
@@ -237,7 +246,7 @@ void stabilize_to_target_temp(bool set_fan=true){
     set_fan_power(FAN_HIGH);
   }
   else {
-    if (is_v3_v4_fan) set_fan_power(FAN_V3_V4_LOW);
+    if (is_v3_v4_fan) set_fan_power(FAN_V3_V4_LOW_ON_PC); // more like set fan ON time
     else set_fan_power(FAN_LOW);
   }
 
@@ -428,21 +437,15 @@ void setup() {
       {
         is_blue_pin_5 = true;
       }
+      else
+      {
+        is_blue_pin_5 = false;
+      }
     }
     else
     {
       is_blue_pin_5 = true;
-      // TODO: Change this to reflect the tempdecks that really got the new fans
-      //       .. not all B versions have the new fans
-      char ab_version = device_serial.charAt(14);
-      if (ab_version == "A")
-      {
-        is_v3_v4_fan = true;
-      }
-      else
-      {
-        is_v3_v4_fan = false;
-      }
+      is_v3_v4_fan = true;
     }
   }
   else

--- a/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
+++ b/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
@@ -276,7 +276,7 @@ void update_led_display(boolean debounce=true){
   if (!MASTER_SET_A_TARGET) {
     lights.set_color_bar(0, 0, 0, 1);  // white
   }
-  else if (TARGET_TEMPERATURE < TEMPERATURE_ROOM) {
+  else if (TARGET_TEMPERATURE <= TEMPERATURE_ROOM) {
     lights.set_color_bar(0, 0, 1, 0);  // blue
   }
   else {
@@ -415,9 +415,9 @@ void setup() {
   bool is_blue_pin_5;
   if (model_version == 3 || model_version == 4)
   {
-    is_v3_v4_fan = true;
     if (model_version == 3)
     {
+      is_v3_v4_fan = true;
       // V3 tempdecks produced after Oct 15 have different LED pin configuration
       // serial number has the production date. eg. TDV03P*20181008*A01
       const uint8_t date_length = 4;  // MMDD
@@ -432,6 +432,17 @@ void setup() {
     else
     {
       is_blue_pin_5 = true;
+      // TODO: Change this to reflect the tempdecks that really got the new fans
+      //       .. not all B versions have the new fans
+      char ab_version = device_serial.charAt(14);
+      if (ab_version == "A")
+      {
+        is_v3_v4_fan = true;
+      }
+      else
+      {
+        is_v3_v4_fan = false;
+      }
     }
   }
   else

--- a/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
+++ b/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
@@ -540,7 +540,23 @@ void setup() {
   if (model_version == 3 || model_version == 4)
   {
     is_v3_v4_fan = true;
-    is_blue_pin_5 = true;
+    if (model_version == 3)
+    {
+      // V3 tempdecks produced after Oct 15 have different LED pin configuration
+      const String serial_ver_template = "TDV03P2018"; // example serial-TDV03P20181008A01
+      const uint8_t date_length = 4;
+      String serial_date = device_serial.substring(
+        serial_ver_template.length(), serial_ver_template.length() + date_length);
+      int v3_date = serial_date.toInt();
+      if (v3_date > 1019)
+      {
+        is_blue_pin_5 = true;
+      }
+    }
+    else
+    {
+      is_blue_pin_5 = true;
+    }
   }
   lights.setup_lights(is_blue_pin_5);
   lights.set_numbers_brightness(0.25);

--- a/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
+++ b/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
@@ -2,152 +2,24 @@
 /////////////////////////////////
 /////////////////////////////////
 
-#include <Arduino.h>
-#include <avr/wdt.h>
+#include "temp-deck.h"
 
-/*
-  PID library written by github user br3ttb:
-  can be found at:
-  https://github.com/br3ttb/Arduino-PID-Library
-*/
-#include <PID_v1.h>
+PID myPID(
+  &CURRENT_TEMPERATURE,
+  &TEMPERATURE_SWING,
+  &TARGET_TEMPERATURE,
+  DOWN_PID_KP, DOWN_PID_KI, DEFAULT_PID_KD,
+  P_ON_M,
+  DIRECT);
 
-/*
-  the below "lights.h" class uses Adafruit's 16-channel PWM I2C driver library
-  can be found at:
-  https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library
-*/
-#include "lights.h"
-
-// load in some custom classes for this device
-#include "memory.h"
-#include "peltiers.h"
-#include "thermistor.h"
-#include "gcode.h"
-
-#define device_version "v2.0.0"
-#define MODEL_VER_TEMPLATE "temp_deck_v"
-#define MODEL_VER_TEMPLATE_LEN sizeof(MODEL_VER_TEMPLATE) - 1
-#define SERIAL_VER_TEMPLATE "TDV03P2018"
-#define SERIAL_VER_TEMPLATE_LEN sizeof(SERIAL_VER_TEMPLATE) - 1
-
-#define PIN_BUZZER 11  // a piezo buzzer we can use tone() with
-#define PIN_FAN 9      // blower-fan controlled by simple PWM analogWrite()
-
-// the maximum temperatures the device can target
-// this is limitted mostly by the 2-digit temperature display
-#define TEMPERATURE_MAX 99
-#define TEMPERATURE_MIN -9
-
-// some temperature zones to help decide on states
-#define TEMPERATURE_FAN_CUTOFF_COLD 15
-#define TEMPERATURE_FAN_CUTOFF_HOT 35
-#define TEMPERATURE_ROOM 23
-
-#define TEMPERATURE_BURN 55
-#define STABILIZING_ZONE 0.5
-
-// values used to scale the thermistors temperature
-// to more accurately reflect the temperature of the top-plate
-#define THERMISTOR_OFFSET_LOW_TEMP 5.25
-#define THERMISTOR_OFFSET_LOW_VALUE -0.1
-#define THERMISTOR_OFFSET_HIGH_TEMP 95
-#define THERMISTOR_OFFSET_HIGH_VALUE -1.4
-const float THERMISTOR_OFFSET_HIGH_TEMP_DIFF = THERMISTOR_OFFSET_HIGH_TEMP - TEMPERATURE_ROOM;
-const float THERMISTOR_OFFSET_LOW_TEMP_DIFF = TEMPERATURE_ROOM - THERMISTOR_OFFSET_LOW_TEMP;
-float _offset_temp_diff = 0.0;
-
-// the intensities of the fan (0.0-1.0)
-#define FAN_HIGH 1.0
-#define FAN_LOW 0.3
-#define FAN_OFF 0.0
-
-// model versions 3.0+ & 4.0+ have a different fan that requires on/off cycles (not PWM)
-#define MAX_FAN_OFF_TIME 2000
-#define FAN_V3_V4_LOW 0.95
-unsigned long fan_on_time = 0;
-unsigned long fan_off_time = MAX_FAN_OFF_TIME;
-unsigned long fan_timestamp = 0;
-bool is_fan_on = false;
-bool is_v3_v4_fan = false;
-
-// LED pins for model versions 3 (post 2018.10.15) & 4: red = 6, blue = 5
-// LED pins for model versions < 3 & 3.0 (pre- 2018.10.15) : red = 5, blue = 6
-bool is_blue_pin_5 = false;
-
-// the "Kd" of the PID never changes in our setup
-// (works according to testing so far...)
-#define DEFAULT_PID_KD 0.0
-
-// the "Kp" and "Ki" value for whenever the target is BELOW current temperature
-// stays constant for all target temperature
-// (works according to testing so far...)
-#define DOWN_PID_KP 0.38
-#define DOWN_PID_KI 0.0275
-
-// the "Kp" and "Ki" value for whenever the target is ABOVE current temperature
-// linear interpolation between LOW and HIGH target values
-// (works according to testing so far...)
-#define UP_PID_LOW_TEMP 40
-#define UP_PID_HIGH_TEMP 100
-#define UP_PID_KP_AT_LOW_TEMP 0.17    // "Kp" when target is UP_PID_LOW_TEMP
-#define UP_PID_KP_AT_HIGH_TEMP 0.26   // "Kp" when target is UP_PID_HIGH_TEMP
-#define UP_PID_KI_AT_LOW_TEMP 0.012   // "Ki" when target is UP_PID_LOW_TEMP
-#define UP_PID_KI_AT_HIGH_TEMP 0.0225 // "Ki" when target is UP_PID_HIGH_TEMP
-
-// the "Kp" and "Ki" value for whenever the target is ABOVE current temperature
-// BUT also in the cold zone (<15deg)
-#define UP_PID_KP_IN_COLD_ZONE 0.21
-#define UP_PID_KI_IN_COLD_ZONE 0.015
-
-// to use with the Arduino IDE's "Serial Plotter" graphing tool
-// (very, very useful when testing PID tuning values)
-// uncomment below line to print temperature and PID information
-
-//#define DEBUG_PLOTTER_ENABLED
-
-#ifdef DEBUG_PLOTTER_ENABLED
-#define DEBUG_PLOTTER_INTERVAL 250
-unsigned long debug_plotter_timestamp = 0;
-#endif
-
-// when a new target-temperature is set, and the peltiers need to shift directions suddenly
-// that is the moment when they draw the most current (4.3 amps). If the fan is on HIGH
-// at the same time (>2.0 amps) then we are over-working our 6.1 amp power supply.
-// So, these variables are used whenever a NEW target temperature is set. They do the following:
-//    1) turn off both the peltiers and fan, and wait until the fan has completely shut down (do nothing until then)
-//    3) once fan is off, turn on the peltiers to the correct state (potentially drawing 4.3 amps!)
-//    4) after the the peltiers' current has dropping some, turn the fan back on
-
-// uncomment to turn off system after setting the temperature
-#define CONSERVE_POWER_ON_SET_TARGET
-
-#ifdef CONSERVE_POWER_ON_SET_TARGET
-unsigned long SET_TEMPERATURE_TIMESTAMP = 0;
-#define millis_till_fan_turns_off 2000 // how long to wait before #1 and #2 from the list above
-#define millis_till_peltiers_drop_current 2000 // how long to wait before #2 and #3 from the list above
-#endif
-
-// -1.0 is full cold peltiers, +1.0 is full hot peltiers, can be between the two
-double TEMPERATURE_SWING;
-double TARGET_TEMPERATURE = TEMPERATURE_ROOM;
-double CURRENT_TEMPERATURE = TEMPERATURE_ROOM;
-bool MASTER_SET_A_TARGET = false;
-
-PID myPID(&CURRENT_TEMPERATURE, &TEMPERATURE_SWING, &TARGET_TEMPERATURE, DOWN_PID_KP, DOWN_PID_KI, DEFAULT_PID_KD, P_ON_M, DIRECT);
-
-String device_serial = "";  // leave empty, this value is read from eeprom during setup()
-String device_model = "";   // leave empty, this value is read from eeprom during setup()
-int model_version;          // value is read from device_model during setup()
+String device_serial;  // this value is read from eeprom during setup()
+String device_model;   // this value is read from eeprom during setup()
 
 Lights lights = Lights();  // controls 2-digit 7-segment numbers, and the RGBW color bar
 Peltiers peltiers = Peltiers();  // 2 peltiers wired in series (-1.0<->1.0 controls polarity and intensity)
 Thermistor thermistor = Thermistor();  // uses thermistor to read calculate the top-plate's temperature
 Gcode gcode = Gcode();  // reads in serial data to parse command and issue reponses
 Memory memory = Memory();  // reads from EEPROM to find device's unique serial, and model number
-
-unsigned long start_bootloader_timestamp = 0;
-const int start_bootloader_timeout = 1000;
 
 /////////////////////////////////
 /////////////////////////////////
@@ -181,6 +53,11 @@ bool is_hot_zone() {
   return CURRENT_TEMPERATURE > TEMPERATURE_FAN_CUTOFF_HOT;
 }
 
+bool is_unsafe_temp()
+{
+  return CURRENT_TEMPERATURE > TEMPERATURE_MAX;
+}
+
 bool is_targeting_cold_zone() {
   return TARGET_TEMPERATURE <= TEMPERATURE_FAN_CUTOFF_COLD;
 }
@@ -194,7 +71,7 @@ bool is_targeting_hot_zone() {
 }
 
 bool is_fan_on_high() {
-  return is_targeting_cold_zone() || (is_targeting_middle_zone() && is_moving_down());
+  return is_targeting_cold_zone() || is_moving_down();
 }
 
 /////////////////////////////////
@@ -369,11 +246,11 @@ void stabilize_to_target_temp(bool set_fan=true){
 }
 
 void stabilize_to_room_temp(bool set_fan=true) {
-  if (is_burning_hot()) {
+  if (is_burning_hot() && !is_unsafe_temp()) {
     set_peltiers_from_pid();
     set_fan_power(FAN_HIGH);
   }
-  else {
+  else if (!is_burning_hot()) {
     peltiers.disable_peltiers();
     set_fan_power(FAN_OFF);
   }
@@ -531,8 +408,11 @@ void setup() {
   memory.read_serial(device_serial);
   memory.read_model(device_model);
   String ver = device_model.substring(MODEL_VER_TEMPLATE_LEN);
-  model_version = ver.toInt();
+  int model_version = ver.toInt();
 
+  // LED pins for model versions 3 (post 2018.10.15) & 4: red = 6, blue = 5
+  // LED pins for model versions < 3 & 3.0 (pre- 2018.10.15) : red = 5, blue = 6
+  bool is_blue_pin_5;
   if (model_version == 3 || model_version == 4)
   {
     is_v3_v4_fan = true;
@@ -554,6 +434,11 @@ void setup() {
       is_blue_pin_5 = true;
     }
   }
+  else
+  {
+    is_v3_v4_fan = false;
+    is_blue_pin_5 = false;
+  }
   lights.setup_lights(is_blue_pin_5);
   lights.set_numbers_brightness(0.25);
   lights.set_color_bar_brightness(0.5);
@@ -574,8 +459,19 @@ void setup() {
   lights.startup_animation(CURRENT_TEMPERATURE, 2000);
 }
 
-void loop(){
+void temp_safety_check()
+{
+  if (is_unsafe_temp())
+  {
+    gcode.print_warning(F("Temperature module overheated! Deactivating."));
+    turn_off_target();
+    peltiers.disable_peltiers();
+    set_fan_power(FAN_HIGH);
+  }
+}
 
+void loop(){
+  temp_safety_check();
   turn_off_serial_lights();
 
 #ifdef DEBUG_PLOTTER_ENABLED

--- a/modules/temp-deck/temp-deck-arduino/temp-deck.h
+++ b/modules/temp-deck/temp-deck-arduino/temp-deck.h
@@ -61,9 +61,15 @@ float _offset_temp_diff = 0.0;
 #define FAN_LOW 0.3
 #define FAN_OFF 0.0
 
-// model versions 3.0+ & 4.0+ have a different fan that requires on/off cycles (not PWM)
-#define MAX_FAN_OFF_TIME 2000
-#define FAN_V3_V4_LOW 0.95
+// some model versions 3.0+ & 4.0+ have a different fan that requires on/off cycles (not PWM)
+#define MAX_FAN_OFF_TIME    4000
+#define FAN_V3_V4_LOW_ON_PC 0.75
+
+// some model v4 fans are indeed PWM. We need to keep their power low enough while
+// pulsing so they are able to turn off momentarily.
+#define FAN_V3_V4_LOW_PWR   100   // PWM value (= 39%)
+#define FAN_V3_V4_HI_PWR    214   // PWM value (= 85%)
+
 unsigned long fan_on_time = 0;
 unsigned long fan_off_time = MAX_FAN_OFF_TIME;
 unsigned long fan_timestamp = 0;

--- a/modules/temp-deck/temp-deck-arduino/temp-deck.h
+++ b/modules/temp-deck/temp-deck-arduino/temp-deck.h
@@ -1,0 +1,135 @@
+#ifndef TEMP_DECK_H
+#define TEMP_DECK_H
+
+#include <Arduino.h>
+#include <avr/wdt.h>
+
+/*
+  PID library written by github user br3ttb:
+  can be found at:
+  https://github.com/br3ttb/Arduino-PID-Library
+*/
+#include <PID_v1.h>
+
+/*
+  the below "lights.h" class uses Adafruit's 16-channel PWM I2C driver library
+  can be found at:
+  https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library
+*/
+#include "lights.h"
+
+// load in some custom classes for this device
+#include "memory.h"
+#include "peltiers.h"
+#include "thermistor.h"
+#include "gcode.h"
+
+#define device_version "v2.0.0"
+#define MODEL_VER_TEMPLATE "temp_deck_v"
+#define MODEL_VER_TEMPLATE_LEN sizeof(MODEL_VER_TEMPLATE) - 1
+#define SERIAL_VER_TEMPLATE "TDV03P2018"
+#define SERIAL_VER_TEMPLATE_LEN sizeof(SERIAL_VER_TEMPLATE) - 1
+
+#define PIN_BUZZER 11  // a piezo buzzer we can use tone() with
+#define PIN_FAN 9      // blower-fan controlled by simple PWM analogWrite()
+
+// the maximum temperatures the device can target
+// this is limitted mostly by the 2-digit temperature display
+#define TEMPERATURE_MAX 99
+#define TEMPERATURE_MIN -9
+
+// some temperature zones to help decide on states
+#define TEMPERATURE_ROOM 23
+#define TEMPERATURE_FAN_CUTOFF_COLD TEMPERATURE_ROOM
+#define TEMPERATURE_FAN_CUTOFF_HOT 35
+
+#define TEMPERATURE_BURN 55
+#define STABILIZING_ZONE 0.5
+
+// values used to scale the thermistors temperature
+// to more accurately reflect the temperature of the top-plate
+#define THERMISTOR_OFFSET_LOW_TEMP 5.25
+#define THERMISTOR_OFFSET_LOW_VALUE -0.1
+#define THERMISTOR_OFFSET_HIGH_TEMP 95
+#define THERMISTOR_OFFSET_HIGH_VALUE -1.4
+const float THERMISTOR_OFFSET_HIGH_TEMP_DIFF = THERMISTOR_OFFSET_HIGH_TEMP - TEMPERATURE_ROOM;
+const float THERMISTOR_OFFSET_LOW_TEMP_DIFF = TEMPERATURE_ROOM - THERMISTOR_OFFSET_LOW_TEMP;
+float _offset_temp_diff = 0.0;
+
+// the intensities of the fan (0.0-1.0)
+#define FAN_HIGH 1.0
+#define FAN_LOW 0.3
+#define FAN_OFF 0.0
+
+// model versions 3.0+ & 4.0+ have a different fan that requires on/off cycles (not PWM)
+#define MAX_FAN_OFF_TIME 2000
+#define FAN_V3_V4_LOW 0.95
+unsigned long fan_on_time = 0;
+unsigned long fan_off_time = MAX_FAN_OFF_TIME;
+unsigned long fan_timestamp = 0;
+bool is_fan_on = false;
+bool is_v3_v4_fan = false;
+
+// the "Kd" of the PID never changes in our setup
+// (works according to testing so far...)
+#define DEFAULT_PID_KD 0.0
+
+// the "Kp" and "Ki" value for whenever the target is BELOW current temperature
+// stays constant for all target temperature
+// (works according to testing so far...)
+#define DOWN_PID_KP 0.38
+#define DOWN_PID_KI 0.0275
+
+// the "Kp" and "Ki" value for whenever the target is ABOVE current temperature
+// linear interpolation between LOW and HIGH target values
+// (works according to testing so far...)
+#define UP_PID_LOW_TEMP 40
+#define UP_PID_HIGH_TEMP 100
+#define UP_PID_KP_AT_LOW_TEMP 0.17    // "Kp" when target is UP_PID_LOW_TEMP
+#define UP_PID_KP_AT_HIGH_TEMP 0.26   // "Kp" when target is UP_PID_HIGH_TEMP
+#define UP_PID_KI_AT_LOW_TEMP 0.012   // "Ki" when target is UP_PID_LOW_TEMP
+#define UP_PID_KI_AT_HIGH_TEMP 0.0225 // "Ki" when target is UP_PID_HIGH_TEMP
+
+// the "Kp" and "Ki" value for whenever the target is ABOVE current temperature
+// BUT also in the cold zone (<15deg)
+#define UP_PID_KP_IN_COLD_ZONE 0.21
+#define UP_PID_KI_IN_COLD_ZONE 0.015
+
+// to use with the Arduino IDE's "Serial Plotter" graphing tool
+// (very, very useful when testing PID tuning values)
+// uncomment below line to print temperature and PID information
+
+//#define DEBUG_PLOTTER_ENABLED
+
+#ifdef DEBUG_PLOTTER_ENABLED
+#define DEBUG_PLOTTER_INTERVAL 250
+unsigned long debug_plotter_timestamp = 0;
+#endif
+
+// when a new target-temperature is set, and the peltiers need to shift directions suddenly
+// that is the moment when they draw the most current (4.3 amps). If the fan is on HIGH
+// at the same time (>2.0 amps) then we are over-working our 6.1 amp power supply.
+// So, these variables are used whenever a NEW target temperature is set. They do the following:
+//    1) turn off both the peltiers and fan, and wait until the fan has completely shut down (do nothing until then)
+//    3) once fan is off, turn on the peltiers to the correct state (potentially drawing 4.3 amps!)
+//    4) after the the peltiers' current has dropping some, turn the fan back on
+
+// uncomment to turn off system after setting the temperature
+#define CONSERVE_POWER_ON_SET_TARGET
+
+#ifdef CONSERVE_POWER_ON_SET_TARGET
+unsigned long SET_TEMPERATURE_TIMESTAMP = 0;
+#define millis_till_fan_turns_off 2000 // how long to wait before #1 and #2 from the list above
+#define millis_till_peltiers_drop_current 2000 // how long to wait before #2 and #3 from the list above
+#endif
+
+// -1.0 is full cold peltiers, +1.0 is full hot peltiers, can be between the two
+double TEMPERATURE_SWING;
+double TARGET_TEMPERATURE = TEMPERATURE_ROOM;
+double CURRENT_TEMPERATURE = TEMPERATURE_ROOM;
+bool MASTER_SET_A_TARGET = false;
+
+unsigned long start_bootloader_timestamp = 0;
+const int start_bootloader_timeout = 1000;
+
+#endif


### PR DESCRIPTION
Closes #72 

This PR fixes the overheating problem caused because of reasons stated in #72 

## Changes
- Include corner temperatures in respective temp zones (TEMPERATURE_FAN_CUTOFF_COLD & TEMPERATURE_FAN_CUTOFF_HOT)
- Make v4 fan behavior same as v3 fans- i.e, use fan on/off instead of pwm. PWM-ing the fan causes unexpected behavior in the control circuitry that uses capacitors and an inductor which probably create some charge/discharge pattern that makes the fan turn off unexpectedly. The result is that the fan isn't ON long enough to push the heat out. 
- Latest v4 tempdecks have a pwm controlled fan which also happens to have a much faster acceleration hence the previous on/off timings were not suiting well for it. So increased the overall on/off period and decreased the power. Note that the code is changed a bit so that the same control works for all v3 and v4 fans and all fans behave similarly.
- Add a version check for proper LED pin assignment (the LED connections changed mid v3 production)
- fixed a gcode set_temperature bug where an `M104` without any temperature specified would count as a valid gcode and result in setting the target as either 0C or the previously set target.