### PR TITLE
feat(thermocycler): LED strip shows thermocycler status

### DIFF
--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
@@ -19,6 +19,8 @@
   GCODE_DEF(deactivate_lid_heating, M108),  \
   GCODE_DEF(set_plate_temp, M104),  \
   GCODE_DEF(get_plate_temp, M105),  \
+  GCODE_DEF(set_led_override, M200),\
+  GCODE_DEF(set_led, M210),         \
   GCODE_DEF(set_ramp_rate, M566),   \
   GCODE_DEF(edit_pid_params, M301), \
   GCODE_DEF(pause, M76),            \

--- a/modules/thermo-cycler/thermo-cycler-arduino/lights.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lights.cpp
@@ -1,0 +1,195 @@
+#include "lights.h"
+
+#if RGBW_NEO
+Adafruit_NeoPixel_ZeroDMA strip(NUM_PIXELS, NEO_PIN, NEO_GRBW);
+#else
+Adafruit_NeoPixel_ZeroDMA strip(NUM_PIXELS, NEO_PIN, NEO_GRB + NEO_KHZ800);
+#endif
+
+#undef COLOR_DEF
+#define COLOR_DEF(_, color) color
+#define COLOR_INDEX(color_name) static_cast<int>(color_name)
+
+const uint32_t COLOR_CODES[] = { COLOR_TABLE };
+
+Lights::Lights(){}
+
+void Lights::setup()
+{
+  pinMode(NEO_PWR, OUTPUT);
+  pinMode(NEO_PIN, OUTPUT);
+  digitalWrite(NEO_PWR, HIGH);
+  strip.begin();
+  strip.setBrightness(70);
+  _action = Light_action::solid;
+  _color = Light_color::white;
+  strip.show();
+}
+
+void Lights::update()
+{
+  // Updates lights acc to _action and _color
+  switch(_action)
+  {
+    case Light_action::solid:
+      _set_strip_color(COLOR_CODES[COLOR_INDEX(_color)]);
+      break;
+    case Light_action::pulsing:
+      _pulse_leds(_color);
+      break;
+    case Light_action::wipe:
+      _color_wipe(_color);
+      break;
+    case Light_action::all_off:
+    default:
+      _set_strip_color(COLOR_CODES[COLOR_INDEX(Light_color::none)]);
+      break;
+  }
+  _prev_action = _action;
+  _prev_color = _color;
+}
+
+void Lights::set_lights(TC_status tc_status)
+{
+  // Set _action and _color acc to tc_status
+  switch(tc_status)
+  {
+    case TC_status::idle:
+      _action = (action_override ? api_action : Light_action::solid);
+      _color = (color_override ? api_color : Light_color::white);
+      break;
+    case TC_status::going_to_hot_target:
+      _action = (action_override ? api_action : Light_action::pulsing);
+      _color = (color_override ? api_color : Light_color::red);
+      break;
+    case TC_status::going_to_cold_target:
+      _action = (action_override ? api_action : Light_action::pulsing);
+      _color = (color_override ? api_color : Light_color::blue);
+      break;
+    case TC_status::at_hot_target:
+      _action = (action_override ? api_action : Light_action::solid);
+      _color = (color_override ? api_color : Light_color::red);
+      break;
+    case TC_status::at_cold_target:
+      _action = (action_override ? api_action : Light_action::solid);
+      _color = (color_override ? api_color : Light_color::blue);
+      break;
+    default:
+      _action = Light_action::solid;
+      _color = Light_color::orange;
+      break;
+  }
+}
+
+void Lights::set_lights(Light_action action, Light_color color)
+{
+  // Set _action and _color to args values
+  _action = action;
+  _color = color;
+}
+
+void Lights::_set_strip_color(uint32_t color)
+{
+  for(int i=0; i<strip.numPixels(); i++)
+  {
+    strip.setPixelColor(i, color); // strip.setPixelColor(n, [white, red, green, blue]);
+    strip.show();
+    delay(1);
+  }
+}
+
+/* Lights::_color_wipe:
+ * This function turns on each pixel in the strip incrementally after a small
+ * delay, creating a 'wipe' of color. Once the entire strip is on, it
+ * similarly turns each pixel off, making it look like the color is being
+ * pushed off the other end of the strip. This creates the desired
+ * continuously rotating light effect.
+ */
+void Lights::_color_wipe(Light_color color) {
+  static uint8_t i = 0;
+  static bool is_no_color_wipe = true;
+  if (_prev_action != Light_action::wipe || _prev_color != color)
+  {
+    _set_strip_color(COLOR_CODES[COLOR_INDEX(color)]);
+    i = 0;
+    is_no_color_wipe = true;
+  }
+  static unsigned long last_update_millis = 0;
+  if (millis() - last_update_millis < WIPE_SPEED_DELAY)
+  {
+    return;
+  }
+  if (i >= strip.numPixels())
+  {
+    i = 0;
+    is_no_color_wipe = !is_no_color_wipe;
+  }
+  if (is_no_color_wipe)
+  {
+    _set_pixel(i, Light_color::none);
+  }
+  else
+  {
+    _set_pixel(i, color);
+  }
+  strip.show();
+  delayMicroseconds(50);
+  last_update_millis = millis();
+  i++;
+}
+
+void Lights::_set_pixel(int pixel, Light_color color) {
+   // NeoPixel
+   strip.setPixelColor(pixel, COLOR_CODES[COLOR_INDEX(color)]);
+}
+
+void Lights::_pulse_leds(Light_color color)
+{
+  static float brightness = 0;
+  static float rad = 0;
+  static unsigned long last_update = 0;
+
+  if (rad >= 3.14)
+  {
+    rad = 0;
+  }
+
+  uint32_t color32 = COLOR_CODES[COLOR_INDEX(color)];
+  uint8_t w = ((color32 & 0xff000000) >> 24);
+  uint8_t r = ((color32 & 0x00ff0000) >> 16);
+  uint8_t g = ((color32 & 0x0000ff00) >> 8);
+  uint8_t b = ((color32 & 0x000000ff) >> 0);
+  if (r)
+  {
+    brightness = sin(rad) * r;
+    r = uint8_t(brightness);
+  }
+  if (g)
+  {
+    brightness = sin(rad) * g;
+    g = uint8_t(brightness);
+  }
+  if (b)
+  {
+    brightness = sin(rad) * b;
+    b = uint8_t(brightness);
+  }
+  if (w)
+  {
+    brightness = sin(rad) * w;
+    w = uint8_t(brightness);
+  }
+
+  uint32_t new_shade = (uint32_t(w) << 24) | (uint32_t(r) << 16) | (uint32_t(g) << 8) | (uint32_t(b) << 0);
+  _set_strip_color(new_shade);
+  delayMicroseconds(50);
+  last_update = millis();
+  if (rad > 1.57)
+  {
+    rad += 0.06;
+  }
+  else
+  {
+    rad += 0.04;
+  }
+}

--- a/modules/thermo-cycler/thermo-cycler-arduino/lights.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lights.h
@@ -1,0 +1,69 @@
+/********* INDICATOR NEOPIXELS *********/
+#ifndef LIGHTS_H
+#define LIGHTS_H
+
+#include "Arduino.h"
+#include <Adafruit_NeoPixel_ZeroDMA.h>
+
+#define NEO_PWR     4
+#define NEO_PIN     A5
+#define NUM_PIXELS  16
+#define WIPE_SPEED_DELAY 50
+
+enum class TC_status
+{
+  idle,
+  going_to_hot_target,
+  going_to_cold_target,
+  at_hot_target,
+  at_cold_target
+};
+
+// Order is WRGB
+// Brights are being toned down
+#define COLOR_TABLE \
+  COLOR_DEF(soft_white, 0xee000000), \
+  COLOR_DEF(white, 0x00eeeeee),      \
+  COLOR_DEF(red, 0x00500000),        \
+  COLOR_DEF(green, 0x0000ee00),      \
+  COLOR_DEF(blue, 0x000000ff),       \
+  COLOR_DEF(orange, 0x00ff8300),     \
+  COLOR_DEF(none, 0x00000000)
+
+#define COLOR_DEF(color_name, _) color_name
+
+enum class Light_action
+{
+  all_off=0,
+  solid,
+  pulsing,
+  wipe
+};
+
+enum class Light_color
+{
+  COLOR_TABLE
+};
+
+class Lights
+{
+  public:
+    Lights();
+    void setup();
+    void update();
+    void set_lights(TC_status);
+    void set_lights(Light_action, Light_color);
+    Light_color api_color;
+    Light_action api_action;
+    bool color_override;
+    bool action_override;
+  private:
+    Light_action _action, _prev_action;
+    Light_color _color, _prev_color;
+    void _set_strip_color(uint32_t color);
+    void _color_wipe(Light_color color);
+    void _set_pixel(int Pixel, Light_color color);
+    void _pulse_leds(Light_color color);
+};
+
+#endif

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -5,15 +5,11 @@ TC_Timer tc_timer;
 GcodeHandler gcode;
 ThermistorsADC temp_probes;
 Lid lid;
+Lights light_strip;
 Peltiers peltiers;
 Fan cover_fan;
 Fan heatsink_fan;
 
-#if RGBW_NEO
-Adafruit_NeoPixel_ZeroDMA strip(NUM_PIXELS, NEO_PIN, NEO_GRBW);
-#else
-Adafruit_NeoPixel_ZeroDMA strip(NUM_PIXELS, NEO_PIN, NEO_GRB + NEO_KHZ800);
-#endif
 
 unsigned long timeStamp = 0;
 
@@ -454,6 +450,40 @@ void read_gcode()
             gcode.idle_temperature_response(current_temperature_plate);
           }
           break;
+        case Gcode::set_led:
+          if (gcode.pop_arg('C'))
+          {
+            light_strip.api_color = static_cast<Light_color>(gcode.popped_arg());
+          }
+          if (gcode.pop_arg('A'))
+          {
+            light_strip.api_action = static_cast<Light_action>(gcode.popped_arg());
+          }
+          break;
+        case Gcode::set_led_override:
+          if (gcode.pop_arg('C'))
+          {
+            if (gcode.popped_arg() == 1)
+            {
+              light_strip.color_override = true;
+            }
+            else if (gcode.popped_arg() == 0)
+            {
+              light_strip.color_override = false;
+            }
+          }
+          if (gcode.pop_arg('A'))
+          {
+            if (gcode.popped_arg() == 1)
+            {
+              light_strip.action_override = true;
+            }
+            else if (gcode.popped_arg() == 0)
+            {
+              light_strip.action_override = false;
+            }
+          }
+          break;
         case Gcode::set_ramp_rate:
           if(master_set_a_target)
           {
@@ -561,9 +591,39 @@ void read_gcode()
   }
 }
 
-/////////////////////////////////
-/////////////////////////////////
-/////////////////////////////////
+void update_light_strip()
+{
+  if (master_set_a_target)
+  {
+    if (is_target_hot())
+    {
+      if (is_at_target())
+      {
+        light_strip.set_lights(TC_status::at_hot_target);
+      }
+      else
+      {
+        light_strip.set_lights(TC_status::going_to_hot_target);
+      }
+    }
+    else
+    {
+      if (is_at_target())
+      {
+        light_strip.set_lights(TC_status::at_cold_target);
+      }
+      else
+      {
+        light_strip.set_lights(TC_status::going_to_cold_target);
+      }
+    }
+  }
+  else
+  {
+    light_strip.set_lights(TC_status::idle);
+  }
+  light_strip.update();
+}
 
 void front_button_callback()
 {
@@ -585,20 +645,6 @@ bool is_front_button_pressed()
     }
   }
   return false;
-}
-
-void set_leds_white()
-{
-  for(int i=0; i<strip.numPixels(); i++)
-  {
-  #if RGBW_NEO
-    strip.setPixelColor(i, 220, 220, 200, 0); // strip.setPixelColor(n, red, green, blue, white);
-  #else
-    strip.setPixelColor(i, 220, 220, 200);
-  #endif
-    strip.show();
-    delay(30);
-  }
 }
 
 void set_25ms_interrupt()
@@ -722,13 +768,7 @@ void setup()
   master_set_a_target = false;
   cover_should_be_hot = false;
 
-  pinMode(NEO_PWR, OUTPUT);
-  pinMode(NEO_PIN, OUTPUT);
-  digitalWrite(NEO_PWR, HIGH);
-  strip.begin();
-  strip.setBrightness(50);
-  strip.show();
-  set_leds_white();
+  light_strip.setup();
 
 #if HW_VERSION >= 3
   pinMode(PIN_FRONT_BUTTON_SW, INPUT);
@@ -869,4 +909,5 @@ void loop()
   timeStamp = micros() - timeStamp;
   /* Check if gcode(s) available on Serial */
   read_gcode();
+  update_light_strip();
 }

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -8,6 +8,7 @@
 #include "gcode.h"
 #include "tc_timer.h"
 #include "fan.h"
+#include "lights.h"
 
 /********* Versions **********/
 /* Version guidelines: */
@@ -19,14 +20,6 @@
 /********* THERMISTORS *********/
 
 #define THERMISTOR_VOLTAGE 1.5
-
-/********* INDICATOR NEOPIXELS *********/
-
-#include <Adafruit_NeoPixel_ZeroDMA.h>
-
-#define NEO_PWR     4
-#define NEO_PIN     A5
-#define NUM_PIXELS  16
 
 /********** HEAT PAD **********/
 


### PR DESCRIPTION
Closes [#3584](https://github.com/Opentrons/opentrons/issues/3584)

LED strip shows different colors/ behavior depending on the following thermocycler states:
```
  idle,
  going_to_hot_target,
  going_to_cold_target,
  at_hot_target,
  at_cold_target
```
**In addition to this, the thermocycler can accept different action & color override settings using gcodes:**
`M200`: enable/ disable color &/or action override. Takes args `C` for color & `A` for action.
eg., Enable color override: `M200 C1`
eg., Disable color & action override: `M200 C0 A0`

`M210`: Set the color &/or action. Args `C` & `A`

_Available colors:_
```
0: soft_white
1: white
2: red
3: green
4: blue
5: orange
6: none
```
_Available actions:_
```
0: all_off
1: solid_color
2: pulsing
3: wipe
```
eg. Set the light strip to pulsing blue color:
`M210 C4 A2`

**These override settings are mainly meant to be used by the api to set the thermocycler to wipe action while implementing `cycle` function. In order to _not_ have the lights transition through multiple states while changing them mid-way, the api should use the following order:**
1. Set light color & action using `M210`
2. Set temperature & enable override in the same line. eg., `M104 S70 M200 A3`