### PR TITLE
feat(thermocycler): open/close lid on button press. Do not deactivate

### DIFF
--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.h
@@ -142,7 +142,7 @@ class Lid
     void _update_status();
     byte _i2c_read();
     uint16_t _to_dac_out(float driver_vref);
-    inline bool _bottom_switch_check();
+    bool _bottom_switch_check();
     Lid_status _status;
     enum class _Lid_switch {
       cover_switch,


### PR DESCRIPTION
Closes [#3808](https://github.com/Opentrons/opentrons/issues/3808)

This PR enables the front button on thermocycler to open the lid when the lid is closed and to close it when it is open.
This operation will not deactivate the thermocycler.