### PR TITLE
fix(thermocycler): fix lid not closing without labware

### DIFF
--- a/modules/thermo-cycler/thermo-cycler-arduino/lid.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lid.h
@@ -79,6 +79,7 @@
 #define LID_OPEN_DOWN_MOTION_ANGLE 3.25
 #endif
 #define LID_OPEN_EXTRA_ANGLE 15.25
+#define LID_CLOSE_EXTRA_ANGLE 5.0
 #define LID_CLOSE_BACKTRACK_ANGLE 3.0
 
 #define TO_INT(an_enum) static_cast<int>(an_enum)


### PR DESCRIPTION
Some DVT thermocyclers were unable to close their lids when there was no labware in them. This was caused due to gear backlash. 

This PR adds a check after normal closing movement and if the lid isn't closed, it'll try to close it again. Detailed explanation of the fix is in the code.