### PR TITLE
fix(thermocycler): room temp not included in either hot or cold

### DIFF
--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -120,7 +120,7 @@ bool is_target_hot()
 
 bool is_target_cold()
 {
-  return target_temperature_plate < TEMPERATURE_ROOM;
+  return target_temperature_plate <= TEMPERATURE_ROOM;
 }
 
 bool is_moving_up(Peltier pel_n = Peltier::no_peltier)


### PR DESCRIPTION
This PR fixes a bug where room temperature of 23C wasn't being included in either hot or cold temp range, which would make the fans & LEDs behave incorrectly