### PR TITLE
feat(thermocycler): edit file path and file types in firmware uploaders

### DIFF
--- a/modules/thermo-cycler/production/firmware_uploader.py
+++ b/modules/thermo-cycler/production/firmware_uploader.py
@@ -16,14 +16,16 @@ from serial.tools.list_ports import comports
 from argparse import ArgumentParser
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
-DEFUALT_FW_FILE_PATH = os.path.join(THIS_DIR, "firmware", "thermo-cycler-arduino.ino.bin")
+DEFAULT_FW_FILE_PATH = os.path.join(THIS_DIR, "firmware", "thermo-cycler-arduino.ino.bin")
 OPENTRONS_VID = 1240
 MAX_SERIAL_LEN = 16
 
 def build_arg_parser():
     arg_parser = ArgumentParser(
         description="Thermocycler firmware uploader")
-    arg_parser.add_argument("-F", "--fw_file", required=False)
+    arg_parser.add_argument("-F", "--fw_file", required=False,
+                            default=DEFAULT_FW_FILE_PATH,
+                            help='Firmware file (default: ..production/firmware/thermo-cycler-arduino.ino.bin)')
     return arg_parser
 
 def find_opentrons_port():
@@ -79,7 +81,7 @@ def upload_sketch(sketch_file, drive):
 def main():
     arg_parser = build_arg_parser()
     args = arg_parser.parse_args()
-    firmware_file = args.fw_file or DEFUALT_FW_FILE_PATH
+    firmware_file = args.fw_file
     print('\n')
     connected_port = None
     try:

--- a/modules/thermo-cycler/production/firmware_uploader.py
+++ b/modules/thermo-cycler/production/firmware_uploader.py
@@ -1,19 +1,30 @@
-# This script searches for a thermocycler port and uploads the pre-built binary
-# from /build/tmp to the module
-# Usage: `python firmware_uploader.py` (No args)
+# This script searches for a thermocycler port and uploads the pre-built .bin
+# from `/production/firmware`, or, a .bin/.uf2 file provided, to the module
+#
+# Usage: `python firmware_uploader.py` or
+#        `python firmware_uploader.py -F my_firmware_file.bin`
 # Requires:
 #   - New uf2 bootloader for thermocycler
-#   - Firmware binary in /build/tmp (This is where `make build` or Arduino->compile
-#     would store the build binary)
+#   - Firmware binary in `production/firmware/`
+#     or path to binary/uf2 file added as argument `-F`
 
+import os
 import uf2conv
 import serial
 import time
 from serial.tools.list_ports import comports
+from argparse import ArgumentParser
 
-FIRMWARE_FILE_PATH = "../../../build/tmp/thermo-cycler-arduino.ino.bin"
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+DEFUALT_FW_FILE_PATH = os.path.join(THIS_DIR, "firmware", "thermo-cycler-arduino.ino.bin")
 OPENTRONS_VID = 1240
 MAX_SERIAL_LEN = 16
+
+def build_arg_parser():
+    arg_parser = ArgumentParser(
+        description="Thermocycler firmware uploader")
+    arg_parser.add_argument("-F", "--fw_file", required=False)
+    return arg_parser
 
 def find_opentrons_port():
     retries = 5
@@ -56,24 +67,30 @@ def find_bootloader_drive():
 def upload_sketch(sketch_file, drive):
     with open(sketch_file, mode='rb') as f:
         inpbuf = f.read()
-    outbuf = uf2conv.convert_to_uf2(inpbuf)
-    print("Converting to uf2, output size: %d, start address: 0x%x" %
-          (len(outbuf), uf2conv.appstartaddr))
+    if uf2conv.is_uf2(inpbuf):
+        outbuf = inpbuf
+    else:
+        outbuf = uf2conv.convert_to_uf2(inpbuf)
+        print("Converting to uf2, output size: %d, start address: 0x%x" %
+              (len(outbuf), uf2conv.appstartaddr))
     print("Flashing %s (%s)" % (drive, uf2conv.board_id(drive)))
     uf2conv.write_file(drive + "/NEW.UF2", outbuf)
 
 def main():
+    arg_parser = build_arg_parser()
+    args = arg_parser.parse_args()
+    firmware_file = args.fw_file or DEFUALT_FW_FILE_PATH
     print('\n')
     connected_port = None
     try:
         print('\nTrigerring Bootloader..')
         trigger_bootloader(find_opentrons_port())
         print('\nUploading application..')
-        upload_sketch(FIRMWARE_FILE_PATH, find_bootloader_drive())
+        upload_sketch(firmware_file, find_bootloader_drive())
         print('\n\n-----------------')
         print('-----------------')
         print('-----------------')
-        print('\n\n Uploaded Sketch: {}'.format(FIRMWARE_FILE_PATH))
+        print('\n\n Uploaded Sketch: {}'.format(firmware_file))
         print('\n\n-----------------')
         print('-----------------')
         print('-----------------')

--- a/modules/thermo-cycler/production/serial_and_firmware_uploader.py
+++ b/modules/thermo-cycler/production/serial_and_firmware_uploader.py
@@ -70,9 +70,12 @@ def find_bootloader_drive():
 def upload_sketch(sketch_file, drive):
     with open(sketch_file, mode='rb') as f:
         inpbuf = f.read()
-    outbuf = uf2conv.convert_to_uf2(inpbuf)
-    print("Converting to uf2, output size: %d, start address: 0x%x" %
-          (len(outbuf), uf2conv.appstartaddr))
+    if uf2conv.is_uf2(inpbuf):
+        outbuf = inpbuf
+    else:
+        outbuf = uf2conv.convert_to_uf2(inpbuf)
+        print("Converting to uf2, output size: %d, start address: 0x%x" %
+              (len(outbuf), uf2conv.appstartaddr))
     print("Flashing %s (%s)" % (drive, uf2conv.board_id(drive)))
     uf2conv.write_file(drive + "/NEW.UF2", outbuf)
 


### PR DESCRIPTION
## overview
SZ team needs to use the `firmware_uploader` to upload the thermocycler firmware to do preliminary tests on each unit's unassembled boards. Hence, making the script use the production firmware as default rather than the dev firmware.

## changes
- added an arg to provide custom file path
- the script now allows usage of both .bin and .uf2 files. This is being added for future use since we will most likely be building firmware artifacts with .uf2 files instead of .bin ones