### PR TITLE
fix(thermocycler): make fw upload scripts windows compatible

### DIFF
--- a/modules/thermo-cycler/production/firmware_uploader.py
+++ b/modules/thermo-cycler/production/firmware_uploader.py
@@ -56,11 +56,13 @@ def find_bootloader_drive():
     # takes around 4 seconds for TCBOOT to register in /Volumes
     retries = 7
     while retries:
-        for d in uf2conv.get_drives():
-            if "TCBOOT" in d:
-                print("Bootloader Volume found")
-                return d
         print("Searching bootloader...")
+        for d in uf2conv.get_drives():
+            with open(os.path.join(d + '/INFO_UF2.TXT'), mode='r') as f:
+                drive_info = f.read()
+                if 'Opentrons Thermocycler M0' in drive_info:
+                    print("Bootloader Volume found")
+                    return d
         retries -= 1
         time.sleep(1)
     raise Exception ('Bootloader volume not found')

--- a/modules/thermo-cycler/production/firmware_uploader.py
+++ b/modules/thermo-cycler/production/firmware_uploader.py
@@ -57,12 +57,10 @@ def find_bootloader_drive():
     retries = 7
     while retries:
         print("Searching bootloader...")
-        for d in uf2conv.get_drives():
-            with open(os.path.join(d + '/INFO_UF2.TXT'), mode='r') as f:
-                drive_info = f.read()
-                if 'Opentrons Thermocycler M0' in drive_info:
-                    print("Bootloader Volume found")
-                    return d
+        for d in uf2conv.get_tc_drives():  # returns only valid TCBOOT volumes
+            # The first detected thermocycler volume is picked
+            print("Bootloader Volume found")
+            return d
         retries -= 1
         time.sleep(1)
     raise Exception ('Bootloader volume not found')

--- a/modules/thermo-cycler/production/serial_and_firmware_uploader.py
+++ b/modules/thermo-cycler/production/serial_and_firmware_uploader.py
@@ -21,8 +21,9 @@ import time
 from serial.tools.list_ports import comports
 from argparse import ArgumentParser
 
-FIRMWARE_FILE_PATH = "firmware/thermo-cycler-arduino.ino.bin"
-EEPROM_WRITER_PATH = "firmware/eepromWriter.ino.bin"
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+FIRMWARE_FILE_PATH = os.path.join(THIS_DIR, "firmware", "thermo-cycler-arduino.ino.bin")
+EEPROM_WRITER_PATH = os.path.join(THIS_DIR, "firmware", "eepromWriter.ino.bin")
 OPENTRONS_VID = 1240
 MAX_SERIAL_LEN = 16
 BAD_BARCODE_MESSAGE = 'Serial longer than expected -> {}'

--- a/modules/thermo-cycler/production/serial_and_firmware_uploader.py
+++ b/modules/thermo-cycler/production/serial_and_firmware_uploader.py
@@ -14,7 +14,7 @@
 
 # python uf2conv.py ../../../build/thermo-cycler/thermo-cycler-arduino.ino.bin
 # -f SAMD21 -d /Volumes/TCBOOT
-
+import os
 import uf2conv
 import serial
 import time
@@ -58,9 +58,11 @@ def find_bootloader_drive():
     retries = 7
     while retries:
         for d in uf2conv.get_drives():
-            if "TCBOOT" in d:
-                print("Bootloader Volume found")
-                return d
+            with open(os.path.join(d + '/INFO_UF2.TXT'), mode='r') as f:
+                drive_info = f.read()
+                if 'Opentrons Thermocycler M0' in drive_info:
+                    print("Bootloader Volume found")
+                    return d
         print("Searching bootloader...")
         retries -= 1
         time.sleep(1)

--- a/modules/thermo-cycler/production/serial_and_firmware_uploader.py
+++ b/modules/thermo-cycler/production/serial_and_firmware_uploader.py
@@ -58,12 +58,10 @@ def find_bootloader_drive():
     # takes around 4 seconds for TCBOOT to register in /Volumes
     retries = 7
     while retries:
-        for d in uf2conv.get_drives():
-            with open(os.path.join(d + '/INFO_UF2.TXT'), mode='r') as f:
-                drive_info = f.read()
-                if 'Opentrons Thermocycler M0' in drive_info:
-                    print("Bootloader Volume found")
-                    return d
+        for d in uf2conv.get_tc_drives():  # returns only valid TCBOOT volumes
+            # The first detected thermocycler volume is picked
+            print("Bootloader Volume found")
+            return d
         print("Searching bootloader...")
         retries -= 1
         time.sleep(1)

--- a/modules/thermo-cycler/production/uf2conv.py
+++ b/modules/thermo-cycler/production/uf2conv.py
@@ -167,7 +167,7 @@ def convert_from_hex_to_uf2(buf):
         resfile += blocks[i].encode(i, numblocks)
     return resfile
 
-def get_drives():
+def get_tc_drives():
     drives = []
     if sys.platform == "win32":
         r = subprocess.check_output(["wmic", "PATH", "Win32_LogicalDisk",
@@ -191,7 +191,10 @@ def get_drives():
 
     def has_info(d):
         try:
-            return os.path.isfile(d + INFO_FILE)
+            if os.path.isfile(d + INFO_FILE):
+                with open(d + INFO_FILE, mode='r') as f:
+                    drive_info = f.read()
+                    return 'Opentrons Thermocycler M0' in drive_info
         except:
             return False
 

--- a/modules/thermo-cycler/production/uf2conv.py
+++ b/modules/thermo-cycler/production/uf2conv.py
@@ -172,7 +172,7 @@ def get_drives():
     if sys.platform == "win32":
         r = subprocess.check_output(["wmic", "PATH", "Win32_LogicalDisk",
                                      "get", "DeviceID,", "VolumeName,",
-                                     "FileSystem,", "DriveType"])
+                                     "FileSystem,", "DriveType"]).decode()
         for line in r.split('\n'):
             words = re.split('\s+', line)
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":


### PR DESCRIPTION
Addresses [#4113](https://github.com/Opentrons/opentrons/issues/4113)

## overview

The uf2conv.py script had a bug where the object containing all drives info was not decoded before doing string manipulation. Also, on windows, drives/ volumes aren't referred to with names but by assigned drive letter (D:/ ..); so instead of looking for a volume called 'TCBOOT', we have to verify whether it's a thermocycler bootloader by verifying INFO_UF2.TXT file contents.

Refer to the issue link above to read about why this change was necessary

