### PR TITLE
feat(thermocycler): add thermistor offset, PID control fans, overshoots for volume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ OLD_PID_INTERVAL ?= true
 HW_VERSION ?= 4
 LID_TESTING ?= false
 RGBW_NEO ?= true
+VOLUME_DEPENDENCY ?= true
 
 .PHONY: build-magdeck
 build-magdeck:
@@ -110,7 +111,8 @@ build-thermocycler:
 	-DUSE_GCODES=$(USE_GCODES) -DLID_WARNING=$(LID_WARNING) \
 	-DHFQ_PWM=$(HFQ_PWM) -DOLD_PID_INTERVAL=$(OLD_PID_INTERVAL) \
 	-DHW_VERSION=$(HW_VERSION) -DLID_TESTING=$(LID_TESTING) \
-	-DRGBW_NEO=$(RGBW_NEO) -DTC_FW_VERSION=\"$(TC_FW_VERSION)\"" \
+	-DRGBW_NEO=$(RGBW_NEO) -DVOLUME_DEPENDENCY=$(VOLUME_DEPENDENCY) \
+	-DTC_FW_VERSION=\"$(TC_FW_VERSION)\"" \
 	> $(ARDUINO15_LOC)/packages/Opentrons/hardware/samd/$(OPENTRONS_SAMD_BOARDS_VER)/platform.local.txt
 	$(ARDUINO) --verify --board Opentrons:samd:thermocycler_m0 $(MODULES_DIR)/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino --verbose-build
 	mkdir -p $(TC_BUILD_DIR)

--- a/modules/thermo-cycler/thermo-cycler-arduino/eeprom.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/eeprom.cpp
@@ -116,6 +116,7 @@ bool Eeprom::set_offset_constant(OffsetConst constant, float val)
     {
       Serial.print("\nError: Failed to write to address:");
       Serial.println(byte(addr+i));
+      pinMode(WP_PIN, INPUT);
       return false; // failed
     }
   }

--- a/modules/thermo-cycler/thermo-cycler-arduino/eeprom.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/eeprom.cpp
@@ -105,12 +105,17 @@ bool Eeprom::set_offset_constant(OffsetConst constant, float val)
     case OffsetConst::C:
       addr = C_LOC;
       break;
+    default:
+      Serial.println("\nError: No constant name provided");
+      return false;
   }
   _erase_eeprom_section(addr, uint8_t(sizeof(this_const.f_val)));
   for (uint8_t i = 0; i < sizeof(this_const.f_val); i++)
   {
     if(!_write_char(byte(addr+i), byte(this_const.b_val[i])))
     {
+      Serial.print("\nError: Failed to write to address:");
+      Serial.println(byte(addr+i));
       return false; // failed
     }
   }
@@ -123,7 +128,8 @@ bool Eeprom::_erase_eeprom_section(uint8_t addr, uint8_t sec_len)
   {
     if(!_write_char(byte(addr+i), byte(0xff)))  // erasing = writing 0xffh
     {
-      Serial.println("\nfailed to erase section");
+      Serial.print("\nError: Failed to erase at address:");
+      Serial.println(byte(addr+i));
       return false;
     }
   }
@@ -145,6 +151,9 @@ float Eeprom::get_offset_constant(OffsetConst constant)
     case OffsetConst::C:
       addr = C_LOC;
       break;
+    default:
+      Serial.println("\nError: No constant name provided");
+      return false;
   }
   for (uint8_t i = 0; i < sizeof(this_const.f_val); i++)
   {

--- a/modules/thermo-cycler/thermo-cycler-arduino/eeprom.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/eeprom.cpp
@@ -1,6 +1,12 @@
 #include "eeprom.h"
 #include <ot_shared_data.h>
 
+union ConstValue
+{ // To access the float value byte by byte
+  float f_val;
+  byte b_val[sizeof(f_val)];
+};
+
 Eeprom::Eeprom()
 {}
 
@@ -49,6 +55,20 @@ String Eeprom::read(MemOption option)
 #endif
 }
 
+bool Eeprom::_write_char(uint8_t word_address, uint8_t value)
+{
+  Wire.beginTransmission(OT_EEPROM_ADDR);
+  Wire.write(word_address);
+  Wire.write(value);
+  byte error = Wire.endTransmission();
+  delay(OT_WR_TIME);
+  if (error)
+  {
+    return false;
+  }
+  return true;
+}
+
 char Eeprom::_read_char(uint8_t word_address)
 {
 #if HW_VERSION >= 4
@@ -65,6 +85,72 @@ char Eeprom::_read_char(uint8_t word_address)
   }
 #endif
   return '~';
+}
+
+bool Eeprom::set_offset_constant(OffsetConst constant, float val)
+{
+  pinMode(WP_PIN, OUTPUT);
+  digitalWrite(WP_PIN, LOW); // Disables write protect
+  ConstValue this_const;
+  this_const.f_val = val;
+  uint8_t addr;
+  switch(constant)
+  {
+    case OffsetConst::A:
+      addr = A_LOC;
+      break;
+    case OffsetConst::B:
+      addr = B_LOC;
+      break;
+    case OffsetConst::C:
+      addr = C_LOC;
+      break;
+  }
+  _erase_eeprom_section(addr, uint8_t(sizeof(this_const.f_val)));
+  for (uint8_t i = 0; i < sizeof(this_const.f_val); i++)
+  {
+    if(!_write_char(byte(addr+i), byte(this_const.b_val[i])))
+    {
+      return false; // failed
+    }
+  }
+  pinMode(WP_PIN, INPUT);
+}
+
+bool Eeprom::_erase_eeprom_section(uint8_t addr, uint8_t sec_len)
+{
+  for (uint8_t i = 0; i < sec_len; i++)
+  {
+    if(!_write_char(byte(addr+i), byte(0xff)))  // erasing = writing 0xffh
+    {
+      Serial.println("\nfailed to erase section");
+      return false;
+    }
+  }
+  return true;
+}
+
+float Eeprom::get_offset_constant(OffsetConst constant)
+{
+  ConstValue this_const;
+  uint8_t addr;
+  switch(constant)
+  {
+    case OffsetConst::A:
+      addr = A_LOC;
+      break;
+    case OffsetConst::B:
+      addr = B_LOC;
+      break;
+    case OffsetConst::C:
+      addr = C_LOC;
+      break;
+  }
+  for (uint8_t i = 0; i < sizeof(this_const.f_val); i++)
+  {
+    this_const.b_val[i] = _read_char(addr+i);
+  }
+  return this_const.f_val;
 }
 
 void Eeprom::setup()

--- a/modules/thermo-cycler/thermo-cycler-arduino/eeprom.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/eeprom.h
@@ -4,7 +4,10 @@
 #include "Arduino.h"
 #include <Wire.h>
 
-#define WP_PIN   26
+#define WP_PIN  26
+#define A_LOC   50
+#define B_LOC   60
+#define C_LOC   70
 
 enum class MemOption
 {
@@ -12,13 +15,30 @@ enum class MemOption
   model
 };
 
+enum class OffsetConst
+{
+  A,
+  B,
+  C
+};
+
+/* EEPROM class can do the following:
+ * 1. Read the stored Serial and Model numbers <`read(option)`>
+ * 2. Read and write values of temp offset constants: a, b, c
+ *    <`set_offset(constant, value)`> and <`get_offset(constant)`>
+ * Reading and writing of all the above parameters is initiated using gcodes.
+ */
 class Eeprom
 {
   public:
     Eeprom();
     String read(MemOption option);
     void setup();
+    bool set_offset_constant(OffsetConst c, float val);
+    float get_offset_constant(OffsetConst c);
   private:
     char _read_char(uint8_t word_address);
+    bool _write_char(uint8_t word_address, uint8_t value);
+    bool _erase_eeprom_section(uint8_t word_address, uint8_t sec_len);
 };
 #endif

--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
@@ -19,13 +19,18 @@
   GCODE_DEF(deactivate_lid_heating, M108),  \
   GCODE_DEF(set_plate_temp, M104),  \
   GCODE_DEF(get_plate_temp, M105),  \
+  GCODE_DEF(deactivate_plate, M14), \
   GCODE_DEF(set_led_override, M200),\
   GCODE_DEF(set_led, M210),         \
   GCODE_DEF(set_ramp_rate, M566),   \
+  GCODE_DEF(get_pid_params, M300),  \
   GCODE_DEF(edit_pid_params, M301), \
   GCODE_DEF(pause, M76),            \
   GCODE_DEF(deactivate_all, M18),   \
   GCODE_DEF(get_device_info, M115), \
+  GCODE_DEF(set_offset_constants, M116), \
+  GCODE_DEF(get_offset_constants, M117), \
+  GCODE_DEF(set_offset, M20), \
   GCODE_DEF(heatsink_fan_pwr_manual, M106), \
   GCODE_DEF(heatsink_fan_auto_on, M107),  \
   GCODE_DEF(dfu, dfu),              \

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
@@ -84,35 +84,35 @@ float ThermistorsADC::right_pair_temperature() {
 }
 
 float ThermistorsADC::front_left_temperature() {
-  return probe_temps[ADC_INDEX_PLATE_FRONT_LEFT];
+  return probe_temps[ADC_INDEX_PLATE_FRONT_LEFT] + plate_temp_offset;
 }
 
 float ThermistorsADC::front_center_temperature() {
-  return probe_temps[ADC_INDEX_PLATE_FRONT_CENTER];
+  return probe_temps[ADC_INDEX_PLATE_FRONT_CENTER] + plate_temp_offset;
 }
 
 float ThermistorsADC::front_right_temperature() {
-  return probe_temps[ADC_INDEX_PLATE_FRONT_RIGHT];
+  return probe_temps[ADC_INDEX_PLATE_FRONT_RIGHT] + plate_temp_offset;
 }
 
 float ThermistorsADC::back_left_temperature() {
-  return probe_temps[ADC_INDEX_PLATE_BACK_LEFT];
+  return probe_temps[ADC_INDEX_PLATE_BACK_LEFT] + plate_temp_offset;
 }
 
 float ThermistorsADC::back_center_temperature() {
-  return probe_temps[ADC_INDEX_PLATE_BACK_CENTER];
+  return probe_temps[ADC_INDEX_PLATE_BACK_CENTER] + plate_temp_offset;
 }
 
 float ThermistorsADC::back_right_temperature() {
-  return probe_temps[ADC_INDEX_PLATE_BACK_RIGHT];
+  return probe_temps[ADC_INDEX_PLATE_BACK_RIGHT] + plate_temp_offset;
 }
 
 float ThermistorsADC::cover_temperature() {
-  return probe_temps[ADC_INDEX_COVER];
+  return probe_temps[ADC_INDEX_COVER];  // No offset
 }
 
 float ThermistorsADC::heat_sink_temperature() {
-  return probe_temps[ADC_INDEX_HEAT_SINK];
+  return probe_temps[ADC_INDEX_HEAT_SINK];  // No offset
 }
 
 

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
@@ -1,6 +1,8 @@
 #include "thermistorsadc.h"
 
-ThermistorsADC::ThermistorsADC() {}
+ThermistorsADC::ThermistorsADC() {
+  plate_temp_offset = 0;
+}
 
 void ThermistorsADC::setup(float voltage) {
   adc_a = new Adafruit_ADS1115(ADDRESS_A);

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.h
@@ -84,6 +84,7 @@ class ThermistorsADC{
             float back_right_temperature();
             float cover_temperature();
             float heat_sink_temperature();
+            float plate_temp_offset;
             bool detected_invalid_val;
 
       private:

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -927,15 +927,19 @@ void TC4_Handler()
 
 void check_saved_offsets()
 { // If erroneous value or no offsets saved in EEPROM, then save the defaults to EEPROM
-  if (isnan(eeprom.get_offset_constant(OffsetConst::A)))
+  // Our offsets have values in range (-1, 1)
+  float temp_a = eeprom.get_offset_constant(OffsetConst::A);
+  float temp_b = eeprom.get_offset_constant(OffsetConst::B);
+  float temp_c = eeprom.get_offset_constant(OffsetConst::C);
+  if (isnan(temp_a) || abs(temp_a) >= 1)
   {
     eeprom.set_offset_constant(OffsetConst::A, CONST_A_DEFAULT);
   }
-  if (isnan(eeprom.get_offset_constant(OffsetConst::B)))
+  if (isnan(temp_b) || abs(temp_b) >= 1)
   {
     eeprom.set_offset_constant(OffsetConst::B, CONST_B_DEFAULT);
   }
-  if (isnan(eeprom.get_offset_constant(OffsetConst::C)))
+  if (isnan(temp_c) || abs(temp_c) >= 1)
   {
     eeprom.set_offset_constant(OffsetConst::C, CONST_C_DEFAULT);
   }

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -121,11 +121,8 @@ double current_heatsink_temp;
 #define PID_FAR_AWAY_THRESH     10
 #define TARGET_TEMP_TOLERANCE   1.5   // Degree Celsius
 
-// TODO: remove once vol<->overshoot table is finalized
-#define PLATE_OVERSHOOT_50uL    1.8   // Degree Celsius
-#define PLATE_UNDERSHOOT_50uL   1.6   // Degree Celsius
 #define OVERSHOOT_DURATION      10000  // millisec
-
+#define DEFAULT_VOLUME          25     // uL
 double current_plate_kp = PID_KP_PLATE_UP;
 double current_plate_ki = PID_KI_PLATE_UP;
 double current_plate_kd = PID_KD_PLATE_UP;
@@ -138,6 +135,7 @@ double this_step_target_temp = TEMPERATURE_ROOM;
 double temperature_swing_plate = 0.5;
 double target_temperature_plate = TEMPERATURE_ROOM;
 double current_temperature_plate = TEMPERATURE_ROOM;
+uint16_t current_volume = DEFAULT_VOLUME;
 
 double testing_offset_temp = target_temperature_plate;
 double current_left_pel_temp = TEMPERATURE_ROOM;

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -26,9 +26,9 @@
 #define THERMISTOR_VOLTAGE 1.5
 
 /* Thermistor offset values */
-/* y = ax1 + bx2 + c
+/* y = Ax1 + Bx2 + C
  * y: offset to plate temp
- * a, b, c: constants
+ * A, B, C: constants
  * x1: current heatsink temp
  * x2: target plate temp
  */
@@ -89,6 +89,18 @@ double current_heatsink_temp;
 #define HEATSINK_FAN_HI_TEMP_3    75
 #define HEATSINK_FAN_OFF_TEMP     36
 #define PELTIER_TEMP_DELTA        2
+
+/****** OVERSHOOT EQUATION ******/
+// y = mx + c
+// y : overshoot
+// m : constant (slope)
+// x : volume (uL)
+// c : constant
+ 
+#define POS_OVERSHOOT_M 0.0105
+#define POS_OVERSHOOT_C 1.0869
+#define NEG_OVERSHOOT_M 0.0133
+#define NEG_OVERSHOOT_C 0.4302
 
 /********* PID: PLATE PELTIERS *********/
 // NOTE: temp_probes.update takes 136-137ms while rest of the loop takes 0-1ms.


### PR DESCRIPTION
This is the PR overarching all temperature tuning issues..
Closes [#3643](https://github.com/Opentrons/opentrons/issues/3643): Adds offsets to thermistors based on the regression model formed with parameters of current heatsink temperature and target temperature. Changed the fan behavior to suit regression model conditions.

Closes [#4144](https://github.com/Opentrons/opentrons/issues/4144): Offset constants are saved to & read from EEPROM. Added gcodes to read and write the constants.

Closes [#4395](https://github.com/Opentrons/opentrons/issues/4395): Added temperature adjustments according to liquid volume. Used a regression model to dynamically calculate the adjustment/ 'overshoot' values for different volumes. Volume amount is passed in `set_temperature` gcode with the param `V`. eg., `M104 S70 V50` sets target 70C for 50uL liquid volume

## Additional changes
- Introduced a 'plate deactivate' gcode which disables just the plate. Required not just right now while testing offset & tuning outcomes but also was mentioned as a long term requirement for protocols.
- Added the ability to edit & read PID constants using gcodes
- Added PID control for fans so we can continuously monitor and control fans based on heatsink temperatures
- Adjusted start time of hold timer to accommodate for the overshoots

## Review requests
- [x] The fan behaves as expected
- [x] The offsets give us results within our specs of +/-0.2 degree C
- [x] Offsets are saved to & read from & implemented correctly
- [x] The new gcodes work as expected
- [x] We get expected overshoots for different liquid volumes
- [x] The code looks good
