### PR TITLE
Temp probe data collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ coverage.xml
 
 # Data from QC tests
 *.csv
+*.xlsx
 
 # Translations
 *.mo

--- a/modules/thermo-cycler/QC/offset_test/Eutechnics_4500_driver.py
+++ b/modules/thermo-cycler/QC/offset_test/Eutechnics_4500_driver.py
@@ -1,0 +1,66 @@
+"""
+This driver is for the Eutechnics 4500 thermometer
+
+Written by Carlos Fernandez
+"""
+import serial
+import time
+import os
+import sys
+
+class Eutechnics(serial.Serial):
+    def __init__(self, port='/dev/ttyUSB0', baudrate=9600, parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE, bytesize=serial.EIGHTBITS, timeout=0.1):
+        self.raise_exceptions = True
+        self.reading_raw = ''
+        self._port = serial.Serial(
+            port=port,
+            baudrate=baudrate,
+            timeout=timeout
+        )
+
+    """This setups the themometer in outputing the temperature
+    This function needs to be called first before retrieving data off the
+    thermometer"""
+    def setup(self):
+        self._port.rts = True
+        self._port.__enter__()
+        condition = True
+        while condition:
+            self._port.write('\r\n'.encode("utf-8"))
+            time.sleep(0.5)
+            self.reading_raw = self._port.readline()
+            #print(self.reading_raw)
+            if self.reading_raw == b'> \r\n':
+                self._port.write('T'.encode("utf-8"))
+                time.sleep(4)
+                condition = False
+        #self.reading_raw = self.readline()
+        #print(self.reading_raw)
+
+    """
+    Return Readings off the thermometer
+    """
+    def temp_read(self):
+        try:
+            condition = True
+            while condition:
+                self._port.write('\r\n'.encode("utf-8"))
+                time.sleep(0.5)
+                self.reading_raw = self.port.readline().strip()
+                #print(self.reading_raw )
+                if self.reading_raw == b'> T':
+                    pass
+                elif self.reading_raw != b'':
+                    #print('Reading Temperature')
+                    condition = False
+            return self.reading_raw.decode()
+        except self.raise_exceptions:
+            raise print('Bad Readings, check the connection')
+
+if __name__ == '__main__':
+    thermometer = Eutechnics(port='COM9')
+    thermometer.unlimited_errors = True
+    thermometer.setup()
+    while True:
+        temp_reading = thermometer.temp_read()
+        print("Temp Reading: ", temp_reading, " C")

--- a/modules/thermo-cycler/QC/offset_test/H1_thermometer.py
+++ b/modules/thermo-cycler/QC/offset_test/H1_thermometer.py
@@ -1,0 +1,66 @@
+import os, sys, time
+import optparse
+from datetime import datetime
+#import thermometer library from local directory
+sys.path.insert(0, os.path.abspath('../../../../../Mechanical-Test/Equipment'))
+#local library
+import Eutechnics_4500_driver as EU
+import csv
+
+def millis():
+   dt = datetime.now() - start_time
+   ms = (dt.days * 24 * 60 * 60 + dt.seconds) * 1000 + dt.microseconds / 1000.0
+   return ms/1000
+
+if __name__ == '__main__':
+    #options to pick from
+    parser = optparse.OptionParser(usage='usage: %prog [options] ')
+    parser.add_option("--time", dest = "time", type = "int",default = 15, help = "time to run")
+    parser.add_option("--target", dest="target", type = float, default = 70, help ="target temp")
+    parser.add_option("-p", "--port", dest = "port", type = "str", default = 'COM34', help = "thermometer port")
+    (options, args) = parser.parse_args(args = None, values = None)
+
+    #Establish  thermometers
+    thermometer_H1 = EU.Eutechnics(port = options.port)
+    t_end = time.time() + 60 * options.time
+    thermometer_H1.setup()
+    #thermometer_H1.temp_read()
+    #Open CSV file with corresponding headers
+    # filename = "results/A09_F4therm_P08I02D0_%s_target_%sC.csv"%(datetime.now().strftime("%m-%d-%y_%H-%M"), options.target)
+    filename = "results/biogener_F4therm_64-to-66_%s_target_%sC.csv"%(datetime.now().strftime("%m-%d-%y_%H-%M"), options.target)
+
+    print(filename)
+    count = 0
+    with open('{}.csv'.format(filename), 'w', newline='') as data_file:
+        test_data={'F4_Temp': None, 'T.offset': None, 'time': None}
+        log_file = csv.DictWriter(data_file, test_data)
+        log_file.writeheader()
+        try:
+            start_time = datetime.now()
+            print("start_time: ", start_time)
+            while time.time() < t_end:
+                H1_temp = thermometer_H1.temp_read()
+                test_data['F10_Temp'] = H1_temp
+                if count > 1:
+                    test_data['T.offset'] = - options.target - float(H1_temp)
+                    test_data['time'] = millis()
+                    log_file.writerow(test_data)
+                    print(test_data)
+                    data_file.flush()
+                else:
+                    test_data['time'] = millis()
+                    log_file.writerow(test_data)
+                    print(test_data)
+                    data_file.flush()
+                count +=1
+            data_file.close()
+            #prompt User
+            print("Test done")
+            input("Press Enter to close terminal")
+        except KeyboardInterrupt:
+            print("Test Cancelled")
+            test_data['Errors'] = "Test Cancelled"
+        except Exception as e:
+            print("ERROR OCCURED")
+            test_data['Errors'] = e
+            raise e

--- a/modules/thermo-cycler/QC/offset_test/H1_thermometer.py
+++ b/modules/thermo-cycler/QC/offset_test/H1_thermometer.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     parser = optparse.OptionParser(usage='usage: %prog [options] ')
     parser.add_option("--time", dest = "time", type = "int",default = 15, help = "time to run")
     parser.add_option("--target", dest="target", type = float, default = 0, help ="target temp")
-    parser.add_option("-p", "--port", dest = "port", type = "str", default = 'COM9', help = "thermometer port")
+    parser.add_option("-p", "--port", dest = "port", type = "str", default = 'COM11', help = "thermometer port")
     (options, args) = parser.parse_args(args = None, values = None)
 
     #Establish  thermometers
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     thermometer_H1.setup()
     #thermometer_H1.temp_read()
     #Open CSV file with corresponding
-    filename = "results/GeneAmp_PCR_40C_to60C_%s_target_%sC.csv"%(datetime.now().strftime("%m-%d-%y_%H-%M"), 'VOL50uL')
+    filename = "results/OT_PCR_70C-to-72C_P30I20D0_%s_target_%sC.csv"%(datetime.now().strftime("%m-%d-%y_%H-%M"), 'VOL50uL')
     print(filename)
     count = 0
     with open('{}.csv'.format(filename), 'w', newline='') as data_file:

--- a/modules/thermo-cycler/QC/offset_test/H1_thermometer.py
+++ b/modules/thermo-cycler/QC/offset_test/H1_thermometer.py
@@ -1,8 +1,6 @@
 import os, sys, time
 import optparse
 from datetime import datetime
-#import thermometer library from local directory
-sys.path.insert(0, os.path.abspath('../../../../../Mechanical-Test/Equipment'))
 #local library
 import Eutechnics_4500_driver as EU
 import csv
@@ -16,8 +14,8 @@ if __name__ == '__main__':
     #options to pick from
     parser = optparse.OptionParser(usage='usage: %prog [options] ')
     parser.add_option("--time", dest = "time", type = "int",default = 15, help = "time to run")
-    parser.add_option("--target", dest="target", type = float, default = 70, help ="target temp")
-    parser.add_option("-p", "--port", dest = "port", type = "str", default = 'COM34', help = "thermometer port")
+    parser.add_option("--target", dest="target", type = float, default = 0, help ="target temp")
+    parser.add_option("-p", "--port", dest = "port", type = "str", default = 'COM9', help = "thermometer port")
     (options, args) = parser.parse_args(args = None, values = None)
 
     #Establish  thermometers
@@ -25,14 +23,12 @@ if __name__ == '__main__':
     t_end = time.time() + 60 * options.time
     thermometer_H1.setup()
     #thermometer_H1.temp_read()
-    #Open CSV file with corresponding headers
-    # filename = "results/A09_F4therm_P08I02D0_%s_target_%sC.csv"%(datetime.now().strftime("%m-%d-%y_%H-%M"), options.target)
-    filename = "results/biogener_F4therm_64-to-66_%s_target_%sC.csv"%(datetime.now().strftime("%m-%d-%y_%H-%M"), options.target)
-
+    #Open CSV file with corresponding
+    filename = "results/GeneAmp_PCR_40C_to60C_%s_target_%sC.csv"%(datetime.now().strftime("%m-%d-%y_%H-%M"), 'VOL50uL')
     print(filename)
     count = 0
     with open('{}.csv'.format(filename), 'w', newline='') as data_file:
-        test_data={'F4_Temp': None, 'T.offset': None, 'time': None}
+        test_data={'F10_Temp': None, 'T.offset': None, 'time': None}
         log_file = csv.DictWriter(data_file, test_data)
         log_file.writeheader()
         try:

--- a/modules/thermo-cycler/QC/offset_test/TC_mini_driver.py
+++ b/modules/thermo-cycler/QC/offset_test/TC_mini_driver.py
@@ -1,0 +1,119 @@
+import sys, os
+import csv
+import time
+import threading
+import serial
+from argparse import ArgumentParser
+
+#---------------------------------------#
+# Users can change these values as required #
+
+TOTAL_RUNS = 1
+
+HI_TEMP_OFFSET = 1.2
+LO_TEMP_OFFSET = 0.4
+
+COVER_TEMP = 105
+PLATE_TEMP_PRE = 10
+PLATE_TEMP_HOLD_1 = (94 - HI_TEMP_OFFSET, 180)
+PLATE_TEMP_REPEAT = [(94 - HI_TEMP_OFFSET, 10), (70 - LO_TEMP_OFFSET, 30), (72 - LO_TEMP_OFFSET, 30)]
+PLATE_TEMP_HOLD_2 = (72 - LO_TEMP_OFFSET, 300)
+PLATE_TEMP_POST = 4
+CYCLES = 29
+
+#---------------------------------------#
+# DO NOT change any of these
+GCODES = True
+TC_GCODE_ROUNDING_PRECISION = 2
+# Use this global var with care. Status will have Hold_time of 0 when there was
+# no hold time set as well as when the hold timer runs out
+
+
+BAUDRATE = 115200
+GCODES = {
+    'OPEN_LID': 'M126',
+    'CLOSE_LID': 'M127',
+    'GET_LID_STATUS': 'M119',
+    'SET_LID_TEMP': 'M140',
+    'GET_LID_TEMP': 'M141',
+    'DEACTIVATE_LID_HEATING': 'M108',
+    'EDIT_PID_PARAMS': 'M301',
+    'SET_PLATE_TEMP': 'M104',
+    'GET_PLATE_TEMP': 'M105',
+    'SET_RAMP_RATE': 'M566',
+    'DEACTIVATE': 'M18',
+    'DEVICE_INFO': 'M115'
+}
+
+SERIAL_ACK = '\r\n'
+
+
+GET_STAT = 'stat{}'.format(SERIAL_ACK)
+DEACTIVATE = '{}{}'.format(GCODES['DEACTIVATE'], SERIAL_ACK)
+
+class thermocycler(serial.Serial):
+    def __init__(self, port='/dev/ttyUSB0', baudrate=115200, timeout = 0.1):
+        self.error_count = 0
+        self.max_errors = 100
+        self.unlimited_errors = False
+        self.raise_exceptions = True
+        self.reading_raw = ''
+        self._port = serial.Serial(
+            	port = port,
+            	baudrate = baudrate,
+                stopbits = serial.STOPBITS_ONE,
+                bytesize = 8,
+                timeout=timeout)
+
+    def _send(self, cmd):
+        print("Sending: {}".format(cmd))
+        self._port.write(cmd.encode())
+
+    def parse_number_from_substring(self, substring, rounding_val):
+        '''
+        Returns the number in the expected string "N:12.3", where "N" is the
+        key, and "12.3" is a floating point value
+
+        For the temp-deck or thermocycler's temperature response, one expected
+        input is something like "T:none", where "none" should return a None value
+        '''
+        try:
+        	value = substring.split(':')[1]
+        	if value.strip().lower() == 'none':
+        		return None
+        	return round(float(value), rounding_val)
+        except (ValueError, IndexError, TypeError, AttributeError):
+        	print('Unexpected argument to parse_number_from_substring:')
+        	raise Exception(
+        		'Unexpected argument to parse_number_from_substring: {}'.format(substring))
+
+    def parse_key_from_substring(self, substring) -> str:
+        '''
+        Returns the axis in the expected string "N:12.3", where "N" is the
+        key, and "12.3" is a floating point value
+        '''
+        try:
+        	return substring.split(':')[0]
+        except (ValueError, IndexError, TypeError, AttributeError):
+        	print('Unexpected argument to parse_key_from_substring:')
+        	raise Exception(
+        		'Unexpected argument to parse_key_from_substring: {}'.format(substring))
+
+    def read_temp(self):
+        #CURRENT_HOLD_TIME = 99
+        #GCODE_DEBUG_PRINT_MODE = 'M111 cont{}'.format(SERIAL_ACK)
+        #self._send(GCODE_DEBUG_PRINT_MODE)
+        while True:
+            serial_line = self._port.readline()
+            if serial_line:
+                serial_list = serial_line.decode().split("\t")
+                serial_list = list(map(lambda x: x.strip(), serial_list))
+                data_res = {}
+                for substr in serial_list:
+                    if substr == '':
+                        continue
+                    key = self.parse_key_from_substring(substr)
+                    value = self.parse_number_from_substring(substr, TC_GCODE_ROUNDING_PRECISION)
+                    data_res[key] = value
+                return data_res #return particular temperature
+            time.sleep(0.1)

--- a/modules/thermo-cycler/QC/offset_test/offset_test.py
+++ b/modules/thermo-cycler/QC/offset_test/offset_test.py
@@ -1,0 +1,193 @@
+"""
+This test script is for internal use only, this uses two Eutechnics 4500 Thermometers to read
+well temperatures. The thermometers are placed in the hottest and coldest locations on the well plate.
+This determines the delta temperature offsets of the well.
+"""
+
+import sys, os, time
+import csv
+import threading
+import subprocess
+from datetime import datetime
+sys.path.insert(0, os.path.abspath(''))
+# Thermocycler mini driver
+import TC_mini_driver
+import optparse
+
+#conver time into milli seconds
+def time_to_seconds():
+   dt = datetime.now() - start_time
+   ms = (dt.days * 24 * 60 * 60 + dt.seconds) * 1000 + dt.microseconds / 1000.0
+   return ms/1000
+
+#Fan duty cycle function
+def fan_power(duty_cycle):
+    FAN_CONTROL = '{} S{}{}'.format(GCODES['FAN_CONTROL'], duty_cycle, SERIAL_ACK)
+    return FAN_CONTROL
+
+def single_thermocycle(ser):
+    time.sleep(2)
+    ser._send(fan_power(options.fan)) # Manual mode for fan control
+    print("Executing fan power: ", options.fan)
+    #initial pre heat for 3mins
+    #ser._send(CYCLE_PROTOCOL_STEPS[0]) # set lid temp
+    ser._send(CYCLE_PROTOCOL_STEPS[1]) # HOLD TEMP
+    #time.sleep(60*end_time + ramp_time)#Hold Temp 3 mins
+    time.sleep(options.time*60 + ramp_time)#Hold Temp 3 mins
+    #ser._send(CYCLE_PROTOCOL_STEPS[2])
+    #print("RAMP DOWN")
+    #time.sleep(40)
+    ser._send(DEACTIVATE)
+
+def thermocycle_protocol(ser):
+    ending_time = 3 #3mins
+    time.sleep(2)
+    ser._send(fan_power(0.2)) # Manual mode for fan control
+    print("Executing ")
+    #initial pre heat for 3mins
+    ser._send(CYCLE_PROTOCOL_STEPS[0]) # set lid temp
+    ser._send(CYCLE_PROTOCOL_STEPS[1]) # HOLD TEMP
+    #time.sleep(60*end_time + ramp_time)#Hold Temp 3 mins
+    time.sleep(pause_time + ramp_time)#Hold Temp 3 mins
+    for cycle in range(10):
+        ser._send(CYCLE_PROTOCOL_STEPS[2])
+        print("RAMP DOWN")
+        time.sleep(PAUSE_TIME)
+        ser._send(CYCLE_PROTOCOL_STEPS[3])
+        print("RAMP UP")
+        time.sleep(PAUSE_TIME)
+    ser._send(DEACTIVATE)
+
+def record_status(filename, ser):
+    t_end = time.time() + 60 * options.time
+    t_end_2 = time.time() + 30
+    threshold = 0.5
+    count = 1
+    previous_reading = 0
+    ret_temp = 0
+    #run for some fixed amount time
+    while time.time() < t_end:
+        temps_list = ser.read_temp()
+        #print(temps_list)
+        #skip first reading
+        if count > 1:
+            previous_reading = ret_temp
+            print("previous reading: ", previous_reading)
+        #Fan logic after first cycle
+        if time.time() > t_end_2:
+            #Only for rampdown
+            if previous_reading-temps_list['T1'] > threshold:
+                print("Delta 1",previous_reading-temps_list['T1'])
+                #ser._send(fan_power(0))
+            elif previous_reading-temps_list['T1'] < threshold:
+                print("Delta 2",previous_reading-temps_list['T1'])
+                #ser._send(fan_power(0))
+        count+=1 # increment count
+        #create history temp variable
+        ret_temp = temps_list['T1']
+        #Record following data from thermocycler
+        test_data['T1'] = temps_list['T1']
+        test_data['T2'] = temps_list['T2']
+        test_data['T3'] = temps_list['T3']
+        test_data['T4'] = temps_list['T4']
+        test_data['T5'] = temps_list['T5']
+        test_data['T6'] = temps_list['T6']
+        test_data['T.heatsink'] = temps_list['T.sink']
+        test_data['T.lid'] = temps_list['T.Lid']
+        test_data['time'] = time_to_seconds()
+        log_file.writerow(test_data)
+        print(test_data)
+        data_file.flush()
+
+if __name__== '__main__':
+    parser = optparse.OptionParser(usage='usage: %prog [options] ')
+    parser.add_option("-t", "--temperature", dest = "temperature",type = "str", default = "90", help = "str Temperature")
+    parser.add_option("--target", dest = "target", type = int, default = 90, help = "target temperature")
+    parser.add_option("--hi_temp", dest = "hi_temp", type = float, default = 90, help = "Hi temperature")
+    parser.add_option("--lo_temp", dest = "lo_temp", type = float, default = 90, help = "lo temperature")
+    parser.add_option("-p", "--pause_time", dest = "pause_time", type = float, default = 18, help = "pause_time ")
+    parser.add_option("--time", dest = "time", type = float, default = 60, help = "run time for data collection")
+    parser.add_option("-f", "--fan", dest = "fan", type = float, default = .15,  help ="fan power value")
+    (options, args) = parser.parse_args(args = None, values = None)
+
+    #---------------------------------------#
+    GCODES = True
+    TC_GCODE_ROUNDING_PRECISION = 2
+    #---------------------------------------#
+    SERIAL_ACK = '\r\n'
+    GCODES = {
+        'OPEN_LID': 'M126',
+        'CLOSE_LID': 'M127',
+        'GET_LID_STATUS': 'M119',
+        'SET_LID_TEMP': 'M140',
+        'GET_LID_TEMP': 'M141',
+        'DEACTIVATE_LID_HEATING': 'M108',
+        'EDIT_PID_PARAMS': 'M301',
+        'SET_PLATE_TEMP': 'M104',
+        'GET_PLATE_TEMP': 'M105',
+        'SET_RAMP_RATE': 'M566',
+        'DEACTIVATE': 'M18',
+        'DEVICE_INFO': 'M115',
+        'FAN_CONTROL': 'M106'
+    }
+    #---------------------------------------#
+    #These parameters are for cycle protocol
+    TOP_LID_TEMP = 105
+    HI_TEMP_PLATE = options.hi_temp
+    LO_TEMP_PLATE = options.lo_temp
+    HI_TEMP_TIME = 70
+    LO_TEMP_TIME = 70
+    ramp_time = 12
+    PAUSE_TIME = ramp_time+ options.time #40 is equal HI_TEMP_TIME/LO_TEMP_TIME
+    PRE_HOLD_TEMP = ramp_time + options.time
+    #---------------------------------------#
+    CYCLE_PROTOCOL_STEPS = [
+        '{} S{}{}'.format(GCODES['SET_LID_TEMP'], TOP_LID_TEMP, SERIAL_ACK),	#0 # SET TOP LID to 105C
+        '{} S{} H{}{}'.format(GCODES['SET_PLATE_TEMP'], HI_TEMP_PLATE, PRE_HOLD_TEMP, SERIAL_ACK), # 1 # HEAT PLATE for 0.5min
+        '{} S{} H{}{}'.format(GCODES['SET_PLATE_TEMP'], LO_TEMP_PLATE, LO_TEMP_TIME, SERIAL_ACK), # 2 # COOL PHASE
+        '{} S{} H{}{}'.format(GCODES['SET_PLATE_TEMP'], HI_TEMP_PLATE, HI_TEMP_TIME, SERIAL_ACK), # 3 # HOT TEMP PHASE
+        '{}{}'.format(GCODES['DEACTIVATE_LID_HEATING'], SERIAL_ACK) #deactivate
+        ]
+    #---------------------------------------#
+    GCODE_DEBUG_PRINT_MODE = 'M111 cont{}'.format(SERIAL_ACK)
+    GET_STAT = 'stat{}'.format(SERIAL_ACK)
+    DEACTIVATE = '{}{}'.format(GCODES['DEACTIVATE'], SERIAL_ACK)
+    #---------------------------------------#
+    #defined thermo-cycler
+    tc = TC_mini_driver.thermocycler(port = 'COM17', timeout=0.5)
+    tc._send(GCODE_DEBUG_PRINT_MODE)
+    tc._send(CYCLE_PROTOCOL_STEPS[0])
+    temperature = 0 # Create temp variable
+    #heat the TOP LID to 105
+    while temperature < 100:
+        temp_dict = tc.read_temp()
+        temperature = temp_dict['T.Lid']
+        #tc._send(fan_power(0.6)) #Fan duty cycle 60 %
+        print("top lid temperature: ", temp_dict['T.Lid'])
+        print("Waiting on temp lid to reach {}".format(CYCLE_PROTOCOL_STEPS[0]))
+
+    file_name = "results/A16_Temp_offset_%s_%sC.csv"%(datetime.now().strftime("%m-%d-%y_%H-%M"), options.target)
+    print(file_name)
+    #open subprocess for thermometers
+    subprocess.Popen(['python',
+                    'H1_thermometer.py'],
+                    creationflags=subprocess.CREATE_NEW_CONSOLE)
+    # subprocess.Popen(['python', 'C5_thermometer.py'],
+    #                 creationflags=subprocess.CREATE_NEW_CONSOLE)
+    # #pause till therometers are readings data
+    time.sleep(6) #Manual time pause to sync subprocess with thermocycler thread
+    with open('{}.csv'.format(file_name), 'w', newline='') as data_file:
+        test_data={'T1':None,'T2':None,'T3':None,'T4':None,'T5':None, 'T6':None,'T.lid':None,'T.heatsink':None, 'time': None}
+        log_file = csv.DictWriter(data_file, test_data)
+        log_file.writeheader()
+        #threads
+        print("Starting protocol and reading")
+        recorder = threading.Thread(target=record_status, args=(file_name, tc, ))
+        protocol_writer = threading.Thread(target=single_thermocycle, args=(tc,), daemon=True)
+        process_list = [recorder, protocol_writer]
+        start_time = datetime.now()
+        print("start_time: ", start_time)
+        for prc in process_list:
+            prc.start()
+        for proc in process_list:
+            proc.join()


### PR DESCRIPTION
These test scripts are used for thermocycling testing

Eutechnics Driver:
The Eutechnics serial driver was copied from Mechanical-Test Repo to this repo locally. The driver establishes a connection to the 4500 Eutechnics temperature probe. Allowing a user to extract the necessary data from the measuring device. 

TC_mini_driver:
The TC_mini_driver.py is a Thermocycler driver i created to write simple Gcode commands to thermocycler.  

offset_test:
The Offset test runs the thermocycler in a thread, while running separate thread to the Eutechnics thermometer. This helps us sync data collection from the thermocycler and the temperature probe measured from the PCR top plate. This test script was used in the first round of offset tesing. 