### PR TITLE
chore(CI, thermocycler): zip deploy files, use arduino 1.8.10, make TC fw uploader feather compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ before_deploy:
   - cp -r ./build modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
   - zip -r modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH.zip modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
   - rm -rf modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
+  - mkdir dist
+  - mv modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH.zip ./dist
 
 deploy:
   - provider: s3
@@ -30,7 +32,8 @@ deploy:
     bucket: opentrons-modules-builds
     region: us-east-2
     skip_cleanup: true
-    file: modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH.zip
+    local_dir: ./dist
+    upload_dir: modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
     on:
       all_branches: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,13 @@ install:
 script:
   - make build TC_FW_VERSION=$THIS_BUILD_TAG
 
+before_deploy:
+  - make clean
+  - mkdir modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
+  - cp -r ./build modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
+  - zip -r modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH.zip modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
+  - rm -rf modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
+
 deploy:
   - provider: s3
     access_key_id: $AWS_ACCESS_KEY_ID
@@ -23,8 +30,7 @@ deploy:
     bucket: opentrons-modules-builds
     region: us-east-2
     skip_cleanup: true
-    local_dir: build/
-    upload-dir: modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
+    file: modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH.zip
     on:
       all_branches: true
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LIBRARIES_DIR := libraries
 MODULES_DIR := modules
 INO_DIR := $(HOME)/arduino_ide
 
-ARDUINO_VERSION ?= 1.8.5
+ARDUINO_VERSION ?= 1.8.10
 ARDUINO_SAMD_VER ?= 1.6.21
 OPENTRONS_BOARDS_VER ?= 1.2.0
 OPENTRONS_SAMD_BOARDS_VER ?= 1.1.0
@@ -70,17 +70,17 @@ setup:
 	echo -n "Arduino SAMD: "
 	$(if $(NO_ARDUINO_SAMD), $(ARDUINO) --install-boards arduino:samd:$(ARDUINO_SAMD_VER), @echo "Arduino SAMD already installed")
 	echo -n "Opentrons SAMD: "
-	$(if $(NO_OPENTRONS_SAMD_BOARDS), $(ARDUINO) --install-boards Opentrons:samd, @echo "Opentrons SAMD already installed")
+	$(if $(NO_OPENTRONS_SAMD_BOARDS), $(ARDUINO) --install-boards Opentrons:samd:$(OPENTRONS_SAMD_BOARDS_VER), @echo "Opentrons SAMD already installed")
 	echo -n "Opentrons modules: "
 	$(if $(NO_OPENTRONS_BOARDS), $(ARDUINO) --install-boards Opentrons:avr, @echo "Opentrons boards already installed")
 
 .PHONY: build
-build: build-magdeck build-tempdeck build-thermocycler build-tc-eeprom clean
+build: build-magdeck build-tempdeck build-thermocycler build-tc-eeprom
 
-MAGDECK_BUILD_DIR := $(BUILDS_DIR)/mag-deck/
-TEMPDECK_BUILD_DIR := $(BUILDS_DIR)/temp-deck/
+MAGDECK_BUILD_DIR := $(BUILDS_DIR)/mag-deck
+TEMPDECK_BUILD_DIR := $(BUILDS_DIR)/temp-deck
 TC_BUILD_DIR := $(BUILDS_DIR)/thermo-cycler
-TC_EEPROM_WR_BUILD_DIR := $(BUILDS_DIR)/tc-eeprom-writer/
+TC_EEPROM_WR_BUILD_DIR := $(BUILDS_DIR)/tc-eeprom-writer
 
 TC_FW_VERSION ?= unknown
 DUMMY_BOARD ?= false

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This should implement the following:
 
 (Windows setup is not implemented in `make` yet. So we will have to install the required files manually)
 
-1. Install Arduino IDE (v1.8.5) from https://www.arduino.cc/en/Main/OldSoftwareReleases#previous
+1. Install Arduino IDE (v1.8.10) from https://www.arduino.cc/en/Main/Software
 2. Install board files:
    - Go to _File->Preferences_ and in _'Additional Boards Manager URLs'_ paste this
    url (if you already have other boards' urls then separate these with commas):

--- a/modules/thermo-cycler/production/firmware_uploader.py
+++ b/modules/thermo-cycler/production/firmware_uploader.py
@@ -9,7 +9,7 @@
 #     or path to binary/uf2 file added as argument `-F`
 #   - BOSSA cmdline tool- https://github.com/shumatech/BOSSA/releases (Tested with 1.9.1)
 
-from pathlib import Path
+from pathlib import PurePath
 import sys
 import serial
 import time
@@ -17,7 +17,7 @@ import subprocess
 from serial.tools.list_ports import comports
 from argparse import ArgumentParser
 
-THIS_DIR = Path.cwd()
+THIS_DIR = PurePath(__file__).parent
 DEFAULT_FW_FILE_PATH = THIS_DIR.joinpath('thermo-cycler-arduino.ino.bin')
 OPENTRONS_VID       = 1240  # 0x04D8
 ADAFRUIT_VID        = 9114  # 0x239A
@@ -30,7 +30,8 @@ def build_arg_parser():
         description="Thermocycler firmware uploader")
     arg_parser.add_argument("-F", "--fw_file", required=False,
                             default=DEFAULT_FW_FILE_PATH,
-                            help='Firmware file (default: ..production/bin/thermo-cycler-arduino.ino.bin)')
+                            help='Firmware file (default: thermo-cycler-arduino.ino.bin '
+                                 'located in same dir as uploader)')
     return arg_parser
 
 def find_opentrons_port(bootloader=False):
@@ -85,6 +86,7 @@ def main():
     args = arg_parser.parse_args()
     firmware_file = args.fw_file
     print('\n')
+    print("FW file: {}".format(firmware_file))
     connected_port = None
     try:
         print('\nTrigerring Bootloader..')

--- a/modules/thermo-cycler/production/firmware_uploader.py
+++ b/modules/thermo-cycler/production/firmware_uploader.py
@@ -19,10 +19,10 @@ from argparse import ArgumentParser
 
 THIS_DIR = PurePath(__file__).parent
 DEFAULT_FW_FILE_PATH = THIS_DIR.joinpath('thermo-cycler-arduino.ino.bin')
-OPENTRONS_VID       = 1240  # 0x04D8
-ADAFRUIT_VID        = 9114  # 0x239A
-TC_BOOTLOADER_PID   = 60690 # 0xED12
-ADAFRUIT_BOOTLD_PID = 11    # 0x000B
+OPENTRONS_VID       = 0x04d8
+ADAFRUIT_VID        = 0x239a
+TC_BOOTLOADER_PID   = 0xed12
+ADAFRUIT_BOOTLD_PID = 0x000b
 MAX_SERIAL_LEN = 16
 
 def build_arg_parser():
@@ -38,10 +38,10 @@ def find_opentrons_port(bootloader=False):
     retries = 5
     while retries:
         for p in comports():
-            if p.vid == OPENTRONS_VID or p.vid == ADAFRUIT_VID:
-                print("Available: {}->\t(pid:{})\t(vid:{})".format(p.device, p.pid, p.vid))
+            if p.vid in (OPENTRONS_VID, ADAFRUIT_VID):
+                print("Available: {0}->\t(pid:{1:#x})\t(vid:{2:#x})".format(p.device, p.pid, p.vid))
                 if bootloader:
-                    if p.pid != TC_BOOTLOADER_PID and p.pid != ADAFRUIT_BOOTLD_PID:
+                    if p.pid not in (TC_BOOTLOADER_PID, ADAFRUIT_BOOTLD_PID):
                         continue
                 print("Port found:{}".format(p.device))
                 if p.pid == ADAFRUIT_BOOTLD_PID:

--- a/modules/thermo-cycler/production/firmware_uploader.py
+++ b/modules/thermo-cycler/production/firmware_uploader.py
@@ -19,8 +19,10 @@ from argparse import ArgumentParser
 
 THIS_DIR = Path.cwd()
 DEFAULT_FW_FILE_PATH = THIS_DIR.joinpath('thermo-cycler-arduino.ino.bin')
-OPENTRONS_VID = 1240
-TC_BOOTLOADER_PID = 0xED12
+OPENTRONS_VID       = 1240  # 0x04D8
+ADAFRUIT_VID        = 9114  # 0x239A
+TC_BOOTLOADER_PID   = 60690 # 0xED12
+ADAFRUIT_BOOTLD_PID = 11    # 0x000B
 MAX_SERIAL_LEN = 16
 
 def build_arg_parser():
@@ -35,12 +37,15 @@ def find_opentrons_port(bootloader=False):
     retries = 5
     while retries:
         for p in comports():
-            print("Available: {}->\t(pid:{})\t(vid:{})".format(p.device, p.pid, p.vid))
-            if p.vid == OPENTRONS_VID:
+            if p.vid == OPENTRONS_VID or p.vid == ADAFRUIT_VID:
+                print("Available: {}->\t(pid:{})\t(vid:{})".format(p.device, p.pid, p.vid))
                 if bootloader:
-                    if p.pid != TC_BOOTLOADER_PID:
+                    if p.pid != TC_BOOTLOADER_PID and p.pid != ADAFRUIT_BOOTLD_PID:
                         continue
                 print("Port found:{}".format(p.device))
+                if p.pid == ADAFRUIT_BOOTLD_PID:
+                    print("--- WARNING!! : Uploading with Adafruit bootloader."
+                          " Please update to TC bootloader ---")
                 time.sleep(1)
                 return p.device
         retries -= 1

--- a/modules/thermo-cycler/production/serial_and_firmware_uploader.py
+++ b/modules/thermo-cycler/production/serial_and_firmware_uploader.py
@@ -17,8 +17,10 @@ from argparse import ArgumentParser
 THIS_DIR = Path.cwd()
 DEFAULT_FW_FILE_PATH = THIS_DIR.resolve().parent.joinpath('thermo-cycler', 'thermo-cycler-arduino.ino.bin')
 EEPROM_WRITER_PATH = THIS_DIR.joinpath('eepromWriter.ino.bin')
-OPENTRONS_VID = 1240
-TC_BOOTLOADER_PID = 0xED12
+OPENTRONS_VID       = 1240  # 0x04D8
+ADAFRUIT_VID        = 9114  # 0x239A
+TC_BOOTLOADER_PID   = 60690 # 0xED12
+ADAFRUIT_BOOTLD_PID = 11    # 0x000B
 MAX_SERIAL_LEN = 16
 BAD_BARCODE_MESSAGE = 'Serial longer than expected -> {}'
 WRITE_FAIL_MESSAGE = 'Data not saved'

--- a/modules/thermo-cycler/production/serial_and_firmware_uploader.py
+++ b/modules/thermo-cycler/production/serial_and_firmware_uploader.py
@@ -17,10 +17,10 @@ from argparse import ArgumentParser
 THIS_DIR = PurePath(__file__).parent
 DEFAULT_FW_FILE_PATH = THIS_DIR.parent.joinpath('thermo-cycler', 'thermo-cycler-arduino.ino.bin')
 EEPROM_WRITER_PATH = THIS_DIR.joinpath('eepromWriter.ino.bin')
-OPENTRONS_VID       = 1240  # 0x04D8
-ADAFRUIT_VID        = 9114  # 0x239A
-TC_BOOTLOADER_PID   = 60690 # 0xED12
-ADAFRUIT_BOOTLD_PID = 11    # 0x000B
+OPENTRONS_VID       = 0x04d8
+ADAFRUIT_VID        = 0x239a
+TC_BOOTLOADER_PID   = 0xed12
+ADAFRUIT_BOOTLD_PID = 0x000b
 MAX_SERIAL_LEN = 16
 BAD_BARCODE_MESSAGE = 'Serial longer than expected -> {}'
 WRITE_FAIL_MESSAGE = 'Data not saved'
@@ -38,7 +38,7 @@ def find_opentrons_port(bootloader=False):
     while retries:
         for p in comports():
             if p.vid == OPENTRONS_VID:
-                print("Available: {}->\t(pid:{})\t(vid:{})".format(p.device, p.pid, p.vid))
+                print("Available: {0}->\t(pid:{1:#x})\t(vid:{2:#x})".format(p.device, p.pid, p.vid))
                 if bootloader:
                     if p.pid != TC_BOOTLOADER_PID:
                         continue

--- a/modules/thermo-cycler/production/serial_and_firmware_uploader.py
+++ b/modules/thermo-cycler/production/serial_and_firmware_uploader.py
@@ -6,7 +6,7 @@
 # NOT Compatible with UF2
 #
 # BOSSA: bossac -p/dev/cu.usbmodem14101 -e -w -v -R --offset=0x2000 thermo-cycler-arduino.ino.bin
-from pathlib import Path
+from pathlib import PurePath
 import sys
 import subprocess
 import serial
@@ -14,8 +14,8 @@ import time
 from serial.tools.list_ports import comports
 from argparse import ArgumentParser
 
-THIS_DIR = Path.cwd()
-DEFAULT_FW_FILE_PATH = THIS_DIR.resolve().parent.joinpath('thermo-cycler', 'thermo-cycler-arduino.ino.bin')
+THIS_DIR = PurePath(__file__).parent
+DEFAULT_FW_FILE_PATH = THIS_DIR.parent.joinpath('thermo-cycler', 'thermo-cycler-arduino.ino.bin')
 EEPROM_WRITER_PATH = THIS_DIR.joinpath('eepromWriter.ino.bin')
 OPENTRONS_VID       = 1240  # 0x04D8
 ADAFRUIT_VID        = 9114  # 0x239A
@@ -30,7 +30,7 @@ def build_arg_parser():
         description="Thermocycler serial & firmware uploader")
     arg_parser.add_argument("-F", "--fw_file", required=False,
                             default=DEFAULT_FW_FILE_PATH,
-                            help='Firmware file (default: ..production/bin/thermo-cycler-arduino.ino.bin)')
+                            help='Firmware file (default: ../thermo-cycler/thermo-cycler-arduino.ino.bin)')
     return arg_parser
 
 def find_opentrons_port(bootloader=False):
@@ -151,6 +151,8 @@ def main():
     args = arg_parser.parse_args()
     firmware_file = args.fw_file
     print('\n')
+    print("Firmware file: {}".format(firmware_file))
+    print("Eeprom writer file: {}".format(EEPROM_WRITER_PATH))
     connected_port = None
     try:
         print('\nTrigerring Bootloader..')


### PR DESCRIPTION
## overview

This PR updates our build environment and deploy process. Also makes the firmware upload script compatible with adafruit feather m0 bootloader.

## changes

1. Arduino versions < 1.8.10 are not compatible with MacOS Catalina so tested and bumped our build env to 1.8.10.
2. We still have a bunch of dev thermocyclers on original feather m0 bootloader so made the upload script compatible with that bootloader.
3. We need an easy way to download all modules firmware files at once, so bundle them up in a zip