### PR TITLE
ci(travis): make deployed file readable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ deploy:
     region: us-east-2
     skip_cleanup: true
     local_dir: ./dist
+    acl: public_read
     upload_dir: modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
     on:
       all_branches: true


### PR DESCRIPTION
This PR makes the deployed firmware binaries' zip publicly readable.