### PR TITLE
feat(thermocycler): make fans start gradually, don't overshoot for ~same temp, cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,8 @@ TC_EEPROM_WR_BUILD_DIR := $(BUILDS_DIR)/tc-eeprom-writer
 
 TC_FW_VERSION ?= unknown
 DUMMY_BOARD ?= false
-USE_GCODES ?= true
 LID_WARNING ?= false
 HFQ_PWM ?= false
-OLD_PID_INTERVAL ?= true
 HW_VERSION ?= 4
 LID_TESTING ?= false
 RGBW_NEO ?= true
@@ -108,8 +106,7 @@ build-tempdeck:
 .PHONY: build-thermocycler
 build-thermocycler:
 	echo "compiler.cpp.extra_flags=-DDUMMY_BOARD=$(DUMMY_BOARD) \
-	-DUSE_GCODES=$(USE_GCODES) -DLID_WARNING=$(LID_WARNING) \
-	-DHFQ_PWM=$(HFQ_PWM) -DOLD_PID_INTERVAL=$(OLD_PID_INTERVAL) \
+	-DLID_WARNING=$(LID_WARNING) -DHFQ_PWM=$(HFQ_PWM) \
 	-DHW_VERSION=$(HW_VERSION) -DLID_TESTING=$(LID_TESTING) \
 	-DRGBW_NEO=$(RGBW_NEO) -DVOLUME_DEPENDENCY=$(VOLUME_DEPENDENCY) \
 	-DTC_FW_VERSION=\"$(TC_FW_VERSION)\"" \

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For thermocycler binaries, a firmware uploader script will also be copied to the
 Use Arduino IDE to compile:
 Select the correct board file for your project from _Tools->board_ (Opentrons Thermocycler M0/ Opentrons Magdeck/ Opentrons Tempdeck)
 
-* NOTE: For Opentrons Thermocycler M0, you will have to set the appropriate flags in the `platform.local.txt` file: Find this file in your Arduino15 folder- a hidden folder usually located in C://Users/username/appData/Local on Windows. You will find the preferences file in `..Arduino15/packages/Opentrons/hardware/samd/1.0.1`. Paste this line in the file above: `compiler.cpp.extra_flags=-DLID_WARNING=false -DHFQ_PWM=false -DOLD_PID_INTERVAL=true -DHW_VERSION=4 -DLID_TESTING=false -DRGBW_NEO=true` (set appropriate flag values)
+* NOTE: For Opentrons Thermocycler M0, you will have to set the appropriate flags in the `platform.local.txt` file: Find this file in your Arduino15 folder- a hidden folder usually located in C://Users/username/appData/Local on Windows. You will find the preferences file in `..Arduino15/packages/Opentrons/hardware/samd/1.0.1`. Paste this line in the file above: `compiler.cpp.extra_flags=-DLID_WARNING=false -DHFQ_PWM=false -DHW_VERSION=4 -DLID_TESTING=false -DRGBW_NEO=true -DVOLUME_DEPENDENCY=true -DTC_FW_VERSION="<YOUR_FW_VERSION_STRING>"` (set appropriate flag values)
 
 Then select _Sketch->Compile_.
 

--- a/modules/thermo-cycler/thermo-cycler-arduino/fan.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/fan.cpp
@@ -5,17 +5,32 @@ Fan::Fan()
 {}
 
 /* Only for the pwm controlled heatsink fan */
-void Fan::set_percentage(float p)
+void Fan::set_percentage(float p, Fan_ramping r)
 {
   enable();
   p = constrain(p, 0, 1);
-  uint8_t val = p * 255.0;
-  current_power = p;
+  if (r == Fan_ramping::On)
+  {
+    const float alpha = 0.1;
+    // Low pass filter to dampen sudden changes in fan speed.
+    // Provides better user experience.
+    current_power = current_power + alpha * (p - current_power);
+  }
+  else
+  {
+    current_power = p;
+  }
+  uint8_t val = current_power * 255.0;
 #if HFQ_PWM
   hfq_analogWrite(_pwm_pin, val);
 #else
   analogWrite(_pwm_pin, val);
 #endif
+}
+
+void Fan::set_percentage(float p)
+{
+  set_percentage(p, Fan_ramping::Off);
 }
 
 /* Only for the pwm controlled heatsink fan */

--- a/modules/thermo-cycler/thermo-cycler-arduino/fan.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/fan.h
@@ -5,6 +5,12 @@
 
 #define ENABLE_DEFAULT_ACTIVE_HIGH  true
 
+enum class Fan_ramping
+{
+  On,
+  Off
+};
+
 /* This class is used to control the two fans in the thermocycler:
  *  - Cover heatpad fan: Digital control (ON/OFF only)
  *  - Heatsink fan: PWM control + ON/OFF control */
@@ -13,6 +19,7 @@ class Fan
   public:
     Fan();
     void set_percentage(float p);
+    void set_percentage(float p, Fan_ramping r);
     void setup_pwm_pin(uint8_t pwm_pin);
     void setup_enable_pin(uint8_t enable_pin, bool active_high);
     void enable();

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.cpp
@@ -117,6 +117,65 @@ float ThermistorsADC::heat_sink_temperature() {
   return probe_temps[ADC_INDEX_HEAT_SINK];  // No offset
 }
 
+float ThermistorsADC::hottest_plate_therm_temp()
+{
+  float hottest_temp = -99.0;
+  if (back_left_temperature() > hottest_temp)
+  {
+    hottest_temp = back_left_temperature();
+  }
+  if (back_center_temperature() > hottest_temp)
+  {
+    hottest_temp = back_center_temperature();
+  }
+  if (back_right_temperature() > hottest_temp)
+  {
+    hottest_temp = back_right_temperature();
+  }
+  if (front_left_temperature() > hottest_temp)
+  {
+    hottest_temp = front_left_temperature();
+  }
+  if (front_center_temperature() > hottest_temp)
+  {
+    hottest_temp = front_center_temperature();
+  }
+  if (front_right_temperature() > hottest_temp)
+  {
+    hottest_temp = front_right_temperature();
+  }
+  return hottest_temp;
+}
+
+float ThermistorsADC::coolest_plate_therm_temp()
+{
+  float coolest_temp = 999.0;
+  if (back_left_temperature() < coolest_temp)
+  {
+    coolest_temp = back_left_temperature();
+  }
+  if (back_center_temperature() < coolest_temp)
+  {
+    coolest_temp = back_center_temperature();
+  }
+  if (back_right_temperature() < coolest_temp)
+  {
+    coolest_temp = back_right_temperature();
+  }
+  if (front_left_temperature() < coolest_temp)
+  {
+    coolest_temp = front_left_temperature();
+  }
+  if (front_center_temperature() < coolest_temp)
+  {
+    coolest_temp = front_center_temperature();
+  }
+  if (front_right_temperature() < coolest_temp)
+  {
+    coolest_temp = front_right_temperature();
+  }
+  return coolest_temp;
+}
 
 uint16_t ThermistorsADC::_read_adc(int index) {
   int res = 0;

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermistorsadc.h
@@ -83,6 +83,8 @@ class ThermistorsADC{
             float back_center_temperature();
             float back_right_temperature();
             float cover_temperature();
+            float hottest_plate_therm_temp();
+            float coolest_plate_therm_temp();
             float heat_sink_temperature();
             float plate_temp_offset;
             bool detected_invalid_val;

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -1049,7 +1049,7 @@ void temp_safety_check()
         )
       )
   {
-    gcode.response("System too hot! Deactivating.");
+    gcode.response("ERROR", "System too hot! Deactivating.");
     deactivate_all();
   }
   // When peltiers are stable, check if all thermistors give approximately
@@ -1058,7 +1058,7 @@ void temp_safety_check()
   if (!just_changed_temp &&
       temp_probes.hottest_plate_therm_temp() - temp_probes.coolest_plate_therm_temp() > ACCEPTABLE_THERM_DIFF)
   {
-    gcode.response("Plate temperature not uniform. Deactivating.");
+    gcode.response("ERROR", "Plate temperature not uniform. Deactivating.");
     deactivate_all();
   }
 }
@@ -1168,7 +1168,7 @@ double plate_overshoot()
   {
     return (POS_OVERSHOOT_M * current_volume + POS_OVERSHOOT_C);
   }
-  else if (this_step_target_temp - current_temperature_plate <= 0.5)
+  else if (this_step_target_temp - current_temperature_plate <= -0.5)
   {
     return -1 * (NEG_OVERSHOOT_M * current_volume + NEG_OVERSHOOT_C);
   }

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -104,17 +104,8 @@ double current_heatsink_temp;
 #define NEG_OVERSHOOT_C 0.4302
 
 /********* PID: PLATE PELTIERS *********/
-// NOTE: temp_probes.update takes 136-137ms while rest of the loop takes 0-1ms.
-//       Using 135ms sample time guarantees that the PID value is computed every
-//       137ms with a very minute error in computation due to 1-2ms difference.
-//       If <135ms, PID computation error will increase
-//       If >=137ms, the compute will miss the window before temp_probes.update
-//       is called again; which makes the next PID compute 2*137ms away
-#if OLD_PID_INTERVAL
-  #define DEFAULT_PLATE_PID_TIME 100
-#else
-  #define DEFAULT_PLATE_PID_TIME 135
-#endif
+
+#define DEFAULT_PLATE_PID_TIME 100
 
 #if HFQ_PWM
   #define PID_KP_PLATE_UP 0.1   //0.11 dampens the first spike but takes slightly longer to stabilize

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -89,6 +89,7 @@ double current_heatsink_temp;
 #define HEATSINK_FAN_HI_TEMP_3    75
 #define HEATSINK_FAN_OFF_TEMP     36
 #define PELTIER_TEMP_DELTA        2
+#define ACCEPTABLE_THERM_DIFF     2 // Difference allowed between any 2 plate thermistors (Celsius)
 
 /****** OVERSHOOT EQUATION ******/
 // y = mx + c
@@ -96,7 +97,7 @@ double current_heatsink_temp;
 // m : constant (slope)
 // x : volume (uL)
 // c : constant
- 
+
 #define POS_OVERSHOOT_M 0.0105
 #define POS_OVERSHOOT_C 1.0869
 #define NEG_OVERSHOOT_M 0.0133


### PR DESCRIPTION
Closes [#3609](https://github.com/Opentrons/opentrons/issues/3609)
## overview

Has following changes:
1. For non-PID fan settings that set a high fan speed, the fans will now ramp up to the high speed instead of jumping to high speed straight away. It's done by implementing a low pass filter. This was needed for a better user experience; we don't want to startle users every time the TC is cooling down.
2. Don't overshoot if the temp we want to go to is very close to the current temperature.
3. As part of safety check, also check for thermistor uniformity. If any thermistors are damaged they will give a much different reading than rest of the thermistors.
4. Removed some flags that we are no longer using.
