### PR TITLE
feat(thermocycler): add error indication with leds and serial messages

### DIFF
--- a/modules/thermo-cycler/thermo-cycler-arduino/lights.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lights.cpp
@@ -40,6 +40,9 @@ void Lights::update()
     case Light_action::wipe:
       _color_wipe(_color);
       break;
+    case Light_action::flashing:
+      _flash_on_off(_color);
+      break;
     case Light_action::all_off:
     default:
       _set_strip_color(COLOR_CODES[COLOR_INDEX(Light_color::none)]);
@@ -57,6 +60,10 @@ void Lights::set_lights(TC_status tc_status)
     case TC_status::idle:
       _action = (action_override ? api_action : Light_action::solid);
       _color = (color_override ? api_color : Light_color::white);
+      break;
+    case TC_status::errored:
+      _action = Light_action::flashing;
+      _color = Light_color::orange;
       break;
     case TC_status::going_to_hot_target:
       _action = (action_override ? api_action : Light_action::pulsing);
@@ -194,4 +201,19 @@ void Lights::_pulse_leds(Light_color color)
       rad += 0.04;
     }
   }
+}
+
+void Lights::_flash_on_off(Light_color color)
+{
+  static unsigned long last_update = 0;
+  static bool led_toggle_state = 0;
+  if (millis() - last_update < FLASHING_INTERVAL)
+  {
+    return;
+  }
+  led_toggle_state ?
+    _set_strip_color(COLOR_CODES[COLOR_INDEX(_color)]) :
+    _set_strip_color(COLOR_CODES[COLOR_INDEX(Light_color::none)]);
+  led_toggle_state = !led_toggle_state;
+  last_update = millis();
 }

--- a/modules/thermo-cycler/thermo-cycler-arduino/lights.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/lights.h
@@ -9,11 +9,13 @@
 #define NEO_PIN     A5
 #define NUM_PIXELS  16
 #define WIPE_SPEED_DELAY 50
-#define PULSE_UPDATE_INTERVAL 13 //millis
+#define PULSE_UPDATE_INTERVAL 13  // millis
+#define FLASHING_INTERVAL     500 // millis
 
 enum class TC_status
 {
   idle,
+  errored,
   going_to_hot_target,
   going_to_cold_target,
   at_hot_target,
@@ -28,7 +30,7 @@ enum class TC_status
   COLOR_DEF(red, 0x00500000),        \
   COLOR_DEF(green, 0x0000ee00),      \
   COLOR_DEF(blue, 0x000000ff),       \
-  COLOR_DEF(orange, 0x00ff8300),     \
+  COLOR_DEF(orange, 0x00ff5300),     \
   COLOR_DEF(none, 0x00000000)
 
 #define COLOR_DEF(color_name, _) color_name
@@ -38,7 +40,8 @@ enum class Light_action
   all_off=0,
   solid,
   pulsing,
-  wipe
+  wipe,
+  flashing
 };
 
 enum class Light_color
@@ -65,6 +68,7 @@ class Lights
     void _color_wipe(Light_color color);
     void _set_pixel(int Pixel, Light_color color);
     void _pulse_leds(Light_color color);
+    void _flash_on_off(Light_color color);
 };
 
 #endif

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -89,7 +89,7 @@ double current_heatsink_temp;
 #define HEATSINK_FAN_HI_TEMP_3    75
 #define HEATSINK_FAN_OFF_TEMP     36
 #define PELTIER_TEMP_DELTA        2
-#define ACCEPTABLE_THERM_DIFF     2 // Difference allowed between any 2 plate thermistors (Celsius)
+#define ACCEPTABLE_THERM_DIFF     4 // Difference allowed between any 2 plate thermistors (Celsius)
 
 /****** OVERSHOOT EQUATION ******/
 // y = mx + c

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler.h
@@ -174,12 +174,21 @@ String device_model;
 #endif
 
 /********* MISC GLOBALS *********/
+enum class Error
+{
+  no_error                      = (0 << 0),
+  system_too_hot                = (1 << 0),
+  invalid_thermistor_value      = (1 << 1),
+  plate_temperature_not_uniform = (1 << 2)
+};
 
+#define ERROR_MASK(error) static_cast<uint8_t>(error)
+
+uint8_t system_errors = ERROR_MASK(Error::no_error);
 bool timer_started = false;
 unsigned long overshoot_start_timestamp = 0;
 #define DEBUG_PRINT_INTERVAL 2000   // millisec
 #define ERROR_PRINT_INTERVAL 2000   // ms
-unsigned long last_error_print = 0;
 bool front_button_pressed = false;
 unsigned long front_button_pressed_at = 0;
 bool timer_interrupted = false;


### PR DESCRIPTION
## overview

This PR adds user-facing error indication of system level errors generated by the thermocycler. This would be useful as a fallback until we put together some structure for detecting and reporting error on the app.
Right now the thermocycler detects 3 system level errors:
`system_too_hot`, `invalid_thermistor_value`, `plate_temperature_not_uniform`

## changes
- organized all (3) systems errors such that they get set as flags in a `system_errors` byte.
- added an LED flashing function that gets implemented if any flag in system_errors is set.
- added a function that just reports all errors indicated by `system_errors` at a regular interval.
- all the 3 errors will now prevent a user from setting a temperature until the issue is fixed *and* the module is power-cycled.
- made `ACCEPTABLE_THERM_DIFF` 4 degC (for now) after discussion with Taylor & Andy