### PR TITLE
revert(thermocycler): revert to not using fan ramping when ramping down plate temp

### DIFF
--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -336,7 +336,7 @@ void auto_fans_for_active_thermocycler()
   else if (is_ramping_down())
   {
     PID_fan.SetMode(MANUAL);
-    heatsink_fan.set_percentage(FAN_PWR_RAMPING_DOWN, Fan_ramping::On);
+    heatsink_fan.set_percentage(FAN_PWR_RAMPING_DOWN);
   }
   else if (target_temperature_plate > HEATSINK_FAN_MED_TEMP)
   {


### PR DESCRIPTION
HW team pointed out that we should test if ramping the fans has any effect on the performance of the thermocycler. Since the fan ramping while going from a higher temp to lower temp (targets > room temp) has some effect on the temperature offsets, it's best to wait to implement this feature until we test it.

The effect of fan when going to targets < room temp isn't detrimental to performance as far as we know, so, ramping during `fans_for_cold_target()` can be left as is.