### PR TITLE
chore(CI, modules): filter tags and use separate fw version for each module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,39 @@ cache:
   directories:
     - ~/arduino_ide
 
-env:
-  - THIS_BUILD_TAG=`git describe --tags`
-
 install:
   - make setup
 
+env:
+  global:
+    - THIS_BUILD_TAG=`git describe --tags`
+    - MD_TAG=`git describe --tags --match "magdeck*"`
+    - TD_TAG=`git describe --tags --match "tempdeck*"`
+    - TC_TAG=`git describe --tags --match "thermocycler*"`
+
+jobs:
+  include:
+    - stage: deploy1
+      name: Branch build
+      env: BRANCH_NAME=$TRAVIS_BRANCH
+      if: tag IS blank
+
+    - stage: deploy2
+      name: Release build
+      env: BRANCH_NAME=release
+      if: tag IS present
+
 script:
-  - make build TC_FW_VERSION=$THIS_BUILD_TAG
+  - make build MD_TAG=$MD_TAG TD_TAG=$TD_TAG TC_TAG=$TC_TAG
 
 before_deploy:
   - make clean
-  - mkdir modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
-  - cp -r ./build modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
-  - zip -r modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH.zip modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
-  - rm -rf modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
+  - mkdir modules-$THIS_BUILD_TAG-$BRANCH_NAME
+  - cp -r ./build modules-$THIS_BUILD_TAG-$BRANCH_NAME
+  - zip -r modules-$THIS_BUILD_TAG-$BRANCH_NAME.zip modules-$THIS_BUILD_TAG-$BRANCH_NAME
+  - rm -rf modules-$THIS_BUILD_TAG-$BRANCH_NAME
   - mkdir dist
-  - mv modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH.zip ./dist
+  - mv modules-$THIS_BUILD_TAG-$BRANCH_NAME.zip ./dist
 
 deploy:
   - provider: s3
@@ -34,7 +50,7 @@ deploy:
     skip_cleanup: true
     local_dir: ./dist
     acl: public_read
-    upload_dir: modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
+    upload_dir: modules-$THIS_BUILD_TAG-$BRANCH_NAME
     on:
       all_branches: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,15 +31,10 @@ jobs:
 
 script:
   - make build MD_TAG=$MD_TAG TD_TAG=$TD_TAG TC_TAG=$TC_TAG
+  - make zip-all
 
 before_deploy:
   - make clean
-  - mkdir modules-$THIS_BUILD_TAG-$BRANCH_NAME
-  - cp -r ./build modules-$THIS_BUILD_TAG-$BRANCH_NAME
-  - zip -r modules-$THIS_BUILD_TAG-$BRANCH_NAME.zip modules-$THIS_BUILD_TAG-$BRANCH_NAME
-  - rm -rf modules-$THIS_BUILD_TAG-$BRANCH_NAME
-  - mkdir dist
-  - mv modules-$THIS_BUILD_TAG-$BRANCH_NAME.zip ./dist
 
 deploy:
   - provider: s3
@@ -48,7 +43,7 @@ deploy:
     bucket: opentrons-modules-builds
     region: us-east-2
     skip_cleanup: true
-    local_dir: ./dist
+    local_dir: ./build
     acl: public_read
     upload_dir: modules-$THIS_BUILD_TAG-$BRANCH_NAME
     on:

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,17 @@ TEMPDECK_BUILD_DIR := $(BUILDS_DIR)/temp-deck
 TC_BUILD_DIR := $(BUILDS_DIR)/thermo-cycler
 TC_EEPROM_WR_BUILD_DIR := $(BUILDS_DIR)/tc-eeprom-writer
 
-TC_FW_VERSION ?= thermocycler@unknown
-FW_VERSION := "$(shell cut -d'@' -f2 <<<'$(TC_FW_VERSION)')"
+# Magdeck flags
+MD_TAG ?= magdeck@unknown
+MD_FW_VERSION := "$(shell cut -d'@' -f2 <<<"$(MD_TAG)")"
+
+# Tempdeck flags
+TD_TAG ?= tempdeck@unknown
+TD_FW_VERSION := "$(shell cut -d'@' -f2 <<<"$(TD_TAG)")"
+
+# Thermocycler flags
+TC_TAG ?= thermocycler@unknown
+TC_FW_VERSION := "$(shell cut -d'@' -f2 <<<"$(TC_TAG)")"
 
 DUMMY_BOARD ?= false
 LID_WARNING ?= false
@@ -95,12 +104,14 @@ VOLUME_DEPENDENCY ?= true
 
 .PHONY: build-magdeck
 build-magdeck:
+	echo "compiler.cpp.extra_flags=-DMD_FW_VERSION=\"$(MD_FW_VERSION)\"" > $(ARDUINO15_LOC)/packages/Opentrons/hardware/avr/$(OPENTRONS_BOARDS_VER)/platform.local.txt
 	$(ARDUINO) --verify --board Opentrons:avr:magdeck32u4cat $(MODULES_DIR)/mag-deck/mag-deck-arduino/mag-deck-arduino.ino --verbose-build
 	mkdir -p $(MAGDECK_BUILD_DIR)
 	cp $(BUILDS_DIR)/tmp/mag-deck-arduino.ino.hex $(MAGDECK_BUILD_DIR)
 
 .PHONY: build-tempdeck
 build-tempdeck:
+	echo "compiler.cpp.extra_flags=-DTD_FW_VERSION=\"$(TD_FW_VERSION)\"" > $(ARDUINO15_LOC)/packages/Opentrons/hardware/avr/$(OPENTRONS_BOARDS_VER)/platform.local.txt
 	$(ARDUINO) --verify --board Opentrons:avr:tempdeck32u4cat $(MODULES_DIR)/temp-deck/temp-deck-arduino/temp-deck-arduino.ino --verbose-build
 	mkdir -p $(TEMPDECK_BUILD_DIR)
 	cp $(BUILDS_DIR)/tmp/temp-deck-arduino.ino.hex $(TEMPDECK_BUILD_DIR)
@@ -111,7 +122,7 @@ build-thermocycler:
 	-DLID_WARNING=$(LID_WARNING) -DHFQ_PWM=$(HFQ_PWM) \
 	-DHW_VERSION=$(HW_VERSION) -DLID_TESTING=$(LID_TESTING) \
 	-DRGBW_NEO=$(RGBW_NEO) -DVOLUME_DEPENDENCY=$(VOLUME_DEPENDENCY) \
-	-DTC_FW_VERSION=\"$(FW_VERSION)\"" \
+	-DTC_FW_VERSION=\"$(TC_FW_VERSION)\"" \
 	> $(ARDUINO15_LOC)/packages/Opentrons/hardware/samd/$(OPENTRONS_SAMD_BOARDS_VER)/platform.local.txt
 	$(ARDUINO) --verify --board Opentrons:samd:thermocycler_m0 $(MODULES_DIR)/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino --verbose-build
 	mkdir -p $(TC_BUILD_DIR)

--- a/modules/mag-deck/mag-deck-arduino/mag-deck-arduino.ino
+++ b/modules/mag-deck/mag-deck-arduino/mag-deck-arduino.ino
@@ -14,9 +14,15 @@
 #include "memory.h"
 #include "gcodemagdeck.h"
 
+/********* Version **********/
+#ifdef MD_FW_VERSION
+  #define FW_VERSION String(MD_FW_VERSION)
+#else
+  #error "No firmware version provided"
+#endif
+
 String device_serial = "";  // leave empty, this value is read from eeprom during setup()
 String device_model = "";   // leave empty, this value is read from eeprom during setup()
-String device_version = "v1.0.1";
 
 GcodeMagDeck gcode = GcodeMagDeck();  // reads in serial data to parse command and issue reponses
 Memory memory = Memory();  // reads from EEPROM to find device's unique serial, and model number
@@ -350,7 +356,7 @@ void loop() {
           gcode.print_current_position(CURRENT_POSITION_MM);
           break;
         case GCODE_DEVICE_INFO:
-          gcode.print_device_info(device_serial, device_model, device_version);
+          gcode.print_device_info(device_serial, device_model, FW_VERSION);
           break;
         case GCODE_DFU:
           gcode.send_ack(); // Send ack here since we not reaching the end of the loop

--- a/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
+++ b/modules/temp-deck/temp-deck-arduino/temp-deck-arduino.ino
@@ -371,7 +371,7 @@ void read_gcode(){
           turn_off_target();
           break;
         case GCODE_DEVICE_INFO:
-          gcode.print_device_info(device_serial, device_model, device_version);
+          gcode.print_device_info(device_serial, device_model, FW_VERSION);
           break;
         case GCODE_DFU:
           gcode.send_ack(); // Send ack here since we not reaching the end of the loop

--- a/modules/temp-deck/temp-deck-arduino/temp-deck.h
+++ b/modules/temp-deck/temp-deck-arduino/temp-deck.h
@@ -24,7 +24,13 @@
 #include "thermistor.h"
 #include "gcode.h"
 
-#define device_version "v2.0.0"
+/********* Version **********/
+#ifdef TD_FW_VERSION
+  #define FW_VERSION String(TD_FW_VERSION)
+#else
+  #error "No firmware version provided"
+#endif
+
 #define MODEL_VER_TEMPLATE "temp_deck_v"
 #define MODEL_VER_TEMPLATE_LEN sizeof(MODEL_VER_TEMPLATE) - 1
 #define SERIAL_VER_TEMPLATE "TDV03P2018"

--- a/modules/thermo-cycler/production/serial_and_firmware_uploader.py
+++ b/modules/thermo-cycler/production/serial_and_firmware_uploader.py
@@ -15,7 +15,7 @@ from serial.tools.list_ports import comports
 from argparse import ArgumentParser
 
 THIS_DIR = PurePath(__file__).parent
-DEFAULT_FW_FILE_PATH = THIS_DIR.parent.joinpath('thermo-cycler', 'thermo-cycler-arduino.ino.bin')
+DEFAULT_FW_FILE_PATH = THIS_DIR.joinpath('thermo-cycler-arduino.ino.bin')
 EEPROM_WRITER_PATH = THIS_DIR.joinpath('eepromWriter.ino.bin')
 OPENTRONS_VID       = 0x04d8
 ADAFRUIT_VID        = 0x239a


### PR DESCRIPTION
## overview

This PR adds versioning for magdeck & tempdeck through git tags. Similar to the thermocycler, the two modules will extract version number from appropriately named tags eg. 'tempdeck@v2.1.0' for tempdeck or 'magdeck@v1.1.0' for magdeck. 

## changes
- pass magdeck & tempdeck firmware versions from git tags to firmware during build
- deploy release firmware with the 'release' suffix

## review requests
- Does the deploy scheme make sense? 
~- The deployed bundle still consists of all 3 modules' firmware bundled together in a zip~ (Changed as per requested to deploy each module firmware in its own zip), except now the firmwares will contain their own version number. So each module will have its own, independent release but the bundle will also contain non-release versions for the other modules. Would this work for the update api?
