### PR TITLE
chore(CI): deploy process per module, one travis job 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,41 +13,48 @@ install:
 env:
   global:
     - THIS_BUILD_TAG=`git describe --tags`
-    - MD_TAG=`git describe --tags --match "magdeck*"`
-    - TD_TAG=`git describe --tags --match "tempdeck*"`
-    - TC_TAG=`git describe --tags --match "thermocycler*"`
+
+# base configs
+_deploy_s3: &deploy_s3
+  provider: s3
+  skip_cleanup: true
+  access_key_id: $AWS_ACCESS_KEY_ID
+  secret_access_key: $AWS_SECRET_ACCESS_KEY
+  region: us-east-2
+  acl: public_read
+  bucket: opentrons-modules-builds
+  dot_match: true
+  on:
+    all_branches: true
 
 jobs:
   include:
-    - stage: deploy1
+    - stage: deploy
       name: Branch build
-      env: BRANCH_NAME=$TRAVIS_BRANCH
       if: tag IS blank
+      script:
+        - make build
+        - make zip-all
+      before_deploy:
+        - make clean
+      deploy:
+        - # upload all branch artifacts to S3
+          <<: *deploy_s3
+          local_dir: ./build
+          upload_dir: modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
 
-    - stage: deploy2
+    - stage: deploy
       name: Release build
-      env: BRANCH_NAME=release
       if: tag IS present
-
-script:
-  - make build MD_TAG=$MD_TAG TD_TAG=$TD_TAG TC_TAG=$TC_TAG
-  - make zip-all
-
-before_deploy:
-  - make clean
-
-deploy:
-  - provider: s3
-    access_key_id: $AWS_ACCESS_KEY_ID
-    secret_access_key: $AWS_SECRET_ACCESS_KEY
-    bucket: opentrons-modules-builds
-    region: us-east-2
-    skip_cleanup: true
-    local_dir: ./build
-    acl: public_read
-    upload_dir: modules-$THIS_BUILD_TAG-$BRANCH_NAME
-    on:
-      all_branches: true
+      script:
+        - make build
+      before_deploy:
+        - source set_release_vars.sh
+      deploy:
+        - # upload module release artifacts to S3
+          <<: *deploy_s3
+          local_dir: $RELEASE_LOCAL_DIR
+          upload-dir: $RELEASE_UPLOAD_DIR
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ cache:
 install:
   - make setup
 
-env:
-  global:
-    - THIS_BUILD_TAG=`git describe --tags`
-
 # base configs
 _deploy_s3: &deploy_s3
   provider: s3
@@ -30,23 +26,12 @@ _deploy_s3: &deploy_s3
 jobs:
   include:
     - stage: deploy
-      name: Branch build
-      if: tag IS blank
+      name: deploy build
       script:
         - make build
-      deploy:
-        - # upload all branch artifacts to S3
-          <<: *deploy_s3
-          local_dir: ./build
-          upload_dir: modules-$THIS_BUILD_TAG-$TRAVIS_BRANCH
-
-    - stage: deploy
-      name: Release build
-      if: tag IS present
-      script:
-        - make build
+        - make zip-all
       before_deploy:
-        - source ./scripts/set_release_vars.sh
+        - source ./scripts/set_build_vars.sh
       deploy:
         - # upload module release artifacts to S3
           <<: *deploy_s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
       script:
         - make build
       before_deploy:
-        - source set_release_vars.sh
+        - source ./scripts/set_release_vars.sh
       deploy:
         - # upload module release artifacts to S3
           <<: *deploy_s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,6 @@ jobs:
       if: tag IS blank
       script:
         - make build
-        - make zip-all
-      before_deploy:
-        - make clean
       deploy:
         - # upload all branch artifacts to S3
           <<: *deploy_s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
         - # upload module release artifacts to S3
           <<: *deploy_s3
           local_dir: $RELEASE_LOCAL_DIR
-          upload-dir: $RELEASE_UPLOAD_DIR
+          upload_dir: $RELEASE_UPLOAD_DIR
 
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -76,24 +76,20 @@ setup:
 	$(if $(NO_OPENTRONS_BOARDS), $(ARDUINO) --install-boards Opentrons:avr, @echo "Opentrons boards already installed")
 
 .PHONY: build
-build: build-magdeck build-tempdeck build-thermocycler build-tc-eeprom
+build: build-magdeck build-tempdeck build-thermocycler
 
 # Magdeck flags
-MD_TAG ?= magdeck@unknown
-MD_FW_VERSION := $(shell cut -d'@' -f2 <<<"$(MD_TAG)")
+MD_FW_VERSION := $(shell git describe --tags --match "magdeck*" | cut -d'@' -f2)
 
 # Tempdeck flags
-TD_TAG ?= tempdeck@unknown
-TD_FW_VERSION := $(shell cut -d'@' -f2 <<<"$(TD_TAG)")
+TD_FW_VERSION := $(shell git describe --tags --match "tempdeck*" | cut -d'@' -f2)
 
 # Thermocycler flags
-TC_TAG ?= thermocycler@unknown
-TC_FW_VERSION := $(shell cut -d'@' -f2 <<<"$(TC_TAG)")
+TC_FW_VERSION := $(shell git describe --tags --match "thermocycler*" | cut -d'@' -f2)
 
 MAGDECK_BUILD_DIR := $(BUILDS_DIR)/mag-deck-$(MD_FW_VERSION)
 TEMPDECK_BUILD_DIR := $(BUILDS_DIR)/temp-deck-$(TD_FW_VERSION)
 TC_BUILD_DIR := $(BUILDS_DIR)/thermo-cycler-$(TC_FW_VERSION)
-TC_EEPROM_WR_BUILD_DIR := $(BUILDS_DIR)/tc-eeprom-writer-$(TC_FW_VERSION)
 
 DUMMY_BOARD ?= false
 LID_WARNING ?= false
@@ -128,26 +124,23 @@ build-thermocycler:
 	-DRGBW_NEO=$(RGBW_NEO) -DVOLUME_DEPENDENCY=$(VOLUME_DEPENDENCY) \
 	-DTC_FW_VERSION=\"$(TC_FW_VERSION)\"" \
 	> $(ARDUINO15_LOC)/packages/Opentrons/hardware/samd/$(OPENTRONS_SAMD_BOARDS_VER)/platform.local.txt
+
+	# build firmware
 	$(ARDUINO) --verify --board Opentrons:samd:thermocycler_m0 $(MODULES_DIR)/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino --verbose-build
 	mkdir -p $(TC_BUILD_DIR)
-	mkdir -p $(TC_EEPROM_WR_BUILD_DIR)
 	cp $(BUILDS_DIR)/tmp/thermo-cycler-arduino.ino.bin $(TC_BUILD_DIR)
-	cp $(BUILDS_DIR)/tmp/thermo-cycler-arduino.ino.bin $(TC_EEPROM_WR_BUILD_DIR) # tc eepromWriter needs the same firmware file
 	cp $(MODULES_DIR)/thermo-cycler/production/firmware_uploader.py $(TC_BUILD_DIR)
 
-.PHONY: build-tc-eeprom
-build-tc-eeprom:
+	# build eeprom writer
 	$(ARDUINO) --verify --board Opentrons:samd:thermocycler_m0 $(MODULES_DIR)/thermo-cycler/production/eepromWriter/eepromWriter.ino --verbose-build
-	mkdir -p $(TC_EEPROM_WR_BUILD_DIR)
-	cp $(BUILDS_DIR)/tmp/eepromWriter.ino.bin $(TC_EEPROM_WR_BUILD_DIR)
-	cp $(MODULES_DIR)/thermo-cycler/production/serial_and_firmware_uploader.py $(TC_EEPROM_WR_BUILD_DIR)
+	cp $(BUILDS_DIR)/tmp/eepromWriter.ino.bin $(TC_BUILD_DIR)
+	cp $(MODULES_DIR)/thermo-cycler/production/serial_and_firmware_uploader.py $(TC_BUILD_DIR)
 
 .PHONY: zip-all
 zip-all:
 	cd $(BUILDS_DIR) && zip -r mag-deck-$(MD_FW_VERSION).zip mag-deck-$(MD_FW_VERSION) \
 	&& zip -r temp-deck-$(TD_FW_VERSION).zip temp-deck-$(TD_FW_VERSION) \
 	&& zip -r thermo-cycler-$(TC_FW_VERSION).zip thermo-cycler-$(TC_FW_VERSION) \
-	&& zip -r tc-eeprom-writer-$(TC_FW_VERSION).zip tc-eeprom-writer-$(TC_FW_VERSION)
 
 .PHONY: clean
 clean:
@@ -155,7 +148,6 @@ clean:
 	rm -rf $(MAGDECK_BUILD_DIR)
 	rm -rf $(TEMPDECK_BUILD_DIR)
 	rm -rf $(TC_BUILD_DIR)
-	rm -rf $(TC_EEPROM_WR_BUILD_DIR)
 
 .PHONY: teardown
 teardown:

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ build-magdeck:
 	$(ARDUINO) --verify --board Opentrons:avr:magdeck32u4cat $(MODULES_DIR)/mag-deck/mag-deck-arduino/mag-deck-arduino.ino --verbose-build
 	mkdir -p $(MAGDECK_BUILD_DIR)
 	cp $(BUILDS_DIR)/tmp/mag-deck-arduino.ino.hex $(MAGDECK_BUILD_DIR)
+	zip -r $(MAGDECK_BUILD_DIR)/mag-deck-$(MD_FW_VERSION).zip $(MAGDECK_BUILD_DIR)/*
+	rm -rf $(BUILDS_DIR)/tmp
 
 .PHONY: build-tempdeck
 build-tempdeck:
@@ -115,6 +117,8 @@ build-tempdeck:
 	cp $(EEPROM_DIR)/eepromWriter.hex $(TEMPDECK_BUILD_DIR)
 	cp $(EEPROM_DIR)/avrdude.conf $(TEMPDECK_BUILD_DIR)
 	cp $(EEPROM_DIR)/write_module_memory.py $(TEMPDECK_BUILD_DIR)
+	zip -r $(TEMPDECK_BUILD_DIR)/temp-deck-$(TD_FW_VERSION).zip $(TEMPDECK_BUILD_DIR)/*
+	rm -rf $(BUILDS_DIR)/tmp
 
 .PHONY: build-thermocycler
 build-thermocycler:
@@ -135,19 +139,8 @@ build-thermocycler:
 	$(ARDUINO) --verify --board Opentrons:samd:thermocycler_m0 $(MODULES_DIR)/thermo-cycler/production/eepromWriter/eepromWriter.ino --verbose-build
 	cp $(BUILDS_DIR)/tmp/eepromWriter.ino.bin $(TC_BUILD_DIR)
 	cp $(MODULES_DIR)/thermo-cycler/production/serial_and_firmware_uploader.py $(TC_BUILD_DIR)
-
-.PHONY: zip-all
-zip-all:
-	cd $(BUILDS_DIR) && zip -r mag-deck-$(MD_FW_VERSION).zip mag-deck \
-	&& zip -r temp-deck-$(TD_FW_VERSION).zip temp-deck \
-	&& zip -r thermo-cycler-$(TC_FW_VERSION).zip thermo-cycler \
-
-.PHONY: clean
-clean:
+	zip -r $(TC_BUILD_DIR)/thermo-cycler-$(TC_FW_VERSION).zip $(TC_BUILD_DIR)/*
 	rm -rf $(BUILDS_DIR)/tmp
-	rm -rf $(MAGDECK_BUILD_DIR)
-	rm -rf $(TEMPDECK_BUILD_DIR)
-	rm -rf $(TC_BUILD_DIR)
 
 .PHONY: teardown
 teardown:

--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,9 @@ TD_FW_VERSION := $(shell git describe --tags --match "tempdeck*" | cut -d'@' -f2
 # Thermocycler flags
 TC_FW_VERSION := $(shell git describe --tags --match "thermocycler*" | cut -d'@' -f2)
 
-MAGDECK_BUILD_DIR := $(BUILDS_DIR)/mag-deck-$(MD_FW_VERSION)
-TEMPDECK_BUILD_DIR := $(BUILDS_DIR)/temp-deck-$(TD_FW_VERSION)
-TC_BUILD_DIR := $(BUILDS_DIR)/thermo-cycler-$(TC_FW_VERSION)
+MAGDECK_BUILD_DIR := $(BUILDS_DIR)/magnetic-module
+TEMPDECK_BUILD_DIR := $(BUILDS_DIR)/temperature-module
+TC_BUILD_DIR := $(BUILDS_DIR)/thermocycler
 
 DUMMY_BOARD ?= false
 LID_WARNING ?= false

--- a/Makefile
+++ b/Makefile
@@ -138,9 +138,9 @@ build-thermocycler:
 
 .PHONY: zip-all
 zip-all:
-	cd $(BUILDS_DIR) && zip -r mag-deck-$(MD_FW_VERSION).zip mag-deck-$(MD_FW_VERSION) \
-	&& zip -r temp-deck-$(TD_FW_VERSION).zip temp-deck-$(TD_FW_VERSION) \
-	&& zip -r thermo-cycler-$(TC_FW_VERSION).zip thermo-cycler-$(TC_FW_VERSION) \
+	cd $(BUILDS_DIR) && zip -r mag-deck-$(MD_FW_VERSION).zip mag-deck \
+	&& zip -r temp-deck-$(TD_FW_VERSION).zip temp-deck \
+	&& zip -r thermo-cycler-$(TC_FW_VERSION).zip thermo-cycler \
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,6 @@ build-magdeck:
 	$(ARDUINO) --verify --board Opentrons:avr:magdeck32u4cat $(MODULES_DIR)/mag-deck/mag-deck-arduino/mag-deck-arduino.ino --verbose-build
 	mkdir -p $(MAGDECK_BUILD_DIR)
 	cp $(BUILDS_DIR)/tmp/mag-deck-arduino.ino.hex $(MAGDECK_BUILD_DIR)
-	zip -r $(MAGDECK_BUILD_DIR)/mag-deck-$(MD_FW_VERSION).zip $(MAGDECK_BUILD_DIR)/*
 	rm -rf $(BUILDS_DIR)/tmp
 
 .PHONY: build-tempdeck
@@ -117,7 +116,6 @@ build-tempdeck:
 	cp $(EEPROM_DIR)/eepromWriter.hex $(TEMPDECK_BUILD_DIR)
 	cp $(EEPROM_DIR)/avrdude.conf $(TEMPDECK_BUILD_DIR)
 	cp $(EEPROM_DIR)/write_module_memory.py $(TEMPDECK_BUILD_DIR)
-	zip -r $(TEMPDECK_BUILD_DIR)/temp-deck-$(TD_FW_VERSION).zip $(TEMPDECK_BUILD_DIR)/*
 	rm -rf $(BUILDS_DIR)/tmp
 
 .PHONY: build-thermocycler
@@ -139,8 +137,19 @@ build-thermocycler:
 	$(ARDUINO) --verify --board Opentrons:samd:thermocycler_m0 $(MODULES_DIR)/thermo-cycler/production/eepromWriter/eepromWriter.ino --verbose-build
 	cp $(BUILDS_DIR)/tmp/eepromWriter.ino.bin $(TC_BUILD_DIR)
 	cp $(MODULES_DIR)/thermo-cycler/production/serial_and_firmware_uploader.py $(TC_BUILD_DIR)
-	zip -r $(TC_BUILD_DIR)/thermo-cycler-$(TC_FW_VERSION).zip $(TC_BUILD_DIR)/*
 	rm -rf $(BUILDS_DIR)/tmp
+
+.PHONY: zip-all
+zip-all:
+	cp -a $(MAGDECK_BUILD_DIR) $(BUILDS_DIR)/mag-deck-$(MD_FW_VERSION)
+	cp -a $(TEMPDECK_BUILD_DIR) $(BUILDS_DIR)/temp-deck-$(TD_FW_VERSION)
+	cp -a $(TC_BUILD_DIR) $(BUILDS_DIR)/thermo-cycler-$(TC_FW_VERSION)
+	cd $(BUILDS_DIR) && zip -r mag-deck/mag-deck-$(MD_FW_VERSION).zip mag-deck-$(MD_FW_VERSION) \
+	&& zip -r temp-deck/temp-deck-$(TD_FW_VERSION).zip temp-deck-$(TD_FW_VERSION) \
+	&& zip -r thermo-cycler/thermo-cycler-$(TC_FW_VERSION).zip thermo-cycler-$(TC_FW_VERSION)
+	rm -rf $(BUILDS_DIR)/mag-deck-$(MD_FW_VERSION)
+	rm -rf $(BUILDS_DIR)/temp-deck-$(TD_FW_VERSION)
+	rm -rf $(BUILDS_DIR)/thermo-cycler-$(TC_FW_VERSION)
 
 .PHONY: teardown
 teardown:

--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,9 @@ TD_FW_VERSION := $(shell git describe --tags --match "tempdeck*" | cut -d'@' -f2
 # Thermocycler flags
 TC_FW_VERSION := $(shell git describe --tags --match "thermocycler*" | cut -d'@' -f2)
 
-MAGDECK_BUILD_DIR := $(BUILDS_DIR)/magnetic-module
-TEMPDECK_BUILD_DIR := $(BUILDS_DIR)/temperature-module
-TC_BUILD_DIR := $(BUILDS_DIR)/thermocycler
+MAGDECK_BUILD_DIR := $(BUILDS_DIR)/mag-deck
+TEMPDECK_BUILD_DIR := $(BUILDS_DIR)/temp-deck
+TC_BUILD_DIR := $(BUILDS_DIR)/thermo-cycler
 
 DUMMY_BOARD ?= false
 LID_WARNING ?= false

--- a/scripts/set_build_vars.sh
+++ b/scripts/set_build_vars.sh
@@ -3,6 +3,7 @@
 BUILDS_DIR="./build"
 
 RELEASE_VERSION=$(cut -d'@' -f2 <<< $TRAVIS_TAG)
+THIS_BUILD_TAG=$(git describe --tags)
 
 case $TRAVIS_TAG in
 
@@ -22,7 +23,8 @@ case $TRAVIS_TAG in
     ;;
 
   *)
-    echo "No tagged module to prepare for release"
+    export RELEASE_LOCAL_DIR=$BUILDS_DIR
+    export RELEASE_UPLOAD_DIR="modules-${THIS_BUILD_TAG}-${TRAVIS_BRANCH}"
     ;;
 
 esac

--- a/scripts/set_release_vars.sh
+++ b/scripts/set_release_vars.sh
@@ -17,7 +17,7 @@ case $TRAVIS_TAG in
     ;;
 
   thermocycler@v*)
-    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/thermocycler"
+    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/thermo-cycler"
     export RELEASE_UPLOAD_DIR="thermocycler/${RELEASE_VERSION}"
     ;;
 

--- a/scripts/set_release_vars.sh
+++ b/scripts/set_release_vars.sh
@@ -7,17 +7,17 @@ RELEASE_VERSION=$(cut -d'@' -f2 <<< $TRAVIS_TAG)
 case $TRAVIS_TAG in
 
   tempdeck@v*)
-    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/temp-deck"
+    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/temperature-module"
     export RELEASE_UPLOAD_DIR="temperature-module/${RELEASE_VERSION}"
     ;;
 
   magdeck@v*)
-    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/mag-deck"
+    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/magnetic-module"
     export RELEASE_UPLOAD_DIR="magnetic-module/${RELEASE_VERSION}"
     ;;
 
   thermocycler@v*)
-    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/thermo-cycler"
+    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/thermocycler"
     export RELEASE_UPLOAD_DIR="thermocycler/${RELEASE_VERSION}"
     ;;
 

--- a/scripts/set_release_vars.sh
+++ b/scripts/set_release_vars.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+BUILDS_DIR="./build"
+
+RELEASE_VERSION=$(cut -d'@' -f2 <<< $TRAVIS_TAG)
+
+case $TRAVIS_TAG in
+
+  tempdeck@v*)
+    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/temp-deck"
+    export RELEASE_UPLOAD_DIR="temperature-module/${RELEASE_VERSION}"
+    ;;
+
+  magdeck@v*)
+    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/mag-deck"
+    export RELEASE_UPLOAD_DIR="magnetic-module/${RELEASE_VERSION}"
+    ;;
+
+  thermocycler@v*)
+    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/thermocycler"
+    export RELEASE_UPLOAD_DIR="thermocycler/${RELEASE_VERSION}"
+    ;;
+
+  *)
+    echo "no tagged module to prepare for release"
+    ;;
+
+esac

--- a/scripts/set_release_vars.sh
+++ b/scripts/set_release_vars.sh
@@ -22,7 +22,7 @@ case $TRAVIS_TAG in
     ;;
 
   *)
-    echo "no tagged module to prepare for release"
+    echo "No tagged module to prepare for release"
     ;;
 
 esac

--- a/scripts/set_release_vars.sh
+++ b/scripts/set_release_vars.sh
@@ -7,17 +7,17 @@ RELEASE_VERSION=$(cut -d'@' -f2 <<< $TRAVIS_TAG)
 case $TRAVIS_TAG in
 
   tempdeck@v*)
-    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/temperature-module"
+    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/temp-deck"
     export RELEASE_UPLOAD_DIR="temperature-module/${RELEASE_VERSION}"
     ;;
 
   magdeck@v*)
-    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/magnetic-module"
+    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/mag-deck"
     export RELEASE_UPLOAD_DIR="magnetic-module/${RELEASE_VERSION}"
     ;;
 
   thermocycler@v*)
-    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/thermocycler"
+    export RELEASE_LOCAL_DIR="${BUILDS_DIR}/thermo-cycler"
     export RELEASE_UPLOAD_DIR="thermocycler/${RELEASE_VERSION}"
     ;;
 


### PR DESCRIPTION
## Overview

This branch incorporates a couple of changes to the release build deployment process for module firmware.  The branch build artifact generation should remain largely unchanged.

The release process is now as follows:
- Push a tag, e.g. "thermocycler@v3.2.1"
- just the "thermocycler" artifacts will be built in travis
- those artifacts will then be dropped (not compressed) in the modules builds s3 bucket within './thermocycler/v3.2.1/' sub-directory

This will give us a steady location for accessing released firmware binaries for the opentrons modules. Especially from the OT-2 software build process in the forthcoming addition at https://github.com/Opentrons/buildroot/pull/67.

