### PR TITLE
fix(magdeck): return false when no number read

### DIFF
--- a/modules/mag-deck/mag-deck-arduino/gcodemagdeck.cpp
+++ b/modules/mag-deck/mag-deck-arduino/gcodemagdeck.cpp
@@ -84,6 +84,10 @@ bool GcodeMagDeck::read_number(char key) {
       return false;
     }
   }
+  else
+  {
+    return false;
+  }
 }
 
 void GcodeMagDeck::print_device_info(String serial, String model, String version) {


### PR DESCRIPTION
Closes #105 

The code was interpreting absence of a gcode parameter as 'parameter present' (in `gcode.read_number()`). The only gcodes that have optional parameters are the movement type gcodes which have current and speed values as optional. Because of this, the gcode interpreter was reading empty values and setting motor current and speed to zero. This was causing the motor to not move, which was making the firmware to freeze and not respond to any serial input.

Adding the else condition to `read_number` makes sure that the gcode interpreter doesn't read from a non existent parameter & fixes the issue.

Note:
It is possible that Arduino1.8.5 (which was used to build the original firmware 2 years ago) had a different (compiler?) behavior that resulted in default return value of 0 because of which this bug wasn't coming to light. I will be testing this

Update:
The above note is correct.