### PR TITLE
feat(thermocycler): automate offset tuning, make 'stat' response immediate

### DIFF
--- a/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
+++ b/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
@@ -1,0 +1,250 @@
+import serial
+import time
+import threading
+from pathlib import PurePath
+from serial.tools.list_ports import comports
+
+THIS_DIR = PurePath(__file__).parent
+OPENTRONS_VID = 0x04d8
+EUTECH_VID = 0x0403
+TC_BAUDRATE = 115200
+EUTECH_BAUDRATE = 9600
+
+EUTECH_TEMPERATURE = 0
+TC_STATUS = {}
+TEMP_STATUS = {}
+
+GCODES = {
+    'OPEN_LID': 'M126',
+    'CLOSE_LID': 'M127',
+    'GET_LID_STATUS': 'M119',
+    'SET_LID_TEMP': 'M140',
+    'GET_LID_TEMP': 'M141',
+    'DEACTIVATE_LID_HEATING': 'M108',
+    'EDIT_PID_PARAMS': 'M301',
+    'SET_PLATE_TEMP': 'M104',
+    'GET_PLATE_TEMP': 'M105',
+    'SET_RAMP_RATE': 'M566',
+    'DEACTIVATE': 'M18',
+    'DEVICE_INFO': 'M115',
+    'SET_OFFSET_CONSTANTS': 'M116',
+    'GET_OFFSET_CONSTANTS': 'M117',
+    'DEBUG_MODE': 'M111',
+    'CONTINUOUS_DEBUG_STAT': 'cont'
+}
+
+TC_GCODE_ROUNDING_PRECISION = 2
+SERIAL_ACK = '\r\n'
+
+LID_TEMP = 105
+
+
+def find_port(vid):
+    retries = 5
+    while retries:
+        for p in comports():
+            if p.vid == vid:
+                print("Available: {0}->\t(pid:{1:#x})\t(vid:{2:#x})".format(
+                        p.device, p.pid, p.vid))
+                print("Port found:{}".format(p.device))
+                time.sleep(1)
+                return p.device
+        retries -= 1
+        time.sleep(0.5)
+    raise RuntimeError('Could not find Opentrons Thermocycler'
+                       'connected over USB')
+
+
+def connect_to_module(port_name):
+    print('Connecting to module...')
+    port = serial.Serial(port_name, 115200, timeout=1)
+    print('Connected.')
+    return port
+
+
+def get_device_info(port):
+    cmd = '{}{}'.format(GCODES['DEVICE_INFO'], SERIAL_ACK)
+    port.write(cmd.encode())
+    time.sleep(1)
+    info = port.readline()
+    return info
+
+
+def send_tc(tc_port, lock, cmd, get_response=False):
+    with lock:
+        response = None
+        cmd += SERIAL_ACK
+        print("Sending: {}".format(cmd))
+        tc_port.write(cmd.encode())
+        if get_response:
+            time.sleep(0.1)
+            response = tc_port.readline()
+        return response
+
+
+def parse_number_from_substring(substring, rounding_val):
+    '''
+    Returns the number in the expected string "N:12.3", where "N" is the
+    key, and "12.3" is a floating point value
+
+    For the temp-deck or thermocycler's temperature response, one expected
+    input is something like "T:none", where "none" should return a None value
+    '''
+    try:
+        value = substring.split(':')[1]
+        if value.strip().lower() == 'none':
+            return None
+        return round(float(value), rounding_val)
+    except (ValueError, IndexError, TypeError, AttributeError):
+        print('Unexpected argument to parse_number_from_substring:')
+        raise Exception('Unexpected argument to parse_number_from_substring:'
+                        ' {}'.format(substring))
+
+
+def parse_key_from_substring(substring) -> str:
+    '''
+    Returns the axis in the expected string "N:12.3", where "N" is the
+    key, and "12.3" is a floating point value
+    '''
+    try:
+        return substring.split(':')[0]
+    except (ValueError, IndexError, TypeError, AttributeError):
+        print('Unexpected argument to parse_key_from_substring:')
+        raise Exception('Unexpected argument to parse_key_from_substring:'
+                        ' {}'.format(substring))
+
+
+def tc_response_to_dict(response_string, separator):
+    res_dict = {}
+    serial_list = response_string.decode().split(separator)
+    serial_list = list(map(lambda x: x.strip(), serial_list))
+    for substr in serial_list:
+        if substr == '':
+            continue
+        key = parse_key_from_substring(substr)
+        value = parse_number_from_substring(
+                                    substr,
+                                    TC_GCODE_ROUNDING_PRECISION)
+        res_dict[key] = value
+    return res_dict
+
+
+def get_tc_stats(port, lock):
+    send_tc(port, lock, GCODES['DEBUG_MODE'])
+    time.sleep(1)
+    port.reset_input_buffer()
+    send_tc(port, lock, GCODES['CONTINUOUS_DEBUG_STAT'])
+    time.sleep(1)
+    while True:
+        with lock:
+            serial_line = port.readline()
+            if serial_line:
+                TC_STATUS = tc_response_to_dict(serial_line, '\t')
+                TC_STATUS['Plt_current'] = TC_STATUS['T1'] + TC_STATUS['T2'] \
+                    + TC_STATUS['T3'] + TC_STATUS['T4'] \
+                    + TC_STATUS['T5'] + TC_STATUS['T6']
+                print("TC status: {}".format(TC_STATUS))
+                print("---------------------")
+        time.sleep(0.1)
+
+
+def get_eutech_temp(port):
+    port.write('T\r\n'.encode())
+    time.sleep(10)  # takes a long time to start getting any data
+    while True:
+        temp = port.readline().decode().strip()
+        if temp:
+            try:
+                EUTECH_TEMPERATURE = float(temp)
+                print("EUTECH probe: {}".format(EUTECH_TEMPERATURE))
+            except:     # ignore non-numeric responses
+                pass
+        time.sleep(0.01)
+
+
+def tc_temp_stability_check(target, tolerance=0.2):
+    # Compares sensor_op & target values over 10 seconds
+    # Returns true if sensor_op is within allowed range of target throughout
+    for i in range(10):
+        if abs(target - TC_STATUS['Plt_current']) > 0.2:
+            return False
+        time.sleep(1)
+    return True
+
+
+def eutech_temp_stability_check(target, tolerance=0.2):
+    # Compares sensor_op & target values over 10 seconds
+    # Returns true if sensor_op is within allowed range of target throughout
+    for i in range(10):
+        if abs(target - EUTECH_TEMPERATURE) > tolerance:
+            return False
+        time.sleep(1)
+    return True
+
+
+def offset_tuning(tc_port, lock):
+    while not EUTECH_TEMPERATURE and not TC_STATUS:
+        time.sleep(0.1)
+    # 1. Set lid temp
+    send_tc(tc_port, lock, '{} {}'.format(GCODES['SET_LID_TEMP'], LID_TEMP))
+    while TC_STATUS['T.Lid'] < LID_TEMP:
+        time.sleep(1)
+    # 2. Set TC to 10C to heat up the heatsink and bring it to usual operating
+    #    temp level
+    send_tc(tc_port, lock, '{} {}'.format(GCODES['SET_PLATE_TEMP'], 10))
+    while TC_STATUS['T.sink'] < 50:
+        time.sleep(0.5)
+    # 3. Set TC to 70C to start tuning
+    send_tc(tc_port, lock, '{} {}'.format(GCODES['SET_PLATE_TEMP'], 70))
+    # Wait until temperature stabilizes
+    while not tc_temp_stability_check(70):
+        time.sleep(0.5)
+    # Make sure heatsink is around 53C
+    while abs(53 - TC_STATUS['T.sink']) > 1:
+        time.sleep(0.5)
+    # Tune the offset at 70
+    if EUTECH_TEMPERATURE != TC_STATUS['Plt_current']:
+        serial_line = send_tc(tc_port, lock, GCODES['GET_OFFSET_CONSTANTS'],
+                              get_response=True)
+        offset_dict = tc_response_to_dict(serial_line, ' ')
+        c_offset = offset_dict['C']
+        c_offset += EUTECH_TEMPERATURE - TC_STATUS['Plt_current']
+        send_tc(tc_port, lock,
+                '{} C{}'.format(GCODES['SET_OFFSET_CONSTANTS'], c_offset))
+        time.sleep(4)
+        retries = 5
+        while not eutech_temp_stability_check(70, tolerance=0):
+            retries -= 1
+            time.sleep(1)
+            if retries == 0:
+                raise Exception("Unable to tune offset at 70")
+        print("-------------------")
+        print("Offset tuning at 70 passed")
+        print("-------------------")
+
+
+if __name__ == '__main__':
+    print("Searching for connected devices..")
+    tc_port = serial.Serial(find_port(OPENTRONS_VID),
+                            TC_BAUDRATE,
+                            timeout=1)
+    eutech_port = serial.Serial(find_port(EUTECH_VID),
+                                EUTECH_BAUDRATE,
+                                timeout=1)
+    print("Connected to thermocycler")
+    print("-------------------")
+    print("Device info:{}".format(get_device_info(tc_port)))
+    print("-------------------")
+    time.sleep(1)
+    print("Please record the serial & model number in spreadsheet. Find the "
+          "average well from QC sheet and attach thermometer probe to it")
+    input("When you are ready to resume with offset tuning, press ENTER")
+    lock = threading.Lock()
+    tc_status_fetcher = threading.Thread(target=get_tc_stats,
+                                         args=(tc_port, lock))
+    eutech_temp_fetcher = threading.Thread(target=get_eutech_temp,
+                                           args=(eutech_port,))
+    offset_tuner = threading.Thread(target=offset_tuning, args=(tc_port, lock))
+    eutech_temp_fetcher.start()
+    tc_status_fetcher.start()
+    tc_status_fetcher.join()

--- a/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
+++ b/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
@@ -521,8 +521,10 @@ if __name__ == '__main__':
     # if flag included, run entire tuning procedure 3 times
     if args.f == True:
         cycles = 3
+        log.info("Flag for complete tuning, running {} cycles of tuning.".format(cycles))
+        get_offset('C')
         set_offset('C', default_c)
-        log.info("Flag for complete tuning, running {} cycles of tuning. Starting c_offset at default {}".format(cycles, default_c))
+        log.info("For complete tune, starting c_offset at default of {}".format(default_c))
 
     # Threads
     tc_status_fetcher = threading.Thread(target=get_tc_stats, daemon=True)

--- a/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
+++ b/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
@@ -236,6 +236,7 @@ def offset_tuning():
     c_adjustment(TUNING_TEMPS[0], t_sink=53, temp_tolerance=0.009)
     if args.b == True:
         b_adjustment()
+        c_adjustment(TUNING_TEMPS[0], t_sink=53, temp_tolerance=0.009)
 
     # Thermocycler prepped. Start c tuning:
     attempts = 3
@@ -330,6 +331,7 @@ def c_adjustment(temp, t_sink=None, temp_tolerance=0.2):
         set_offset('C', new_c)
         time.sleep(5)
         stabilize_everything(temp, t_sink)
+        log_status()
         return 'adjusted'
     else:
         return 'not adjusted'

--- a/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
+++ b/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
@@ -279,7 +279,7 @@ def stabilize_everything(temp, t_sink=None):
         log_status()
 
     log.info("Waiting for Eutech probe to stabilize...")
-    while not eutech_temp_stability_check(tolerance=0.019):
+    while not eutech_temp_stability_check(tolerance=0.01):
         time.sleep(0.5)
     log.info("EUTECH probe temp stabilized.")
     log_status()
@@ -404,6 +404,7 @@ def build_arg_parser():
     arg_parser.add_argument("-L", "--loglevel", required=False,
                             default='INFO')
     arg_parser.add_argument("-p", "--eutech_port_name", required=True)
+    arg_parser.add_argument("-m", "--tc_port_name", required=True)
     arg_parser.add_argument("-b", action = "store_true")
     return arg_parser
 
@@ -418,8 +419,8 @@ if __name__ == '__main__':
 
     # Connections
     print("Searching for connected devices..")
-    tc_port = serial_comm.find_port(OPENTRONS_VID)
-    tc = serial_comm.SerialComm(tc_port, log_level)
+    # tc_port = serial_comm.find_port(OPENTRONS_VID)
+    tc = serial_comm.SerialComm(args.tc_port_name, log_level)
     eutech_port = serial.Serial(args.eutech_port_name,
                                 EUTECH_BAUDRATE,
                                 timeout=1)

--- a/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
+++ b/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
@@ -518,12 +518,12 @@ if __name__ == '__main__':
         print("Done.")
 
     cycles = 1
+    get_offset('B')  # print b_offset at start of test
+    get_offset('C')  # print c_offset at start of test
 
-    # if flag included, run entire tuning procedure 3 times
-    if args.f == True:
+    if args.f == True:  # if flag included, run entire tuning procedure 3 times
         cycles = 3
         log.info("Flag for complete tuning, running {} cycles of tuning.".format(cycles))
-        get_offset('C')
         set_offset('C', default_c)
         log.info("For complete tune, starting c_offset at default of {}".format(default_c))
 

--- a/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
+++ b/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
@@ -259,23 +259,27 @@ def stabilize_everything(temp, t_sink=None):
         time.sleep(0.5)
     log.info("TC Temperature stabilized.")
     log_status()
+    if t_sink:
+        log.info("Waiting for heatsink to reach 51-55 C...".format(t_sink))
+        if TC_STATUS['T.sink'] - t_sink > 2:
+            set_fan(False, 0.25) # increase fan speed to cool heatsink
+        while abs(TC_STATUS['T.sink'] - t_sink) > 2:
+            time.sleep(0.1)
+        set_fan(True)
+        log.info("Heatsink temperature achieved.")
+        log_status()
+
     log.info("Waiting for Eutech probe to stabilize...")
     while not eutech_temp_stability_check(tolerance=0.019):
         time.sleep(0.5)
     log.info("EUTECH probe temp stabilized.")
     log_status()
-    if t_sink:
-        log.info("Waiting for heatsink to reach 51-55 C...".format(t_sink))
-        while abs(TC_STATUS['T.sink'] - t_sink) > 2:
-            pass
-        log.info("Heatsink temperature achieved.")
-        log_status()
 
 
 def set_fan(auto, speed=None):
     if not auto:
         tc.send_and_get_response(
-            '{} {}'.format(GCODES['SET_FAN_SPEED'], speed))
+            '{} S{}'.format(GCODES['SET_FAN_SPEED'], speed))
     else:
         tc.send_and_get_response(GCODES['AUTO_FAN'])
 

--- a/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
+++ b/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
@@ -339,22 +339,6 @@ def tuning_readjustments(temp):
         time.sleep(0.5)
     log.info(" ---- EUTECH probe temp stabilized ---- ")
 
-    # If target temperature is 70C, make sure heatsink around 53C
-    if temp == 70:
-        while abs(53 - TC_STATUS['T.sink']) > 2:
-            time.sleep(0.5)
-            send_tc(tc_port, lock, '{} S{}'.format(GCODES['SET_FAN_SPEED'], 0.25)) # increase fan speed to cool heatsink
-        send_tc(tc_port, lock, '{}'.format(GCODES['AUTO_FAN']))
-        log.info(" ---- Heatsink is approx. 53C ---- ")
-
-        # Wait until temperature stabilizes when heatsink at proper temp
-        while not tc_temp_stability_check(temp):
-            time.sleep(0.5)
-        log.info(" ---- TC Temperature stabilized ----")
-        while not eutech_temp_stability_check():
-            time.sleep(0.5)
-        log.info(" ---- EUTECH probe temp stabilized ---- ")
-
     # Record experimental temperature before adjusted c_offset
     record_vals.append([temp, EUTECH_TEMPERATURE])
 

--- a/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
+++ b/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
@@ -18,6 +18,7 @@ EUTECH_TEMPERATURE = None
 TC_STATUS = {}
 TUNING_OVER = False
 TC_SERIAL = None
+default_c = 0.15
 all_c_offsets = []
 
 
@@ -445,8 +446,8 @@ def calc_final_c_offset(record_vals):
                 fail_count += 1
 
         if fail_count > 1:
-            log.info("Not enough successful tunes. Returning c_offset to default of 0.15.")
-            final_c = 0.15
+            log.info("Not enough successful tunes. Returning c_offset to default of {}.".format(default_c))
+            final_c = default_c
         else:
             if record_vals[0] == 'FAIL': # if first attempt fails, take average of attempt 2/3
                 final_c = (record_vals[1]+record_vals[2])/2
@@ -520,7 +521,8 @@ if __name__ == '__main__':
     # if flag included, run entire tuning procedure 3 times
     if args.f == True:
         cycles = 3
-        log.info("Flag for complete tuning, running {} cycles of tuning".format(cycles))
+        set_offset('C', default_c)
+        log.info("Flag for complete tuning, running {} cycles of tuning. Starting c_offset at default {}".format(cycles, default_c))
 
     # Threads
     tc_status_fetcher = threading.Thread(target=get_tc_stats, daemon=True)

--- a/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
+++ b/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
@@ -72,6 +72,7 @@ def get_device_info(port, lock):
     port.reset_input_buffer()
     info = send_tc(port, lock, GCODES['DEVICE_INFO'], get_response=True)
     port.reset_input_buffer()
+
     return info
 
 
@@ -204,7 +205,7 @@ def eutech_temp_stability_check(target=None, tolerance=0.2):
     if target is None:
         prev_temp = EUTECH_TEMPERATURE
         for i in range(10):
-            if abs(prev_temp - EUTECH_TEMPERATURE) > 0.015:
+            if abs(prev_temp - EUTECH_TEMPERATURE) > 0.003:
                 return False
             prev_temp = EUTECH_TEMPERATURE
             time.sleep(2)
@@ -357,6 +358,8 @@ if __name__ == '__main__':
                                 EUTECH_BAUDRATE,
                                 timeout=1)
     lock = threading.Lock()
+    # Disable continuous debug stat if in debug mode
+    send_tc(tc_port, lock, GCODES['PRINT_DEBUG_STAT'])
     log.info("Connected to thermocycler")
     print("-------------------")
     log.info("Device info:{}".format(get_device_info(tc_port, lock)))

--- a/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
+++ b/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
@@ -1,8 +1,11 @@
 import serial
 import time
 import threading
+import logging
 from pathlib import PurePath
 from serial.tools.list_ports import comports
+from argparse import ArgumentParser
+
 
 THIS_DIR = PurePath(__file__).parent
 OPENTRONS_VID = 0x04d8
@@ -13,6 +16,8 @@ EUTECH_BAUDRATE = 9600
 EUTECH_TEMPERATURE = None
 TC_STATUS = {}
 TEMP_STATUS = {}
+OFFSET_TUNER = None
+log = logging.getLogger(__name__)
 
 GCODES = {
     'OPEN_LID': 'M126',
@@ -30,6 +35,7 @@ GCODES = {
     'SET_OFFSET_CONSTANTS': 'M116',
     'GET_OFFSET_CONSTANTS': 'M117',
     'DEBUG_MODE': 'M111',
+    'PRINT_DEBUG_STAT': 'stat',
     'CONTINUOUS_DEBUG_STAT': 'cont'
 }
 
@@ -62,11 +68,10 @@ def connect_to_module(port_name):
     return port
 
 
-def get_device_info(port):
-    cmd = '{}{}'.format(GCODES['DEVICE_INFO'], SERIAL_ACK)
-    port.write(cmd.encode())
-    time.sleep(1)
-    info = port.readline()
+def get_device_info(port, lock):
+    port.reset_input_buffer()
+    info = send_tc(port, lock, GCODES['DEVICE_INFO'], get_response=True)
+    port.reset_input_buffer()
     return info
 
 
@@ -74,13 +79,13 @@ def send_tc(tc_port, lock, cmd, get_response=False):
     with lock:
         response = bytearray(b'')
         cmd += SERIAL_ACK
-        print("Sending: {}".format(cmd))
+        log.debug("Sending: {}".format(cmd))
         tc_port.write(cmd.encode())
         if get_response:
             time.sleep(0.1)
             while tc_port.in_waiting:
                 response.extend(tc_port.readline())
-        print("Received:{}".format(response))
+        log.debug("Received:{}".format(response))
         return response
 
 
@@ -139,7 +144,7 @@ def get_tc_stats(port, lock):
     port.reset_input_buffer()
     send_tc(port, lock, GCODES['CONTINUOUS_DEBUG_STAT'])
     time.sleep(1)
-    while True:
+    while OFFSET_TUNER.is_alive():
         with lock:
             serial_line = port.readline()
             if serial_line:
@@ -150,8 +155,15 @@ def get_tc_stats(port, lock):
             current_temp = tc_response_to_dict(get_temp_res, ' ')
             _tc_status['Plt_current'] = current_temp['C']
         TC_STATUS = _tc_status
-        print("TC status: {}".format(TC_STATUS))
-        print("---------------------")
+        printy_stat_keys = ['Plt_Target', 'Plt_current', 'Cov_Target', 'T.Lid',
+                            'T.sink', 'T.offset', 'Fan', 'millis']
+        print("TC status:", end=" ")
+        for (k, v) in TC_STATUS.items():
+            if k in printy_stat_keys:
+                print("{}: {} \t".format(k, v), end=" ")
+            # if k not in printy_stat_keys:
+            #     log.debug("{}: {}".format(k, v))
+        print()
         time.sleep(0.1)
 
 
@@ -160,13 +172,15 @@ def get_eutech_temp(port):
     port.write('T\r\n'.encode())
     time.sleep(10)  # takes a long time to start getting any data
     t = 0
-    while True:
+    while OFFSET_TUNER.is_alive():
         temp = port.readline().decode().strip()
         if temp:
             try:
                 EUTECH_TEMPERATURE = float(temp)
-                if time.time() - t > 2:
+                if time.time() - t > 1:
+                    # print("---------------------")
                     print("EUTECH probe: {}".format(EUTECH_TEMPERATURE))
+                    # print("---------------------")
                     t = time.time()
             except ValueError:     # ignore non-numeric responses from Eutech
                 pass
@@ -179,72 +193,99 @@ def tc_temp_stability_check(target, tolerance=0.2):
     for i in range(10):
         if abs(target - TC_STATUS['Plt_current']) > 0.2:
             return False
-        time.sleep(1)
+        time.sleep(2)
     return True
 
 
-def eutech_temp_stability_check(target, tolerance=0.2):
+def eutech_temp_stability_check(target=None, tolerance=0.2):
     # Compares sensor_op & target values over 10 seconds
     # Returns true if sensor_op is within allowed range of target throughout
-    for i in range(10):
-        if abs(target - EUTECH_TEMPERATURE) > tolerance:
-            return False
-        time.sleep(1)
+    if target is None:
+        prev_temp = EUTECH_TEMPERATURE
+        for i in range(10):
+            if abs(prev_temp - EUTECH_TEMPERATURE) > 0.015:
+                return False
+            prev_temp = EUTECH_TEMPERATURE
+            time.sleep(2)
+    else:
+        for i in range(10):
+            if abs(target - EUTECH_TEMPERATURE) > tolerance:
+                return False
+            time.sleep(2)
     return True
 
 
 def offset_tuning(tc_port, lock):
-    print("###### STARTING OFFSET TUNER ######")
+    log.info("###### STARTING OFFSET TUNER ######")
     while EUTECH_TEMPERATURE is None or TC_STATUS == {}:
         time.sleep(0.4)
-        print("Waiting for temp statuses from both thermometer & TC")
+        log.info("Waiting for temp statuses from both thermometer & TC")
     # 1. Set lid temp
-    print(" ---- Setting lid temperature ---- ")
+    log.info(" ---- Setting lid temperature ---- ")
     send_tc(tc_port, lock, '{} {}'.format(GCODES['SET_LID_TEMP'], LID_TEMP))
     while TC_STATUS['T.Lid'] < LID_TEMP:
         time.sleep(1)
-    print(" ---- Lid temp reached ----")
+    log.info(" ---- Lid temp reached ----")
     # 2. Set TC to 10C to heat up the heatsink and bring it to usual operating
     #    temp level
-    print(" ---- Set plate to 10C & wait until heatsink is 50C ---- ")
+    log.info(" ---- Set plate to 10C & wait until heatsink is 50C ---- ")
     send_tc(tc_port, lock, '{} S{}'.format(GCODES['SET_PLATE_TEMP'], 10))
     while TC_STATUS['T.sink'] < 50:
         time.sleep(0.5)
-    print(" ---- Heatsink temp reached ---- ")
+    log.info(" ---- Heatsink temp reached ---- ")
     # 3. Set TC to 70C to start tuning
-    print(" ---- Set plate to 70C and start tuning ---- ")
+    log.info(" ---- Set plate to 70C and start tuning ---- ")
     send_tc(tc_port, lock, '{} S{}'.format(GCODES['SET_PLATE_TEMP'], 70))
     # Wait until temperature stabilizes
     while not tc_temp_stability_check(70):
         time.sleep(0.5)
-    print(" ---- Temperature stabilized ----")
+    log.info(" ---- TC Temperature stabilized ----")
+    while not eutech_temp_stability_check():
+        time.sleep(0.5)
+    log.info(" ---- EUTECH probe temp stabilized ---- ")
     # Make sure heatsink is around 53C
     while abs(53 - TC_STATUS['T.sink']) > 2:
         time.sleep(0.5)
-    print(" ---- Heatsink is approx. 53C ---- ")
+    log.info(" ---- Heatsink is approx. 53C ---- ")
     # Tune the offset at 70
     if abs(EUTECH_TEMPERATURE - TC_STATUS['Plt_current']) > 0.009:
-        print(" ====> Temperatures not equal. Updating offset ====> ")
+        log.info(" ====> Temperatures not equal. Updating offset ====> ")
         serial_line = send_tc(tc_port, lock, GCODES['GET_OFFSET_CONSTANTS'],
                               get_response=True)
         offset_dict = tc_response_to_dict(serial_line, '\n')
         c_offset = offset_dict['C']
         c_offset += round((EUTECH_TEMPERATURE - TC_STATUS['Plt_current']), 3)
+        log.info("Setting C offset to {}".format(c_offset))
         send_tc(tc_port, lock,
                 '{} C{}'.format(GCODES['SET_OFFSET_CONSTANTS'], c_offset))
         time.sleep(4)
-        retries = 5
-        while not eutech_temp_stability_check(70, tolerance=0.005):
+        retries = 10
+        while not eutech_temp_stability_check(70, tolerance=0.009):
+            print("Temp probe not yet stable. Retry#{}".format(retries))
             retries -= 1
-            time.sleep(2)
+            time.sleep(5)
             if retries == 0:
                 raise Exception("Unable to tune offset at 70")
-    print("-------------------")
+    print("\n-------------------")
     print("Offset tuning at 70 passed")
     print("-------------------")
+    # 4. Check tuning at 72C
+
+
+def build_arg_parser():
+    arg_parser = ArgumentParser(description="Thermocycler offset tuner")
+    arg_parser.add_argument("-L", "--loglevel", required=False,
+                            default='INFO')
+    return arg_parser
 
 
 if __name__ == '__main__':
+    arg_parser = build_arg_parser()
+    args = arg_parser.parse_args()
+    numeric_level = getattr(logging, args.loglevel.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError('Invalid log level: %s' % args.loglevel)
+    logging.basicConfig(level=numeric_level)
     print("Searching for connected devices..")
     tc_port = serial.Serial(find_port(OPENTRONS_VID),
                             TC_BAUDRATE,
@@ -252,22 +293,25 @@ if __name__ == '__main__':
     eutech_port = serial.Serial(find_port(EUTECH_VID),
                                 EUTECH_BAUDRATE,
                                 timeout=1)
-    print("Connected to thermocycler")
+    lock = threading.Lock()
+    log.info("Connected to thermocycler")
     print("-------------------")
-    print("Device info:{}".format(get_device_info(tc_port)))
+    log.info("Device info:{}".format(get_device_info(tc_port, lock).decode()))
     print("-------------------")
     time.sleep(1)
     print("Please record the serial & model number in spreadsheet. Find the "
           "average well from QC sheet and attach thermometer probe to it")
     input("When you are ready to resume with offset tuning, press ENTER")
-    lock = threading.Lock()
     tc_status_fetcher = threading.Thread(target=get_tc_stats,
                                          args=(tc_port, lock))
     eutech_temp_fetcher = threading.Thread(target=get_eutech_temp,
                                            args=(eutech_port,))
-    offset_tuner = threading.Thread(target=offset_tuning, args=(tc_port, lock))
+    OFFSET_TUNER = threading.Thread(target=offset_tuning, args=(tc_port, lock))
+    OFFSET_TUNER.start()
     eutech_temp_fetcher.start()
     tc_status_fetcher.start()
-    offset_tuner.start()
-    offset_tuner.join()
-    # TODO: Deactivate TC and reset debug mode
+    OFFSET_TUNER.join()
+    log.info("Deactivating thermocycler.")
+    send_tc(tc_port, lock, GCODES['DEACTIVATE'])
+    log.info("Disabling continuous status.")
+    send_tc(tc_port, lock, GCODES['PRINT_DEBUG_STAT'])

--- a/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
+++ b/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
@@ -328,12 +328,11 @@ def c_adjustment(temp, t_sink=None, temp_tolerance=0.2):
                 buffer_tolerance = buffer_tolerance*(-1) 
             new_c = c + (difference + buffer_tolerance)
         set_offset('C', new_c)
-        return 'adjusted'
         time.sleep(5)
+        stabilize_everything(temp, t_sink)
+        return 'adjusted'
     else:
         return 'not adjusted'
-    time.sleep(3)
-    stabilize_everything(temp, t_sink)
 
 def b_adjustment():
     log.info("ADJUSTING B OFFSET ====>")
@@ -343,7 +342,7 @@ def b_adjustment():
     # Solve for m & k using observed datapoints
     # Then find b_offset for ideal condition of y =  94C - 40C
     get_offset('B')     # Just for comparison & documentation purposes
-    b_vals = (0.005, 0.05)
+    b_vals = (0.005, 0.06)
     ideal_temps = (70, 94, 70, 40)
     observed_temps = {}
     for val in b_vals:

--- a/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
+++ b/modules/thermo-cycler/QC/offset_tuning/offset_tuning.py
@@ -48,6 +48,7 @@ TC_GCODE_ROUNDING_PRECISION = 2
 SERIAL_ACK = '\r\n'
 
 LID_TEMP = 105
+TUNING_TEMPS = (70, 72, 94, 70, 40)
 
 
 def find_port(vid):
@@ -75,24 +76,25 @@ def connect_to_module(port_name):
 
 def get_device_info(port, lock):
     port.reset_input_buffer()
-    info = send_tc(port, lock, GCODES['DEVICE_INFO'], get_response=True)
+    info = send_and_get_response(port, lock, GCODES['DEVICE_INFO'])
     port.reset_input_buffer()
 
     return info
 
 
-def send_tc(tc_port, lock, cmd, get_response=False):
+def send_and_get_response(tc_port, lock, cmd):
     with lock:
         response_str = ''
         cmd += SERIAL_ACK
         log.debug("Sending: {}".format(cmd))
         tc_port.write(cmd.encode())
-        if get_response:
-            raw_response = bytearray(b'')
-            time.sleep(0.1)
-            while tc_port.in_waiting:
-                raw_response.extend(tc_port.readline())
-            response_str = raw_response.decode().replace('ok', '').strip()
+        raw_response = bytearray(b'')
+        time.sleep(0.1)
+        while True:
+            raw_response.extend(tc_port.readline())
+            if not tc_port.in_waiting:
+                break
+        response_str = raw_response.decode().replace('ok', '').strip()
         log.debug("Received:{}".format(response_str))
         return response_str
 
@@ -133,6 +135,7 @@ def tc_response_to_dict(response_string, separator):
     res_dict = {}
     serial_list = response_string.split(separator)
     serial_list = list(map(lambda x: x.strip(), serial_list))
+    log.debug("Serial list:{}".format(serial_list))
     for substr in serial_list:
         if substr == '':
             continue
@@ -147,23 +150,23 @@ def tc_response_to_dict(response_string, separator):
 def get_tc_stats(port, lock):
     global TC_STATUS
     _tc_status = {}
-    send_tc(port, lock, GCODES['DEBUG_MODE'])
-    time.sleep(1)
+    send_and_get_response(port, lock, GCODES['DEBUG_MODE'])
     port.reset_input_buffer()
-    send_tc(port, lock, GCODES['CONTINUOUS_DEBUG_STAT'])
-    time.sleep(1)
+    t = 0
     while OFFSET_TUNER.is_alive():
-        with lock:
-            serial_line = port.readline()
-            if serial_line:
-                _tc_status = tc_response_to_dict(serial_line.decode(), '\t')
-        temp_res = send_tc(port, lock, GCODES['GET_PLATE_TEMP'],
-                           get_response=True)
+        # Get debug status
+        status_res = send_and_get_response(port, lock,
+                                           GCODES['PRINT_DEBUG_STAT'])
+        _tc_status = tc_response_to_dict(status_res, '\t')
+        temp_res = send_and_get_response(port, lock, GCODES['GET_PLATE_TEMP'])
+
+        # Get current plate temp
         if temp_res:
             current_temp = tc_response_to_dict(temp_res, ' ')
             _tc_status['Plt_current'] = current_temp['C']
         TC_STATUS = _tc_status
-        t = 0
+
+        # Print status every 2 seconds
         if time.time() - t >= 2:
             print("TC status:", end=" ")
             for (k, v) in TC_STATUS.items():
@@ -173,7 +176,7 @@ def get_tc_stats(port, lock):
                     log.debug("{}: {}".format(k, v))
             print()
             t = time.time()
-        time.sleep(0.1)
+        time.sleep(1)
 
 
 def get_eutech_temp(port):
@@ -197,8 +200,8 @@ def get_eutech_temp(port):
 def tc_temp_stability_check(target, tolerance=0.2):
     # Compares sensor_op & target values over 10 seconds
     # Returns true if sensor_op is within allowed range of target throughout
-    for i in range(1-):
-        if abs(target - TC_STATUS['Plt_current']) > 0.2:
+    for i in range(10):
+        if abs(target - TC_STATUS['Plt_current']) > tolerance:
             return False
         time.sleep(2)
     return True
@@ -225,187 +228,117 @@ def eutech_temp_stability_check(target=None, tolerance=0.2):
 def offset_tuning(tc_port, lock):
     global record_vals
     record_vals = []
+    time.sleep(100)
+    # # Heat lid:
+    # send_and_get_response(tc_port, lock, GCODES['SET_LID_TEMP'])
+    # # Heat up heatsink:
+    # send_and_get_response(tc_port, lock,
+    #                       '{} S10'.format(GCODES['SET_PLATE_TEMP']))
+    # while TC_STATUS['T.sink'] < 58:
+    #     pass
+    #
+    # tuning_done = False
+    # # Thermocycler prepped. Start tuning:
+    # while not tuning_done:
+    #     c_adjustment(TUNING_TEMPS[0], t_sink=53, temp_tolerance=0.009)
+    #     for temp in TUNING_TEMPS:
+    #         log.info("==== Tuning for {}C ====".format(temp))
+    #         if c_adjustment(temp) == 'adjusted':
+    #             tuning_done = False
+    #             break
+    #         else:
+    #             tuning_done = True
 
-    log.info("###### STARTING OFFSET TUNER ######")
-    while EUTECH_TEMPERATURE is None or TC_STATUS == {}:
-        time.sleep(0.4)
-        log.info("Waiting for temp statuses from both thermometer & TC")
 
-    # 1. Set lid temp
-    log.info(" ---- Setting lid temperature ---- ")
-    send_tc(tc_port, lock, '{} {}'.format(GCODES['SET_LID_TEMP'], LID_TEMP))
-    while TC_STATUS['T.Lid'] < LID_TEMP:
+# def c_adjustment(temp, t_sink=None, temp_tolerance=0.1):
+#     send_and_get_response(tc_port, lock,
+#                           '{} S{}'.format(GCODES['SET_PLATE_TEMP'], temp))
+#     # Wait until temperature stabilizes
+#     while not tc_temp_stability_check(temp):
+#         time.sleep(0.5)
+#     log.info(" ---- TC Temperature stabilized ----")
+#     while not eutech_temp_stability_check():
+#         time.sleep(0.5)
+#     log.info(" ---- EUTECH probe temp stabilized ---- ")
+#     pass
+
+
+# def tuning_readjustments(temp, t_sink=None, temp_tolerance=0.1):
+#     global c_changed
+#     c_changed = False
+#
+#     # Check tuning at given temp
+#     log.info(" ---- Set plate to {}C and check if"
+#              " tuning adjustment required ---- ".format(temp))
+#     send_and_get_response(tc_port, lock,
+#                           '{} S{}'.format(GCODES['SET_PLATE_TEMP'], temp))
+#     # Wait until temperature stabilizes
+#     while not tc_temp_stability_check(temp):
+#         time.sleep(0.5)
+#     log.info(" ---- TC Temperature stabilized ----")
+#     while not eutech_temp_stability_check():
+#         time.sleep(0.5)
+#     log.info(" ---- EUTECH probe temp stabilized ---- ")
+#
+#     # Record experimental temperature before adjusted c_offset
+#     record_vals.append([temp, EUTECH_TEMPERATURE])
+#
+#     # Tune the offset at tempC
+#     if abs(EUTECH_TEMPERATURE - TC_STATUS['Plt_current']) > 0.1:
+#         log.info(" ====> Temperatures not equal. Updating offset ====> ")
+#         serial_line = send_and_get_response(tc_port,
+#                                              lock,
+#                                              GCODES['GET_OFFSET_CONSTANTS'])
+#         offset_dict = tc_response_to_dict(serial_line, '\n')
+#         c_offset = offset_dict['C']
+#
+#         # Determine whether EUTECH_TEMP is too low or too high
+#         # allow up to +-0.1C deviation from Plt_current
+#         difference = round((EUTECH_TEMPERATURE - TC_STATUS['Plt_current']),
+#                        3)
+#         acceptable_tolerance = 0.1
+#         if difference > 0:
+#             acceptable_tolerance = -0.1
+#         c_offset += (difference + acceptable_tolerance)
+#         log.info("Setting C offset to {}".format(c_offset))
+#         c_changed = True    # change marker to show that c was changed
+#         # record the new C value to add to summary csv
+#         record_vals.append(['c_offset', c_offset])
+#         print('record_vals = ', record_vals)
+#         send_and_get_response(tc_port, lock,
+#                               '{} C{}'.format(GCODES['SET_OFFSET_CONSTANTS'],
+#                                               c_offset))
+#         time.sleep(4)
+#         retries = 10
+#         while not eutech_temp_stability_check(temp, tolerance=0.1):
+#             print("Temp probe not yet stable. Retry#{}".format(retries))
+#             retries -= 1
+#             time.sleep(5)
+#             if retries == 0:
+#                 raise Exception("Unable to tune offset at {}C".format(temp))
+#
+#     if c_changed is True:
+#         record_vals.append([temp, EUTECH_TEMPERATURE])
+#
+#     print("\n-------------------")
+#     print("Offset tuning at {}C passed".format(temp))
+#     print("-------------------")
+
+
+def cooldown_tc(tc_port, lock):
+    send_and_get_response(tc_port, lock,
+                          '{} S{}'.format(GCODES['SET_FAN_SPEED'], 0.6))
+    send_and_get_response(tc_port, lock, GCODES['OPEN_LID'])
+    while TC_STATUS['T.sink'] > 30:
         time.sleep(1)
-    log.info(" ---- Lid temp reached ----")
+    send_and_get_response(tc_port, lock, GCODES['AUTO_FAN'])
 
-    # 2. Set TC to 10C to heat up the heatsink and bring it to usual operating
-    #    temp level
-    log.info(" ---- Set plate to 10C & wait until heatsink is 58C ---- ")
-    send_tc(tc_port, lock, '{} S{}'.format(GCODES['SET_PLATE_TEMP'], 10))
-    while TC_STATUS['T.sink'] < 58:
-        time.sleep(0.5)
-    log.info(" ---- Heatsink temp reached ---- ")
-
-    # 3. Set TC to 70C to start tuning
-    log.info(" ---- Set plate to 70C and start tuning ---- ")
-    send_tc(tc_port, lock, '{} S{}'.format(GCODES['SET_PLATE_TEMP'], 70))
-    # Wait until temperature stabilizes
-    while not tc_temp_stability_check(70):
-        time.sleep(0.5)
-    log.info(" ---- TC Temperature stabilized ----")
-    while not eutech_temp_stability_check():
-        time.sleep(0.5)
-    log.info(" ---- EUTECH probe temp stabilized ---- ")
-
-    # Make sure heatsink is around 53C
-    while abs(53 - TC_STATUS['T.sink']) > 2:
-        time.sleep(0.5)
-        # if heatsink overheated, increase fan speed to cool faster 
-        if (TC_STATUS['T.sink'] - 53) > 2:
-            send_tc(tc_port, lock, '{} S{}'.format(GCODES['SET_FAN_SPEED'], 0.25)) # increase fan speed to cool heatsink
-    send_tc(tc_port, lock, '{}'.format(GCODES['AUTO_FAN']))
-    log.info(" ---- Heatsink is approx. 53C ---- ")
-
-    # After heatsink cooled, wait until temperature stabilizes again
-    while not tc_temp_stability_check(70):
-        time.sleep(0.5)
-    log.info(" ---- TC Temperature stabilized ----")
-    while not eutech_temp_stability_check():
-        time.sleep(0.5)
-    log.info(" ---- EUTECH probe temp stabilized ---- ")
-
-    # Tune the offset at 70
-    if abs(EUTECH_TEMPERATURE - TC_STATUS['Plt_current']) > 0.009:
-        log.info(" ====> Temperatures not equal. Updating offset ====> ")
-        serial_line = send_tc(tc_port, lock, GCODES['GET_OFFSET_CONSTANTS'],
-                              get_response=True)
-        offset_dict = tc_response_to_dict(serial_line, '\n')
-        c_offset = offset_dict['C']
-        c_offset += round((EUTECH_TEMPERATURE - TC_STATUS['Plt_current']), 3)
-        log.info("Setting C offset to {}".format(c_offset))
-        send_tc(tc_port, lock,
-                '{} C{}'.format(GCODES['SET_OFFSET_CONSTANTS'], c_offset))
-
-        time.sleep(4)
-
-        # Make sure heatsink is around 53C
-        while abs(53 - TC_STATUS['T.sink']) > 2:
-            time.sleep(0.5)
-            # if heatsink overheated, increase fan speed to cool faster 
-            if (TC_STATUS['T.sink'] - 53) > 2:
-                send_tc(tc_port, lock, '{} S{}'.format(GCODES['SET_FAN_SPEED'], 0.25)) # increase fan speed to cool heatsink
-        send_tc(tc_port, lock, '{}'.format(GCODES['AUTO_FAN']))
-        log.info(" ---- Heatsink is approx. 53C ---- ")
-
-        # After heatsink cooled, wait until temperature stabilizes again
-        while not tc_temp_stability_check(70):
-            time.sleep(0.5)
-        log.info(" ---- TC Temperature stabilized ----")
-
-        retries = 10
-        while not eutech_temp_stability_check(70, tolerance=0.009):
-            print("Temp probe not yet stable. Retry#{}".format(retries))
-            retries -= 1
-            time.sleep(5)
-            if retries == 0:
-                raise Exception("Unable to tune offset at 70")
-        log.info(" ---- EUTECH probe temp stabilized ---- ")
-
-
-    # Record starting c_offset value for summary csv
-    serial_line = send_tc(tc_port, lock, GCODES['GET_OFFSET_CONSTANTS'],
-                          get_response=True)
-    offset_dict = tc_response_to_dict(serial_line, '\n')
-    c_offset = offset_dict['C']
-    record_vals.append(['c_offset', c_offset])
-    print('record_vals = ', record_vals)
-
-    print("\n-------------------")
-    print("Offset tuning at 70 passed")
-    record_vals.append([70, EUTECH_TEMPERATURE])
-    print("-------------------")
-
-    # Test whether TC can reach multiple targets at a single c_offset
-    targets = [70, 72, 94, 70, 40, 70]
-
-    i=1 # start at 72C
-    while i < len(targets):
-        tuning_readjustments(targets[i])
-        if c_changed == True:
-            i = 0 # if c_offset was changed, start at the first target temperatures (70C)
-            log.info("C offset changed, go back to first target temp")
-        else:
-            i+=1 # if c_offset did not change, go to next target temperature
-            log.info("C offset unchanged, go to next target temp")
-
-    print("\n-------------------")
-    print("Offset tuning with Eutechnics probe 1 passed")
-    print("-------------------")
-
-
-def tuning_readjustments(temp):
-    global c_changed
-    c_changed = False
-
-    # Check tuning at given temp
-    log.info(" ---- Set plate to {}C and check if tuning adjustment required ---- ".format(temp))
-    send_tc(tc_port, lock, '{} S{}'.format(GCODES['SET_PLATE_TEMP'], temp))
-    # Wait until temperature stabilizes
-    while not tc_temp_stability_check(temp):
-        time.sleep(0.5)
-    log.info(" ---- TC Temperature stabilized ----")
-    while not eutech_temp_stability_check():
-        time.sleep(0.5)
-    log.info(" ---- EUTECH probe temp stabilized ---- ")
-
-    # Record experimental temperature before adjusted c_offset
-    record_vals.append([temp, EUTECH_TEMPERATURE])
-
-    # Tune the offset at tempC
-    if abs(EUTECH_TEMPERATURE - TC_STATUS['Plt_current']) > 0.1:
-        log.info(" ====> Temperatures not equal. Updating offset ====> ")
-        serial_line = send_tc(tc_port, lock, GCODES['GET_OFFSET_CONSTANTS'],
-                              get_response=True)
-        offset_dict = tc_response_to_dict(serial_line, '\n')
-        c_offset = offset_dict['C']
-
-        # Determine whether EUTECH_TEMP is too low or too high
-        # allow up to +-0.1C deviation from Plt_current
-        difference = round((EUTECH_TEMPERATURE - TC_STATUS['Plt_current']), 3)
-        acceptable_tolerance = 0.1
-        if difference > 0:
-            acceptable_tolerance = -0.1
-        c_offset += (difference + acceptable_tolerance)
-
-        log.info("Setting C offset to {}".format(c_offset))
-        c_changed = True # change marker to show that c was changed
-        record_vals.append(['c_offset', c_offset]) # record the new C value to add to summary csv
-        print('record_vals = ', record_vals)
-        send_tc(tc_port, lock,
-                '{} C{}'.format(GCODES['SET_OFFSET_CONSTANTS'], c_offset))
-        time.sleep(4)
-        retries = 10
-        while not eutech_temp_stability_check(temp, tolerance=0.1):
-            print("Temp probe not yet stable. Retry#{}".format(retries))
-            retries -= 1
-            time.sleep(5)
-            if retries == 0:
-                raise Exception("Unable to tune offset at {}C".format(temp))
-
-    if c_changed == True:
-        record_vals.append([temp, EUTECH_TEMPERATURE])
-
-    print("\n-------------------")
-    print("Offset tuning at {}C passed".format(temp))
-    print("-------------------")
 
 def write_summary(record_vals):
     info = get_device_info(tc_port, lock)
-
     start = info.find('TC')
     end = info.find(' model')
     tc_serial = info[start:end]
-
     print('record_vals = ', record_vals)
     f_name = "tc-tuning_{}.csv".format(tc_serial)
 
@@ -413,12 +346,11 @@ def write_summary(record_vals):
         writer = csv.writer(f)
         test = {'target_temp': None, 'experimental_temp': None}
         log_file = csv.DictWriter(f, test)
-        log_file.writeheader() # writes header to csv
-
+        log_file.writeheader()  # writes header to csv
         for item in record_vals:
             write_csv(log_file, test, item)
-
-        writer.writerow({'{}'.format(datetime.now().strftime("%m-%d-%y_%H:%M_%p"))})
+        writer.writerow({'{}'.format(
+                        datetime.now().strftime("%m-%d-%y_%H:%M_%p"))})
         f.flush()
 
 
@@ -428,10 +360,21 @@ def write_csv(log_file, test, record_vals):
     log_file.writerow(test)
 
 
+def end_tuning(lock, tc_port):
+    write_summary(record_vals)
+    log.info("Deactivating thermocycler.")
+    send_and_get_response(tc_port, lock, GCODES['DEACTIVATE'])
+    log.info("Disabling debug mode.")
+    send_and_get_response(tc_port, lock,
+                          '{} S0'.format(GCODES['DEBUG_MODE']))
+    cooldown_tc(tc_port, lock)
+
+
 def build_arg_parser():
     arg_parser = ArgumentParser(description="Thermocycler offset tuner")
     arg_parser.add_argument("-L", "--loglevel", required=False,
                             default='INFO')
+    arg_parser.add_argument("-p", "--eutech_port_name", required=True)
     return arg_parser
 
 
@@ -448,13 +391,13 @@ if __name__ == '__main__':
     print("Searching for connected devices..")
     tc_port = serial.Serial(find_port(OPENTRONS_VID),
                             TC_BAUDRATE,
-                            timeout=1)
-    eutech_port = serial.Serial('COM13',
+                            timeout=60)
+    eutech_port = serial.Serial(args.eutech_port_name,
                                 EUTECH_BAUDRATE,
                                 timeout=1)
     lock = threading.Lock()
     # Disable continuous debug stat if in debug mode
-    send_tc(tc_port, lock, GCODES['PRINT_DEBUG_STAT'])
+    send_and_get_response(tc_port, lock, GCODES['PRINT_DEBUG_STAT'])
     log.info("Connected to thermocycler")
     print("-------------------")
     log.info("Device info:{}".format(get_device_info(tc_port, lock)))
@@ -465,14 +408,13 @@ if __name__ == '__main__':
     input("When you are ready to resume with offset tuning, press ENTER")
 
     # Close lid if open:
-    lid_status = send_tc(tc_port, lock, GCODES['GET_LID_STATUS'],
-                         get_response=True)
+    lid_status = send_and_get_response(tc_port, lock, GCODES['GET_LID_STATUS'])
     if lid_status != "Lid:closed":
         log.error("LID IS NOT CLOSED !!!")
         if input("To close lid, enter Y").upper() != 'Y':
             raise RuntimeError("Cannot proceed tuning with lid open. Exiting")
-        send_tc(tc_port, lock, GCODES['CLOSE_LID'])
-        time.sleep(40)
+        send_and_get_response(tc_port, lock, GCODES['CLOSE_LID'])
+        print("Done.")
         tc_port.reset_input_buffer()
 
     # Threads
@@ -486,9 +428,4 @@ if __name__ == '__main__':
     tc_status_fetcher.start()
     OFFSET_TUNER.join()
 
-    write_summary(record_vals)
-
-    log.info("Deactivating thermocycler.")
-    send_tc(tc_port, lock, GCODES['DEACTIVATE'])
-    log.info("Disabling continuous status.")
-    send_tc(tc_port, lock, GCODES['PRINT_DEBUG_STAT'])
+    end_tuning()

--- a/modules/thermo-cycler/QC/offset_tuning/serial_comm.py
+++ b/modules/thermo-cycler/QC/offset_tuning/serial_comm.py
@@ -1,0 +1,60 @@
+import serial
+from serial.tools.list_ports import comports
+import time
+import threading
+import logging
+
+
+TC_BAUDRATE = 115200
+SERIAL_ACK = '\r\n'
+log = logging.getLogger(__name__)
+
+
+def find_port(vid):
+    retries = 5
+    while retries:
+        for p in comports():
+            if p.vid == vid:
+                print("Available: {0}->\t(pid:{1:#x})\t(vid:{2:#x})".format(
+                        p.device, p.pid, p.vid))
+                print("Port found:{}".format(p.device))
+                time.sleep(1)
+                return p.device
+        retries -= 1
+        time.sleep(0.5)
+    raise RuntimeError('Could not find Opentrons Thermocycler'
+                       'connected over USB')
+
+
+class SerialComm:
+    def __init__(self, port_name, log_level=logging.INFO):
+        self.port = self.connect_to_module(port_name)
+        self.serial_lock = threading.Lock()
+        logging.basicConfig(level=log_level)
+        self.port.reset_input_buffer()
+
+    def connect_to_module(self, port_name):
+        print('Connecting to module...')
+        port = serial.Serial(port_name, 115200, timeout=60)
+        print('Connected.')
+        return port
+
+    def send_and_get_response(self, cmd):
+        with self.serial_lock:
+            response_str = ''
+            cmd += SERIAL_ACK
+            log.debug("Sending: {}".format(cmd))
+            self.port.write(cmd.encode())
+            raw_response = bytearray(b'')
+            time.sleep(0.1)
+            while True:
+                raw_response.extend(self.port.readline())
+                if not self.port.in_waiting:
+                    break
+            response_str = raw_response.decode().replace('ok', '').strip()
+            log.debug("Received:{}".format(response_str))
+            return response_str
+
+
+if __name__ == '__main__':
+    pass

--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.cpp
@@ -211,7 +211,7 @@ void GcodeHandler::add_debug_response(String param, float val)
 {
   Serial.print(param);
   Serial.print(F(": "));
-  Serial.print(val);
+  Serial.print(val, 4);
   Serial.print(F("\t"));
 }
 

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -460,13 +460,6 @@ void deactivate_plate()
 
 void debug_status_prints()
 {
-  static unsigned long lastPrint = 0;
-
-  if (millis() - lastPrint < DEBUG_PRINT_INTERVAL)
-  {
-    return;
-  }
-  lastPrint = millis();
   // Target
   gcode.add_debug_response("Plt_Target", target_temperature_plate);
   gcode.add_debug_response("Cov_Target", target_temperature_cover);
@@ -809,6 +802,13 @@ void read_gcode()
   }
   if (continuous_debug_stat_mode)
   {
+    static unsigned long lastPrint = 0;
+
+    if (millis() - lastPrint < DEBUG_PRINT_INTERVAL)
+    {
+      return;
+    }
+    lastPrint = millis();
     debug_status_prints();
   }
 }


### PR DESCRIPTION
Closes #98 
## overview

TC offset tuning tunes the thermocycler offsets to keep the TC plate temperatures within the specs. Tunes the B & C offsets according to this doc: https://docs.google.com/document/d/14exU49dWMJCu1ZlC0dI2caO9682fbA5z1bPjl2HYyDk/

## changes

- added offset tuning QC script
- made debug `stat` gcode respond immediately instead of with a delay. (The delay was between two consecutive responses and not between the time the gcode was received & the time its response was sent)

## review requests

- make sure the code looks good
- make sure the tuning works as expected

Notes: script takes 2 args: -L for log level (default INFO) and -p for thermometer port name (eg., `-p=COM10`). It saves the logs to a file in the current directory with the unit's serial number as the name
