### PR TITLE
feat(write_module_memory): support gen2 magdecks and tempdecks

### DIFF
--- a/eepromWriter/write_module_memory.py
+++ b/eepromWriter/write_module_memory.py
@@ -28,7 +28,10 @@ MODELS = {
     'TDV03': 'temp_deck_v3.0',  # this model has the new fans with pcb fan_v4
     'TDV04': 'temp_deck_v4.0',  # this model has the new fans with pcb fan_v4.1
     'TDV15': 'temp_deck_v15',   # koozie + pwm fans
+    'TDV20': 'temp_deck_v20',  # koozie + fans + actual rebranding
     'MDV01': 'mag_deck_v1.1'
+    'MDV01': 'mag_deck_v1.1',
+    'MDV20': 'mag_deck_v20'
 }
 
 DIR_NAME = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
These will save their model version as 20 to fit with how we do the rest
of the models (e.g. 1.5) and avoid firmware refactors