### PR TITLE
feat(thermocycler): improve temp status response & debug stat response

### DIFF
--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.cpp
@@ -161,15 +161,20 @@ void GcodeHandler::device_info_response(String serial, String model, String vers
   Serial.println();
 }
 
-void GcodeHandler::targetting_temperature_response(float target_temp,
-                                    float current_temp, float time_remaining)
+void GcodeHandler::targetting_temperature_response(float target_temp, float current_temp,
+                                                   float time_remaining,  float total_hold_time,
+                                                   bool at_target)
 {
   Serial.print(F("T:"));
   Serial.print(target_temp, SERIAL_DIGITS_IN_RESPONSE);
   Serial.print(F(" C:"));
   Serial.print(current_temp, SERIAL_DIGITS_IN_RESPONSE);
   Serial.print(F(" H:"));
-  Serial.println((unsigned int)time_remaining);
+  Serial.print((unsigned int)time_remaining);
+  Serial.print(F(" Total_H:"));
+  Serial.print((unsigned int)total_hold_time);
+  Serial.print(F(" At_target?:"));
+  Serial.println(at_target);
 }
 
 void GcodeHandler::targetting_temperature_response(float target_temp,
@@ -195,6 +200,7 @@ void GcodeHandler::idle_lid_temperature_response(float current_temp)
   Serial.print(F(" C:"));
   Serial.println(current_temp, SERIAL_DIGITS_IN_RESPONSE);
 }
+
 void GcodeHandler::response(String param, String msg)
 {
   Serial.print(param);
@@ -211,7 +217,7 @@ void GcodeHandler::add_debug_response(String param, float val)
 {
   Serial.print(param);
   Serial.print(F(": "));
-  Serial.print(val);
+  Serial.print(val, 4);
   Serial.print(F("\t"));
 }
 

--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.cpp
@@ -191,7 +191,9 @@ void GcodeHandler::idle_temperature_response(float current_temp)
   Serial.print(F("T:none"));
   Serial.print(F(" C:"));
   Serial.print(current_temp, SERIAL_DIGITS_IN_RESPONSE);
-  Serial.println(F(" H:none"));
+  Serial.print(F(" H:none"));
+  Serial.print(F(" Total_H:none"));
+  Serial.println(F(" At_target?:0"));
 }
 
 void GcodeHandler::idle_lid_temperature_response(float current_temp)

--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.cpp
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.cpp
@@ -217,8 +217,14 @@ void GcodeHandler::add_debug_response(String param, float val)
 {
   Serial.print(param);
   Serial.print(F(": "));
-  Serial.print(val, 4);
+  Serial.print(val, DIGITS_IN_DEBUG_RESPONSE);
   Serial.print(F("\t"));
+}
+
+void GcodeHandler::system_error_message(String message)
+{
+  Serial.print(F("Error:"));
+  Serial.print(message + " ");
 }
 
 void GcodeHandler::add_debug_timestamp()

--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
@@ -8,6 +8,7 @@
 #define MAX_SERIAL_BUFFER_LENGTH    100
 #define MAX_SERIAL_DIGITS_IN_NUMBER 7
 #define SERIAL_DIGITS_IN_RESPONSE   3
+#define DIGITS_IN_DEBUG_RESPONSE    4
 
 #define GCODES_TABLE  \
   GCODE_DEF(no_code, -),            \
@@ -81,6 +82,7 @@ class GcodeHandler
       bool pop_arg(char key);
       void response(String msg);
       void response(String param, String msg);
+      void system_error_message(String msg);
       void add_debug_response(String param, float val);
       void add_debug_timestamp();
 

--- a/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
+++ b/modules/thermo-cycler/thermo-cycler-arduino/gcode.h
@@ -72,8 +72,9 @@ class GcodeHandler
       bool buffer_empty();
       void device_info_response(String serial, String model, String version);
       void targetting_temperature_response(float target_temp, float current_temp);
-      void targetting_temperature_response(float target_temp,
-                                           float current_temp, float time_left);
+      void targetting_temperature_response(float target_temp, float current_temp,
+                                           float time_left, float total_hold_time,
+                                           bool at_target);
       void idle_temperature_response(float current_temp);
       void idle_lid_temperature_response(float current_temp);
       float popped_arg();

--- a/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
+++ b/modules/thermo-cycler/thermo-cycler-arduino/thermo-cycler-arduino.ino
@@ -1055,7 +1055,6 @@ void print_all_thermistor_values()
   plate_thermistors_status_prints();  // Plate Thermistors
   gcode.add_debug_response("T.Lid", temp_probes.cover_temperature()); // Cover
   gcode.add_debug_response("T.sink", current_heatsink_temp); // Heatsink
-  // Thermistor error status:
   gcode.add_debug_response("T_error", int(temp_probes.detected_invalid_val));
   gcode.response(""); // CR+LF
 }
@@ -1248,15 +1247,15 @@ void print_errors_if_any()
   {
     if (system_errors & ERROR_MASK(Error::system_too_hot))
     {
-      gcode.response("Error", "System too hot");
+      gcode.system_error_message("System too hot.");
     }
     if (system_errors & ERROR_MASK(Error::invalid_thermistor_value))
     {
-      gcode.response("Error", "Found an invalid thermistor value");
+      gcode.system_error_message("Found an invalid thermistor value.");
     }
     if (system_errors & ERROR_MASK(Error::plate_temperature_not_uniform))
     {
-      gcode.response("Error", "Plate temperature is not uniform");
+      gcode.system_error_message("Plate temperature is not uniform.");
     }
     print_all_thermistor_values();
   }


### PR DESCRIPTION
Closes #116

## overview

This PR adds improvements to TC responses. These have been a long pending features and with more TCs out in the field, is becoming more and more crucial to implement these in order to debug issues faster. More work to follow in the epic [Thermocycler: Detailed status and errors ](https://app.zenhub.com/workspaces/opentrons-hmg-5e1cdf98e04060788ad94e32/issues/opentrons/opentrons/6541)

## changes

- added two fields to temperature status response: 
  
  1. total hold time. A follow-up to [#6479](https://github.com/Opentrons/opentrons/pull/6479) 
  2. temperature is at target. This is a good-to-have field since it will give the driver/ API a good idea about whether temperature overshoot is over and the plate temperatures are stable/stabilizing near target. Right now, the only way to know that is by monitoring the plate temperatures over a specific time window and checking if they are in an acceptable temperature range. Though not a bad technique, it makes the api & firmware give different results for 'when' is the plate at target. 
  So, the response to `M105` will now look like `T:50 C:47 H:20 T_Hold:50 At_target?:0`
- moved the time gap check out of debug 'stat' response (which was there primarily for continuous
debug prints) so that a 'stat' command gets an immediate response.
- cleaned up redundant error messages
- added thermistor values to error messages. So an example error message would look like:
`Error:Plate temperature is not uniform. T1: 36.6511	T2: 41.5688	T3: 41.0032	T4: 41.5809	T5: 41.1606	T6: 40.8699	T.Lid: 22.9323	T.sink: 38.3661	T_error: 0.0000`


## questions

~Will the new error message with thermistor values be read & logged fully by the TCPoller or will it only read the first line and issue a pause?~ 
Answered in comment below. Made changes accordingly to make the message a one-liner

