### PR TITLE
feat(heater-shaker): Add freertos

### DIFF
--- a/cmake/FindSTM32F303BSP.cmake
+++ b/cmake/FindSTM32F303BSP.cmake
@@ -42,9 +42,15 @@ FetchContent_GetProperties(STM32_F303_BSP_SOURCE
   )
 
 file(GLOB_RECURSE hal_driver_sources ${bsp_source}/Drivers/STM32F3xx_HAL_Driver/Src/*.c)
+set(freertos_source ${bsp_source}/Middlewares/Third_Party/FreeRTOS/Source)
+set(freertos_port_source ${freertos_source}/portable/GCC/ARM_CM4F)
+file(GLOB freertos_common_sources ${freertos_source}/*.c)
 
 add_library(STM32F303BSP STATIC
-  ${hal_driver_sources})
+  ${hal_driver_sources}
+  ${freertos_common_sources}
+  ${freertos_port_source}/port.c
+  $<IF:$<BOOL:$<TARGET_PROPERTY:FREERTOS_HEAP_IMPLEMENTATION>>,${freertos_source}/portable/MemMang/$<TARGET_PROPERTY:FREERTOS_HEAP_IMPLEMENTATION>.c,"">)
 
 
 target_include_directories(
@@ -53,6 +59,8 @@ target_include_directories(
          ${bsp_source}/Drivers/STM32F3xx_HAL_Driver/Inc/Legacy
          ${bsp_source}/Drivers/CMSIS/Device/ST/STM32F3xx/Include
          ${bsp_source}/Drivers/CMSIS/Core/Include
+         ${freertos_source}/include
+         ${freertos_port_source}
   )
 
 set(STM32F303BSP_FOUND ${bsp_populated} PARENT_SCOPE)

--- a/cmake/STM32GCCCrossToolchain.cmake
+++ b/cmake/STM32GCCCrossToolchain.cmake
@@ -21,7 +21,7 @@ set(CMAKE_ASM_COMPILER "${CROSS_GCC_BINDIR}/${GCC_CROSS_TRIPLE}-gcc")
 set(CMAKE_CXX_COMPILER "${CROSS_GCC_BINDIR}/${GCC_CROSS_TRIPLE}-g++")
 
 set(GCC_CROSS_BASE_FLAGS
-  "-mthumb -mcpu=cortex-m4 -mfloat-abi=soft -specs=nosys.specs -specs=nano.specs -fpic -ffunction-sections -fdata-sections -fno-lto")
+  "-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -specs=nosys.specs -specs=nano.specs -fpic -ffunction-sections -fdata-sections -fno-lto")
 set(CMAKE_C_COMPILER_TARGET thumbv7m-unknown-none-eabi)
 set(CMAKE_CXX_COMPILER_TARGET thumbv7m-unknown-none-eabi)
 set(CMAKE_C_FLAGS ${GCC_CROSS_BASE_FLAGS})

--- a/stm32-modules/heater-shaker/README.md
+++ b/stm32-modules/heater-shaker/README.md
@@ -1,0 +1,30 @@
+# Heater/Shaker Firmware
+
+This directory has the code for the heater/shaker
+
+## Relevant build system targets
+
+### Cross-build
+When cross-compiling the firmware (using the `stm32-cross` cmake preset, running `cmake --build ./build-stm32-cross`), you can
+- Build the firmware: `cmake --build ./build-stm32-cross --target heater-shaker`
+- Build the firmware, connect to a debugger, and upload it: `cmake --build ./build-stm32-cross --target heater-shaker-debug`
+- Lint the firmware: `cmake --build ./build-stm32-cross --target heater-shaker-lint`
+- Format the firmware: `cmake --build ./build-stm32-cross --target heater-shaker-format`
+
+### Host-build
+When compiling the firmware using your local compiler (using the `stm32-host` cmake preset, running `cmake --build ./build-stm32-host`), you can
+- Build tests: `cmake --build ./build-stm32-host --target heater-shaker-tests`
+- Run tests: `cmake --build ./build-stm32-host --target test`
+- Format tests: `cmake --build ./build-stm32-test --target heater-shaker-format`
+
+## File Structure
+- `./tests/` contains the test-specific entrypoints and actual test code
+- `./firmware` contains the code that only runs on the device itself
+- `./src` contains the code that can be either cross- or host-compiled, and therefore can and should be tested
+- `./include` contains all the headers, sorted by subdirectory - e.g. `include/firmware/` is where include files for firmware-specific things live. This is done (rather than the reverse, `firmware/include`) so that code can have liens like `#include "firmware/whatever.hpp"`, which makes it apparent in the code itself what domain the header is in.
+
+## Style
+
+We enforce style with [clang-format](https://clang.llvm.org/docs/ClangFormat.html), using the [google C++ style](https://google.github.io/styleguide/cppguide.html). We lint using [clang-tidy](https://clang.llvm.org/extra/clang-tidy/). The configurations for these tools are in the root of the repo (they're hidden files on Unix-likes, `.clang-tidy` and `.clang-format`). 
+
+We use [Catch2](https://github.com/catchorg/Catch2) for testing.

--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -7,11 +7,17 @@ find_package(OpenOCD)
 
 # Add source files that should be checked by clang-tidy here
 set(HS_FW_LINTABLE_SRCS
-  ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/heater_control_task.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/motor_control_task.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ui_control_task.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/host_comms_control_task.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp)
 
 # Add source files that should NOT be checked by clang-tidy here
 set(HS_FW_NONLINTABLE_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/system_stm32f3xx.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/stm32f3xx_it.c
   ${CMAKE_CURRENT_SOURCE_DIR}/startup_stm32f303xe.s)
 
 add_executable(heater-shaker
@@ -39,6 +45,8 @@ set_target_properties(heater-shaker
   C_STANDARD_REQUIRED TRUE
   )
 
+target_include_directories(heater-shaker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
 target_compile_options(heater-shaker
   PUBLIC
   -Wall
@@ -58,6 +66,9 @@ target_include_directories(STM32F303BSP
   PUBLIC .)
 target_compile_definitions(STM32F303BSP
   PUBLIC STM32F303xE)
+set_target_properties(STM32F303BSP
+  PROPERTIES
+  FREERTOS_HEAP_IMPLEMENTATION "heap_5")
 
 # Fills in the template with values specified by the find_package(OpenOCD) call above
 configure_file(./gdbinit.template ./gdbinit)

--- a/stm32-modules/heater-shaker/firmware/FreeRTOSConfig.h
+++ b/stm32-modules/heater-shaker/firmware/FreeRTOSConfig.h
@@ -1,0 +1,173 @@
+/*
+ * FreeRTOS Kernel V10.0.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/*-----------------------------------------------------------
+ * this is a template configuration files
+ *
+ * These definitions should be adjusted for your particular hardware and
+ * application requirements.
+ *
+ * These parameters and more are described within the 'configuration' section of
+ *the FreeRTOS API documentation available on the FreeRTOS.org web site.
+ *
+ * See http://www.freertos.org/a00110.html
+ *----------------------------------------------------------*/
+
+/* Ensure stdint is only used by the compiler, and not the assembler. */
+#if defined(__ICCARM__) || defined(__CC_ARM) || defined(__GNUC__)
+#include <stdint.h>
+extern uint32_t SystemCoreClock;
+#endif
+
+/*  CMSIS-RTOSv2 defines 56 levels of priorities. To be able to use them
+ *  all and avoid application misbehavior,
+ * configUSE_PORT_OPTIMISED_TASK_SELECTION must be set to 0 and
+ * configMAX_PRIORITIES to 56
+ *
+ */
+/* #define configUSE_PORT_OPTIMISED_TASK_SELECTION	0*/
+/* #define configMAX_PRIORITIES					( 56 ) */
+#define configUSE_PREEMPTION 1
+#define configUSE_IDLE_HOOK 0
+#define configUSE_TICK_HOOK 0
+#define configMAX_PRIORITIES (7)
+#define configSUPPORT_STATIC_ALLOCATION 1
+#define configCPU_CLOCK_HZ (SystemCoreClock)
+#define configTICK_RATE_HZ ((TickType_t)1000)
+#define configMINIMAL_STACK_SIZE ((uint16_t)128)
+#define configTOTAL_HEAP_SIZE ((size_t)(15 * 1024))
+#define configMAX_TASK_NAME_LEN (16)
+#define configUSE_TRACE_FACILITY 1
+#define configUSE_16_BIT_TICKS 0
+#define configIDLE_SHOULD_YIELD 1
+#define configUSE_MUTEXES 1
+#define configQUEUE_REGISTRY_SIZE 8
+#define configCHECK_FOR_STACK_OVERFLOW 0
+#define configUSE_RECURSIVE_MUTEXES 1
+#define configUSE_MALLOC_FAILED_HOOK 0
+#define configUSE_APPLICATION_TASK_TAG 0
+#define configUSE_COUNTING_SEMAPHORES 1
+#define configGENERATE_RUN_TIME_STATS 0
+
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES 0
+#define configMAX_CO_ROUTINE_PRIORITIES (2)
+
+/* Software timer definitions. */
+#define configUSE_TIMERS 0
+#define configTIMER_TASK_PRIORITY (2)
+#define configTIMER_QUEUE_LENGTH 10
+#define configTIMER_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 2)
+
+/* Set the following definitions to 1 to include the API function, or zero
+to exclude the API function. */
+#define INCLUDE_vTaskPrioritySet 1
+#define INCLUDE_uxTaskPriorityGet 1
+#define INCLUDE_vTaskDelete 1
+#define INCLUDE_vTaskCleanUpResources 0
+#define INCLUDE_vTaskSuspend 1
+#define INCLUDE_vTaskDelayUntil 0
+#define INCLUDE_vTaskDelay 1
+#define INCLUDE_xTaskGetSchedulerState 1
+
+/*------------- CMSIS-RTOS V2 specific defines -----------*/
+/* When using CMSIS-RTOSv2 set configSUPPORT_STATIC_ALLOCATION to 1
+ * is mandatory to avoid compile errors.
+ * CMSIS-RTOS V2 implmentation requires the following defines
+ *
+#define configSUPPORT_STATIC_ALLOCATION          1   <-- cmsis_os threads are
+created using xTaskCreateStatic() API #define configMAX_PRIORITIES (56) <--
+Priority range in CMSIS-RTOS V2 is [0 .. 56] #define
+configUSE_PORT_OPTIMISED_TASK_SELECTION 0    <-- when set to 1,
+configMAX_PRIORITIES can't be more than 32 which is not suitable for the new
+CMSIS-RTOS v2 priority range
+*/
+
+/* the CMSIS-RTOS V2 FreeRTOS wrapper is dependent on the heap implementation
+used
+ * by the application thus the correct define need to be enabled from the list
+ * below
+ *
+//define USE_FreeRTOS_HEAP_1
+//define USE_FreeRTOS_HEAP_2
+//define USE_FreeRTOS_HEAP_3
+//define USE_FreeRTOS_HEAP_4
+//define USE_FreeRTOS_HEAP_5
+*/
+
+/* Cortex-M specific definitions. */
+#ifdef __NVIC_PRIO_BITS
+/* __BVIC_PRIO_BITS will be specified when CMSIS is being used. */
+#define configPRIO_BITS __NVIC_PRIO_BITS
+#else
+#define configPRIO_BITS 4 /* 15 priority levels */
+#endif
+
+/* The lowest interrupt priority that can be used in a call to a "set priority"
+function. */
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY 0xf
+
+/* The highest interrupt priority that can be used by any interrupt service
+routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT CALL
+INTERRUPT SAFE FREERTOS API FUNCTIONS FROM ANY INTERRUPT THAT HAS A HIGHER
+PRIORITY THAN THIS! (higher priorities are lower numeric values. */
+#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY 5
+
+/* Interrupt priorities used by the kernel port layer itself.  These are generic
+to all Cortex-M ports, and do not rely on any particular library functions. */
+#define configKERNEL_INTERRUPT_PRIORITY \
+    (configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
+/* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
+See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY \
+    (configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
+
+/* Normal assert() semantics without relying on the provision of an assert.h
+header file. */
+#define configASSERT(x)           \
+    if ((x) == 0) {               \
+        taskDISABLE_INTERRUPTS(); \
+        for (;;)                  \
+            ;                     \
+    }
+
+/* Definitions that map the FreeRTOS port interrupt handlers to their CMSIS
+   standard names. */
+#define vPortSVCHandler SVC_Handler
+#define xPortPendSVHandler PendSV_Handler
+
+/* IMPORTANT: FreeRTOS is using the SysTick as internal time base, thus make
+   sure the system and peripherials are using a different time base (TIM based
+   for example).
+ */
+#define xPortSysTickHandler SysTick_Handler
+
+#endif /* FREERTOS_CONFIG_H */

--- a/stm32-modules/heater-shaker/firmware/freertos_idle_timer_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/freertos_idle_timer_task.cpp
@@ -1,0 +1,27 @@
+/*
+ * Configuration for the FreeRTOS idle task, which is necessary when we told it
+ * we're using static allocation. Provides the same configuration as the other
+ * stacks, but in callback form (vApplicationGetIdleTaskMemory is called by the
+ * RTOS internals)
+ */
+
+#include <array>
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+StaticTask_t
+    idle_task_tcb;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+std::array<StackType_t, configMINIMAL_STACK_SIZE>
+    idle_task_stack;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+// This is a callback defined in a C file so it has to be linked as such
+extern "C" void vApplicationGetIdleTaskMemory(
+    StaticTask_t **ppxIdleTaskTCBBuffer, StackType_t **ppxIdleTaskStackBuffer,
+    uint32_t *pulIdleTaskStackSize) {
+    // Same configuration as in the other tasks, but a smaller stack
+    *ppxIdleTaskTCBBuffer = &idle_task_tcb;
+    *ppxIdleTaskStackBuffer = idle_task_stack.data();
+    *pulIdleTaskStackSize = idle_task_stack.size();
+}

--- a/stm32-modules/heater-shaker/firmware/heater_control_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/heater_control_task.cpp
@@ -1,0 +1,35 @@
+/*
+ * firmware-specific internals and hooks for heater control
+ */
+#include "firmware/heater_control_task.hpp"
+
+#include <array>
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+namespace heater_control_task {
+
+static constexpr uint32_t stack_size = 500;
+// Stack as an array because there's no added overhead and why not
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static std::array<StackType_t, stack_size> stack;
+
+// internal data structure for freertos to store task state
+static StaticTask_t
+    data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+// Actual function that runs the task
+void run(void *param) {  // NOLINT(misc-unused-parameters)
+    static constexpr uint32_t delay_ticks = 100;
+    while (true) {
+        vTaskDelay(delay_ticks);
+    }
+}
+
+// Starter that spins up the thread
+auto start() -> TaskHandle_t {
+    return xTaskCreateStatic(run, "HeaterControl", stack.size(), nullptr, 1,
+                             stack.data(), &data);
+}
+}  // namespace heater_control_task

--- a/stm32-modules/heater-shaker/firmware/host_comms_control_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/host_comms_control_task.cpp
@@ -1,0 +1,34 @@
+/*
+ * firmware-specific functions, data, and hooks for host comms control
+ */
+#include "firmware/host_comms_control_task.hpp"
+
+#include <array>
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+namespace host_comms_control_task {
+static constexpr uint32_t stack_size = 500;
+// Stack as a std::array because why not
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static std::array<StackType_t, stack_size> stack;
+
+// Internal FreeRTOS data structure
+static StaticTask_t
+    data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+// Actual function that runs in the task
+void run(void *param) {  // NOLINT(misc-unused-parameters)
+    static constexpr uint32_t delay_ticks = 100;
+    while (true) {
+        vTaskDelay(delay_ticks);
+    }
+}
+
+// Function that creates and spins up the task
+auto start() -> TaskHandle_t {
+    return xTaskCreateStatic(run, "HostCommsControl", stack.size(), nullptr, 1,
+                             stack.data(), &data);
+}
+}  // namespace host_comms_control_task

--- a/stm32-modules/heater-shaker/firmware/main.cpp
+++ b/stm32-modules/heater-shaker/firmware/main.cpp
@@ -1,5 +1,4 @@
 #include "FreeRTOS.h"
-
 #include "firmware/heater_control_task.hpp"
 #include "firmware/host_comms_control_task.hpp"
 #include "firmware/motor_control_task.hpp"

--- a/stm32-modules/heater-shaker/firmware/main.cpp
+++ b/stm32-modules/heater-shaker/firmware/main.cpp
@@ -1,11 +1,15 @@
+#include "FreeRTOS.h"
 
-volatile bool
-    loopy =  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-    false;
+#include "firmware/heater_control_task.hpp"
+#include "firmware/host_comms_control_task.hpp"
+#include "firmware/motor_control_task.hpp"
+#include "firmware/ui_control_task.hpp"
 
 auto main() -> int {
-    while (true) {
-        loopy = !loopy;
-    }
+    ui_control_task::start();
+    heater_control_task::start();
+    motor_control_task::start();
+    host_comms_control_task::start();
+    vTaskStartScheduler();
     return 0;
 }

--- a/stm32-modules/heater-shaker/firmware/motor_control_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/motor_control_task.cpp
@@ -1,0 +1,35 @@
+/*
+ * firmware-specific internals and hooks for motor control
+ */
+#include "firmware/motor_control_task.hpp"
+
+#include <array>
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+namespace motor_control_task {
+static constexpr uint32_t stack_size = 500;
+// Stack as a std::array because why not
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+std::array<StackType_t, stack_size> stack;
+// Internal FreeRTOS data structure for the task
+
+StaticTask_t
+    data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+// Actual function that runs inside the task
+void run(void *param) {  // NOLINT(misc-unused-parameters)
+    static constexpr uint32_t delay_ticks = 100;
+    while (true) {
+        vTaskDelay(delay_ticks);
+    }
+}
+
+// Starter function that creates and spins off the task
+auto start() -> TaskHandle_t {
+    return xTaskCreateStatic(run, "MotorControl", stack.size(), nullptr, 1,
+                             stack.data(), &data);
+}
+
+}  // namespace motor_control_task

--- a/stm32-modules/heater-shaker/firmware/stm32f3xx_hal_conf.h
+++ b/stm32-modules/heater-shaker/firmware/stm32f3xx_hal_conf.h
@@ -36,7 +36,7 @@ extern "C" {
 #define HAL_ADC_MODULE_ENABLED
 #define HAL_CAN_MODULE_ENABLED
 /* #define HAL_CAN_LEGACY_MODULE_ENABLED */
-#define HAL_CEC_MODULE_ENABLED
+/* #define HAL_CEC_MODULE_ENABLED */
 #define HAL_COMP_MODULE_ENABLED
 #define HAL_CORTEX_MODULE_ENABLED
 #define HAL_CRC_MODULE_ENABLED
@@ -49,7 +49,7 @@ extern "C" {
 #define HAL_PCCARD_MODULE_ENABLED
 #define HAL_GPIO_MODULE_ENABLED
 #define HAL_EXTI_MODULE_ENABLED
-#define HAL_HRTIM_MODULE_ENABLED
+/* #define HAL_HRTIM_MODULE_ENABLED */
 #define HAL_I2C_MODULE_ENABLED
 #define HAL_I2S_MODULE_ENABLED
 #define HAL_IRDA_MODULE_ENABLED
@@ -59,7 +59,7 @@ extern "C" {
 #define HAL_PWR_MODULE_ENABLED
 #define HAL_RCC_MODULE_ENABLED
 #define HAL_RTC_MODULE_ENABLED
-#define HAL_SDADC_MODULE_ENABLED
+/* #define HAL_SDADC_MODULE_ENABLED */
 #define HAL_SMARTCARD_MODULE_ENABLED
 #define HAL_SMBUS_MODULE_ENABLED
 #define HAL_SPI_MODULE_ENABLED
@@ -215,7 +215,7 @@ extern "C" {
  * @brief Uncomment the line below to expanse the "assert_param" macro in the
  *        HAL drivers code
  */
-/*#define USE_FULL_ASSERT    1U*/
+/*#define USE_FULL_ASSERT    1*/
 
 /* Includes ------------------------------------------------------------------*/
 /**
@@ -366,7 +366,7 @@ extern "C" {
 #ifdef USE_FULL_ASSERT
 /**
  * @brief  The assert_param macro is used for function's parameters check.
- * @param  expr If expr is false, it calls assert_failed function
+ * @param  expr: If expr is false, it calls assert_failed function
  *         which reports the name of the source file and the source
  *         line number of the call that failed.
  *         If expr is true, it returns no value.

--- a/stm32-modules/heater-shaker/firmware/stm32f3xx_it.c
+++ b/stm32-modules/heater-shaker/firmware/stm32f3xx_it.c
@@ -1,0 +1,127 @@
+/**
+  ******************************************************************************
+  * @file    Templates/Src/stm32f3xx_it.c
+  * @author  MCD Application Team
+  * @brief   Main Interrupt Service Routines.
+  *          This file provides template for all exceptions handler and 
+  *          peripherals interrupt service routine.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f3xx_it.h"
+
+/** @addtogroup STM32F3xx_HAL_Examples
+  * @{
+  */
+
+/** @addtogroup Templates
+  * @{
+  */
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/******************************************************************************/
+/*            Cortex-M4 Processor Exceptions Handlers                         */
+/******************************************************************************/
+
+/**
+  * @brief   This function handles NMI exception.
+  * @param  None
+  * @retval None
+  */
+void NMI_Handler(void)
+{
+}
+
+/**
+  * @brief  This function handles Hard Fault exception.
+  * @param  None
+  * @retval None
+  */
+void HardFault_Handler(void)
+{
+  /* Go to infinite loop when Hard Fault exception occurs */
+  while (1)
+  {
+  }
+}
+
+/**
+  * @brief  This function handles Memory Manage exception.
+  * @param  None
+  * @retval None
+  */
+void MemManage_Handler(void)
+{
+  /* Go to infinite loop when Memory Manage exception occurs */
+  while (1)
+  {
+  }
+}
+
+/**
+  * @brief  This function handles Bus Fault exception.
+  * @param  None
+  * @retval None
+  */
+void BusFault_Handler(void)
+{
+  /* Go to infinite loop when Bus Fault exception occurs */
+  while (1)
+  {
+  }
+}
+
+/**
+  * @brief  This function handles Usage Fault exception.
+  * @param  None
+  * @retval None
+  */
+void UsageFault_Handler(void)
+{
+  /* Go to infinite loop when Usage Fault exception occurs */
+  while (1)
+  {
+  }
+}
+
+/**
+  * @brief  This function handles Debug Monitor exception.
+  * @param  None
+  * @retval None
+  */
+void DebugMon_Handler(void)
+{
+}
+
+/*
+ * SVC, PendSV, and SysTick are all handled by freertos
+ */
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32-modules/heater-shaker/firmware/stm32f3xx_it.h
+++ b/stm32-modules/heater-shaker/firmware/stm32f3xx_it.h
@@ -1,0 +1,49 @@
+/**
+ ******************************************************************************
+ * @file    Templates/Inc/stm32f3xx_it.h
+ * @author  MCD Application Team
+ * @brief   This file contains the headers of the interrupt handlers.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F3xx_IT_H
+#define __STM32F3xx_IT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions ------------------------------------------------------- */
+
+void NMI_Handler(void);
+void HardFault_Handler(void);
+void MemManage_Handler(void);
+void BusFault_Handler(void);
+void UsageFault_Handler(void);
+void SVC_Handler(void);
+void DebugMon_Handler(void);
+void PendSV_Handler(void);
+void SysTick_Handler(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F3xx_IT_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32-modules/heater-shaker/firmware/system_stm32f3xx.c
+++ b/stm32-modules/heater-shaker/firmware/system_stm32f3xx.c
@@ -287,22 +287,6 @@ void SystemCoreClockUpdate (void)
   * @}
   */
 
-void HardFault_Handler(void) {
-  while (1);
-}
-
-void MemManage_Handler(void) {
-  while(1);
-}
-
-void BusFault_Handler(void) {
-  while(1);
-}
-
-void UsageFault_Handler(void) {
-  while(1);
-}
-
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
 

--- a/stm32-modules/heater-shaker/firmware/ui_control_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/ui_control_task.cpp
@@ -1,0 +1,35 @@
+/*
+ * firmware-specific functions and data for ui control task
+ */
+#include "firmware/ui_control_task.hpp"
+
+#include <array>
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+namespace ui_control_task {
+static constexpr uint32_t stack_size = 500;
+// Stack as a std::array because why not. Quiet lint because, well, we have to
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static std::array<StackType_t, stack_size> stack;
+
+// Internal FreeRTOS data structure for the task
+static StaticTask_t
+    data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+// Actual function that runs inside the task, unused param because we don't get
+// to pick the function type
+static void run(void *param) {  // NOLINT(misc-unused-parameters)
+    static constexpr uint32_t delay_ticks = 100;
+    while (true) {
+        vTaskDelay(delay_ticks);
+    }
+}
+
+// Function that spins up the task
+auto start() -> TaskHandle_t {
+    return xTaskCreateStatic(run, "UIControl", stack.size(), nullptr, 1,
+                             stack.data(), &data);
+}
+}  // namespace ui_control_task

--- a/stm32-modules/heater-shaker/include/firmware/heater_control_task.hpp
+++ b/stm32-modules/heater-shaker/include/firmware/heater_control_task.hpp
@@ -1,0 +1,12 @@
+/*
+ * Interface for the firmware-specific parts of the heater control task
+ */
+#pragma once
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+namespace heater_control_task {
+     // Function that starts the task
+     auto start() -> TaskHandle_t;
+}

--- a/stm32-modules/heater-shaker/include/firmware/host_comms_control_task.hpp
+++ b/stm32-modules/heater-shaker/include/firmware/host_comms_control_task.hpp
@@ -1,0 +1,11 @@
+/*
+ * Interface for the firmware-specifc parts of the host comms task
+ */
+#pragma once
+#include "FreeRTOS.h"
+#include "task.h"
+
+namespace host_comms_control_task {
+     // Function that starts the task
+     auto start() -> TaskHandle_t;
+}

--- a/stm32-modules/heater-shaker/include/firmware/motor_control_task.hpp
+++ b/stm32-modules/heater-shaker/include/firmware/motor_control_task.hpp
@@ -1,0 +1,12 @@
+/*
+ * Interface for the firmware-specific parts of the motor control task
+ */
+
+#pragma once
+#include "FreeRTOS.h"
+#include "task.h"
+
+namespace motor_control_task {
+     // Function to call to start the task
+     auto start() -> TaskHandle_t;
+}

--- a/stm32-modules/heater-shaker/include/firmware/ui_control_task.hpp
+++ b/stm32-modules/heater-shaker/include/firmware/ui_control_task.hpp
@@ -1,0 +1,12 @@
+/*
+ * Interface for the firmware-specific parts of the UI task
+ */
+#pragma once
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+namespace ui_control_task {
+     // Function that actually starts the task
+     auto start() -> TaskHandle_t;
+}


### PR DESCRIPTION
Compiles in the FreeRTOS implementation build in to the STM32F303
BSP (not the CMSIS RTOS, though, because we are not ever going to change
the RTOS thank you very much and support and docs for FreeRTOS are much
more widely available).

This uses FreeRTOS's static allocation setup, in addition to (at this
point) heap implementation 5 - might change that. We want static
allocation for as much as we can get away with, and separate
per-use-case memory pools for the rest (e.g. for messages sent over
queues).

This also sets up and runs the main tasks that the firmware will have -
motor control, heater control, UI control, and host communications
control. They don't do anything yet though.