### PR TITLE
feat(heater-shaker): add generic gcode parser

### DIFF
--- a/stm32-modules/heater-shaker/include/heater-shaker/gcode_parser.h
+++ b/stm32-modules/heater-shaker/include/heater-shaker/gcode_parser.h
@@ -1,4 +1,0 @@
-#ifndef __GCODE_PARSER_H_
-#define __GCODE_PARSER_H_
-
-#endif  // __GCODE_PARSER_H_

--- a/stm32-modules/heater-shaker/include/heater-shaker/gcode_parser.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/gcode_parser.hpp
@@ -1,0 +1,228 @@
+/*
+** gcode_parser - a templated gcode parser for use anywhere
+*/
+#pragma once
+
+#include <stdio.h>
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+
+namespace gcode {
+
+/*
+ * gcode::gobble_whitespace is a convenience function to strip out any
+ * whitespace from an input; the returned iterator is after any whitespace at
+ * the head of the input.
+ */
+template <typename Input, typename Limit>
+requires std::forward_iterator<Input>&&
+    std::sized_sentinel_for<Limit, Input> auto
+    gobble_whitespace(const Input& start_from, const Limit stop_at) -> Input {
+    // this has to be a lambda because std::isspace's prototype does not
+    // interact well with template argument deduction, sadly
+    return std::find_if_not(
+        start_from, stop_at,
+        [](const unsigned char c) -> bool { return std::isspace(c); });
+}
+
+/*
+ *  gcode::prefix_matches is a convenience function for gcode parsers that
+ * checks length and matches a char array representing a prefix. If the match
+ * fails, the returned iterator is the same as passed in; if it succeeds, it
+ * will point to immediately after the prefix in the input.
+ */
+template <typename Input, typename Limit, typename PrefixArray>
+requires std::forward_iterator<Input>&& std::sized_sentinel_for<Limit, Input>&&
+    std::convertible_to<std::iter_value_t<Input>,
+                        typename PrefixArray::value_type> auto
+    prefix_matches(const Input& start_from, const Limit stop_at,
+                   const PrefixArray& prefix) -> Input {
+    if (static_cast<size_t>(stop_at - start_from) <= prefix.size()) {
+        return start_from;
+    }
+    if (!std::equal(prefix.cbegin(), prefix.cend(), start_from)) {
+        return start_from;
+    }
+    return start_from + prefix.size();
+}
+
+/*
+ * gcode::parse_value is a convenience function for parsing a value out of a
+ * gcode string. If the match succeeds, the optional part of the pair will be
+ * filled in and the iterator part of the pair will point to just past the value
+ * (which will therefore be a whitespace). If the match fails, the optional part
+ * of the pair will be empty, and the iterator part of the pair will point to
+ * the input.
+ *
+ * This function folds in both the calls to the value-from-string parsing
+ * functions and some basic structural verification. Because gcodes and gcode
+ * arguments are separated with spaces, and because we're only going to parse
+ * strings that are complete and therefore delimited with newlines, any value
+ * should be followed by something that passes std::isspace(). If it isn't, then
+ * we've got malformed input (e.g. a float value with a decimal point in a
+ * context that expects an int).
+ */
+template <typename ValueType, typename Input, typename Limit,
+          size_t working_buf_size = 32>
+requires std::forward_iterator<Input>&& std::sized_sentinel_for<Limit, Input>&&
+    std::integral<ValueType> auto
+    parse_value(const Input& start_from, const Limit stop_at)
+        -> std::pair<std::optional<ValueType>, Input> {
+    ValueType value = 0;
+    Input working = start_from;
+    auto [after_ptr, ec] = std::from_chars(&(*working), &(*stop_at), value);
+    if (ec != std::errc()) {
+        // some error occurred
+        return std::make_pair(std::optional<ValueType>(), start_from);
+    }
+    if (!std::isspace(*after_ptr)) {
+        // gcodes should be terminated by some whitespace, either a space
+        // separating it from the next gcode or an \r\n terminator sequence
+        return std::make_pair(std::optional<ValueType>(), start_from);
+    }
+    auto after = working + (after_ptr - &(*working));
+    return std::make_pair(std::optional<ValueType>(value), after);
+}
+
+// sadly we need a float-specific version that works completely differently
+// because std::from_chars isn't implemented at least in gcc 10, because the
+// language specification makes it very hard. working_buf_size will be the size
+// of the temporary array allocated ON THE STACK (so keep it nice and small) to
+// ensure that the input has a null in it somewhere since we have to use sscanf
+// for this.
+template <typename ValueType, typename Input, typename Limit,
+          size_t working_buf_size = 32>
+requires std::forward_iterator<Input>&& std::sized_sentinel_for<Limit, Input>&&
+    std::floating_point<ValueType> auto
+    parse_value(const Input& start_from, const Limit stop_at)
+        -> std::pair<std::optional<ValueType>, Input> {
+    ValueType value = 0;
+    std::array<std::iter_value_t<Input>, working_buf_size> buf;
+    std::copy(start_from, std::min(stop_at, start_from + working_buf_size),
+              buf.begin());
+    buf.at(std::min(buf.size() - 1,
+                    static_cast<size_t>(stop_at - start_from))) = 0;
+    int distance = 0;
+    int worked = sscanf(&(*start_from), "%f%n", &value, &distance);
+    if (worked != 1) {
+        return std::make_pair(std::optional<ValueType>(), start_from);
+    }
+    auto after = start_from + distance;
+    if (after == stop_at || !std::isspace(*after)) {
+        return std::make_pair(std::optional<ValueType>(), start_from);
+    }
+    return std::make_pair(std::optional<ValueType>(value), after);
+}
+
+template <typename... GCodes>
+class GroupParser {
+  public:
+    using ParseResult = std::variant<std::monostate, GCodes...>;
+
+    /*
+     * gcode::parse_available is the main interface to the parser. It is capable
+     * of handling any data structure that provides forward iterators (checked
+     * in the template requirements).
+     *
+     * It will parse the first gcode available in the iterator passed in and
+     * return it, if any. That means it should be called multiple times, passing
+     * the iterator returned in .second each time, to iteratively parse out
+     * gcodes from the input string.
+     *
+     * As long as it is only called on an input that should be complete (e.g.
+     * ends with \r\n), then any failure to parse a gcode indicates a malformed
+     * input (rather than an incomplete input).
+     *
+     * If invalid data leads the input (as in, a full match pass of all
+     * subparsers starting at start_from fails) then the input is rejected, and
+     * the returned iterator is set to the end.
+     *
+     * You use this by creating the class instance templated with the kinds of
+     * gcodes you want to use:
+     *
+     * auto parser = GroupParser<GCode1, GCode2, ..., GCodeN>();
+     *
+     * This is mostly to make the template interface of parse_available less
+     * complex; no state is held by the object created in this way.
+     *
+     * You then call parse_available using whatever iterators you have:
+     *
+     * std::array string = "G0 \r\n";
+     * auto start = string.cbegin();
+     * auto result = parse_available(start, string.cend());
+     *
+     * The result is a std::variant of all the kinds of gcodes sent as template
+     * arguments to the class and std::monostate, which represents the empty
+     * state, paired with an iterator pointing to the place that the next parse
+     * run should start.
+     */
+    template <typename Input, typename Limit>
+    requires std::forward_iterator<Input>&&
+        std::sized_sentinel_for<Limit, Input> auto
+        parse_available(Input start_from, const Limit stop_at)
+            -> std::pair<ParseResult, Input> {
+        // Take out all whitespace at the head of the string
+        start_from = gobble_whitespace(start_from, stop_at);
+        // We need to prep a result to capture in the lambda in the fold
+        // expression below because the fold expression can't really condense
+        // its results any other way
+        auto result = ParseResult(std::monostate());
+
+        // the meat of the function is a template fold expression
+        // (https://en.cppreference.com/w/cpp/language/fold), variant 1. This is
+        // how you iterate at runtime over a set of template arguments.
+        (  // the template-fold needs delimiters around it, so this starts the
+           // fold We need something to condense the results of every parse
+           // operation into the variant. This lambda definition, which captures
+           // our predefined result and our current iterator by reference, does
+           // that. It will actually get compiled to a couple different
+           // implementations, and its job is to take the std::optional that
+           // each gcode parser returns and coalesce the results into the
+           // std::variant union type.
+            [&result, &start_from](decltype(
+                GCodes::parse(start_from, stop_at)) this_result) -> void {
+                // the rule here is that we take the first match, so we only
+                // store the result if there's nothing in our variant yet, and
+                // the parse succeeded.
+                if (this_result.first.has_value() &&
+                    std::holds_alternative<std::monostate>(result)) {
+                    result = *(this_result.first);
+                    start_from = this_result.second;
+                }
+            }  // this ends the lambda definition
+               // Once we've defined the lambda, we can call it immediately; the
+               // argument we give it is the result of caling GCodes::parse().
+               // GCodes:: will get expanded into the specific element of our
+               // template parameter pack that we're currently processing The
+               // comma is actually operator, which is an operator that returns
+               // the thing on its right. It does nothing here other than
+               // satisfy the requirement that a tmeplate fold must have an
+               // operator.
+            (GCodes::parse(start_from, stop_at)),
+            ...);  // and our mandatory ... element ends the fold
+
+        if (std::holds_alternative<std::monostate>(result)) {
+            // After the fold completes, either result has not been filled in
+            // and still holds the monostate it was created with, in which case
+            // parsing has failed, which - given that this function requires a
+            // fully terminated string - means the string does not hold valid
+            // gcode and thus no further parsing should be done, so we can
+            // return the end iterator
+            return std::make_pair(result, stop_at);
+        } else {
+            // or result has been filled in, we have a gcode to return, and we
+            // need to use start_from, which has been modified by whichever
+            // lambda invocation it was that succeeded and now points to the
+            // location in the input at which the next parse run should start.
+            return std::make_pair(result, start_from);
+        }
+    }
+};
+}  // namespace gcode

--- a/stm32-modules/heater-shaker/include/heater-shaker/gcodes.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/gcodes.hpp
@@ -1,0 +1,135 @@
+/*
+** Definitions of valid gcodes understood by the heater/shaker; intended to work
+*with
+** the gcode parser in gcode_parser.hpp
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <cstdint>
+#include <iterator>
+#include <optional>
+#include <utility>
+
+#include "heater-shaker/gcode_parser.hpp"
+
+namespace gcode {
+struct SetRPM {
+    /*
+    ** Set RPM uses the spindle-speed code from standard gcode, M3 (CW)
+    ** Format: M3 S<RPM>
+    ** Example: M3 S500 sets target rpm to 500
+    */
+    using ParseResult = std::optional<SetRPM>;
+    uint32_t rpm;
+
+    template <typename InputIt, typename Limit>
+    requires std::contiguous_iterator<InputIt>&&
+        std::sized_sentinel_for<Limit, InputIt> static auto
+        parse(const InputIt& input, Limit limit)
+            -> std::pair<ParseResult, InputIt> {
+        // minimal m3 command
+        constexpr auto prefix = std::array{'M', '3', ' ', 'S'};
+
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+
+        auto value_res = parse_value<uint32_t>(working, limit);
+
+        if (!value_res.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(SetRPM{.rpm = static_cast<uint32_t>(
+                                                     value_res.first.value())}),
+                              value_res.second);
+    }
+};
+
+struct SetTemperature {
+    /*
+    ** SetTemperature uses a standard set-tool-temperature gcode, M104
+    ** Format: M104 S<temp>
+    ** Example: M104 S25 sets target temperature to 25C
+    */
+    using ParseResult = std::optional<SetTemperature>;
+    float temperature;
+
+    template <typename InputIt, typename Limit>
+    requires std::contiguous_iterator<InputIt>&&
+        std::sized_sentinel_for<Limit, InputIt> static auto
+        parse(const InputIt& input, Limit limit)
+            -> std::pair<ParseResult, InputIt> {
+        constexpr auto prefix = std::array{'M', '1', '0', '4', ' ', 'S'};
+
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+
+        auto value_res = parse_value<float>(working, limit);
+
+        if (!value_res.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+
+        if (value_res.first.value() < 0) {
+            return std::make_pair(ParseResult(), input);
+        }
+
+        return std::make_pair(
+            ParseResult(SetTemperature{.temperature = value_res.first.value()}),
+            value_res.second);
+    }
+};
+
+struct GetTemperature {
+    /*
+    ** GetTemperature keys off a standard get-tool-temperature gcode, M105
+    ** Format: M105
+    ** Example: M105
+    */
+    using ParseResult = std::optional<GetTemperature>;
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<Limit, InputIt> static auto
+        parse(const InputIt& input, Limit limit)
+            -> std::pair<ParseResult, InputIt> {
+        constexpr auto prefix = std::array{'M', '1', '0', '5'};
+
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(GetTemperature()), working);
+    }
+};
+
+struct GetRPM {
+    /*
+    ** GetRPM keys off a random gcode that sometimes does the right thing since
+    *it's not
+    ** like it's standardized or anything, M123
+    ** Format: M123
+    ** Example: M123
+    */
+    using ParseResult = std::optional<GetRPM>;
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<Limit, InputIt> static auto
+        parse(const InputIt& input, Limit limit)
+            -> std::pair<ParseResult, InputIt> {
+        constexpr auto prefix = std::array{'M', '1', '2', '3'};
+
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(GetRPM()), working);
+    }
+};
+}  // namespace gcode

--- a/stm32-modules/heater-shaker/src/gcode_parser.cpp
+++ b/stm32-modules/heater-shaker/src/gcode_parser.cpp
@@ -1,1 +1,0 @@
-#include "gcode_parser.h"

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -6,6 +6,8 @@ include(AddBuildAndTestTarget)
 
 add_executable(heater-shaker
   task_builder.cpp
+  test_gcode_parse.cpp
+  test_gcodes.cpp
   test_main.cpp)
 target_include_directories(heater-shaker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 set_target_properties(heater-shaker

--- a/stm32-modules/heater-shaker/tests/test_gcode_parse.cpp
+++ b/stm32-modules/heater-shaker/tests/test_gcode_parse.cpp
@@ -1,0 +1,162 @@
+#include <algorithm>
+#include <array>
+#include <iterator>
+#include <optional>
+#include <utility>
+
+#include "catch2/catch.hpp"
+#include "heater-shaker/gcode_parser.hpp"
+
+struct G28D2 {
+    using ParseResult = std::optional<G28D2>;
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<Limit, InputIt> static auto
+        parse(const InputIt& input, Limit limit)
+            -> std::pair<ParseResult, InputIt> {
+        auto code = std::array{'G', '2', '8', '.', '2'};
+        if (static_cast<size_t>(limit - input) >= code.size() &&
+            std::equal(code.cbegin(), code.cend(), input)) {
+            return std::make_pair(ParseResult(G28D2()), input + code.size());
+        } else {
+            return std::make_pair(ParseResult(), input);
+        }
+    }
+};
+
+struct M105 {
+    using ParseResult = std::optional<M105>;
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<Limit, InputIt> static auto
+        parse(const InputIt& input, Limit limit)
+            -> std::pair<ParseResult, InputIt> {
+        using namespace std::string_literals;
+        auto code = std::array{'M', '1', '0', '5'};
+        if (static_cast<size_t>(limit - input) >= code.size() &&
+            std::equal(code.cbegin(), code.cend(), input)) {
+            return std::make_pair(ParseResult(M105()), input + code.size());
+        } else {
+            return std::make_pair(ParseResult(), input);
+        }
+    }
+};
+
+SCENARIO("GroupParser handles gcodes", "[gcode]") {
+    GIVEN("A GroupParser with a couple recognizers") {
+        auto parser = gcode::GroupParser<G28D2, M105>();
+        AND_GIVEN("an empty string") {
+            const std::string empty = "";
+            WHEN("calling parse()") {
+                auto begin = empty.cbegin();
+                auto result = parser.parse_available(begin, empty.cend());
+
+                THEN("The result is empty") {
+                    REQUIRE(
+                        std::holds_alternative<std::monostate>(result.first));
+                    REQUIRE(result.second == empty.cbegin());
+                }
+            }
+        }
+        AND_GIVEN("a string with delimieters but no gcode") {
+            const std::string with_delimiters = "\r\n";
+            WHEN("calling parse()") {
+                auto begin = with_delimiters.cbegin();
+                auto result =
+                    parser.parse_available(begin, with_delimiters.cend());
+
+                THEN("The result is empty") {
+                    REQUIRE(
+                        std::holds_alternative<std::monostate>(result.first));
+                    REQUIRE(result.second == with_delimiters.cend());
+                }
+            }
+        }
+
+        AND_GIVEN("a string with one gcode") {
+            const std::string has_gcode = "G28.2\r\n";
+            WHEN("calling parse() the first time") {
+                auto begin = has_gcode.cbegin();
+                auto result = parser.parse_available(begin, has_gcode.cend());
+                THEN("the first result is the gcode and parsing remains") {
+                    REQUIRE(std::holds_alternative<G28D2>(result.first));
+                    REQUIRE(result.second != has_gcode.cend());
+                }
+                AND_WHEN("calling parse() again") {
+                    auto nothing_else =
+                        parser.parse_available(result.second, has_gcode.cend());
+                    THEN("the second result is empty and parsing is done") {
+                        REQUIRE(std::holds_alternative<std::monostate>(
+                            nothing_else.first));
+                        REQUIRE(nothing_else.second == has_gcode.cend());
+                    }
+                }
+            }
+        }
+
+        AND_GIVEN("a string with several gcodes") {
+            const std::string multiple_gcodes = "G28.2 M105 G28.2\r\n";
+            WHEN("calling parse() the first time") {
+                auto begin = multiple_gcodes.cbegin();
+                auto first_result =
+                    parser.parse_available(begin, multiple_gcodes.cend());
+                THEN(
+                    "the first result is the first gcode and parsing remains") {
+                    REQUIRE(std::holds_alternative<G28D2>(first_result.first));
+                    REQUIRE(first_result.second != multiple_gcodes.cend());
+                }
+                AND_WHEN("calling parse() the second time") {
+                    auto second_result = parser.parse_available(
+                        first_result.second, multiple_gcodes.cend());
+                    THEN(
+                        "the second result is the second gcode and parsing "
+                        "remains") {
+                        REQUIRE(
+                            std::holds_alternative<M105>(second_result.first));
+                        REQUIRE(second_result.second != multiple_gcodes.cend());
+                    }
+                    AND_WHEN("calling parse() the third time") {
+                        auto third_result = parser.parse_available(
+                            second_result.second, multiple_gcodes.cend());
+                        THEN(
+                            "the third result is the third gcode and parsing "
+                            "remains") {
+                            REQUIRE(std::holds_alternative<G28D2>(
+                                third_result.first));
+                            REQUIRE(third_result.second !=
+                                    multiple_gcodes.cend());
+                        }
+                        AND_WHEN("calling parse() the fourth time") {
+                            auto no_result = parser.parse_available(
+                                third_result.second, multiple_gcodes.cend());
+                            THEN(
+                                "the fourth result is empty and parsing is "
+                                "done") {
+                                REQUIRE(std::holds_alternative<std::monostate>(
+                                    no_result.first));
+                                REQUIRE(no_result.second ==
+                                        multiple_gcodes.cend());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        AND_GIVEN("a string with invalid data") {
+            const std::string all_invalid = "ajahsdkjahsdf\r\n";
+            WHEN("calling parse()") {
+                auto begin = all_invalid.cbegin();
+                auto first_result =
+                    parser.parse_available(begin, all_invalid.cend());
+                THEN("the result is empty and parsing is done") {
+                    REQUIRE(std::holds_alternative<std::monostate>(
+                        first_result.first));
+                    REQUIRE(first_result.second == all_invalid.cend());
+                }
+            }
+        }
+    }
+}

--- a/stm32-modules/heater-shaker/tests/test_gcodes.cpp
+++ b/stm32-modules/heater-shaker/tests/test_gcodes.cpp
@@ -1,0 +1,358 @@
+#include <array>
+
+#include "catch2/catch.hpp"
+#include "heater-shaker/gcodes.hpp"
+
+SCENARIO("SetRPM parser works") {
+    GIVEN("an empty string") {
+        std::string to_parse = "";
+
+        WHEN("calling parse") {
+            auto result =
+                gcode::SetRPM::parse(to_parse.cbegin(), to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a fully non-matching string") {
+        std::string to_parse = "asdhalghasdasd ";
+
+        WHEN("calling parse") {
+            auto result =
+                gcode::SetRPM::parse(to_parse.cbegin(), to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with prefix only") {
+        auto to_parse = std::array{'M', '3', ' ', 'S'};
+
+        WHEN("calling parse") {
+            auto result =
+                gcode::SetRPM::parse(to_parse.cbegin(), to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a subprefix matching only") {
+        std::string to_parse = "Masdlasfhalsd\r\n";
+        WHEN("calling parse") {
+            auto result =
+                gcode::SetRPM::parse(to_parse.cbegin(), to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a prefix matching but bad data") {
+        std::string to_parse = "M3 Salsjdhas\r\n";
+        WHEN("calling parse") {
+            auto result =
+                gcode::SetRPM::parse(to_parse.cbegin(), to_parse.cend());
+
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a matching prefix and float data") {
+        std::string to_parse = "M3 S1000.0\r\n";
+        WHEN("calling parse") {
+            auto result =
+                gcode::SetRPM::parse(to_parse.cbegin(), to_parse.cend());
+
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a matching prefix and a negative value") {
+        std::string to_parse = "M3 S-10\r\n";
+        WHEN("calling parse") {
+            auto result =
+                gcode::SetRPM::parse(to_parse.cbegin(), to_parse.cend());
+
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a matching prefix and positive integral data") {
+        std::string to_parse = "M3 S1000\r\n";
+        WHEN("calling parse") {
+            auto result =
+                gcode::SetRPM::parse(to_parse.cbegin(), to_parse.cend());
+
+            THEN("a gcode should be parsed") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.first.value().rpm == 1000);
+                REQUIRE(result.second == to_parse.cbegin() + 8);
+            }
+        }
+    }
+
+    GIVEN("a string with valid data and content afterwards") {
+        std::string to_parse = "M3 S1000 asgasasd";
+        WHEN("calling parse") {
+            auto result =
+                gcode::SetRPM::parse(to_parse.cbegin(), to_parse.cend());
+
+            THEN("a gcode should be parsed") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.first.value().rpm == 1000);
+                AND_THEN(
+                    "the iterator should past just past the end of the gcode") {
+                    REQUIRE(result.second == to_parse.cbegin() + 8);
+                }
+            }
+        }
+    }
+}
+
+SCENARIO("SetTemperature parser works") {
+    GIVEN("an empty string") {
+        std::string to_parse = "";
+
+        WHEN("calling parse") {
+            auto result = gcode::SetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a fully non-matching string") {
+        std::string to_parse = "asdhalghasdasd ";
+
+        WHEN("calling parse") {
+            auto result = gcode::SetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with prefix only") {
+        auto to_parse = std::array{'M', '1', '0', '4', ' ', 'S'};
+
+        WHEN("calling parse") {
+            auto result = gcode::SetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a subprefix matching only") {
+        std::string to_parse = "Masdlasfhalsd\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a prefix matching but bad data") {
+        std::string to_parse = "M104 Salsjdhas\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a matching prefix and a negative value") {
+        std::string to_parse = "M104 S-10\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a matching prefix and positive float data") {
+        std::string to_parse = "M104 S25.25\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+
+            THEN("a value should be parsed") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.first.value().temperature == 25.25);
+                REQUIRE(result.second == to_parse.cbegin() + 11);
+            }
+        }
+    }
+
+    GIVEN("a string with a matching prefix and positive integral data") {
+        std::string to_parse = "M104 S25\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+
+            THEN("a gcode should be parsed") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.first.value().temperature == 25);
+                REQUIRE(result.second == to_parse.cbegin() + 8);
+            }
+        }
+    }
+
+    GIVEN("a string with valid data and content afterwards") {
+        std::string to_parse = "M104 S25.25 asgasasd";
+        WHEN("calling parse") {
+            auto result = gcode::SetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+
+            THEN("a gcode should be parsed") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.first.value().temperature == 25.25);
+                AND_THEN(
+                    "the iterator should point just past the end of the "
+                    "gcode") {
+                    REQUIRE(result.second == to_parse.cbegin() + 11);
+                }
+            }
+        }
+    }
+}
+
+SCENARIO("GetTemperature parser works") {
+    GIVEN("an empty string") {
+        std::string to_parse = "";
+
+        WHEN("calling parse") {
+            auto result = gcode::GetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a fully non-matching string") {
+        std::string to_parse = "asdhalghasdasd ";
+
+        WHEN("calling parse") {
+            auto result = gcode::GetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a subprefix matching only") {
+        std::string to_parse = "Masdlasfhalsd\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::GetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a good gcode") {
+        auto to_parse = std::array{'M', '1', '0', '5', '\r', '\n'};
+
+        WHEN("calling parse") {
+            auto result = gcode::GetTemperature::parse(to_parse.cbegin(),
+                                                       to_parse.cend());
+            THEN("a gcode should be parsed") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin() + 4);
+            }
+        }
+    }
+}
+
+SCENARIO("GetRPM parser works") {
+    GIVEN("an empty string") {
+        std::string to_parse = "";
+
+        WHEN("calling parse") {
+            auto result =
+                gcode::GetRPM::parse(to_parse.cbegin(), to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a fully non-matching string") {
+        std::string to_parse = "asdhalghasdasd ";
+
+        WHEN("calling parse") {
+            auto result =
+                gcode::GetRPM::parse(to_parse.cbegin(), to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a subprefix matching only") {
+        std::string to_parse = "Masdlasfhalsd\r\n";
+        WHEN("calling parse") {
+            auto result =
+                gcode::GetRPM::parse(to_parse.cbegin(), to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a good gcode") {
+        auto to_parse = std::array{'M', '1', '2', '3', '\r', '\n'};
+
+        WHEN("calling parse") {
+            auto result =
+                gcode::GetRPM::parse(to_parse.cbegin(), to_parse.cend());
+            THEN("a gcode should be parsed") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin() + 4);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a generic (limited, single-level) parser-combinator style gcode
parser using templates.

This parser (in gcode_parser.hpp) parses gcodes, one at a time, out of a
"complete" gcode command string - a command string that ends in a
newline delimiter and therefore represents upstream's intent that the
command is complete.

While the parser isn't yet instantiated in the application code, because
there's not really anything that can feed it data yet, it is fully
tested and ready for use.