### PR TITLE
feat(heater-shaker): add tested PID calculator

### DIFF
--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -61,7 +61,8 @@ target_compile_options(heater-shaker
 
 target_link_libraries(
   heater-shaker
-  STM32F303BSP_Drivers STM32F303BSP_USB STM32F303BSP_FreeRTOS)
+  STM32F303BSP_Drivers STM32F303BSP_USB STM32F303BSP_FreeRTOS heater-shaker-core)
+
 
 target_include_directories(STM32F303BSP_Drivers
   PUBLIC .)
@@ -117,9 +118,10 @@ set(CLANG_EXTRA_ARGS ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 list(TRANSFORM CLANG_EXTRA_ARGS PREPEND --extra-arg=-I)
 # This helps with clang accepting what GCC accepts around the implementations of the message queue
 list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-frelaxed-template-template-args")
+get_target_property(core_sources heater-shaker-core SOURCES)
 add_custom_target(heater-shaker-lint
   ALL
-  COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${HS_FW_LINTABLE_SRCS} --config=)
+  COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${HS_FW_LINTABLE_SRCS} ${core_sources} --config=)
 
 # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
 # arguable misuse of the concept) to the appropriate cross-gdb with

--- a/stm32-modules/heater-shaker/include/heater-shaker/pid.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/pid.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+class PID {
+  public:
+    PID() = delete;
+    PID(float kp, float ki, float kd);
+    PID(float kp, float ki, float kd, float windup_limit_high,
+        float windup_limit_low);
+    auto compute(float error) -> float;
+    auto reset() -> void;
+    [[nodiscard]] auto kp() const -> float;
+    [[nodiscard]] auto ki() const -> float;
+    [[nodiscard]] auto kd() const -> float;
+    [[nodiscard]] auto windup_limit_high() const -> float;
+    [[nodiscard]] auto windup_limit_low() const -> float;
+    [[nodiscard]] auto integrator() const -> float;
+    [[nodiscard]] auto last_error() const -> float;
+
+  private:
+    const float _kp;
+    const float _ki;
+    const float _kd;
+    const float _windup_limit_high;
+    const float _windup_limit_low;
+    float _integrator;
+    float _last_error;
+};

--- a/stm32-modules/heater-shaker/src/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/src/CMakeLists.txt
@@ -1,3 +1,26 @@
 # This CMakeLists.txt handles compiling all the parts of the heater-shaker
 # module that are portable between host and cross compilation as a static
 # library. It is included in both host and cross configurations.
+
+add_library(heater-shaker-core STATIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/pid.cpp
+  )
+
+set_target_properties(heater-shaker-core
+  PROPERTIES CXX_STANDARD 20
+             CXX_STANDARD_REQUIRED TRUE)
+
+target_include_directories(heater-shaker-core
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
+target_compile_options(heater-shaker-core
+  PRIVATE
+  -Wall
+  -Werror
+  -Weffc++
+  -Wreorder
+  -Wsign-promo
+  -Wextra-semi
+  -Wctor-dtor-privacy
+  -fno-rtti
+  )

--- a/stm32-modules/heater-shaker/src/pid.cpp
+++ b/stm32-modules/heater-shaker/src/pid.cpp
@@ -1,0 +1,45 @@
+#include "heater-shaker/pid.hpp"
+
+#include <algorithm>
+#include <limits>
+
+PID::PID(float kp, float ki, float kd)
+    : PID(kp, ki, kd, std::numeric_limits<float>::infinity(),
+          -std::numeric_limits<float>::infinity()) {}
+
+PID::PID(float kp, float ki, float kd, float windup_limit_high,
+         float windup_limit_low)
+    : _kp(kp),
+      _ki(ki),
+      _kd(kd),
+      _windup_limit_high(windup_limit_high),
+      _windup_limit_low(windup_limit_low),
+      _integrator(0),
+      _last_error(0) {}
+
+auto PID::kp() const -> float { return _kp; }
+
+auto PID::ki() const -> float { return _ki; }
+
+auto PID::kd() const -> float { return _kd; }
+
+auto PID::windup_limit_high() const -> float { return _windup_limit_high; }
+
+auto PID::windup_limit_low() const -> float { return _windup_limit_low; }
+
+auto PID::integrator() const -> float { return _integrator; }
+
+auto PID::last_error() const -> float { return _last_error; }
+
+auto PID::compute(float error) -> float {
+    _integrator =
+        std::clamp(error + _integrator, _windup_limit_low, _windup_limit_high);
+    const float errdiff = error - _last_error;
+    _last_error = error;
+    return (_kp * error) + (_kd * errdiff) + (_ki * _integrator);
+}
+
+auto PID::reset() -> void {
+    _integrator = 0;
+    _last_error = 0;
+}

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(heater-shaker
   task_builder.cpp
   test_gcode_parse.cpp
   test_gcodes.cpp
+  test_pid.cpp
   test_main.cpp)
 target_include_directories(heater-shaker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 set_target_properties(heater-shaker
@@ -25,7 +26,7 @@ target_compile_options(heater-shaker
   -Wextra-semi
   -Wctor-dtor-privacy
   -fno-rtti)
-target_link_libraries(heater-shaker Catch2::Catch2)
+target_link_libraries(heater-shaker heater-shaker-core Catch2::Catch2)
 
 catch_discover_tests(heater-shaker)
 add_build_and_test_target(heater-shaker)

--- a/stm32-modules/heater-shaker/tests/test_pid.cpp
+++ b/stm32-modules/heater-shaker/tests/test_pid.cpp
@@ -1,0 +1,219 @@
+#include <limits>
+#include <vector>
+
+#include "catch2/catch.hpp"
+#include "heater-shaker/pid.hpp"
+
+SCENARIO("PID controller") {
+    GIVEN("a PID controller initialized with all 0 coeffs") {
+        auto p = PID(0, 0, 0);
+        WHEN("calculating a value") {
+            auto result = p.compute(12312.0);
+            THEN("the result should be 0") { REQUIRE(result == 0.0); }
+            AND_WHEN("calculating a subsequent value") {
+                auto result2 = p.compute(221351.2);
+                THEN("the result should remain 0") { REQUIRE(result2 == 0.0); }
+            }
+        }
+    }
+    GIVEN("a PID controller") {
+        auto p = PID(1.0, 2.0, 3.0, 4.0, -5.0);
+        WHEN("querying the accessors for static data") {
+            auto kp = p.kp();
+            auto ki = p.ki();
+            auto kd = p.kd();
+            auto windup_high = p.windup_limit_high();
+            auto windup_low = p.windup_limit_low();
+            THEN("the queried values should match the ctor values") {
+                REQUIRE(kp == 1.0);
+                REQUIRE(ki == 2.0);
+                REQUIRE(kd == 3.0);
+                REQUIRE(windup_high == 4.0);
+                REQUIRE(windup_low == -5.0);
+            }
+        }
+        WHEN("computing values") {
+            p.compute(2.0);
+            p.compute(3.0);
+            THEN("the updated state should be correct") {
+                REQUIRE(p.last_error() == 3.0);
+                REQUIRE(p.integrator() == 4.0);
+            }
+        }
+    }
+    GIVEN("a PID controller with only kp") {
+        auto p = PID(2.0, 0, 0);
+        WHEN("repeatedly calculating controls") {
+            std::vector<float> results(8);
+            std::vector<float> inputs = {0, 1, 2, 3, 4, 5, 6, 7};
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error) { return p.compute(error); });
+            THEN("the result should depend only on the current input") {
+                std::vector<float> intended(8);
+                std::transform(inputs.cbegin(), inputs.cend(), intended.begin(),
+                               [](float error) { return error * 2.0; });
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+        WHEN("calculating controls with a reset after every calculation") {
+            std::vector<float> results(8);
+            std::vector<float> inputs = {0, 1, 2, 3, 4, 5, 6, 7};
+            std::transform(inputs.cbegin(), inputs.cend(), results.begin(),
+                           [&p](const float& error) {
+                               p.reset();
+                               return p.compute(error);
+                           });
+            THEN("the result should depend only on the current input") {
+                std::vector<float> intended(8);
+                std::transform(inputs.cbegin(), inputs.cend(), intended.begin(),
+                               [](float error) { return error * 2.0; });
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+    }
+    GIVEN("a PID controller with only kd") {
+        auto p = PID(0, 0, 1.0);
+        WHEN("repeatedly calculating controls") {
+            std::vector<float> results(8);
+            std::vector<float> inputs = {0, 1, 2, 4, 8, 16, 32, 64};
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error) { return p.compute(error); });
+            THEN("the result should depend only on the trailing difference") {
+                std::vector<float> intended;
+                intended.reserve(8);
+                auto output_iter = intended.begin();
+                auto trailing_input = inputs.cbegin();
+                bool is_first = true;
+                std::for_each(inputs.cbegin(), inputs.cend(),
+                              [&output_iter, &trailing_input, &is_first,
+                               &intended](float error) {
+                                  if (is_first) {
+                                      is_first = false;
+                                      intended.push_back(error);
+                                  } else {
+                                      auto last = *trailing_input;
+                                      trailing_input++;
+                                      intended.push_back(error - last);
+                                  }
+                              });
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+        WHEN("resetting in between calculations") {
+            std::vector<float> results(8);
+            std::vector<float> inputs = {0, 1, 2, 4, 8, 16, 32, 64};
+            std::transform(inputs.cbegin(), inputs.cend(), results.begin(),
+                           [&p](const float& error) {
+                               p.reset();
+                               return p.compute(error);
+                           });
+            THEN("the result should always calculate a difference from 0") {
+                REQUIRE_THAT(results, Catch::Matchers::Equals(inputs));
+            }
+        }
+    }
+
+    GIVEN("a PID controller with only ki and no windup limiters") {
+        auto p = PID(0, 1.0, 0);
+        WHEN("repeatedly calculating controls from positive errors") {
+            std::vector<float> results(8);
+            std::vector<float> inputs = {2, 2, 2, 2, 2, 2, 2, 2};
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error) { return p.compute(error); });
+            THEN("the result should accumulate without bound") {
+                std::vector<float> intended;
+                for (size_t i = 0; i < inputs.size(); i++) {
+                    intended.push_back((i + 1) * 2);
+                }
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+
+        WHEN("repeatedly calculating controls from negative errors") {
+            std::vector<float> results(8);
+            std::vector<float> inputs = {-10, -10, -10, -10,
+                                         -10, -10, -10, -10};
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error) { return p.compute(error); });
+            THEN("the result should accumulate without bound") {
+                std::vector<float> intended;
+                for (size_t i = 0; i < inputs.size(); i++) {
+                    intended.push_back((i + 1) * -10.0);
+                }
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+
+        WHEN("alternating input signs") {
+            std::vector<float> results(8);
+            std::vector<float> inputs = {10, -10, -10, 10, 10, 10, -10, -10};
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error) { return p.compute(error); });
+            THEN("the integral term is properly cancelled") {
+                std::vector<float> intended = {10, 0, -10, 0, 10, 20, 10, 0};
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+    }
+
+    GIVEN("a PID controller with only ki and a windup limiter") {
+        auto p = PID(0, 2, 0, 16, -12);
+        WHEN("repeatedly calculating controls from positive errors") {
+            std::vector<float> inputs = {3, 3, 3, 3, 3, 3, 3, 3};
+            std::vector<float> results(8);
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error) { return p.compute(error); });
+            THEN("the result should accumulate and clip at bound") {
+                std::vector<float> intended = {6, 12, 18, 24, 30, 32, 32, 32};
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+
+        WHEN("repeatedly calculating controls from negative errors") {
+            std::vector<float> inputs = {-2, -2, -2, -2, -2, -2, -2, -2};
+            std::vector<float> results(8);
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error) { return p.compute(error); });
+            THEN("the result should accumulate and clip at bound") {
+                std::vector<float> intended = {-4,  -8,  -12, -16,
+                                               -20, -24, -24, -24};
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+
+        WHEN("alternating input signs") {
+            std::vector<float> results(6);
+            std::vector<float> inputs = {10, 10, -16, -10, -10, 12};
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error) { return p.compute(error); });
+            THEN(
+                "the integral term is properly cancelled by negating the "
+                "clip") {
+                std::vector<float> intended = {20, 32, 0, -20, -24, 0};
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+    }
+
+    GIVEN("a PID controller with all coeffs set and windup limiters present") {
+        auto p = PID(2, -1, 1, 10, -12);
+        WHEN("repeatedly calculating controls") {
+            THEN("the result should behave correctly from first principles") {
+                REQUIRE(p.compute(1) == 2);
+                REQUIRE(p.last_error() == 1);
+                REQUIRE(p.integrator() == 1);
+                REQUIRE(p.compute(2) == 2);
+                REQUIRE(p.last_error() == 2);
+                REQUIRE(p.integrator() == 3);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a PID calculator integration. This is the core of a PID
controller. It computes a control output based on an error input,
certain historical data (for the integral and derivative term) and
pre-configured coefficients.

In addition, the heater-shaker src/ directory is now compiled as a
static library that is linked into the firmware and the tests,
respectively. Having the core in a separate static library continues to
enforce the need to keep code in the core separate from the firmware.