### PR TITLE
chore(stm32): add CMake custom config example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ arduino_ide
 build-stm32-cross/
 stm32-tools/
 build-stm32-host/
+
+# Custom CMake Config
+/CMakeUserPresets.json

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you are running on macOS, you might run into this error:
 error: 'concepts' file not found
 ```
 
-This means that the clang verison on your system does not support Concepts. You will need to do `brew install gcc@10` and copy the `examples/CMakeUserPresets.json` to the root directory. You can then specify this custom configration by using `cmake --preset=stm32-host-gcc`.
+This means that the clang version on your system does not support Concepts. You will need to do `brew install gcc@10` and copy the `examples/CMakeUserPresets.json` to the root directory. You can then specify this custom configration by using `cmake --preset=stm32-host-gcc`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ For the STM32 modules, if you configure the host toolchain: `cmake --preset=stm3
 
 Individual tests may set their own check targets; for instance, you can build and run only the heater-shaker tests by running `cmake --build ./build-stm32-host --target heater-shaker-build-and-test`.
 
+### Custom Configuration
+
+If you are running on macOS, you might run into this error: 
+
+```
+error: 'concepts' file not found
+```
+
+This means that the clang verison on your system does not support Concepts. You will need to do `brew install gcc@10` and copy the `examples/CMakeUserPresets.json` to the root directory. You can then specify this custom configration by using `cmake --preset=stm32-host-gcc`.
+
 ## Contributing
 
 When writing or changing the cmake build system, please follow [modern CMake](https://cliutils.gitlab.io/modern-cmake) practices. Use targets; use generator expressions to set properties on those targets rather than setting ``CMAKE_DEBUG_FLAGS``; write CMake like the programming language it is.

--- a/examples/CMakeUserPresets.json
+++ b/examples/CMakeUserPresets.json
@@ -1,0 +1,19 @@
+{
+    "version": 1,
+    "cmakeMinimumRequired": {
+      "major": 3,
+      "minor": 19,
+      "patch": 0
+    },
+    "configurePresets": [
+      {
+        "name": "stm32-host-gcc",
+        "inherits": "stm32-host",
+        "displayName": "STM32 module host builds forcing g++",
+        "cacheVariables": {
+            "CMAKE_C_COMPILER": "gcc-10",
+            "CMAKE_CXX_COMPILER": "g++-10"
+        }
+      }
+    ]
+}


### PR DESCRIPTION
If you are using macOS and depending on the version, the Clang may or may not support Concepts. This can cause an error  when you run the stm32 module tests. To solve it, you need to (1) install `gcc@10` using homebrew, and then configure a `CMakeUserPresets.json` at the root of the repo to use the installed gcc as your compiler.

### Changelog
- update readme
- add an example of the preset file