### PR TITLE
feat(heater-shaker): bring up message interaction via USB serial

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,clang-analyzer-*,bugprone-*,cppcoreguidelines-*,misc-*,modernize-*,readability-*,-readability-magic-numbers,performance-*'
+Checks:          '-*,clang-analyzer-*,bugprone-*,cppcoreguidelines-*,-cppcoreguidelines-pro-type-vararg,misc-*,modernize-*,readability-*,-readability-magic-numbers,performance-*'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*/stm32-modules/.*hpp'
 AnalyzeTemporaryDtors: false

--- a/stm32-modules/heater-shaker/firmware/freertos_comms_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/freertos_comms_task.cpp
@@ -18,15 +18,19 @@
 #pragma GCC diagnostic pop
 
 #include "firmware/freertos_message_queue.hpp"
+#include "hal/double_buffer.hpp"
 #include "heater-shaker/host_comms_task.hpp"
+#include "heater-shaker/messages.hpp"
 #include "heater-shaker/tasks.hpp"
 
 struct CommsTaskFreeRTOS {
     USBD_CDC_ItfTypeDef cdc_class_fops;
     USBD_HandleTypeDef usb_handle;
     USBD_CDC_LineCodingTypeDef linecoding;
-    std::array<uint8_t, CDC_DATA_HS_MAX_PACKET_SIZE * 4> rx_buf;
-    std::array<uint8_t, CDC_DATA_HS_MAX_PACKET_SIZE * 4> tx_buf;
+
+    double_buffer::DoubleBuffer<char, CDC_DATA_HS_MAX_PACKET_SIZE * 4> rx_buf;
+    double_buffer::DoubleBuffer<char, CDC_DATA_HS_MAX_PACKET_SIZE * 4> tx_buf;
+    char *committed_rx_buf_ptr;
 };
 
 static auto CDC_Init() -> int8_t;
@@ -67,7 +71,7 @@ static CommsTaskFreeRTOS _local_task = {
          .datatype = 0x08},
     .rx_buf = {},
     .tx_buf = {},
-};
+    .committed_rx_buf_ptr = nullptr};
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _top_task = host_comms_task::HostCommsTask(_comms_queue);
@@ -83,20 +87,50 @@ static std::array<StackType_t, stack_size> stack;
 static StaticTask_t
     data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+extern "C" {
+extern __ALIGN_BEGIN uint8_t
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    USBD_CDC_CfgHSDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIGN_END;
+extern __ALIGN_BEGIN uint8_t
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    USBD_CDC_CfgFSDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIGN_END;
+}
+
 // Actual function that runs in the task
 void run(void *param) {  // NOLINT(misc-unused-parameters)
-    static constexpr uint32_t delay_ticks = 1;
     auto *task_pair = static_cast<decltype(_tasks) *>(param);
     auto *local_task = task_pair->second;
+    auto *top_task = task_pair->first;
+    // This clears the capability bit that would be other sent upstream
+    // indicating we handle flow control line setting from host, which we don't,
+    // which leads to delays and annoying kernel messages. See
+    // stm32f303-bsp/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c:174
+    // for annotated descriptor definitions
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    USBD_CDC_CfgHSDesc[30] = 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    USBD_CDC_CfgFSDesc[30] = 0;
     USBD_Init(&local_task->usb_handle, &CDC_Desc, 0);
     USBD_RegisterClass(&local_task->usb_handle, USBD_CDC_CLASS);
     USBD_CDC_RegisterInterface(&local_task->usb_handle,
                                &local_task->cdc_class_fops);
     USBD_SetClassConfig(&local_task->usb_handle, 0);
     USBD_Start(&local_task->usb_handle);
+    local_task->committed_rx_buf_ptr = local_task->rx_buf.committed()->data();
     while (true) {
-        USBD_CDC_ReceivePacket(&local_task->usb_handle);
-        vTaskDelay(delay_ticks);
+        auto length_to_xmit =
+            top_task->run_once(local_task->tx_buf.accessible()->data(),
+                               local_task->tx_buf.accessible()->size());
+        if (length_to_xmit != 0) {
+            local_task->tx_buf.swap();
+            USBD_CDC_SetTxBuffer(
+                &_local_task.usb_handle,
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                reinterpret_cast<uint8_t *>(
+                    local_task->tx_buf.committed()->data()),
+                length_to_xmit);
+            USBD_CDC_TransmitPacket(&_local_task.usb_handle);
+        }
     }
 }
 
@@ -114,7 +148,10 @@ auto start()
 
 static auto CDC_Init() -> int8_t {
     using namespace host_comms_control_task;
-    USBD_CDC_SetRxBuffer(&_local_task.usb_handle, _local_task.rx_buf.data());
+    USBD_CDC_SetRxBuffer(
+        &_local_task.usb_handle,
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<uint8_t *>(_local_task.rx_buf.committed()->data()));
     return (0);
 }
 
@@ -122,6 +159,8 @@ static auto CDC_DeInit() -> int8_t {
     /*
        Add your deinitialization code here
     */
+    using namespace host_comms_control_task;
+    _local_task.committed_rx_buf_ptr = _local_task.rx_buf.committed()->data();
     return (0);
 }
 
@@ -188,14 +227,77 @@ static auto CDC_Control(uint8_t cmd, uint8_t *pbuf, uint16_t length) -> int8_t {
     return (0);
 }
 
+/*
+** CDC_Receive is a callback hook invoked from the CDC class internals in an
+**
+** interrupt context. Buf points to the pre-provided rx buf, into which the data
+** from the hardware-isolated USB packet memory area has been copied; Len is a
+** pointer to the length of data.
+**
+** Because the host may send any number of characters in one USB packet - for
+** instance, a host that is using programmatic access to the serial device may
+** send an entire message, while a host that is someone typing into a serial
+** terminal may send one character per packet - we have to accumulate characters
+** somewhere until a full message is assembled. To avoid excessive copying, we
+** do this by changing the exact location of the rx buffer we give the
+** USB infrastructure. The rules are
+**
+** - We always start after a buffer swap with the beginning of the committed
+**   buffer
+** - When we receive a message
+**   - if there's a newline (indicating a complete message), we swap the buffers
+**     and  send the one that just got swapped out to the task for parsing
+**   - if there's not a newline,
+**     - if, after the message we just received, there is not enough space for
+**       an entire packet in the buffer, we swap the buffers and send the
+**       swapped-out one to the task, where it will probably be ignored
+**     - if, after the message we just received, there's enough space in the
+**       buffer, we don't swap the buffers, but advance our read pointer to just
+**       after the message we received
+*/
+
 // NOLINTNEXTLINE(readability-non-const-parameter)
 static auto CDC_Receive(uint8_t *Buf, uint32_t *Len) -> int8_t {
+    using namespace host_comms_control_task;
+    ssize_t remaining_buffer_count =
+        (_local_task.rx_buf.committed()->data()
+         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+         + _local_task.rx_buf.committed()->size()) -
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<char *>(Buf + *Len);
+
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    std::copy(Buf, Buf + *Len,
-              host_comms_control_task::_tasks.second->tx_buf.begin());
-    USBD_CDC_SetTxBuffer(&host_comms_control_task::_tasks.second->usb_handle,
-                         host_comms_control_task::_tasks.second->tx_buf.data(),
-                         *Len);
-    return USBD_CDC_TransmitPacket(
-        &host_comms_control_task::_tasks.second->usb_handle);
+    if ((std::find_if(Buf, Buf + *Len,
+                      [](auto ch) { return ch == '\n' || ch == '\r'; }) !=
+         (Buf +  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+          *Len)) ||
+        remaining_buffer_count <
+            static_cast<ssize_t>(CDC_DATA_HS_MAX_PACKET_SIZE)) {
+        // there was a newline in this message, can pass on
+        auto message =
+            messages::HostCommsMessage(messages::IncomingMessageFromHost{
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                .buffer = reinterpret_cast<const char *>(
+                    _local_task.rx_buf.committed()->data()),
+                .length = static_cast<size_t>(
+                    *Len +
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                    (Buf - reinterpret_cast<uint8_t *>(
+                               _local_task.rx_buf.committed()->data())))});
+        static_cast<void>(
+            _top_task.get_message_queue().try_send_from_isr(message));
+        _local_task.rx_buf.swap();
+        _local_task.committed_rx_buf_ptr =
+            _local_task.rx_buf.committed()->data();
+    } else {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        _local_task.committed_rx_buf_ptr += *Len;
+    }
+
+    USBD_CDC_SetRxBuffer(
+        &_local_task.usb_handle,
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<uint8_t *>(_local_task.committed_rx_buf_ptr));
+    USBD_CDC_ReceivePacket(&_local_task.usb_handle);
+    return USBD_OK;
 }

--- a/stm32-modules/heater-shaker/firmware/freertos_comms_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/freertos_comms_task.cpp
@@ -142,16 +142,18 @@ auto start()
                                      &_tasks, 1, stack.data(), &data);
     _comms_queue.provide_handle(handle);
     return tasks::Task<TaskHandle_t, decltype(_top_task)>{.handle = handle,
-                                                          .task = _top_task};
+                                                          .task = &_top_task};
 }
 }  // namespace host_comms_control_task
 
 static auto CDC_Init() -> int8_t {
     using namespace host_comms_control_task;
+    _local_task.committed_rx_buf_ptr = _local_task.rx_buf.committed()->data();
     USBD_CDC_SetRxBuffer(
         &_local_task.usb_handle,
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        reinterpret_cast<uint8_t *>(_local_task.rx_buf.committed()->data()));
+        reinterpret_cast<uint8_t *>(_local_task.committed_rx_buf_ptr));
+    USBD_CDC_ReceivePacket(&_local_task.usb_handle);
     return (0);
 }
 

--- a/stm32-modules/heater-shaker/firmware/freertos_heater_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/freertos_heater_task.cpp
@@ -50,6 +50,6 @@ auto start() -> tasks::Task<TaskHandle_t,
                                      &_task, 1, _stack.data(), &_data);
     _heater_queue.provide_handle(handle);
     return tasks::Task<TaskHandle_t, decltype(_task)>{.handle = handle,
-                                                      .task = _task};
+                                                      .task = &_task};
 }
 }  // namespace heater_control_task

--- a/stm32-modules/heater-shaker/firmware/freertos_heater_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/freertos_heater_task.cpp
@@ -36,12 +36,10 @@ static FreeRTOSMessageQueue<heater_task::Message>
 static auto _task = heater_task::HeaterTask(_heater_queue);
 
 // Actual function that runs the task
-void run(void *param) {  // NOLINT(misc-unused-parameters)
-    static constexpr uint32_t delay_ticks = 100;
+void run(void *param) {
     auto *task_class = static_cast<decltype(_task) *>(param);
-    static_cast<void>(task_class);
     while (true) {
-        vTaskDelay(delay_ticks);
+        task_class->run_once();
     }
 }
 

--- a/stm32-modules/heater-shaker/firmware/freertos_motor_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/freertos_motor_task.cpp
@@ -35,10 +35,10 @@ StaticTask_t
     data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 // Actual function that runs inside the task
-void run(void *param) {  // NOLINT(misc-unused-parameters)
-    static constexpr uint32_t delay_ticks = 100;
+void run(void *param) {
+    auto *task_class = static_cast<decltype(_task) *>(param);
     while (true) {
-        vTaskDelay(delay_ticks);
+        task_class->run_once();
     }
 }
 

--- a/stm32-modules/heater-shaker/firmware/freertos_motor_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/freertos_motor_task.cpp
@@ -50,7 +50,7 @@ auto start()
 
     _motor_queue.provide_handle(handle);
     return tasks::Task<TaskHandle_t, decltype(_task)>{.handle = handle,
-                                                      .task = _task};
+                                                      .task = &_task};
 }
 
 }  // namespace motor_control_task

--- a/stm32-modules/heater-shaker/firmware/freertos_ui_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/freertos_ui_task.cpp
@@ -50,6 +50,6 @@ auto start()
                                      stack.data(), &data);
     _ui_queue.provide_handle(handle);
     return tasks::Task<TaskHandle_t, decltype(_task)>{.handle = handle,
-                                                      .task = _task};
+                                                      .task = &_task};
 }
 }  // namespace ui_control_task

--- a/stm32-modules/heater-shaker/firmware/main.cpp
+++ b/stm32-modules/heater-shaker/firmware/main.cpp
@@ -9,22 +9,16 @@
 #include "heater-shaker/tasks.hpp"
 #include "system_stm32f3xx.h"
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+tasks::Tasks<FreeRTOSMessageQueue> tasks_aggregator;
+
 auto main() -> int {
     HardwareInit();
     auto ui = ui_control_task::start();
     auto heater = heater_control_task::start();
     auto motor = motor_control_task::start();
     auto comms = host_comms_control_task::start();
-    tasks::Tasks<FreeRTOSMessageQueue> tasks = {
-        .heater = heater.task,
-        .comms = comms.task,
-        .motor = motor.task,
-        .ui = ui.task,
-    };
-    tasks.heater.provide_tasks(&tasks);
-    tasks.comms.provide_tasks(&tasks);
-    tasks.motor.provide_tasks(&tasks);
-    tasks.ui.provide_tasks(&tasks);
+    tasks_aggregator.initialize(heater.task, comms.task, motor.task, ui.task);
     vTaskStartScheduler();
     return 0;
 }

--- a/stm32-modules/heater-shaker/firmware/usbd_conf.c
+++ b/stm32-modules/heater-shaker/firmware/usbd_conf.c
@@ -162,6 +162,10 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
   // Set up the static endpoint 0 pmas
   HAL_PCDEx_PMAConfig(pdev->pData, 0x00, PCD_SNG_BUF, 0x18);
   HAL_PCDEx_PMAConfig(pdev->pData, 0x80, PCD_SNG_BUF, 0x58);
+  HAL_PCDEx_PMAConfig(pdev->pData , CDC_IN_EP , PCD_SNG_BUF, 0xC0);
+  HAL_PCDEx_PMAConfig(pdev->pData , CDC_OUT_EP , PCD_SNG_BUF, 0x110);
+  HAL_PCDEx_PMAConfig(pdev->pData , CDC_CMD_EP , PCD_SNG_BUF, 0x100);
+
 
   return USBD_OK;
 }

--- a/stm32-modules/heater-shaker/include/hal/double_buffer.hpp
+++ b/stm32-modules/heater-shaker/include/hal/double_buffer.hpp
@@ -1,0 +1,49 @@
+#pragma once
+#include <array>
+
+namespace double_buffer {
+/*
+** Doublebuffering helper.
+**
+** This maintains two buffers (as std::array), initialized in the class body.
+*Its
+** main use is with pointers and therefore it is not copyable or movable.
+**
+** This double-buffer can be used with an interface that requires a pointer to
+** a buffer for some probably hardware-assisted communication method, where a
+** buffer needs to be committed into the subsystem and not touched until the
+** subsystem indicates it is ready. The other buffer meanwhile can be used for
+** whatever the application requires.
+**
+** Swapping should be done under the control of some system that knows that
+** each subsystem is ready.
+*/
+template <typename Datatype, size_t Size>
+class DoubleBuffer {
+    using Buffer = std::array<Datatype, Size>;
+
+  public:
+    DoubleBuffer() : _committed(&_a), _accessible(&_b) {}
+    DoubleBuffer(const DoubleBuffer& other) = delete;
+    auto operator=(const DoubleBuffer& other) -> DoubleBuffer& = delete;
+    DoubleBuffer(DoubleBuffer&& other) noexcept = delete;
+    auto operator=(DoubleBuffer&& other) noexcept -> DoubleBuffer& = delete;
+    ~DoubleBuffer() = default;
+
+    [[nodiscard]] auto committed() const -> Buffer* { return _committed; }
+    [[nodiscard]] auto accessible() const -> Buffer* { return _accessible; }
+
+    void swap() {
+        Buffer* temp = _committed;
+        _committed = _accessible;
+        _accessible = temp;
+    }
+
+  private:
+    Buffer _a = {};
+    Buffer _b = {};
+
+    Buffer* _committed;
+    Buffer* _accessible;
+};
+};  // namespace double_buffer

--- a/stm32-modules/heater-shaker/include/hal/message_queue.hpp
+++ b/stm32-modules/heater-shaker/include/hal/message_queue.hpp
@@ -19,10 +19,17 @@ concept MessageQueue = requires(MQ mq, MessageType mt, const MQ cmq,
     ->std::same_as<bool>;
     { mq.try_send(cmt) }
     ->std::same_as<bool>;
+    // Queues must have a receive that takes a message instance by ptr
+    {mq.recv(&mt)};
     // Queues must have a try-receive that takes a message instance by ptr for
     // filling in.
     { mq.try_recv(&mt) }
     ->std::same_as<bool>;
+    // Queues must have a try-receive that takes a message instance by ptr for
+    // filling in, and takes a timeout
+    { mq.try_recv(&mt, 8) }
+    ->std::same_as<bool>;
+
     // Queues must have a const method to check whether there are messages.
     { cmq.has_message() }
     ->std::same_as<bool>;

--- a/stm32-modules/heater-shaker/include/heater-shaker/ack_cache.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/ack_cache.hpp
@@ -1,0 +1,69 @@
+/*
+** The ack cache is a way to keep around gcode messages that have not yet
+** been executed. It maps a copy of the actual gcode object sent by the
+** host with the internal message id.
+**
+** This is not done with an actual map because that would need to allocate.
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <variant>
+
+template <size_t max_size, typename... Contents>
+struct AckCache {
+    using Payload = std::variant<std::monostate, Contents...>;
+    AckCache() : cache{CacheWrapper{0, Payload(std::monostate())}} {}
+
+    static constexpr size_t size = max_size;
+
+    template <typename ContentElement>
+    auto add(const ContentElement& element) -> uint32_t {
+        for (auto cache_element = cache.begin(); cache_element != cache.end();
+             cache_element++) {
+            if (std::holds_alternative<std::monostate>(
+                    cache_element->contents)) {
+                cache_element->contents = Payload(element);
+                cache_element->id = next_id;
+                next_id++;
+                if (next_id == 0) {
+                    next_id++;
+                }
+                return cache_element->id;
+            }
+        }
+        return 0;
+    }
+
+    auto remove_if_present(uint32_t id) -> Payload {
+        auto which = std::find_if(
+            cache.begin(), cache.end(),
+            [&id](auto element) -> bool { return element.id == id; });
+        if (which == cache.end()) {
+            return Payload(std::monostate());
+        }
+        auto payload = which->contents;
+        which->contents = std::monostate();
+        which->id = 0;
+        return payload;
+    }
+
+    auto clear() -> void {
+        for (auto& cache_element : cache) {
+            cache_element.contents = std::monostate();
+            cache_element.id = 0;
+        }
+    }
+
+  private:
+    // Present only for testing; do not use
+    friend class _AckCacheTestHook;
+    struct CacheWrapper {
+        uint32_t id;
+        Payload contents;
+    };
+    std::array<CacheWrapper, max_size> cache;
+    uint32_t next_id = 1;
+};

--- a/stm32-modules/heater-shaker/include/heater-shaker/errors.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/errors.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#include <algorithm>
+#include <concepts>
+#include <cstring>
+
+namespace errors {
+template <typename ErrorType>
+concept Error = requires(ErrorType err) {
+    { err.errorstring() }
+    ->std::same_as<const char*>;
+};
+
+template <typename ErrorType>
+requires Error<ErrorType> constexpr auto write_into(char* buf, size_t available)
+    -> size_t {
+    auto* wrote_to = std::copy(
+        ErrorType::errorstring(),
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        ErrorType::errorstring() +
+            std::min(strlen(ErrorType::errorstring()), available),
+        buf);
+    return &(*wrote_to) - buf;
+}
+struct USBTXBufOverrun {
+    static constexpr auto errorstring() -> const char* {
+        return "ERR001:tx buffer overrun\n";
+    }
+    static constexpr auto code() -> uint32_t { return 1; }
+};
+struct InternalQueueFull {
+    static constexpr auto errorstring() -> const char* {
+        return "ERR002:internal queue full\n";
+    }
+    static constexpr auto code() -> uint32_t { return 2; }
+};
+struct UnhandledGCode {
+    static constexpr auto errorstring() -> const char* {
+        return "ERR003:unhandled or unknown gcode\n";
+    }
+    static constexpr auto code() -> uint32_t { return 3; }
+};
+struct GCodeCacheFull {
+    static constexpr auto errorstring() -> const char* {
+        return "ERR004:gcode cache full\n";
+    }
+    static constexpr auto code() -> uint32_t { return 4; }
+};
+
+struct BadMessageAcknowledgement {
+    static constexpr auto errorstring() -> const char* {
+        return "ERR005:bad message ack\n";
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    static constexpr auto code() -> uint32_t { return 5; }
+};
+};  // namespace errors

--- a/stm32-modules/heater-shaker/include/heater-shaker/heater_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/heater_task.hpp
@@ -24,6 +24,8 @@ template <template <class> class QueueImpl>
 requires MessageQueue<QueueImpl<Message>, Message> class HeaterTask {
     using Queue = QueueImpl<Message>;
 
+    static constexpr const uint32_t WAIT_TIME_TICKS = 100;
+
   public:
     explicit HeaterTask(Queue& q) : message_queue(q), task_registry(nullptr) {}
     HeaterTask(const HeaterTask& other) = delete;
@@ -37,7 +39,49 @@ requires MessageQueue<QueueImpl<Message>, Message> class HeaterTask {
         task_registry = other_tasks;
     }
 
+    /**
+     * run_once() runs one spin of the task. This means it
+     * - Waits for a message, or for a timeout so it can run its controller
+     * - If there's a message, handles the message
+     *   - which may include altering its controller state
+     *   - which may include sending a response
+     * - Runs its controller
+     * */
+    auto run_once() -> void {
+        auto message = Message(std::monostate());
+
+        // This is the call down to the provided queue. It will block for
+        // anywhere up to the provided timeout, which drives the controller
+        // frequency.
+
+        static_cast<void>(message_queue.try_recv(&message, WAIT_TIME_TICKS));
+        std::visit(
+            [this](const auto& msg) -> void { this->visit_message(msg); },
+            message);
+    }
+
   private:
+    auto visit_message(const std::monostate& _ignore) -> void {
+        static_cast<void>(_ignore);
+    }
+
+    auto visit_message(const messages::SetTemperatureMessage& msg) -> void {
+        auto response =
+            messages::AcknowledgePrevious{.responding_to_id = msg.id};
+        static_cast<void>(task_registry->comms.get_message_queue().try_send(
+            messages::HostCommsMessage(response)));
+    }
+
+    auto visit_message(const messages::GetTemperatureMessage& msg) -> void {
+        auto response = messages::GetTemperatureResponse{
+            .responding_to_id = msg.id,
+            .current_temperature =
+                99,  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            .setpoint_temperature =
+                48};  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        static_cast<void>(task_registry->comms.get_message_queue().try_send(
+            messages::HostCommsMessage(response)));
+    }
     Queue& message_queue;
     tasks::Tasks<QueueImpl>* task_registry;
 };

--- a/stm32-modules/heater-shaker/include/heater-shaker/heater_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/heater_task.hpp
@@ -68,7 +68,7 @@ requires MessageQueue<QueueImpl<Message>, Message> class HeaterTask {
     auto visit_message(const messages::SetTemperatureMessage& msg) -> void {
         auto response =
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
-        static_cast<void>(task_registry->comms.get_message_queue().try_send(
+        static_cast<void>(task_registry->comms->get_message_queue().try_send(
             messages::HostCommsMessage(response)));
     }
 
@@ -79,7 +79,7 @@ requires MessageQueue<QueueImpl<Message>, Message> class HeaterTask {
                 99,  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
             .setpoint_temperature =
                 48};  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-        static_cast<void>(task_registry->comms.get_message_queue().try_send(
+        static_cast<void>(task_registry->comms->get_message_queue().try_send(
             messages::HostCommsMessage(response)));
     }
     Queue& message_queue;

--- a/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
@@ -75,7 +75,11 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
      *
      * This function returns the amount of data it actually wrote into tx_into.
      **/
-    auto run_once(char* tx_into, size_t tx_length_available) -> size_t {
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        run_once(InputIt tx_into, InputLimit tx_limit) -> InputLimit {
         auto message = Message(std::monostate());
 
         // This is the call down to the provided queue. It may block
@@ -90,8 +94,8 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
         // to member function, and you can't really do that with variant visit.
         // we also need to current the transmit buffer details in.
         auto visit_helper = [this, tx_into,
-                             tx_length_available](auto& message) -> size_t {
-            return this->visit_message(message, tx_into, tx_length_available);
+                             tx_limit](auto& message) -> InputIt {
+            return this->visit_message(message, tx_into, tx_limit);
         };
 
         // now, calling visit on the visit helper will pass through the calls to
@@ -112,141 +116,131 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
      * handles incoming messages from usb does essentially this same pattern
      * again for whatever gcodes it parses.
      * */
-    auto visit_message(const messages::IncomingMessageFromHost& msg,
-                       char* tx_into, size_t tx_length_available) -> size_t {
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        visit_message(const messages::IncomingMessageFromHost& msg,
+                      InputIt tx_into, InputLimit tx_limit) -> InputIt {
         // The parser is only really guaranteed to work if the message is
         // complete, ending in a newline, so let's make sure of that
         auto parser = GCodeParser();
         const auto* newline_at = std::find_if(
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            msg.buffer, msg.buffer + msg.length,
+            msg.buffer, msg.limit,
             [](const auto& ch) { return ch == '\n' || ch == '\r'; });
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        if (newline_at == (msg.buffer + msg.length)) {
-            return 0;
+        if (newline_at == msg.limit) {
+            return tx_into;
         }
         // We're going to accumulate all the responses or errors we need into
         // our tx buffer if we can, so let's make some temps we're free to
         // modify.
         const auto* current = msg.buffer;
-        size_t written = 0;
-        size_t current_available_length = tx_length_available;
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-        char* current_tx_head = tx_into;
+        InputIt current_tx_head = tx_into;
         // As in run_once, we're going to use std::visit to invoke a set of
         // member function overloads that also take other arguments, so we need
         // a lambda that closes over the extra arguments and curries them into
         // the member functions, as well as currying in the this pointer
-        auto visit_helper = [this, &current_tx_head, &current_available_length](
-                                auto gcode) -> std::pair<bool, size_t> {
-            return this->visit_gcode(gcode, current_tx_head,
-                                     current_available_length);
+        auto visit_helper = [this, &current_tx_head, &tx_limit](
+                                auto gcode) -> std::pair<bool, InputIt> {
+            return this->visit_gcode(gcode, current_tx_head, tx_limit);
         };
         while (true) {
             // Parse an incremental gcode
-            auto maybe_parsed =
-                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-                parser.parse_available(current, msg.buffer + msg.length);
+            auto maybe_parsed = parser.parse_available(current, msg.limit);
             current = maybe_parsed.second;
             // Visit it; this may write stuff to the transmit buffer, send
             // further messages, etc
             auto handled = std::visit(visit_helper, maybe_parsed.first);
             // Account for anything the handler might have written
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            current_available_length -= handled.second;
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            current_tx_head += handled.second;
-            written += handled.second;
-
-            if (written >= current_available_length) {
+            current_tx_head = handled.second;
+            if (current_tx_head >= tx_limit) {
                 // Something bad has happened, we overran or are about to
                 // overrun our tx buffer, should let upstream know
-                if (sizeof(errors::USBTXBufOverrun::errorstring()) <=
-                    tx_length_available) {
-                    errors::write_into<errors::USBTXBufOverrun>(
-                        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-                        tx_into + tx_length_available -
-                            strlen(errors::USBTXBufOverrun::errorstring()),
-                        strlen(errors::USBTXBufOverrun::errorstring()));
-                }
-                written = tx_length_available;
+                current_tx_head = errors::write_into(
+                    tx_into, tx_limit, errors::ErrorCode::USB_TX_OVERRUN);
+
                 break;
             }
 
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            if ((!handled.first) || (current == msg.buffer + msg.length)) {
+            if ((!handled.first) || (current == msg.limit)) {
                 // parse done
                 break;
             }
         }
-        return written;
+        return current_tx_head;
     }
 
-    // NOLINTNEXTLINE(readability-non-const-parameter)
-    auto visit_message(const messages::AcknowledgePrevious& msg, char* tx_into,
-                       size_t tx_length_available) -> size_t {
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        visit_message(const messages::AcknowledgePrevious& msg, InputIt tx_into,
+                      InputLimit tx_limit) -> InputIt {
         auto cache_entry =
             ack_only_cache.remove_if_present(msg.responding_to_id);
         return std::visit(
-            [tx_into, tx_length_available](auto cache_element) {
+            [tx_into, tx_limit](auto cache_element) {
                 using T = std::decay_t<decltype(cache_element)>;
                 if constexpr (std::is_same_v<std::monostate, T>) {
-                    return errors::write_into<
-                        errors::BadMessageAcknowledgement>(tx_into,
-                                                           tx_length_available);
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
                 } else {
-                    return cache_element.write_response_into(
-                        tx_into, tx_length_available);
+                    return cache_element.write_response_into(tx_into, tx_limit);
                 }
             },
             cache_entry);
     }
-    // NOLINTNEXTLINE(readability-non-const-parameter)
-    auto visit_message(const std::monostate& ignore, char* tx_into,
-                       size_t tx_length_available) -> size_t {
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        visit_message(const std::monostate& ignore, InputIt tx_into,
+                      InputLimit tx_limit) -> InputIt {
         static_cast<void>(ignore);
         static_cast<void>(tx_into);
-        static_cast<void>(tx_length_available);
-        return 0;
+        static_cast<void>(tx_limit);
+        return tx_into;
     }
 
-    auto visit_message(const messages::GetTemperatureResponse& response,
-                       // NOLINTNEXTLINE(readability-non-const-parameter)
-                       char* tx_into, size_t tx_length_available) -> size_t {
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        visit_message(const messages::GetTemperatureResponse& response,
+                      InputIt tx_into, InputLimit tx_limit) -> InputIt {
         auto cache_entry =
             get_temp_cache.remove_if_present(response.responding_to_id);
         return std::visit(
-            [tx_into, tx_length_available, response](auto cache_element) {
+            [tx_into, tx_limit, response](auto cache_element) {
                 using T = std::decay_t<decltype(cache_element)>;
                 if constexpr (std::is_same_v<std::monostate, T>) {
-                    return errors::write_into<
-                        errors::BadMessageAcknowledgement>(tx_into,
-                                                           tx_length_available);
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
                 } else {
                     return cache_element.write_response_into(
-                        tx_into, tx_length_available,
-                        response.current_temperature,
+                        tx_into, tx_limit, response.current_temperature,
                         response.setpoint_temperature);
                 }
             },
             cache_entry);
     }
 
-    // NOLINTNEXTLINE(readability-non-const-parameter)
-    auto visit_message(const messages::GetRPMResponse& response, char* tx_into,
-                       size_t tx_length_available) -> size_t {
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        visit_message(const messages::GetRPMResponse& response, InputIt tx_into,
+                      InputLimit tx_limit) -> InputIt {
         auto cache_entry =
             get_rpm_cache.remove_if_present(response.responding_to_id);
         return std::visit(
-            [tx_into, tx_length_available, response](auto cache_element) {
+            [tx_into, tx_limit, response](auto cache_element) {
                 using T = std::decay_t<decltype(cache_element)>;
                 if constexpr (std::is_same_v<std::monostate, T>) {
-                    return errors::write_into<
-                        errors::BadMessageAcknowledgement>(tx_into,
-                                                           tx_length_available);
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
                 } else {
                     return cache_element.write_response_into(
-                        tx_into, tx_length_available, response.current_rpm,
+                        tx_into, tx_limit, response.current_rpm,
                         response.setpoint_rpm);
                 }
             },
@@ -260,100 +254,118 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
      * */
 
     // our parse-done handler does nothing
-    // NOLINTNEXTLINE(readability-non-const-parameter)
-    auto visit_gcode(const std::monostate& ignore, char* tx_into,
-                     size_t tx_length_available) -> std::pair<bool, size_t> {
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        visit_gcode(const std::monostate& ignore, InputIt tx_into,
+                    InputLimit tx_limit) -> std::pair<bool, InputIt> {
         static_cast<void>(ignore);
         static_cast<void>(tx_into);
-        static_cast<void>(tx_length_available);
-        return std::make_pair(true, 0);
+        static_cast<void>(tx_limit);
+        return std::make_pair(true, tx_into);
     }
 
-    auto visit_gcode(const gcode::SetRPM& gcode, char* tx_into,
-                     size_t tx_length_available) -> std::pair<bool, size_t> {
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        visit_gcode(const gcode::SetRPM& gcode, InputIt tx_into,
+                    InputLimit tx_limit) -> std::pair<bool, InputIt> {
         auto id = ack_only_cache.add(gcode);
         if (id == 0) {
-            return std::make_pair(false,
-                                  errors::write_into<errors::GCodeCacheFull>(
-                                      tx_into, tx_length_available));
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
         }
         auto message =
             messages::SetRPMMessage{.id = id, .target_rpm = gcode.rpm};
         if (!task_registry->motor->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
-            auto written = errors::write_into<errors::InternalQueueFull>(
-                tx_into, tx_length_available);
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
             ack_only_cache.remove_if_present(id);
-            return std::make_pair(false, written);
+            return std::make_pair(false, wrote_to);
         }
-        return std::make_pair(true, 0);
+        return std::make_pair(true, tx_into);
     }
 
-    auto visit_gcode(const gcode::GetRPM& gcode, char* tx_into,
-                     size_t tx_length_available) -> std::pair<bool, size_t> {
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        visit_gcode(const gcode::GetRPM& gcode, InputIt tx_into,
+                    InputLimit tx_limit) -> std::pair<bool, InputIt> {
         auto id = get_rpm_cache.add(gcode);
         if (id == 0) {
-            return std::make_pair(false,
-                                  errors::write_into<errors::GCodeCacheFull>(
-                                      tx_into, tx_length_available));
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
         }
         auto message = messages::GetRPMMessage{.id = id};
         if (!task_registry->motor->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
-            auto written = errors::write_into<errors::InternalQueueFull>(
-                tx_into, tx_length_available);
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
             get_rpm_cache.remove_if_present(id);
-            return std::make_pair(false, written);
+            return std::make_pair(false, wrote_to);
         }
-        return std::make_pair(true, 0);
+        return std::make_pair(true, tx_into);
     }
 
-    auto visit_gcode(const gcode::SetTemperature& gcode, char* tx_into,
-                     size_t tx_length_available) -> std::pair<bool, size_t> {
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        visit_gcode(const gcode::SetTemperature& gcode, InputIt tx_into,
+                    InputLimit tx_limit) -> std::pair<bool, InputIt> {
         auto id = ack_only_cache.add(gcode);
         if (id == 0) {
-            return std::make_pair(false,
-                                  errors::write_into<errors::GCodeCacheFull>(
-                                      tx_into, tx_length_available));
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
         }
         auto message = messages::SetTemperatureMessage{
             .id = id,
             .target_temperature = static_cast<uint32_t>(gcode.temperature)};
         if (!task_registry->heater->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
-            auto written = errors::write_into<errors::InternalQueueFull>(
-                tx_into, tx_length_available);
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
             ack_only_cache.remove_if_present(id);
-            return std::make_pair(false, written);
+            return std::make_pair(false, wrote_to);
         }
-        return std::make_pair(true, 0);
+        return std::make_pair(true, tx_into);
     }
 
-    auto visit_gcode(const gcode::GetTemperature& gcode, char* tx_into,
-                     size_t tx_length_available) -> std::pair<bool, size_t> {
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        visit_gcode(const gcode::GetTemperature& gcode, InputIt tx_into,
+                    InputLimit tx_limit) -> std::pair<bool, InputIt> {
         auto id = get_temp_cache.add(gcode);
         if (id == 0) {
-            return std::make_pair(false,
-                                  errors::write_into<errors::GCodeCacheFull>(
-                                      tx_into, tx_length_available));
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
         }
         auto message = messages::GetTemperatureMessage{.id = id};
         if (!task_registry->heater->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
-            auto written = errors::write_into<errors::InternalQueueFull>(
-                tx_into, tx_length_available);
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
             get_temp_cache.remove_if_present(id);
-            return std::make_pair(false, written);
+            return std::make_pair(false, wrote_to);
         }
-        return std::make_pair(true, 0);
+        return std::make_pair(true, tx_into);
     }
 
     // Our error handler just writes an error and bails
-    auto visit_gcode(const GCodeParser::ParseError& _ignore, char* tx_into,
-                     size_t tx_length_available) -> std::pair<bool, size_t> {
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        visit_gcode(const GCodeParser::ParseError& _ignore, InputIt tx_into,
+                    InputLimit tx_limit) -> std::pair<bool, InputIt> {
         static_cast<void>(_ignore);
-        return std::make_pair(false, errors::write_into<errors::UnhandledGCode>(
-                                         tx_into, tx_length_available));
+        return std::make_pair(
+            false, errors::write_into(tx_into, tx_limit,
+                                      errors::ErrorCode::UNHANDLED_GCODE));
     }
     Queue& message_queue;
     tasks::Tasks<QueueImpl>* task_registry;

--- a/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
@@ -4,9 +4,16 @@
 #pragma once
 
 #include <array>
+#include <cstring>
+#include <optional>
+#include <utility>
 #include <variant>
 
 #include "hal/message_queue.hpp"
+#include "heater-shaker/ack_cache.hpp"
+#include "heater-shaker/errors.hpp"
+#include "heater-shaker/gcode_parser.hpp"
+#include "heater-shaker/gcodes.hpp"
 #include "heater-shaker/messages.hpp"
 #include "heater-shaker/tasks.hpp"
 
@@ -25,10 +32,24 @@ using Message = messages::HostCommsMessage;
 template <template <class> class QueueImpl>
 requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
     using Queue = QueueImpl<Message>;
+    using GCodeParser =
+        gcode::GroupParser<gcode::SetRPM, gcode::SetTemperature, gcode::GetRPM,
+                           gcode::GetTemperature>;
+    using AckOnlyCache = AckCache<8, gcode::SetRPM, gcode::SetTemperature>;
+    using GetTempCache = AckCache<8, gcode::GetTemperature>;
+    using GetRPMCache = AckCache<8, gcode::GetRPM>;
 
   public:
+    static constexpr size_t TICKS_TO_WAIT_ON_SEND = 10;
     explicit HostCommsTask(Queue& q)
-        : message_queue(q), task_registry(nullptr) {}
+        : message_queue(q),
+          task_registry(nullptr),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
+          ack_only_cache(),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
+          get_temp_cache(),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
+          get_rpm_cache() {}
     HostCommsTask(const HostCommsTask& other) = delete;
     auto operator=(const HostCommsTask& other) -> HostCommsTask& = delete;
     HostCommsTask(HostCommsTask&& other) noexcept = delete;
@@ -39,9 +60,306 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
         task_registry = other_tasks;
     }
 
+    /**
+     * run_once() runs one spin of the task. This means it
+     * - waits for a message to come in on its queue (either from another task,
+     *or from the USB input handling machinery)
+     * - handles the message
+     *   - which may include sending other messages
+     *   - which may include writing back a response string
+     *
+     * A buffer for the response string is provided by the caller, and it's
+     *sadly provided as a c-style pointer+length pair because that's
+     *fundamentally what it is. We could wrap it as an iterator pair, but it's
+     *nice to be honest.
+     *
+     * This function returns the amount of data it actually wrote into tx_into.
+     **/
+    auto run_once(char* tx_into, size_t tx_length_available) -> size_t {
+        auto message = Message(std::monostate());
+
+        // This is the call down to the provided queue. It may block
+        // indefinitely
+        message_queue.recv(&message);
+
+        // We should now be guaranteed to have a message, and can visit it to do
+        // our actual work.
+
+        // we need a this-capturing lambda to pass on the call to our set of
+        // member function overloads because otherwise we would need a pointer
+        // to member function, and you can't really do that with variant visit.
+        // we also need to current the transmit buffer details in.
+        auto visit_helper = [this, tx_into,
+                             tx_length_available](auto& message) -> size_t {
+            return this->visit_message(message, tx_into, tx_length_available);
+        };
+
+        // now, calling visit on the visit helper will pass through the calls to
+        // our message handlers, and will pass through whatever the messages
+        // return (aka how much data they wrote, if any) to the caller.
+        return std::visit(visit_helper, message);
+    }
+
   private:
+    /**
+     * visit_message is a set of overloads for all the messages that the task
+     * accepts. Because of the way we're calling this, in a lambda with an auto
+     * param passed to std::visit, the compiler ensures that we have a handler
+     * for every kind of message we accept. All these functions have uniform
+     * arguments (the particular message they handle and the tx buffer details)
+     * and the same return type (how many bytes they put into the buffer, if
+     * any). They may call other handler functions - for instance, the one that
+     * handles incoming messages from usb does essentially this same pattern
+     * again for whatever gcodes it parses.
+     * */
+    auto visit_message(const messages::IncomingMessageFromHost& msg,
+                       char* tx_into, size_t tx_length_available) -> size_t {
+        // The parser is only really guaranteed to work if the message is
+        // complete, ending in a newline, so let's make sure of that
+        auto parser = GCodeParser();
+        const auto* newline_at = std::find_if(
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            msg.buffer, msg.buffer + msg.length,
+            [](const auto& ch) { return ch == '\n' || ch == '\r'; });
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        if (newline_at == (msg.buffer + msg.length)) {
+            return 0;
+        }
+        // We're going to accumulate all the responses or errors we need into
+        // our tx buffer if we can, so let's make some temps we're free to
+        // modify.
+        const auto* current = msg.buffer;
+        size_t written = 0;
+        size_t current_available_length = tx_length_available;
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+        char* current_tx_head = tx_into;
+        // As in run_once, we're going to use std::visit to invoke a set of
+        // member function overloads that also take other arguments, so we need
+        // a lambda that closes over the extra arguments and curries them into
+        // the member functions, as well as currying in the this pointer
+        auto visit_helper = [this, &current_tx_head, &current_available_length](
+                                auto gcode) -> std::pair<bool, size_t> {
+            return this->visit_gcode(gcode, current_tx_head,
+                                     current_available_length);
+        };
+        while (true) {
+            // Parse an incremental gcode
+            auto maybe_parsed =
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                parser.parse_available(current, msg.buffer + msg.length);
+            current = maybe_parsed.second;
+            // Visit it; this may write stuff to the transmit buffer, send
+            // further messages, etc
+            auto handled = std::visit(visit_helper, maybe_parsed.first);
+            // Account for anything the handler might have written
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            current_available_length -= handled.second;
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            current_tx_head += handled.second;
+            written += handled.second;
+
+            if (written >= current_available_length) {
+                // Something bad has happened, we overran or are about to
+                // overrun our tx buffer, should let upstream know
+                if (sizeof(errors::USBTXBufOverrun::errorstring()) <=
+                    tx_length_available) {
+                    errors::write_into<errors::USBTXBufOverrun>(
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                        tx_into + tx_length_available -
+                            strlen(errors::USBTXBufOverrun::errorstring()),
+                        strlen(errors::USBTXBufOverrun::errorstring()));
+                }
+                written = tx_length_available;
+                break;
+            }
+
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            if ((!handled.first) || (current == msg.buffer + msg.length)) {
+                // parse done
+                break;
+            }
+        }
+        return written;
+    }
+
+    // NOLINTNEXTLINE(readability-non-const-parameter)
+    auto visit_message(const messages::AcknowledgePrevious& msg, char* tx_into,
+                       size_t tx_length_available) -> size_t {
+        auto cache_entry =
+            ack_only_cache.remove_if_present(msg.responding_to_id);
+        return std::visit(
+            [tx_into, tx_length_available](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (std::is_same_v<std::monostate, T>) {
+                    return errors::write_into<
+                        errors::BadMessageAcknowledgement>(tx_into,
+                                                           tx_length_available);
+                } else {
+                    return cache_element.write_response_into(
+                        tx_into, tx_length_available);
+                }
+            },
+            cache_entry);
+    }
+    // NOLINTNEXTLINE(readability-non-const-parameter)
+    auto visit_message(const std::monostate& ignore, char* tx_into,
+                       size_t tx_length_available) -> size_t {
+        static_cast<void>(ignore);
+        static_cast<void>(tx_into);
+        static_cast<void>(tx_length_available);
+        return 0;
+    }
+
+    auto visit_message(const messages::GetTemperatureResponse& response,
+                       // NOLINTNEXTLINE(readability-non-const-parameter)
+                       char* tx_into, size_t tx_length_available) -> size_t {
+        auto cache_entry =
+            get_temp_cache.remove_if_present(response.responding_to_id);
+        return std::visit(
+            [tx_into, tx_length_available, response](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (std::is_same_v<std::monostate, T>) {
+                    return errors::write_into<
+                        errors::BadMessageAcknowledgement>(tx_into,
+                                                           tx_length_available);
+                } else {
+                    return cache_element.write_response_into(
+                        tx_into, tx_length_available,
+                        response.current_temperature,
+                        response.setpoint_temperature);
+                }
+            },
+            cache_entry);
+    }
+
+    // NOLINTNEXTLINE(readability-non-const-parameter)
+    auto visit_message(const messages::GetRPMResponse& response, char* tx_into,
+                       size_t tx_length_available) -> size_t {
+        auto cache_entry =
+            get_rpm_cache.remove_if_present(response.responding_to_id);
+        return std::visit(
+            [tx_into, tx_length_available, response](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (std::is_same_v<std::monostate, T>) {
+                    return errors::write_into<
+                        errors::BadMessageAcknowledgement>(tx_into,
+                                                           tx_length_available);
+                } else {
+                    return cache_element.write_response_into(
+                        tx_into, tx_length_available, response.current_rpm,
+                        response.setpoint_rpm);
+                }
+            },
+            cache_entry);
+    }
+
+    /**
+     * visit_gcode() is a set of member function overloads, each of which is
+     * called when we parse the appropriate gcode out of the receive buffer.
+     * They also get the transmit buffer details so they can write back data.
+     * */
+
+    // our parse-done handler does nothing
+    // NOLINTNEXTLINE(readability-non-const-parameter)
+    auto visit_gcode(const std::monostate& ignore, char* tx_into,
+                     size_t tx_length_available) -> std::pair<bool, size_t> {
+        static_cast<void>(ignore);
+        static_cast<void>(tx_into);
+        static_cast<void>(tx_length_available);
+        return std::make_pair(true, 0);
+    }
+
+    auto visit_gcode(const gcode::SetRPM& gcode, char* tx_into,
+                     size_t tx_length_available) -> std::pair<bool, size_t> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(false,
+                                  errors::write_into<errors::GCodeCacheFull>(
+                                      tx_into, tx_length_available));
+        }
+        auto message =
+            messages::SetRPMMessage{.id = id, .target_rpm = gcode.rpm};
+        if (!task_registry->motor.get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto written = errors::write_into<errors::InternalQueueFull>(
+                tx_into, tx_length_available);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, written);
+        }
+        return std::make_pair(true, 0);
+    }
+
+    auto visit_gcode(const gcode::GetRPM& gcode, char* tx_into,
+                     size_t tx_length_available) -> std::pair<bool, size_t> {
+        auto id = get_rpm_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(false,
+                                  errors::write_into<errors::GCodeCacheFull>(
+                                      tx_into, tx_length_available));
+        }
+        auto message = messages::GetRPMMessage{.id = id};
+        if (!task_registry->motor.get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto written = errors::write_into<errors::InternalQueueFull>(
+                tx_into, tx_length_available);
+            get_rpm_cache.remove_if_present(id);
+            return std::make_pair(false, written);
+        }
+        return std::make_pair(true, 0);
+    }
+
+    auto visit_gcode(const gcode::SetTemperature& gcode, char* tx_into,
+                     size_t tx_length_available) -> std::pair<bool, size_t> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(false,
+                                  errors::write_into<errors::GCodeCacheFull>(
+                                      tx_into, tx_length_available));
+        }
+        auto message = messages::SetTemperatureMessage{
+            .id = id,
+            .target_temperature = static_cast<uint32_t>(gcode.temperature)};
+        if (!task_registry->heater.get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto written = errors::write_into<errors::InternalQueueFull>(
+                tx_into, tx_length_available);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, written);
+        }
+        return std::make_pair(true, 0);
+    }
+
+    auto visit_gcode(const gcode::GetTemperature& gcode, char* tx_into,
+                     size_t tx_length_available) -> std::pair<bool, size_t> {
+        auto id = get_temp_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(false,
+                                  errors::write_into<errors::GCodeCacheFull>(
+                                      tx_into, tx_length_available));
+        }
+        auto message = messages::GetTemperatureMessage{.id = id};
+        if (!task_registry->heater.get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto written = errors::write_into<errors::InternalQueueFull>(
+                tx_into, tx_length_available);
+            get_temp_cache.remove_if_present(id);
+            return std::make_pair(false, written);
+        }
+        return std::make_pair(true, 0);
+    }
+
+    // Our error handler just writes an error and bails
+    auto visit_gcode(const GCodeParser::ParseError& _ignore, char* tx_into,
+                     size_t tx_length_available) -> std::pair<bool, size_t> {
+        static_cast<void>(_ignore);
+        return std::make_pair(false, errors::write_into<errors::UnhandledGCode>(
+                                         tx_into, tx_length_available));
+    }
     Queue& message_queue;
     tasks::Tasks<QueueImpl>* task_registry;
+    AckOnlyCache ack_only_cache;
+    GetTempCache get_temp_cache;
+    GetRPMCache get_rpm_cache;
 };
 
 };  // namespace host_comms_task

--- a/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
@@ -279,7 +279,7 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
         }
         auto message =
             messages::SetRPMMessage{.id = id, .target_rpm = gcode.rpm};
-        if (!task_registry->motor.get_message_queue().try_send(
+        if (!task_registry->motor->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto written = errors::write_into<errors::InternalQueueFull>(
                 tx_into, tx_length_available);
@@ -298,7 +298,7 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
                                       tx_into, tx_length_available));
         }
         auto message = messages::GetRPMMessage{.id = id};
-        if (!task_registry->motor.get_message_queue().try_send(
+        if (!task_registry->motor->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto written = errors::write_into<errors::InternalQueueFull>(
                 tx_into, tx_length_available);
@@ -319,7 +319,7 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
         auto message = messages::SetTemperatureMessage{
             .id = id,
             .target_temperature = static_cast<uint32_t>(gcode.temperature)};
-        if (!task_registry->heater.get_message_queue().try_send(
+        if (!task_registry->heater->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto written = errors::write_into<errors::InternalQueueFull>(
                 tx_into, tx_length_available);
@@ -338,7 +338,7 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
                                       tx_into, tx_length_available));
         }
         auto message = messages::GetTemperatureMessage{.id = id};
-        if (!task_registry->heater.get_message_queue().try_send(
+        if (!task_registry->heater->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto written = errors::write_into<errors::InternalQueueFull>(
                 tx_into, tx_length_available);

--- a/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
@@ -1,33 +1,93 @@
 #pragma once
 #include <array>
+#include <concepts>
 #include <variant>
 
 namespace messages {
-struct SetRPMMessage {
-    uint32_t rpm;
+
+template <typename IdType, typename MessageType>
+auto get_own_id(const MessageType& message) -> IdType {
+    return message.id;
+}
+
+template <typename IdType, typename MessageType>
+auto get_responding_to_id(const MessageType& message) -> IdType {
+    return message.responding_to_id;
+}
+
+template <typename MessageType>
+concept Message = requires(MessageType mt) {
+    { get_own_id(mt) }
+    ->std::same_as<uint32_t>;
 };
-struct DeactivateMessage {};
-struct HomeMessage {};
-struct SetTempMessage {
+
+template <typename ResponseType>
+concept Response = requires(ResponseType rt) {
+    { get_responding_to_id(rt) }
+    ->std::same_as<uint32_t>;
+};
+
+/*
+** Message structs initiate actions. These may be changes in physical state, or
+** a request to send back some data. Each carries an ID, which should be copied
+*into
+** the response.
+*/
+struct SetRPMMessage {
+    uint32_t id;
+    uint32_t target_rpm;
+};
+
+struct SetTemperatureMessage {
+    uint32_t id;
     uint32_t target_temperature;
 };
-struct UpdateTemperatureMessage {
-    float temperature;
+
+struct GetTemperatureMessage {
+    uint32_t id;
 };
 
-struct UpdateRPMMessage {
-    uint32_t rpm;
+struct GetRPMMessage {
+    uint32_t id;
 };
 
-constexpr size_t RESPONSE_LENGTH = 128;
-
-struct SendResponseMessage {
-    std::array<char, RESPONSE_LENGTH> msg;
+/*
+** Response structs either confirm actions or fulfill actions. Because some
+*messages
+** don't have actual data associated with their response, AcknowledgePrevious is
+*a
+** generic response that carries only its responding_id and carries only the
+** implication that the message has been received and acted upon. Responses like
+** SetTemperatureResponse on the other hand serve to confirm that the action has
+** been completed, and also carry the actual data requested.
+*/
+struct GetTemperatureResponse {
+    uint32_t responding_to_id;
+    uint32_t current_temperature;
+    uint32_t setpoint_temperature;
 };
 
-using HeaterMessage = ::std::variant<SetTempMessage, DeactivateMessage>;
+struct GetRPMResponse {
+    uint32_t responding_to_id;
+    uint32_t current_rpm;
+    uint32_t setpoint_rpm;
+};
+
+struct AcknowledgePrevious {
+    uint32_t responding_to_id;
+};
+
+struct IncomingMessageFromHost {
+    const char* buffer;
+    size_t length;
+};
+
+using HeaterMessage = ::std::variant<std::monostate, SetTemperatureMessage,
+                                     GetTemperatureMessage>;
 using MotorMessage =
-    ::std::variant<SetRPMMessage, DeactivateMessage, HomeMessage>;
-using UIMessage = ::std::variant<UpdateTemperatureMessage, UpdateRPMMessage>;
-using HostCommsMessage = ::std::variant<SendResponseMessage>;
+    ::std::variant<std::monostate, SetRPMMessage, GetRPMMessage>;
+using UIMessage = ::std::variant<GetTemperatureResponse, GetRPMResponse>;
+using HostCommsMessage =
+    ::std::variant<std::monostate, IncomingMessageFromHost, AcknowledgePrevious,
+                   GetTemperatureResponse, GetRPMResponse>;
 };  // namespace messages

--- a/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
@@ -79,7 +79,7 @@ struct AcknowledgePrevious {
 
 struct IncomingMessageFromHost {
     const char* buffer;
-    size_t length;
+    const char* limit;
 };
 
 using HeaterMessage = ::std::variant<std::monostate, SetTemperatureMessage,

--- a/stm32-modules/heater-shaker/include/heater-shaker/motor_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/motor_task.hpp
@@ -19,6 +19,7 @@ using Message = ::messages::MotorMessage;
 template <template <class> class QueueImpl>
 requires MessageQueue<QueueImpl<Message>, Message> class MotorTask {
     using Queue = QueueImpl<Message>;
+    static constexpr const uint32_t WAIT_TIME_TICKS = 100;
 
   public:
     explicit MotorTask(Queue& q) : message_queue(q), task_registry(nullptr) {}
@@ -32,7 +33,41 @@ requires MessageQueue<QueueImpl<Message>, Message> class MotorTask {
         task_registry = other_tasks;
     }
 
+    auto run_once() -> void {
+        auto message = Message(std::monostate());
+
+        // This is the call down to the provided queue. It will block for
+        // anywhere up to the provided timeout, which drives the controller
+        // frequency.
+
+        static_cast<void>(message_queue.try_recv(&message, WAIT_TIME_TICKS));
+        std::visit(
+            [this](const auto& msg) -> void { this->visit_message(msg); },
+            message);
+    }
+
   private:
+    auto visit_message(const std::monostate& _ignore) -> void {
+        static_cast<void>(_ignore);
+    }
+
+    auto visit_message(const messages::SetRPMMessage& msg) -> void {
+        auto response =
+            messages::AcknowledgePrevious{.responding_to_id = msg.id};
+        static_cast<void>(task_registry->comms.get_message_queue().try_send(
+            messages::HostCommsMessage(response)));
+    }
+
+    auto visit_message(const messages::GetRPMMessage& msg) -> void {
+        auto response = messages::GetRPMResponse{
+            .responding_to_id = msg.id,
+            .current_rpm =
+                1050,  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            .setpoint_rpm =
+                3500};  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        static_cast<void>(task_registry->comms.get_message_queue().try_send(
+            messages::HostCommsMessage(response)));
+    }
     Queue& message_queue;
     tasks::Tasks<QueueImpl>* task_registry;
 };

--- a/stm32-modules/heater-shaker/include/heater-shaker/motor_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/motor_task.hpp
@@ -54,7 +54,7 @@ requires MessageQueue<QueueImpl<Message>, Message> class MotorTask {
     auto visit_message(const messages::SetRPMMessage& msg) -> void {
         auto response =
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
-        static_cast<void>(task_registry->comms.get_message_queue().try_send(
+        static_cast<void>(task_registry->comms->get_message_queue().try_send(
             messages::HostCommsMessage(response)));
     }
 
@@ -65,7 +65,7 @@ requires MessageQueue<QueueImpl<Message>, Message> class MotorTask {
                 1050,  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
             .setpoint_rpm =
                 3500};  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-        static_cast<void>(task_registry->comms.get_message_queue().try_send(
+        static_cast<void>(task_registry->comms->get_message_queue().try_send(
             messages::HostCommsMessage(response)));
     }
     Queue& message_queue;

--- a/stm32-modules/heater-shaker/include/heater-shaker/task_concept.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/task_concept.hpp
@@ -1,4 +1,0 @@
-#ifndef __TASK_CONCEPT_H_
-#define __TASK_CONCEPT_H_
-
-#endif  // __TASK_CONCEPT_H_

--- a/stm32-modules/heater-shaker/include/heater-shaker/tasks.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/tasks.hpp
@@ -53,8 +53,8 @@ struct Tasks {
     Tasks(heater_task::HeaterTask<QueueImpl>* heater_in,
           host_comms_task::HostCommsTask<QueueImpl>* comms_in,
           motor_task::MotorTask<QueueImpl>* motor_in,
-          ui_task::UITask<QueueImpl>* ui_in):
-      heater(nullptr), comms(nullptr), motor(nullptr), ui(nullptr) {
+          ui_task::UITask<QueueImpl>* ui_in)
+        : heater(nullptr), comms(nullptr), motor(nullptr), ui(nullptr) {
         initialize(heater_in, comms_in, motor_in, ui_in);
     }
 

--- a/stm32-modules/heater-shaker/include/heater-shaker/tasks.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/tasks.hpp
@@ -42,16 +42,43 @@ namespace tasks {
 template <typename RTOSHandle, class PortableTask>
 struct Task {
     RTOSHandle handle;
-    PortableTask& task;
+    PortableTask* task;
 };
 
 /* Aggregator for initialized task objects that can be injected into those
  objects after they are created */
 template <template <class> class QueueImpl>
 struct Tasks {
-    heater_task::HeaterTask<QueueImpl>& heater;
-    host_comms_task::HostCommsTask<QueueImpl>& comms;
-    motor_task::MotorTask<QueueImpl>& motor;
-    ui_task::UITask<QueueImpl>& ui;
+    Tasks() = default;
+    Tasks(heater_task::HeaterTask<QueueImpl>* heater_in,
+          host_comms_task::HostCommsTask<QueueImpl>* comms_in,
+          motor_task::MotorTask<QueueImpl>* motor_in,
+          ui_task::UITask<QueueImpl>* ui_in):
+      heater(nullptr), comms(nullptr), motor(nullptr), ui(nullptr) {
+        initialize(heater_in, comms_in, motor_in, ui_in);
+    }
+
+    auto initialize(heater_task::HeaterTask<QueueImpl>* heater_in,
+                    host_comms_task::HostCommsTask<QueueImpl>* comms_in,
+                    motor_task::MotorTask<QueueImpl>* motor_in,
+                    ui_task::UITask<QueueImpl>* ui_in) -> void {
+        heater = heater_in;
+        comms = comms_in;
+        motor = motor_in;
+        ui = ui_in;
+        heater->provide_tasks(this);
+        comms->provide_tasks(this);
+        motor->provide_tasks(this);
+        ui->provide_tasks(this);
+    }
+
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    heater_task::HeaterTask<QueueImpl>* heater;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    host_comms_task::HostCommsTask<QueueImpl>* comms;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    motor_task::MotorTask<QueueImpl>* motor;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    ui_task::UITask<QueueImpl>* ui;
 };
 }  // namespace tasks

--- a/stm32-modules/heater-shaker/include/heater-shaker/utility.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/utility.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <iterator>
+
+template <typename Input, typename InLimit, typename Output, typename OutLimit>
+requires std::forward_iterator<Input>&& std::forward_iterator<Output>&&
+    std::sized_sentinel_for<Input, InLimit>&&
+        std::sized_sentinel_for<Output, OutLimit> constexpr auto
+        copy_min_range(Input dest_start, InLimit dest_limit,
+                       Output source_start, OutLimit source_end) -> Input {
+    return std::copy(
+        source_start,
+        std::min(source_end, source_start + (dest_limit - dest_start)),
+        dest_start);
+}
+
+template <typename Input, typename InLimit>
+requires std::forward_iterator<Input>&&
+    std::sized_sentinel_for<Input, InLimit> constexpr auto
+    write_string_to_iterpair(Input start, InLimit end, const char* str)
+        -> Input {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return copy_min_range(start, end, str, str + strlen(str));
+}

--- a/stm32-modules/heater-shaker/include/test/test_message_queue.hpp
+++ b/stm32-modules/heater-shaker/include/test/test_message_queue.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <deque>
+#include <stdexcept>
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 template <typename Message, size_t queue_size = 10>
@@ -22,7 +23,8 @@ class TestMessageQueue {
         return true;
     }
 
-    [[nodiscard]] auto try_recv(Message* message) -> bool {
+    [[nodiscard]] auto try_recv(Message* message, uint32_t timeout_ticks = 0)
+        -> bool {
         if (backing_deque.empty()) {
             return false;
         } else {
@@ -30,6 +32,15 @@ class TestMessageQueue {
             backing_deque.pop_front();
             return true;
         }
+    }
+
+    auto recv(Message* message) -> void {
+        if (backing_deque.empty()) {
+            throw new std::runtime_error(
+                "don't do something that calls recv() with an empty buffer");
+        }
+        *message = backing_deque.front();
+        backing_deque.pop_front();
     }
 
     [[nodiscard]] auto has_message() const -> bool {

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(heater-shaker
   test_pid.cpp
   test_double_buffer.cpp
   test_host_comms_task.cpp
+  test_motor_task.cpp
   test_ack_cache.cpp
   test_errors.cpp
   test_main.cpp)

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(heater-shaker
   test_motor_task.cpp
   test_ack_cache.cpp
   test_errors.cpp
+  test_message_passing.cpp
   test_main.cpp)
 target_include_directories(heater-shaker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 set_target_properties(heater-shaker

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(heater-shaker
   test_gcodes.cpp
   test_pid.cpp
   test_double_buffer.cpp
+  test_ack_cache.cpp
   test_errors.cpp
   test_main.cpp)
 target_include_directories(heater-shaker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(heater-shaker
   test_gcode_parse.cpp
   test_gcodes.cpp
   test_pid.cpp
+  test_double_buffer.cpp
   test_main.cpp)
 target_include_directories(heater-shaker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 set_target_properties(heater-shaker

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(heater-shaker
   test_gcodes.cpp
   test_pid.cpp
   test_double_buffer.cpp
+  test_host_comms_task.cpp
   test_ack_cache.cpp
   test_errors.cpp
   test_main.cpp)

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(heater-shaker
   test_gcodes.cpp
   test_pid.cpp
   test_double_buffer.cpp
+  test_errors.cpp
   test_main.cpp)
 target_include_directories(heater-shaker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 set_target_properties(heater-shaker

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(heater-shaker
   test_pid.cpp
   test_double_buffer.cpp
   test_host_comms_task.cpp
+  test_heater_task.cpp
   test_motor_task.cpp
   test_ack_cache.cpp
   test_errors.cpp

--- a/stm32-modules/heater-shaker/tests/task_builder.cpp
+++ b/stm32-modules/heater-shaker/tests/task_builder.cpp
@@ -9,15 +9,7 @@ TaskBuilder::TaskBuilder()
       motor_task(motor_queue),
       heater_queue("heater"),
       heater_task(heater_queue),
-      task_aggregator{.heater = heater_task,
-                      .comms = host_comms_task,
-                      .motor = motor_task,
-                      .ui = ui_task} {
-    host_comms_task.provide_tasks(&task_aggregator);
-    ui_task.provide_tasks(&task_aggregator);
-    motor_task.provide_tasks(&task_aggregator);
-    heater_task.provide_tasks(&task_aggregator);
-}
+      task_aggregator(&heater_task, &host_comms_task, &motor_task, &ui_task) {}
 
 auto TaskBuilder::build() -> std::shared_ptr<TaskBuilder> {
     return std::shared_ptr<TaskBuilder>(new TaskBuilder());

--- a/stm32-modules/heater-shaker/tests/test_ack_cache.cpp
+++ b/stm32-modules/heater-shaker/tests/test_ack_cache.cpp
@@ -1,0 +1,119 @@
+#include <limits>
+#include <variant>
+
+#include "catch2/catch.hpp"
+#include "heater-shaker/ack_cache.hpp"
+
+struct Element1 {
+    uint32_t foo;
+};
+
+struct Element2 {
+    float bar;
+};
+
+class _AckCacheTestHook {
+  public:
+    template <typename CacheKind>
+    static void set_id(CacheKind& cache, uint32_t next_id) {
+        cache.next_id = next_id;
+    }
+};
+
+SCENARIO("testing ack cache functionality") {
+    GIVEN("an ack cache with a couple elements") {
+        auto cache = AckCache<8, Element1, Element2>();
+        WHEN("finding a value in an empty cache") {
+            auto found = cache.remove_if_present(1231254);
+            THEN("nothing should be found") {
+                REQUIRE(std::holds_alternative<std::monostate>(found));
+            }
+        }
+        WHEN("adding to the cache") {
+            auto id1 = cache.add(Element1(10));
+            auto id2 = cache.add(Element2(2.5));
+            THEN("you should get a different id every time") {
+                REQUIRE(id1 != id2);
+                REQUIRE(id1 != 0);
+            }
+        }
+
+        WHEN("removing valid items from the cache") {
+            auto added1 = Element2(3.4);
+            auto added2 = Element2(5.2);
+            auto id1 = cache.add(added1);
+            auto id2 = cache.add(added2);
+            auto removed1 = cache.remove_if_present(id1);
+            auto removed2 = cache.remove_if_present(id2);
+            THEN("each removed item should be correct") {
+                REQUIRE(std::holds_alternative<Element2>(removed1));
+                REQUIRE(std::holds_alternative<Element2>(removed2));
+                REQUIRE(std::get<Element2>(removed1).bar == added1.bar);
+                REQUIRE(std::get<Element2>(removed2).bar == added2.bar);
+            }
+        }
+
+        WHEN("removing invalid items from a non-empty cache") {
+            auto added1 = Element1(2);
+            auto added2 = Element2(3.56);
+            auto id1 = cache.add(added1);
+            auto id2 = cache.add(added2);
+            uint32_t bad_id = 99;
+            CHECK(bad_id != id1);
+            CHECK(bad_id != id2);
+            auto removed_invalid = cache.remove_if_present(bad_id);
+            THEN("the removed item should be invalid") {
+                REQUIRE(
+                    std::holds_alternative<std::monostate>(removed_invalid));
+            }
+            AND_WHEN("subsequently removing a valid item") {
+                auto removed2 = cache.remove_if_present(id2);
+                THEN("the removed item should be correct") {
+                    REQUIRE(std::holds_alternative<Element2>(removed2));
+                    REQUIRE(std::get<Element2>(removed2).bar == added2.bar);
+                }
+            }
+        }
+
+        WHEN("forcing the id to roll over") {
+            _AckCacheTestHook::set_id(cache,
+                                      std::numeric_limits<uint32_t>::max());
+            auto added1 = Element1(10);
+            auto added2 = Element2(10.22);
+            auto id1 = cache.add(added1);
+            auto id2 = cache.add(added2);
+
+            THEN("the ids should skip 0") {
+                REQUIRE(id1 != 0);
+                REQUIRE(id2 != 0);
+                REQUIRE(id2 < id1);
+            }
+            AND_WHEN("removing the items") {
+                auto removed2 = cache.remove_if_present(id2);
+                auto removed1 = cache.remove_if_present(id1);
+                THEN("the removed items should be valid") {
+                    REQUIRE(std::holds_alternative<Element2>(removed2));
+                    REQUIRE(std::holds_alternative<Element1>(removed1));
+                    REQUIRE(std::get<Element2>(removed2).bar == added2.bar);
+                    REQUIRE(std::get<Element1>(removed1).foo == added1.foo);
+                }
+            }
+        }
+        WHEN("adding another element to a full cache") {
+            for (size_t i = 0; i < cache.size; i++) {
+                auto throwaway = Element1(i + 2);
+                cache.add(throwaway);
+            }
+            auto rejected = Element2(2.15123);
+            auto rejected_id = cache.add(rejected);
+            THEN("the element should have id 0") { REQUIRE(rejected_id == 0); }
+            AND_WHEN("trying to find the rejected element") {
+                auto rejected_removed = cache.remove_if_present(rejected_id);
+                THEN("it should not be found") {
+                    REQUIRE(std::holds_alternative<std::monostate>(
+                        rejected_removed));
+                }
+            }
+        }
+    }
+}

--- a/stm32-modules/heater-shaker/tests/test_double_buffer.cpp
+++ b/stm32-modules/heater-shaker/tests/test_double_buffer.cpp
@@ -1,0 +1,18 @@
+#include "catch2/catch.hpp"
+#include "hal/double_buffer.hpp"
+
+SCENARIO("double buffer swapping") {
+    GIVEN("a double buffer") {
+        auto db = double_buffer::DoubleBuffer<uint8_t, 256>();
+        REQUIRE(db.committed() != db.accessible());
+        WHEN("calling swap") {
+            THEN("the accessors should be swapped") {
+                auto old_committed = db.committed();
+                auto old_accessible = db.accessible();
+                db.swap();
+                REQUIRE(old_committed == db.accessible());
+                REQUIRE(old_accessible == db.committed());
+            }
+        }
+    }
+}

--- a/stm32-modules/heater-shaker/tests/test_errors.cpp
+++ b/stm32-modules/heater-shaker/tests/test_errors.cpp
@@ -8,15 +8,16 @@ SCENARIO("testing error writing") {
     GIVEN("a buffer long enough for an error") {
         auto buffer = std::string(64, 'c');
         WHEN("writing an error into it") {
-            auto written = errors::write_into<errors::USBTXBufOverrun>(
-                buffer.data(), buffer.size());
+            auto written =
+                errors::write_into(buffer.begin(), buffer.end(),
+                                   errors::ErrorCode::USB_TX_OVERRUN);
             THEN("the error is written into the buffer") {
-                REQUIRE_THAT(buffer,
-                             Catch::Matchers::StartsWith(
-                                 errors::USBTXBufOverrun::errorstring()));
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "ERR001:tx buffer overrun\n"));
                 AND_THEN("the length was appropriately returned") {
                     REQUIRE(written ==
-                            strlen(errors::USBTXBufOverrun::errorstring()));
+                            buffer.begin() +
+                                strlen("ERR001:tx buffer overrun\n"));
                 }
             }
         }
@@ -24,14 +25,17 @@ SCENARIO("testing error writing") {
     GIVEN("a buffer too small for an error") {
         auto buffer = std::string(2, 'c');
         WHEN("trying to write an error into it") {
-            auto written = errors::write_into<errors::InternalQueueFull>(
-                buffer.data(), buffer.size());
+            auto written =
+                errors::write_into(buffer.begin(), buffer.end(),
+                                   errors::ErrorCode::INTERNAL_QUEUE_FULL);
             THEN(
                 "the error written into only the space available in the "
                 "buffer") {
                 REQUIRE_THAT(buffer,
                              Catch::Matchers::Equals(std::string("ER")));
-                AND_THEN("the amount written is 0") { REQUIRE(written == 2); }
+                AND_THEN("the amount written is 0") {
+                    REQUIRE(written == buffer.begin() + 2);
+                }
             }
         }
     }

--- a/stm32-modules/heater-shaker/tests/test_errors.cpp
+++ b/stm32-modules/heater-shaker/tests/test_errors.cpp
@@ -1,0 +1,38 @@
+#include <array>
+#include <cstring>
+
+#include "catch2/catch.hpp"
+#include "heater-shaker/errors.hpp"
+
+SCENARIO("testing error writing") {
+    GIVEN("a buffer long enough for an error") {
+        auto buffer = std::string(64, 'c');
+        WHEN("writing an error into it") {
+            auto written = errors::write_into<errors::USBTXBufOverrun>(
+                buffer.data(), buffer.size());
+            THEN("the error is written into the buffer") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::StartsWith(
+                                 errors::USBTXBufOverrun::errorstring()));
+                AND_THEN("the length was appropriately returned") {
+                    REQUIRE(written ==
+                            strlen(errors::USBTXBufOverrun::errorstring()));
+                }
+            }
+        }
+    }
+    GIVEN("a buffer too small for an error") {
+        auto buffer = std::string(2, 'c');
+        WHEN("trying to write an error into it") {
+            auto written = errors::write_into<errors::InternalQueueFull>(
+                buffer.data(), buffer.size());
+            THEN(
+                "the error written into only the space available in the "
+                "buffer") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::Equals(std::string("ER")));
+                AND_THEN("the amount written is 0") { REQUIRE(written == 2); }
+            }
+        }
+    }
+}

--- a/stm32-modules/heater-shaker/tests/test_gcode_parse.cpp
+++ b/stm32-modules/heater-shaker/tests/test_gcode_parse.cpp
@@ -151,9 +151,10 @@ SCENARIO("GroupParser handles gcodes", "[gcode]") {
                 auto begin = all_invalid.cbegin();
                 auto first_result =
                     parser.parse_available(begin, all_invalid.cend());
-                THEN("the result is empty and parsing is done") {
-                    REQUIRE(std::holds_alternative<std::monostate>(
-                        first_result.first));
+                THEN("the result is an error and parsing is done") {
+                    REQUIRE(
+                        std::holds_alternative<decltype(parser)::ParseError>(
+                            first_result.first));
                     REQUIRE(first_result.second == all_invalid.cend());
                 }
             }

--- a/stm32-modules/heater-shaker/tests/test_gcodes.cpp
+++ b/stm32-modules/heater-shaker/tests/test_gcodes.cpp
@@ -124,6 +124,29 @@ SCENARIO("SetRPM parser works") {
             }
         }
     }
+
+    GIVEN("a response buffer large enough for the response") {
+        std::string response_buf(64, 'c');
+        WHEN("filling the response") {
+            auto written = gcode::SetRPM::write_response_into(
+                response_buf.data(), response_buf.size());
+            THEN("the response should be filled") {
+                REQUIRE_THAT(response_buf,
+                             Catch::Matchers::StartsWith("M3 OK\n"));
+                REQUIRE(written == 6);
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the response") {
+        std::string response_buf(10, 'c');
+        auto written =
+            gcode::SetRPM::write_response_into(response_buf.data(), 3);
+        THEN("the response should be filled only up to its size") {
+            REQUIRE_THAT(response_buf, Catch::Matchers::Equals("M3 ccccccc"));
+            REQUIRE(written == 3);
+        }
+    }
 }
 
 SCENARIO("SetTemperature parser works") {
@@ -249,6 +272,30 @@ SCENARIO("SetTemperature parser works") {
             }
         }
     }
+
+    GIVEN("a response buffer large enough for the response") {
+        std::string buffer(64, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetTemperature::write_response_into(
+                buffer.data(), buffer.size());
+            THEN("the response should be written") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M104 OK\n"));
+                REQUIRE(written == 8);
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the response") {
+        std::string buffer(10, 'c');
+        WHEN("filling response") {
+            auto written =
+                gcode::SetTemperature::write_response_into(buffer.data(), 5);
+            THEN("the response should be written only up to the size") {
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals("M104 ccccc"));
+                REQUIRE(written == 5);
+            }
+        }
+    }
 }
 
 SCENARIO("GetTemperature parser works") {
@@ -302,6 +349,32 @@ SCENARIO("GetTemperature parser works") {
             }
         }
     }
+
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(64, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetTemperature::write_response_into(
+                buffer.data(), buffer.size(), 10, 25);
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::StartsWith("M105 C10 T25 OK\n"));
+                REQUIRE(written == 16);
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetTemperature::write_response_into(
+                buffer.data(), 7, 10, 25);
+            THEN("the response should write only up to the available space") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::Equals("M105 Ccccccccccc"));
+                REQUIRE(written == 7);
+            }
+        }
+    }
 }
 
 SCENARIO("GetRPM parser works") {
@@ -352,6 +425,32 @@ SCENARIO("GetRPM parser works") {
             THEN("a gcode should be parsed") {
                 REQUIRE(result.first.has_value());
                 REQUIRE(result.second == to_parse.cbegin() + 4);
+            }
+        }
+    }
+
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(64, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetRPM::write_response_into(
+                buffer.data(), buffer.size(), 10, 25);
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::StartsWith("M123 C10 T25 OK\n"));
+                REQUIRE(written == 16);
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written =
+                gcode::GetRPM::write_response_into(buffer.data(), 7, 10, 25);
+            THEN("the response should write only up to the available space") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::Equals("M123 Ccccccccccc"));
+                REQUIRE(written == 7);
             }
         }
     }

--- a/stm32-modules/heater-shaker/tests/test_gcodes.cpp
+++ b/stm32-modules/heater-shaker/tests/test_gcodes.cpp
@@ -129,22 +129,22 @@ SCENARIO("SetRPM parser works") {
         std::string response_buf(64, 'c');
         WHEN("filling the response") {
             auto written = gcode::SetRPM::write_response_into(
-                response_buf.data(), response_buf.size());
+                response_buf.begin(), response_buf.end());
             THEN("the response should be filled") {
                 REQUIRE_THAT(response_buf,
                              Catch::Matchers::StartsWith("M3 OK\n"));
-                REQUIRE(written == 6);
+                REQUIRE(written == response_buf.begin() + 6);
             }
         }
     }
 
     GIVEN("a response buffer not large enough for the response") {
         std::string response_buf(10, 'c');
-        auto written =
-            gcode::SetRPM::write_response_into(response_buf.data(), 3);
+        auto written = gcode::SetRPM::write_response_into(
+            response_buf.begin(), response_buf.begin() + 3);
         THEN("the response should be filled only up to its size") {
             REQUIRE_THAT(response_buf, Catch::Matchers::Equals("M3 ccccccc"));
-            REQUIRE(written == 3);
+            REQUIRE(written == response_buf.begin() + 3);
         }
     }
 }
@@ -277,10 +277,10 @@ SCENARIO("SetTemperature parser works") {
         std::string buffer(64, 'c');
         WHEN("filling response") {
             auto written = gcode::SetTemperature::write_response_into(
-                buffer.data(), buffer.size());
+                buffer.begin(), buffer.end());
             THEN("the response should be written") {
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M104 OK\n"));
-                REQUIRE(written == 8);
+                REQUIRE(written == buffer.begin() + 8);
             }
         }
     }
@@ -288,11 +288,11 @@ SCENARIO("SetTemperature parser works") {
     GIVEN("a response buffer not large enough for the response") {
         std::string buffer(10, 'c');
         WHEN("filling response") {
-            auto written =
-                gcode::SetTemperature::write_response_into(buffer.data(), 5);
+            auto written = gcode::SetTemperature::write_response_into(
+                buffer.begin(), buffer.begin() + 5);
             THEN("the response should be written only up to the size") {
                 REQUIRE_THAT(buffer, Catch::Matchers::Equals("M104 ccccc"));
-                REQUIRE(written == 5);
+                REQUIRE(written == buffer.begin() + 5);
             }
         }
     }
@@ -354,11 +354,11 @@ SCENARIO("GetTemperature parser works") {
         std::string buffer(64, 'c');
         WHEN("filling response") {
             auto written = gcode::GetTemperature::write_response_into(
-                buffer.data(), buffer.size(), 10, 25);
+                buffer.begin(), buffer.end(), 10, 25);
             THEN("the response should be written in full") {
                 REQUIRE_THAT(buffer,
                              Catch::Matchers::StartsWith("M105 C10 T25 OK\n"));
-                REQUIRE(written == 16);
+                REQUIRE(written == buffer.begin() + 16);
             }
         }
     }
@@ -367,11 +367,11 @@ SCENARIO("GetTemperature parser works") {
         std::string buffer(16, 'c');
         WHEN("filling response") {
             auto written = gcode::GetTemperature::write_response_into(
-                buffer.data(), 7, 10, 25);
+                buffer.begin(), buffer.begin() + 7, 10, 25);
             THEN("the response should write only up to the available space") {
                 REQUIRE_THAT(buffer,
                              Catch::Matchers::Equals("M105 Ccccccccccc"));
-                REQUIRE(written == 7);
+                REQUIRE(written == buffer.begin() + 7);
             }
         }
     }
@@ -433,11 +433,11 @@ SCENARIO("GetRPM parser works") {
         std::string buffer(64, 'c');
         WHEN("filling response") {
             auto written = gcode::GetRPM::write_response_into(
-                buffer.data(), buffer.size(), 10, 25);
+                buffer.begin(), buffer.end(), 10, 25);
             THEN("the response should be written in full") {
                 REQUIRE_THAT(buffer,
                              Catch::Matchers::StartsWith("M123 C10 T25 OK\n"));
-                REQUIRE(written == 16);
+                REQUIRE(written == buffer.begin() + 16);
             }
         }
     }
@@ -445,12 +445,12 @@ SCENARIO("GetRPM parser works") {
     GIVEN("a response buffer not large enough for the formatted response") {
         std::string buffer(16, 'c');
         WHEN("filling response") {
-            auto written =
-                gcode::GetRPM::write_response_into(buffer.data(), 7, 10, 25);
+            auto written = gcode::GetRPM::write_response_into(
+                buffer.begin(), buffer.begin() + 7, 10, 25);
             THEN("the response should write only up to the available space") {
                 REQUIRE_THAT(buffer,
                              Catch::Matchers::Equals("M123 Ccccccccccc"));
-                REQUIRE(written == 7);
+                REQUIRE(written == buffer.begin() + 7);
             }
         }
     }

--- a/stm32-modules/heater-shaker/tests/test_heater_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_heater_task.cpp
@@ -1,0 +1,67 @@
+#include "catch2/catch.hpp"
+#include "heater-shaker/heater_task.hpp"
+#include "heater-shaker/messages.hpp"
+#include "test/task_builder.hpp"
+
+SCENARIO("heater task basic functionality") {
+    GIVEN("a heater task") {
+        auto tasks = TaskBuilder::build();
+        WHEN("calling run_once() with no messages") {
+            THEN("the task should work fine") {
+                REQUIRE_NOTHROW(tasks->get_heater_task().run_once());
+            }
+        }
+    }
+}
+
+SCENARIO("heater task message passing") {
+    GIVEN("a heater task") {
+        auto tasks = TaskBuilder::build();
+        WHEN("sending a set-temperature message") {
+            auto message = messages::SetTemperatureMessage{
+                .id = 1231, .target_temperature = 45};
+            tasks->get_heater_queue().backing_deque.push_back(
+                messages::HeaterMessage(message));
+            tasks->get_heater_task().run_once();
+            THEN("the task should get the message") {
+                REQUIRE(tasks->get_heater_queue().backing_deque.empty());
+                AND_THEN("the task should respond to the message") {
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
+                    auto response =
+                        tasks->get_host_comms_queue().backing_deque.front();
+                    tasks->get_host_comms_queue().backing_deque.pop_front();
+                    REQUIRE(
+                        std::holds_alternative<messages::AcknowledgePrevious>(
+                            response));
+                    auto ack =
+                        std::get<messages::AcknowledgePrevious>(response);
+                    REQUIRE(ack.responding_to_id == message.id);
+                }
+            }
+        }
+        WHEN("sending a get-temperature message") {
+            auto message = messages::GetTemperatureMessage{.id = 999};
+            tasks->get_heater_queue().backing_deque.push_back(
+                messages::HeaterMessage(message));
+            tasks->get_heater_task().run_once();
+            THEN("the task should get the message") {
+                REQUIRE(tasks->get_heater_queue().backing_deque.empty());
+                AND_THEN("the task should respond to the message") {
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
+                    auto response =
+                        tasks->get_host_comms_queue().backing_deque.front();
+                    tasks->get_host_comms_queue().backing_deque.pop_front();
+                    REQUIRE(std::holds_alternative<
+                            messages::GetTemperatureResponse>(response));
+                    auto gettemp =
+                        std::get<messages::GetTemperatureResponse>(response);
+                    REQUIRE(gettemp.responding_to_id == message.id);
+                    REQUIRE(gettemp.setpoint_temperature == 48);
+                    REQUIRE(gettemp.current_temperature == 99);
+                }
+            }
+        }
+    }
+}

--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -1,0 +1,365 @@
+#include <cstring>
+#include <string>
+
+#include "catch2/catch.hpp"
+#include "heater-shaker/errors.hpp"
+#include "heater-shaker/messages.hpp"
+#include "test/task_builder.hpp"
+
+SCENARIO("usb message parsing") {
+    GIVEN("a host_comms_task") {
+        auto tasks = TaskBuilder::build();
+        std::string tx_buf(128, 'c');
+        WHEN("calling run_once() with nothing in the queue") {
+            THEN("the task should call recv(), which should throw") {
+                REQUIRE_THROWS(tasks->get_host_comms_task().run_once(
+                    tx_buf.data(), tx_buf.size()));
+            }
+        }
+        WHEN("calling run_once() with an empty gcode message") {
+            auto message_text = std::string("\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    message_text.data(), message_text.size()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            THEN("the task should call recv() and get the message") {
+                REQUIRE_NOTHROW(tasks->get_host_comms_task().run_once(
+                    tx_buf.data(), tx_buf.size()));
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+            }
+            THEN("the task writes nothing to the transmit buffer") {
+                auto written = tasks->get_host_comms_task().run_once(
+                    tx_buf.data(), tx_buf.size());
+                REQUIRE(written == 0);
+                REQUIRE_THAT(tx_buf,
+                             Catch::Matchers::Equals(std::string(128, 'c')));
+            }
+        }
+        WHEN(
+            "calling run_once() with an insufficient tx buffer when it wants "
+            "to write data") {
+            auto message_text = std::string("aslkdhasd\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    message_text.data(), message_text.size()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            std::string small_buf(errors::USBTXBufOverrun::errorstring());
+            auto written = tasks->get_host_comms_task().run_once(
+                small_buf.data(), small_buf.size());
+            REQUIRE_THAT(small_buf,
+                         Catch::Matchers::Equals(
+                             errors::USBTXBufOverrun::errorstring()));
+            REQUIRE(written == strlen(errors::USBTXBufOverrun::errorstring()));
+        }
+        WHEN("calling run_once() with a malformed gcode message") {
+            auto message_text = std::string("aosjhdakljshd\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    message_text.data(), message_text.size()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            THEN("the task writes an error to the transmit buffer") {
+                auto written = tasks->get_host_comms_task().run_once(
+                    tx_buf.data(), tx_buf.size());
+                REQUIRE(written ==
+                        strlen(errors::UnhandledGCode::errorstring()));
+                REQUIRE_THAT(tx_buf,
+                             Catch::Matchers::StartsWith(
+                                 errors::UnhandledGCode::errorstring()));
+            }
+        }
+    }
+}
+
+SCENARIO("message passing for ack-only gcodes from usb input") {
+    GIVEN("a host_comms task") {
+        auto tasks = TaskBuilder::build();
+        std::string tx_buf(128, 'c');
+        WHEN("sending a set-temp") {
+            auto message_text = std::string("M104 S100\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    message_text.data(), message_text.size()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.data(), tx_buf.size());
+            THEN(
+                "the task should pass the message on to the heater and not "
+                "immediately ack") {
+                REQUIRE(tasks->get_heater_queue().backing_deque.size() != 0);
+                auto heater_message =
+                    tasks->get_heater_queue().backing_deque.front();
+                auto set_temp_message =
+                    std::get<messages::SetTemperatureMessage>(heater_message);
+                tasks->get_heater_queue().backing_deque.pop_front();
+                REQUIRE(set_temp_message.target_temperature == 100);
+                REQUIRE(written_firstpass == 0);
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{.responding_to_id =
+                                                          set_temp_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.data(),
+                                                              tx_buf.size());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("M104 OK\n"));
+                        REQUIRE(written_secondpass == 8);
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending a bad response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = set_temp_message.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.data(),
+                                                              tx_buf.size());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > 0);
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
+        WHEN("sending a set-rpm") {
+            auto message_text = std::string("M3 S3000\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    message_text.data(), message_text.size()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.data(), tx_buf.size());
+            THEN(
+                "the task should pass the message on to the motor and not "
+                "immediately ack") {
+                REQUIRE(tasks->get_motor_queue().backing_deque.size() != 0);
+                auto motor_message =
+                    tasks->get_motor_queue().backing_deque.front();
+                auto set_rpm_message =
+                    std::get<messages::SetRPMMessage>(motor_message);
+                tasks->get_motor_queue().backing_deque.pop_front();
+                REQUIRE(set_rpm_message.target_rpm == 3000);
+                REQUIRE(written_firstpass == 0);
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{.responding_to_id =
+                                                          set_rpm_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.data(),
+                                                              tx_buf.size());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("M3 OK\n"));
+                        REQUIRE(written_secondpass == 6);
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending a bad response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = set_rpm_message.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.data(),
+                                                              tx_buf.size());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > 0);
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
+    }
+}
+
+SCENARIO("message passing for response-carrying gcodes from usb input") {
+    GIVEN("a host_comms task") {
+        auto tasks = TaskBuilder::build();
+        std::string tx_buf(128, 'c');
+        WHEN("sending a get-temp") {
+            auto message_text = std::string("M105\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    message_text.data(), message_text.size()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.data(), tx_buf.size());
+            THEN(
+                "the task should pass the message on to the heater and not "
+                "immediately ack") {
+                REQUIRE(tasks->get_heater_queue().backing_deque.size() != 0);
+                auto heater_message =
+                    tasks->get_heater_queue().backing_deque.front();
+                REQUIRE(std::holds_alternative<messages::GetTemperatureMessage>(
+                    heater_message));
+                auto get_temp_message =
+                    std::get<messages::GetTemperatureMessage>(heater_message);
+                tasks->get_heater_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == 0);
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::GetTemperatureResponse{
+                            .responding_to_id = get_temp_message.id,
+                            .current_temperature = 47,
+                            .setpoint_temperature = 0});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.data(),
+                                                              tx_buf.size());
+                    THEN("the task should respond to the get-temp message") {
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "M105 C47 T0 OK\n"));
+                        REQUIRE(written_secondpass == 15);
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN(
+                    "sending a response with wrong id back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::GetTemperatureResponse{
+                            .responding_to_id = get_temp_message.id + 1,
+                            .current_temperature = 99,
+                            .setpoint_temperature = 20});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.data(),
+                                                              tx_buf.size());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > 0);
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN(
+                    "sending a response with wrong message type back to the "
+                    "comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{.responding_to_id =
+                                                          get_temp_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.data(),
+                                                              tx_buf.size());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > 0);
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
+        WHEN("sending a get-rpm") {
+            auto message_text = std::string("M123\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    message_text.data(), message_text.size()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.data(), tx_buf.size());
+            THEN(
+                "the task should pass the message on to the motor and not "
+                "immediately ack") {
+                REQUIRE(tasks->get_motor_queue().backing_deque.size() != 0);
+                auto motor_message =
+                    tasks->get_motor_queue().backing_deque.front();
+                REQUIRE(std::holds_alternative<messages::GetRPMMessage>(
+                    motor_message));
+                auto get_rpm_message =
+                    std::get<messages::GetRPMMessage>(motor_message);
+                tasks->get_motor_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == 0);
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response =
+                        messages::HostCommsMessage(messages::GetRPMResponse{
+                            .responding_to_id = get_rpm_message.id,
+                            .current_rpm = 1500,
+                            .setpoint_rpm = 1750});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.data(),
+                                                              tx_buf.size());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "M123 C1500 T1750 OK\n"));
+                        REQUIRE(written_secondpass == 20);
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN(
+                    "sending a response with wrong id back to the comms task") {
+                    auto response =
+                        messages::HostCommsMessage(messages::GetRPMResponse{
+                            .responding_to_id = get_rpm_message.id + 1,
+                            .current_rpm = 9999,
+                            .setpoint_rpm = 1590});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.data(),
+                                                              tx_buf.size());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > 0);
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN(
+                    "sending a response with wrong message type back to the "
+                    "comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{.responding_to_id =
+                                                          get_rpm_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.data(),
+                                                              tx_buf.size());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > 0);
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/stm32-modules/heater-shaker/tests/test_message_passing.cpp
+++ b/stm32-modules/heater-shaker/tests/test_message_passing.cpp
@@ -1,7 +1,8 @@
 #include <string>
+
 #include "catch2/catch.hpp"
-#include "test/task_builder.hpp"
 #include "heater-shaker/messages.hpp"
+#include "test/task_builder.hpp"
 
 SCENARIO("testing full message passing integration") {
     GIVEN("a full set of tasks") {
@@ -9,58 +10,70 @@ SCENARIO("testing full message passing integration") {
         WHEN("sending a set-rpm message by string to the host comms task") {
             std::string message_str = "M3 S2000\n";
             tasks->get_host_comms_queue().backing_deque.push_back(
-                messages::HostCommsMessage(
-                    messages::IncomingMessageFromHost(&*message_str.begin(), &*message_str.end())));
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_str.begin(), &*message_str.end())));
             THEN("after spinning both tasks, we get a response") {
                 auto response_buffer = std::string(64, 'c');
-                auto written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
+                auto written = tasks->get_host_comms_task().run_once(
+                    response_buffer.begin(), response_buffer.end());
                 REQUIRE(written == response_buffer.begin());
                 tasks->get_motor_task().run_once();
-                written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
-                REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith("M3 OK\n"));
+                written = tasks->get_host_comms_task().run_once(
+                    response_buffer.begin(), response_buffer.end());
+                REQUIRE_THAT(response_buffer,
+                             Catch::Matchers::StartsWith("M3 OK\n"));
             }
         }
         WHEN("sending a get-rpm message by string to the host comms task") {
             std::string message_str = "M123\n";
             tasks->get_host_comms_queue().backing_deque.push_back(
-                messages::HostCommsMessage(
-                    messages::IncomingMessageFromHost(&*message_str.begin(), &*message_str.end())));
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_str.begin(), &*message_str.end())));
             THEN("after spinning both tasks, we get a response") {
                 auto response_buffer = std::string(64, 'c');
-                auto written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
+                auto written = tasks->get_host_comms_task().run_once(
+                    response_buffer.begin(), response_buffer.end());
                 REQUIRE(written == response_buffer.begin());
                 tasks->get_motor_task().run_once();
-                written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
-                REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith("M123 C1050 T3500 OK\n"));
+                written = tasks->get_host_comms_task().run_once(
+                    response_buffer.begin(), response_buffer.end());
+                REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith(
+                                                  "M123 C1050 T3500 OK\n"));
             }
         }
         WHEN("sending a set-temp message by string to the host comms task") {
             std::string message_str = "M104 S75\n";
             tasks->get_host_comms_queue().backing_deque.push_back(
-                messages::HostCommsMessage(
-                    messages::IncomingMessageFromHost(&*message_str.begin(), &*message_str.end())));
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_str.begin(), &*message_str.end())));
             THEN("after spinning both tasks, we get a response") {
                 auto response_buffer = std::string(64, 'c');
-                auto written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
+                auto written = tasks->get_host_comms_task().run_once(
+                    response_buffer.begin(), response_buffer.end());
                 REQUIRE(written == response_buffer.begin());
                 tasks->get_heater_task().run_once();
-                written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
-                REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith("M104 OK\n"));
+                written = tasks->get_host_comms_task().run_once(
+                    response_buffer.begin(), response_buffer.end());
+                REQUIRE_THAT(response_buffer,
+                             Catch::Matchers::StartsWith("M104 OK\n"));
             }
         }
 
         WHEN("sending a get-temp message by string to the host comms task") {
             std::string message_str = "M105\n";
             tasks->get_host_comms_queue().backing_deque.push_back(
-                messages::HostCommsMessage(
-                    messages::IncomingMessageFromHost(&*message_str.begin(), &*message_str.end())));
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_str.begin(), &*message_str.end())));
             THEN("after spinning both tasks, we get a reponse") {
                 auto response_buffer = std::string(64, 'c');
-                auto written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
+                auto written = tasks->get_host_comms_task().run_once(
+                    response_buffer.begin(), response_buffer.end());
                 REQUIRE(written == response_buffer.begin());
                 tasks->get_heater_task().run_once();
-                written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
-                REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith("M105 C99 T48 OK\n"));
+                written = tasks->get_host_comms_task().run_once(
+                    response_buffer.begin(), response_buffer.end());
+                REQUIRE_THAT(response_buffer,
+                             Catch::Matchers::StartsWith("M105 C99 T48 OK\n"));
             }
         }
     }

--- a/stm32-modules/heater-shaker/tests/test_message_passing.cpp
+++ b/stm32-modules/heater-shaker/tests/test_message_passing.cpp
@@ -1,0 +1,67 @@
+#include <string>
+#include "catch2/catch.hpp"
+#include "test/task_builder.hpp"
+#include "heater-shaker/messages.hpp"
+
+SCENARIO("testing full message passing integration") {
+    GIVEN("a full set of tasks") {
+        auto tasks = TaskBuilder::build();
+        WHEN("sending a set-rpm message by string to the host comms task") {
+            std::string message_str = "M3 S2000\n";
+            tasks->get_host_comms_queue().backing_deque.push_back(
+                messages::HostCommsMessage(
+                    messages::IncomingMessageFromHost(message_str.data(), message_str.size())));
+            THEN("after spinning both tasks, we get a response") {
+                auto response_buffer = std::string(64, 'c');
+                auto written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
+                REQUIRE(written == 0);
+                tasks->get_motor_task().run_once();
+                written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
+                REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith("M3 OK\n"));
+            }
+        }
+        WHEN("sending a get-rpm message by string to the host comms task") {
+            std::string message_str = "M123\n";
+            tasks->get_host_comms_queue().backing_deque.push_back(
+                messages::HostCommsMessage(
+                    messages::IncomingMessageFromHost(message_str.data(), message_str.size())));
+            THEN("after spinning both tasks, we get a response") {
+                auto response_buffer = std::string(64, 'c');
+                auto written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
+                REQUIRE(written == 0);
+                tasks->get_motor_task().run_once();
+                written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
+                REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith("M123 C1050 T3500 OK\n"));
+            }
+        }
+        WHEN("sending a set-temp message by string to the host comms task") {
+            std::string message_str = "M104 S75\n";
+            tasks->get_host_comms_queue().backing_deque.push_back(
+                messages::HostCommsMessage(
+                    messages::IncomingMessageFromHost(message_str.data(), message_str.size())));
+            THEN("after spinning both tasks, we get a response") {
+                auto response_buffer = std::string(64, 'c');
+                auto written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
+                REQUIRE(written == 0);
+                tasks->get_heater_task().run_once();
+                written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
+                REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith("M104 OK\n"));
+            }
+        }
+
+        WHEN("sending a get-temp message by string to the host comms task") {
+            std::string message_str = "M105\n";
+            tasks->get_host_comms_queue().backing_deque.push_back(
+                messages::HostCommsMessage(
+                    messages::IncomingMessageFromHost(message_str.data(), message_str.size())));
+            THEN("after spinning both tasks, we get a reponse") {
+                auto response_buffer = std::string(64, 'c');
+                auto written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
+                REQUIRE(written == 0);
+                tasks->get_heater_task().run_once();
+                written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
+                REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith("M105 C99 T48 OK\n"));
+            }
+        }
+    }
+}

--- a/stm32-modules/heater-shaker/tests/test_message_passing.cpp
+++ b/stm32-modules/heater-shaker/tests/test_message_passing.cpp
@@ -10,13 +10,13 @@ SCENARIO("testing full message passing integration") {
             std::string message_str = "M3 S2000\n";
             tasks->get_host_comms_queue().backing_deque.push_back(
                 messages::HostCommsMessage(
-                    messages::IncomingMessageFromHost(message_str.data(), message_str.size())));
+                    messages::IncomingMessageFromHost(&*message_str.begin(), &*message_str.end())));
             THEN("after spinning both tasks, we get a response") {
                 auto response_buffer = std::string(64, 'c');
-                auto written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
-                REQUIRE(written == 0);
+                auto written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
+                REQUIRE(written == response_buffer.begin());
                 tasks->get_motor_task().run_once();
-                written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
+                written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
                 REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith("M3 OK\n"));
             }
         }
@@ -24,13 +24,13 @@ SCENARIO("testing full message passing integration") {
             std::string message_str = "M123\n";
             tasks->get_host_comms_queue().backing_deque.push_back(
                 messages::HostCommsMessage(
-                    messages::IncomingMessageFromHost(message_str.data(), message_str.size())));
+                    messages::IncomingMessageFromHost(&*message_str.begin(), &*message_str.end())));
             THEN("after spinning both tasks, we get a response") {
                 auto response_buffer = std::string(64, 'c');
-                auto written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
-                REQUIRE(written == 0);
+                auto written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
+                REQUIRE(written == response_buffer.begin());
                 tasks->get_motor_task().run_once();
-                written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
+                written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
                 REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith("M123 C1050 T3500 OK\n"));
             }
         }
@@ -38,13 +38,13 @@ SCENARIO("testing full message passing integration") {
             std::string message_str = "M104 S75\n";
             tasks->get_host_comms_queue().backing_deque.push_back(
                 messages::HostCommsMessage(
-                    messages::IncomingMessageFromHost(message_str.data(), message_str.size())));
+                    messages::IncomingMessageFromHost(&*message_str.begin(), &*message_str.end())));
             THEN("after spinning both tasks, we get a response") {
                 auto response_buffer = std::string(64, 'c');
-                auto written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
-                REQUIRE(written == 0);
+                auto written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
+                REQUIRE(written == response_buffer.begin());
                 tasks->get_heater_task().run_once();
-                written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
+                written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
                 REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith("M104 OK\n"));
             }
         }
@@ -53,13 +53,13 @@ SCENARIO("testing full message passing integration") {
             std::string message_str = "M105\n";
             tasks->get_host_comms_queue().backing_deque.push_back(
                 messages::HostCommsMessage(
-                    messages::IncomingMessageFromHost(message_str.data(), message_str.size())));
+                    messages::IncomingMessageFromHost(&*message_str.begin(), &*message_str.end())));
             THEN("after spinning both tasks, we get a reponse") {
                 auto response_buffer = std::string(64, 'c');
-                auto written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
-                REQUIRE(written == 0);
+                auto written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
+                REQUIRE(written == response_buffer.begin());
                 tasks->get_heater_task().run_once();
-                written = tasks->get_host_comms_task().run_once(response_buffer.data(), response_buffer.size());
+                written = tasks->get_host_comms_task().run_once(response_buffer.begin(), response_buffer.end());
                 REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith("M105 C99 T48 OK\n"));
             }
         }

--- a/stm32-modules/heater-shaker/tests/test_motor_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_motor_task.cpp
@@ -1,0 +1,66 @@
+#include "catch2/catch.hpp"
+#include "heater-shaker/messages.hpp"
+#include "heater-shaker/motor_task.hpp"
+#include "test/task_builder.hpp"
+
+SCENARIO("motor task basic functionality") {
+    GIVEN("a motor task") {
+        auto tasks = TaskBuilder::build();
+        WHEN("calling run_once() with no messages") {
+            THEN("the task should wokr fine") {
+                REQUIRE_NOTHROW(tasks->get_heater_task().run_once());
+            }
+        }
+    }
+}
+
+SCENARIO("motor task message poassing") {
+    GIVEN("a motor task") {
+        auto tasks = TaskBuilder::build();
+        WHEN("sending a set-rpm message") {
+            auto message =
+                messages::SetRPMMessage{.id = 222, .target_rpm = 1254};
+            tasks->get_motor_queue().backing_deque.push_back(
+                messages::MotorMessage(message));
+            tasks->get_motor_task().run_once();
+            THEN("the task should get the message") {
+                REQUIRE(tasks->get_motor_queue().backing_deque.empty());
+                AND_THEN("the task should respond to the message") {
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
+                    auto response =
+                        tasks->get_host_comms_queue().backing_deque.front();
+                    tasks->get_host_comms_queue().backing_deque.pop_front();
+                    REQUIRE(
+                        std::holds_alternative<messages::AcknowledgePrevious>(
+                            response));
+                    auto ack =
+                        std::get<messages::AcknowledgePrevious>(response);
+                    REQUIRE(ack.responding_to_id == message.id);
+                }
+            }
+        }
+        WHEN("sending a get-rpm message") {
+            auto message = messages::GetRPMMessage{.id = 123};
+            tasks->get_motor_queue().backing_deque.push_back(
+                messages::MotorMessage(message));
+            tasks->get_motor_task().run_once();
+            THEN("the task should get the message") {
+                REQUIRE(tasks->get_motor_queue().backing_deque.empty());
+                AND_THEN("the task should respond to the message") {
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
+                    auto response =
+                        tasks->get_host_comms_queue().backing_deque.front();
+                    tasks->get_host_comms_queue().backing_deque.pop_front();
+                    REQUIRE(std::holds_alternative<messages::GetRPMResponse>(
+                        response));
+                    auto getrpm = std::get<messages::GetRPMResponse>(response);
+                    REQUIRE(getrpm.responding_to_id == message.id);
+                    REQUIRE(getrpm.current_rpm == 1050);
+                    REQUIRE(getrpm.setpoint_rpm == 3500);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This (big - should I split it up?) PR adds everything necessary to not just be a simple loopback on USB, but actually
- Listen to a host when connected
- Parse incoming messages for GCode
- Translate those messages to internal messages to send to other tasks, returning errors if necessary
- Send the messages to other tasks
- Have those other tasks response
- Eventually respond with the data or acknowledgements from the other tasks

This therefore required a lot of work in better defining the messages to be passed; handling the parsing, and the message handling in all of the relevant tasks; and one million little fixes on the USB side of things for problems that had been masked by the system actually trying to be a loopback.

The commits in the PR have been pretty closely janitored and have messages proportionate to their complexity, so I'd recommend browsing this PR by commit rather than looking at all the file changes at once.

## New Functionality
- Responds to M3 (set-spindle-speed, `M3 Snnnn\n`), M123 (get status, `M123\n` returns `M123 Cnnnn Tnnnn OK\n` for current and target rpm; these are hardcoded for now), M104 (set temperature, `M104 Snnn\n`), and M105 (get temperature, `M105\n` returns `M105 Cnnn Tnnn OK\n`, hardcoded for now like RPM)
- Has errors for if you spam it too much (a human will not be able to do this, a python script might)
- Has tests for all the above including a full roundtrip test from string to string implying the message roundtrips

## Testing
- Put it on an NFF probably, or hack together some nucleos to get a programmable micro that owns a USB 
- Plug it in to your computer
- Connect to it with your serial interface of choice; as a longtime serial terminal sommelier, I'd recommend `python -m serial.tools.miniterm /dev/ttywhatever 115200`
- _Marvel_ at the lack of kernel logs complaining about not being able to set flow control
- _ooh_ at being able to type `M105\n` and get a lovely response back,  
- _aahhh_ at being able to type a bunch of random stuff and hit enter and get a nicely formatted error with number back
- _wail_ at the code in `freertos_comms_task.cpp`. I apologize for nothing, there are no sins, laws, or morals in USB