### PR TITLE
feat(heater-shaker): configure softpower

### DIFF
--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -63,6 +63,7 @@ set(HS_FW_NONLINTABLE_SRCS
   ${MOTOR_DIR}/mc_tasks.c
   ${MOTOR_DIR}/stm32f30x_mc_it.c
   ${MOTOR_DIR}/regular_conversion_manager.c
+  ${UI_DIR}/ui_hardware.c
   )
 
 add_executable(heater-shaker

--- a/stm32-modules/heater-shaker/firmware/ui_task/freertos_ui_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/ui_task/freertos_ui_task.cpp
@@ -11,6 +11,11 @@
 #include "heater-shaker/ui_task.hpp"
 #include "task.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvolatile"
+#include "ui_hardware.h"
+#pragma GCC diagnostic pop
+
 namespace ui_control_task {
 
 enum class Notifications : uint8_t {
@@ -37,6 +42,7 @@ static StaticTask_t
 // Actual function that runs inside the task, unused param because we don't get
 // to pick the function type
 static void run(void *param) {  // NOLINT(misc-unused-parameters)
+    ui_hardware_setup();
     static constexpr uint32_t delay_ticks = 100;
     while (true) {
         vTaskDelay(delay_ticks);

--- a/stm32-modules/heater-shaker/firmware/ui_task/ui_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/ui_task/ui_hardware.c
@@ -1,0 +1,13 @@
+#include "stm32f3xx_hal.h"
+#include "ui_hardware.h"
+
+void ui_hardware_setup(void) {
+    GPIO_InitTypeDef gpio_init = {
+      .Pin = SOFTPOWER_BUTTON_SENSE_PIN | SOFTPOWER_UNPLUG_SENSE_PIN,
+      .Mode = GPIO_MODE_INPUT,
+      .Pull = GPIO_NOPULL,
+      .Speed = GPIO_SPEED_FREQ_LOW,
+    };
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+    HAL_GPIO_Init(SOFTPOWER_PORT, &gpio_init);
+}

--- a/stm32-modules/heater-shaker/firmware/ui_task/ui_hardware.h
+++ b/stm32-modules/heater-shaker/firmware/ui_task/ui_hardware.h
@@ -1,0 +1,17 @@
+#ifndef UI_HARDWARE_H__
+#define UI_HARDWARE_H__
+#include "stm32f3xx_hal_gpio.h"
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#define SOFTPOWER_BUTTON_SENSE_PIN GPIO_PIN_4
+#define SOFTPOWER_UNPLUG_SENSE_PIN GPIO_PIN_5
+#define SOFTPOWER_PORT GPIOB
+
+void ui_hardware_setup(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  // _HARDWARE_H__


### PR DESCRIPTION
The soft power button is the first element of the UI that we'll support.
It consists of, at this stage, making sure that the pin connected to the
button sense isn't pulled down because that breaks the softpower
circuit. It (and the pin for sensing the power being unplugged, though
that's less critical) needs to be an input without pull resistors.

This PR is targeted on the motor PR just because that PR changes a bunch of directories, it should be merged into edge once the motor PR is merged.

## Testing
- Flash this PR onto an nff
- Press the soft power button
- It should turn off
- Press the soft power button
- It should turn on
- Press the... you get it