### PR TITLE
chore(heater-shaker): add flash target

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Open the `/modules/.../<file_name>.ino` file in Arduino, select the appropriate 
 
 The stm32 modules have debug harnessing built in; for instance, running `cmake --build ./build-stm32-cross --target heater-shaker-debug` will build the firmware and spin up the cross gdb and openocd. This target by default (because of commands in the gdbinit) will reset the board and upload the built firmware; if you want to use the firmware currently flashed to the board, run everything manually.
 
+The stm32 modules also have flash targets for when you want to flash the board but not actually run a debugger; running `cmake --build ./build-stm32-cross --target heater-shaker-flash` will build the firmware and then use openocd to flash it to the target.
+
+
 ## test
 
 This is not implemented for the arduino modules.

--- a/stm32-modules/heater-shaker/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/CMakeLists.txt
@@ -20,11 +20,13 @@ file(GLOB_RECURSE HS_SOURCES_FOR_FORMAT ./*.cpp ./*.hpp ./*.h)
 add_custom_target(
   heater-shaker-format
   ALL
+  COMMENT "Formatting code"
   COMMAND ${Clang_CLANGFORMAT_EXECUTABLE} -style=file -i ${HS_SOURCES_FOR_FORMAT}
   )
 
 # Target for use in ci - warnings are errors, doesn't edit files
 add_custom_target(
   heater-shaker-format-ci
+  COMMENT "Checking format"
   COMMAND ${Clang_CLANGFORMAT_EXECUTABLE} -style=file -Werror --ferror-limit=0 -n ${HS_SOURCES_FOR_FORMAT}
 )

--- a/stm32-modules/heater-shaker/README.md
+++ b/stm32-modules/heater-shaker/README.md
@@ -10,6 +10,7 @@ When cross-compiling the firmware (using the `stm32-cross` cmake preset, running
 - Build the firmware, connect to a debugger, and upload it: `cmake --build ./build-stm32-cross --target heater-shaker-debug`
 - Lint the firmware: `cmake --build ./build-stm32-cross --target heater-shaker-lint`
 - Format the firmware: `cmake --build ./build-stm32-cross --target heater-shaker-format`
+- Flash the firmware to a board: `cmake --build ./build-stm32-cross --target heater-shaker-flash`
 
 ### Debugging
 There's a target called `heater-shaker-debug` that will build the firmware and then spin up a gdb, spin up an openocd, and connect the two; load some useful python scripts; connect to an st-link that should be already plugged in; automatically upload the firmware, and drop you at a breakpoint at boot time. This should all download itself and be ready as soon as `cmake --preset=stm32-cross .` completes, with one exception: Gdb python support is incredibly weird and will somehow always find your python2 that the system has, no matter how hard you try to avoid this. The scripts should work fine, but you have to install setuptools so `pkg_resources` is available, since this isn't really something we want to "install" by downloading it to some random directory and dropping it in gdb's embedded python interpreter's package path, so do the lovely

--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -120,6 +120,7 @@ list(TRANSFORM CLANG_EXTRA_ARGS PREPEND --extra-arg=-I)
 list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-frelaxed-template-template-args")
 get_target_property(core_sources heater-shaker-core SOURCES)
 add_custom_target(heater-shaker-lint
+  COMMENT "Linting"
   ALL
   COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${HS_FW_LINTABLE_SRCS} ${core_sources} --config=)
 
@@ -130,6 +131,14 @@ add_custom_target(heater-shaker-lint
 # should be running the entire time and that's tough to accomplish
 # in a custom command
 add_custom_target(heater-shaker-debug
+  COMMENT "Starting gdb and openocd"
   COMMAND heater-shaker
   USES_TERMINAL
   )
+
+# Runs openocd to flash the board (without using a debugger)
+add_custom_target(heater-shaker-flash
+  COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${OpenOCD_SCRIPTROOT}/board/st_nucleo_f3.cfg" "-c" "program $<TARGET_FILE:heater-shaker>;exit"
+  VERBATIM
+  COMMENT "Flashing board"
+  DEPENDS heater-shaker)


### PR DESCRIPTION
We have a target for debugging, but it's actually kind of annoying to
use it to do a flash where you don't actually want to debug.

Add a cmake target that just calls openocd to flash the board and exits.

Also add a couple comments (which get printed in the console) to some
other cmake utilities.

## Testing
- Configure cmake `cmake --preset=stm32-cross .`
- Flash a board `cmake --build ./build-stm32-cross --target heater-shaker-flash`
- it should work