### PR TITLE
feat(heater-shaker): print subdegree temps

### DIFF
--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -75,7 +75,8 @@ target_link_options(heater-shaker
   PRIVATE
   "LINKER:-T,${SYSTEM_DIR}/STM32F303RETx_FLASH.ld"
   "LINKER:--print-memory-usage"
-  "LINKER:--error-unresolved-symbols")
+  "LINKER:--error-unresolved-symbols"
+  "LINKER:-u,_printf_float")
 
 # Incurs at least a relink when you change the linker file (and a recompile of main
 # but hopefully that's quick)

--- a/stm32-modules/heater-shaker/include/heater-shaker/gcodes.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/gcodes.hpp
@@ -122,7 +122,7 @@ struct GetTemperature {
         write_response_into(InputIt buf, InLimit limit,
                             double current_temperature,
                             double setpoint_temperature) -> InputIt {
-        auto res = snprintf(&*buf, (limit-buf), "M105 C%0.2f T%0.2f OK\n",
+        auto res = snprintf(&*buf, (limit - buf), "M105 C%0.2f T%0.2f OK\n",
                             static_cast<float>(current_temperature),
                             static_cast<float>(setpoint_temperature));
         if (res <= 0) {

--- a/stm32-modules/heater-shaker/include/heater-shaker/gcodes.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/gcodes.hpp
@@ -122,35 +122,13 @@ struct GetTemperature {
         write_response_into(InputIt buf, InLimit limit,
                             double current_temperature,
                             double setpoint_temperature) -> InputIt {
-        static constexpr const char* prefix = "M105 C";
-        char* char_next = &*buf;
-        char* char_limit = &*limit;
-        char_next = write_string_to_iterpair(char_next, char_limit, prefix);
-
-        auto res = snprintf(char_next, (char_limit - char_next), "%0.2f",
-                            static_cast<float>(current_temperature));
+        auto res = snprintf(&*buf, (limit-buf), "M105 C%0.2f T%0.2f OK\n",
+                            static_cast<float>(current_temperature),
+                            static_cast<float>(setpoint_temperature));
         if (res <= 0) {
-            return buf + (char_next - &*buf) - 1;
+            return buf;
         }
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        char_next += std::min(static_cast<ptrdiff_t>(char_limit - char_next),
-                              static_cast<ptrdiff_t>(res));
-
-        static constexpr const char* setpoint_prefix = " T";
-        char_next =
-            write_string_to_iterpair(char_next, char_limit, setpoint_prefix);
-        res = snprintf(char_next, (char_limit - char_next), "%0.2f",
-                       static_cast<float>(setpoint_temperature));
-        if (res <= 0) {
-            return buf + (char_next - &*buf) - 1;
-        }
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        char_next += std::min(static_cast<ptrdiff_t>(char_limit - char_next),
-                              static_cast<ptrdiff_t>(res));
-
-        static constexpr const char* suffix = " OK\n";
-        char_next = write_string_to_iterpair(char_next, char_limit, suffix);
-        return buf + (char_next - &*buf);
+        return buf + res;
     }
     template <typename InputIt, typename Limit>
     requires std::forward_iterator<InputIt>&&

--- a/stm32-modules/heater-shaker/include/heater-shaker/heater_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/heater_task.hpp
@@ -159,10 +159,8 @@ requires MessageQueue<QueueImpl<Message>, Message> class HeaterTask {
         errors::ErrorCode code = pad_a.error != errors::ErrorCode::NO_ERROR
                                      ? pad_a.error
                                      : pad_b.error;
-        auto avg_temp =
-            static_cast<int16_t>((static_cast<int32_t>(pad_a.temp_c) +
-                                  static_cast<int32_t>(pad_b.temp_c)) /
-                                 2);
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        auto avg_temp = (pad_a.temp_c + pad_b.temp_c) / 2.0;
         auto response = messages::GetTemperatureResponse{
             .responding_to_id = msg.id,
             .current_temperature = avg_temp,

--- a/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
@@ -361,8 +361,7 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
         auto message = messages::SetTemperatureMessage{
-            .id = id,
-            .target_temperature = static_cast<uint32_t>(gcode.temperature)};
+            .id = id, .target_temperature = gcode.temperature};
         if (!task_registry->heater->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
@@ -43,7 +43,7 @@ struct SetRPMMessage {
 
 struct SetTemperatureMessage {
     uint32_t id;
-    uint32_t target_temperature;
+    double target_temperature;
 };
 
 struct GetTemperatureMessage {
@@ -87,8 +87,8 @@ struct ErrorMessage {
 */
 struct GetTemperatureResponse {
     uint32_t responding_to_id;
-    int16_t current_temperature;
-    uint32_t setpoint_temperature;
+    double current_temperature;
+    double setpoint_temperature;
     errors::ErrorCode with_error = errors::ErrorCode::NO_ERROR;
 };
 

--- a/stm32-modules/heater-shaker/tests/test_gcodes.cpp
+++ b/stm32-modules/heater-shaker/tests/test_gcodes.cpp
@@ -355,11 +355,11 @@ SCENARIO("GetTemperature parser works") {
         std::string buffer(64, 'c');
         WHEN("filling response") {
             auto written = gcode::GetTemperature::write_response_into(
-                buffer.begin(), buffer.end(), 10, 25);
+                buffer.begin(), buffer.end(), 10.25, 25.001);
             THEN("the response should be written in full") {
-                REQUIRE_THAT(buffer,
-                             Catch::Matchers::StartsWith("M105 C10 T25 OK\n"));
-                REQUIRE(written == buffer.begin() + 16);
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "M105 C10.25 T25.00 OK\n"));
+                REQUIRE(written == buffer.begin() + 22);
             }
         }
     }
@@ -370,9 +370,10 @@ SCENARIO("GetTemperature parser works") {
             auto written = gcode::GetTemperature::write_response_into(
                 buffer.begin(), buffer.begin() + 7, 10, 25);
             THEN("the response should write only up to the available space") {
-                REQUIRE_THAT(buffer,
-                             Catch::Matchers::Equals("M105 Ccccccccccc"));
-                REQUIRE(written == buffer.begin() + 7);
+                std::string response = "M105 Ccccccccccc";
+                response.at(6) = '\0';
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
             }
         }
     }

--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -352,8 +352,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                                                               tx_buf.end());
                     THEN("the task should respond to the get-temp message") {
                         REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "M105 C47 T0 OK\n"));
-                        REQUIRE(written_secondpass == tx_buf.begin() + 15);
+                                                 "M105 C47.00 T0.00 OK\n"));
+                        REQUIRE(written_secondpass == tx_buf.begin() + 21);
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }

--- a/stm32-modules/heater-shaker/tests/test_message_passing.cpp
+++ b/stm32-modules/heater-shaker/tests/test_message_passing.cpp
@@ -78,8 +78,8 @@ SCENARIO("testing full message passing integration") {
                 tasks->get_heater_task().run_once();
                 written = tasks->get_host_comms_task().run_once(
                     response_buffer.begin(), response_buffer.end());
-                REQUIRE_THAT(response_buffer,
-                             Catch::Matchers::StartsWith("M105 C95 T48 OK\n"));
+                REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith(
+                                                  "M105 C95.20 T48.00 OK\n"));
             }
         }
 


### PR DESCRIPTION
We convert and hold all our temperatures in doubles, but weren't
printing them that way, because, well, look at this commit.

We now print them, which requires using snprintf, because nobody's
implemented std::to_chars for float or double.

## Testing
- See if you get nice numbers with decimal points when you send an M105
- No actual conversion code changed anywhere, just the printing code, so that's pretty much it