### PR TITLE
feat(heater-shaker): Handle the heater power error latch

### DIFF
--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(_mc_static INTERFACE mc)
 set(HS_FW_LINTABLE_SRCS
   ${SYSTEM_DIR}/main.cpp
   ${HEATER_DIR}/freertos_heater_task.cpp
+  ${HEATER_DIR}/heater_policy.cpp
   ${MOTOR_DIR}/freertos_motor_task.cpp
   ${MOTOR_DIR}/motor_policy.cpp
   ${UI_DIR}/freertos_ui_task.cpp

--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -77,7 +77,8 @@ target_link_options(heater-shaker
   "LINKER:-T,${SYSTEM_DIR}/STM32F303RETx_FLASH.ld"
   "LINKER:--print-memory-usage"
   "LINKER:--error-unresolved-symbols"
-  "LINKER:-u,_printf_float")
+  "LINKER:-u,_printf_float"
+  "LINKER:-u,_scanf_float")
 
 # Incurs at least a relink when you change the linker file (and a recompile of main
 # but hopefully that's quick)

--- a/stm32-modules/heater-shaker/firmware/heater_task/freertos_heater_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/heater_task/freertos_heater_task.cpp
@@ -85,6 +85,7 @@ static void handle_conversion(const conversion_results *results) {
 // Actual function that runs the task
 void run(void *param) {
     auto *local_tasks = static_cast<HeaterTasks *>(param);
+    static_cast<void>(local_tasks->policy.try_reset_power_good());
     while (true) {
         local_tasks->heater_main_task.run_once(local_tasks->policy);
     }

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
@@ -53,7 +53,7 @@ void gpio_setup(void) {
     // Power good latch pin GPIO output pullup to ensure
     // it doesn't affect the latch when not driven
     gpio_init.Pin = HEATER_PGOOD_LATCH_PIN;
-    gpio_init.Mode = GPIO_MODE_AF_PP;
+    gpio_init.Mode = GPIO_MODE_OUTPUT_PP;
     gpio_init.Pull = GPIO_PULLUP;
     HAL_GPIO_Init(HEATER_PGOOD_SENSE_PORT, &gpio_init);
     HAL_GPIO_WritePin(HEATER_PGOOD_LATCH_PORT,

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
@@ -28,8 +28,13 @@ heater_hardware *HEATER_HW_HANDLE = NULL;
 #define NTC_PAD_B_PORT GPIOE
 #define NTC_BOARD_PIN (1<<13)
 #define NTC_BOARD_PORT GPIOE
+#define HEATER_PGOOD_SENSE_PORT GPIOD
+#define HEATER_PGOOD_SENSE_PIN (1<<12)
+#define HEATER_PGOOD_LATCH_PORT GPIOD
+#define HEATER_PGOOD_LATCH_PIN (1<<13)
 
 void gpio_setup(void) {
+    // NTC sense pis all routed to the ADC
     GPIO_InitTypeDef gpio_init = {
     .Pin = (NTC_PAD_B_PIN | NTC_BOARD_PIN),
     .Mode = GPIO_MODE_ANALOG,
@@ -39,6 +44,21 @@ void gpio_setup(void) {
     HAL_GPIO_Init(NTC_PAD_B_PORT, &gpio_init);
     gpio_init.Pin = NTC_PAD_A_PIN;
     HAL_GPIO_Init(NTC_PAD_A_PORT, &gpio_init);
+
+    // Power good sense pin GPIO input nopull
+    gpio_init.Pin = HEATER_PGOOD_SENSE_PIN;
+    gpio_init.Mode = GPIO_MODE_INPUT;
+    HAL_GPIO_Init(HEATER_PGOOD_SENSE_PORT, &gpio_init);
+
+    // Power good latch pin GPIO output pullup to ensure
+    // it doesn't affect the latch when not driven
+    gpio_init.Pin = HEATER_PGOOD_LATCH_PIN;
+    gpio_init.Mode = GPIO_MODE_AF_PP;
+    gpio_init.Pull = GPIO_PULLUP;
+    HAL_GPIO_Init(HEATER_PGOOD_SENSE_PORT, &gpio_init);
+    HAL_GPIO_WritePin(HEATER_PGOOD_LATCH_PORT,
+                      HEATER_PGOOD_LATCH_PIN,
+                      GPIO_PIN_SET);
 }
 
 void adc_setup(ADC_HandleTypeDef* adc) {
@@ -64,6 +84,7 @@ void heater_hardware_setup(heater_hardware* hardware) {
     hardware->hardware_internal = (void*)&_internals;
     _internals.reading_which = NTC_PAD_A;
     __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOD_CLK_ENABLE();
     __HAL_RCC_GPIOE_CLK_ENABLE();
     __HAL_RCC_ADC34_CLK_ENABLE();
     gpio_setup();
@@ -92,6 +113,23 @@ void heater_hardware_begin_conversions(heater_hardware* hardware) {
     }
 
     HAL_ADC_Start_IT(&hardware->ntc_adc);
+}
+
+bool heater_hardware_sense_power_good() {
+    return (HAL_GPIO_ReadPin(HEATER_PGOOD_SENSE_PORT, HEATER_PGOOD_SENSE_PIN)
+            == GPIO_PIN_SET);
+}
+
+void heater_hardware_drive_pg_latch_low() {
+    HAL_GPIO_WritePin(HEATER_PGOOD_LATCH_PORT,
+                      HEATER_PGOOD_LATCH_PIN,
+                      GPIO_PIN_RESET);
+}
+
+void heater_hardware_release_pg_latch() {
+    HAL_GPIO_WritePin(HEATER_PGOOD_LATCH_PORT,
+                      HEATER_PGOOD_LATCH_PIN,
+                      GPIO_PIN_SET);
 }
 
 
@@ -155,7 +193,6 @@ void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc) {
             break;}
     }
 }
-
 
 static void init_error(void) {
     while (1);

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.h
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif  // __cplusplus
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #include "stm32f3xx_hal.h"
@@ -30,6 +31,9 @@ typedef struct {
 void heater_hardware_setup(heater_hardware* hardware);
 void heater_hardware_teardown(heater_hardware* hardware);
 void heater_hardware_begin_conversions(heater_hardware* hardware);
+bool heater_hardware_sense_power_good();
+void heater_hardware_drive_pg_latch_low();
+void heater_hardware_release_pg_latch();
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.cpp
@@ -1,4 +1,8 @@
 #include "heater_policy.hpp"
+
+#include "FreeRTOS.h"
+#include "task.h"
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wvolatile"
 #include "heater_hardware.h"
@@ -7,9 +11,23 @@
 HeaterPolicy::HeaterPolicy(heater_hardware* hardware)
     : hardware_handle(hardware) {}
 
-// These functions only return literals to keep the commits clean
-// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-[[nodiscard]] auto HeaterPolicy::power_good() const -> bool { return true; }
+// These functions have the nolints because yes, they _could_ be static; yes,
+// they _could_ be const; but the semantics we want to expose here are that
+// - they require internal state (they do, but it's implicit in the micro)
+// - power_good inherently does not modify state but try_reset_power_good does
+//   because it could change a gpio output
+// But none of this is really happening in the c++ side.
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-[[nodiscard]] auto HeaterPolicy::try_reset_power_good() -> bool { return true; }
+[[nodiscard]] auto HeaterPolicy::power_good() const -> bool {
+    return heater_hardware_sense_power_good();
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static,readability-make-member-function-const)
+[[nodiscard]] auto HeaterPolicy::try_reset_power_good() -> bool {
+    heater_hardware_drive_pg_latch_low();
+    vTaskDelay(HEATER_LATCH_DRIVE_DELAY_TICKS);
+    heater_hardware_release_pg_latch();
+    vTaskDelay(HEATER_LATCH_RELEASE_TO_SENSE_DELAY_TICKS);
+    return power_good();
+}

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.cpp
@@ -1,0 +1,15 @@
+#include "heater_policy.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvolatile"
+#include "heater_hardware.h"
+#pragma GCC diagnostic pop
+
+HeaterPolicy::HeaterPolicy(heater_hardware* hardware)
+    : hardware_handle(hardware) {}
+
+// These functions only return literals to keep the commits clean
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+[[nodiscard]] auto HeaterPolicy::power_good() const -> bool { return true; }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+[[nodiscard]] auto HeaterPolicy::try_reset_power_good() -> bool { return true; }

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.hpp
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvolatile"
+#include "heater_hardware.h"
+#pragma GCC diagnostic pop
+
+class HeaterPolicy {
+  public:
+    HeaterPolicy() = delete;
+    explicit HeaterPolicy(heater_hardware* hardware);
+    [[nodiscard]] auto power_good() const -> bool;
+    [[nodiscard]] auto try_reset_power_good() -> bool;
+
+  private:
+    heater_hardware* hardware_handle;
+};

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.hpp
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.hpp
@@ -12,6 +12,16 @@ class HeaterPolicy {
     [[nodiscard]] auto power_good() const -> bool;
     [[nodiscard]] auto try_reset_power_good() -> bool;
 
+    // The latch hardware requires some amount of time where the latch is held
+    // low. That time isn't very long (it's ns, this is digital logic) but it is
+    // non-zero, and this is how long we can delay without busy waiting
+    static constexpr uint32_t HEATER_LATCH_DRIVE_DELAY_TICKS = 1;
+    // Similarly, we need to wait a bit between releasing the latch line and
+    // sensing the output; this also isn't very long (though it's microseconds
+    // this time), but again this is our finest wait without busywaiting, so
+    // that's what we use
+    static constexpr uint32_t HEATER_LATCH_RELEASE_TO_SENSE_DELAY_TICKS = 1;
+
   private:
     heater_hardware* hardware_handle;
 };

--- a/stm32-modules/heater-shaker/include/heater-shaker/errors.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/errors.hpp
@@ -50,6 +50,7 @@ enum class ErrorCode {
     HEATER_THERMISTOR_BOARD_SHORT = 208,
     HEATER_THERMISTOR_BOARD_OVERTEMP = 209,
     HEATER_THERMISTOR_BOARD_DISCONNECTED = 210,
+    HEATER_HARDWARE_ERROR_LATCH = 211,
 };
 
 auto from_motor_error(uint16_t error_bitmap, MotorErrorOffset which)

--- a/stm32-modules/heater-shaker/include/heater-shaker/gcodes.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/gcodes.hpp
@@ -265,6 +265,7 @@ struct GetTemperatureDebug {
      * - Pad A last ADC reading (AD)
      * - Pad B last ADC reading (BD)
      * - Board last ADC reading (OD)
+     * - power good (PG)
      * */
     using ParseResult = std::optional<GetTemperatureDebug>;
 
@@ -274,12 +275,13 @@ struct GetTemperatureDebug {
         write_response_into(InputIt buf, InLimit limit, double pad_a_temp,
                             double pad_b_temp, double board_temp,
                             uint16_t pad_a_adc, uint16_t pad_b_adc,
-                            uint16_t board_adc) -> InputIt {
+                            uint16_t board_adc, bool power_good) -> InputIt {
         auto res = snprintf(
             &*buf, (limit - buf),
-            "M105.D AT%0.2f BT%0.2f OT%0.2f AD%d BD%d OD%d OK\n",
+            "M105.D AT%0.2f BT%0.2f OT%0.2f AD%d BD%d OD%d PG%d OK\n",
             static_cast<float>(pad_a_temp), static_cast<float>(pad_b_temp),
-            static_cast<float>(board_temp), pad_a_adc, pad_b_adc, board_adc);
+            static_cast<float>(board_temp), pad_a_adc, pad_b_adc, board_adc,
+            power_good ? 1 : 0);
         if (res <= 0) {
             return buf;
         }

--- a/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
@@ -264,7 +264,7 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
                         tx_into, tx_limit, response.pad_a_temperature,
                         response.pad_b_temperature, response.board_temperature,
                         response.pad_a_adc, response.pad_b_adc,
-                        response.board_adc);
+                        response.board_adc, response.power_good);
                 }
             },
             cache_entry);

--- a/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
@@ -47,9 +47,8 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
     explicit HostCommsTask(Queue& q)
         : message_queue(q),
           task_registry(nullptr),
-          // These nolints are because if you don't have these inits, host builds
-          // complain
-          // NOLINTNEXTLINE(readability-redundant-member-init)
+          // These nolints are because if you don't have these inits, host
+          // builds complain NOLINTNEXTLINE(readability-redundant-member-init)
           ack_only_cache(),
           // NOLINTNEXTLINE(readability-redundant-member-init)
           get_temp_cache(),
@@ -444,7 +443,6 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
             get_temp_debug_cache.remove_if_present(id);
             return std::make_pair(false, wrote_to);
         }
-
 
         return std::make_pair(true, tx_into);
     }

--- a/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
@@ -104,6 +104,7 @@ struct GetTemperatureDebugResponse {
     uint16_t pad_a_adc;
     uint16_t pad_b_adc;
     uint16_t board_adc;
+    bool power_good;
 };
 
 struct GetRPMResponse {

--- a/stm32-modules/heater-shaker/include/test/task_builder.hpp
+++ b/stm32-modules/heater-shaker/include/test/task_builder.hpp
@@ -7,6 +7,7 @@
 #include "heater-shaker/motor_task.hpp"
 #include "heater-shaker/tasks.hpp"
 #include "heater-shaker/ui_task.hpp"
+#include "test/test_heater_policy.hpp"
 #include "test/test_message_queue.hpp"
 #include "test/test_motor_policy.hpp"
 
@@ -50,6 +51,10 @@ struct TaskBuilder {
     }
     auto get_motor_policy() -> TestMotorPolicy& { return motor_policy; }
 
+    auto get_heater_policy() -> TestHeaterPolicy& { return heater_policy; }
+
+    auto run_heater_task() -> void { heater_task.run_once(heater_policy); }
+
   private:
     TaskBuilder();
     TestMessageQueue<host_comms_task::Message> host_comms_queue;
@@ -62,4 +67,5 @@ struct TaskBuilder {
     heater_task::HeaterTask<TestMessageQueue> heater_task;
     tasks::Tasks<TestMessageQueue> task_aggregator;
     TestMotorPolicy motor_policy;
+    TestHeaterPolicy heater_policy;
 };

--- a/stm32-modules/heater-shaker/include/test/test_heater_policy.hpp
+++ b/stm32-modules/heater-shaker/include/test/test_heater_policy.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 class TestHeaterPolicy {
   public:
@@ -10,7 +11,11 @@ class TestHeaterPolicy {
     auto set_power_good(bool pgood) -> void;
     auto set_can_reset(bool can_reset) -> void;
 
+    auto try_reset_call_count() const -> size_t;
+    auto reset_try_reset_call_count() -> void;
+
   private:
     bool power_good_val;
     bool may_reset;
+    size_t try_reset_calls;
 };

--- a/stm32-modules/heater-shaker/include/test/test_heater_policy.hpp
+++ b/stm32-modules/heater-shaker/include/test/test_heater_policy.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+class TestHeaterPolicy {
+  public:
+    TestHeaterPolicy();
+    explicit TestHeaterPolicy(bool pgood, bool can_reset);
+    [[nodiscard]] auto power_good() const -> bool;
+    [[nodiscard]] auto try_reset_power_good() -> bool;
+
+    auto set_power_good(bool pgood) -> void;
+    auto set_can_reset(bool can_reset) -> void;
+
+  private:
+    bool power_good_val;
+    bool may_reset;
+};

--- a/stm32-modules/heater-shaker/src/errors.cpp
+++ b/stm32-modules/heater-shaker/src/errors.cpp
@@ -42,6 +42,8 @@ const char* const HEATER_THERMISTOR_BOARD_OVERTEMP =
     "ERR209:heater:board thermistor overtemp\n";
 const char* const HEATER_THERMISTOR_BOARD_DISCONNECTED =
     "ERR210:heater:board thermistor disconnected\n";
+const char* const HEATER_HARDWARE_ERROR_LATCH =
+    "ERR211:heater:hardware error latch set\n";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
@@ -79,6 +81,7 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(HEATER_THERMISTOR_BOARD_SHORT);
         HANDLE_CASE(HEATER_THERMISTOR_BOARD_OVERTEMP);
         HANDLE_CASE(HEATER_THERMISTOR_BOARD_DISCONNECTED);
+        HANDLE_CASE(HEATER_HARDWARE_ERROR_LATCH);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ include(AddBuildAndTestTarget)
 add_executable(heater-shaker
   task_builder.cpp
   test_motor_policy.cpp
+  test_heater_policy.cpp
   test_gcode_parse.cpp
   test_gcodes.cpp
   test_pid.cpp

--- a/stm32-modules/heater-shaker/tests/task_builder.cpp
+++ b/stm32-modules/heater-shaker/tests/task_builder.cpp
@@ -10,7 +10,8 @@ TaskBuilder::TaskBuilder()
       heater_queue("heater"),
       heater_task(heater_queue),
       task_aggregator(&heater_task, &host_comms_task, &motor_task, &ui_task),
-      motor_policy() {}
+      motor_policy(),
+      heater_policy() {}
 
 auto TaskBuilder::build() -> std::shared_ptr<TaskBuilder> {
     return std::shared_ptr<TaskBuilder>(new TaskBuilder());

--- a/stm32-modules/heater-shaker/tests/test_gcodes.cpp
+++ b/stm32-modules/heater-shaker/tests/test_gcodes.cpp
@@ -661,12 +661,12 @@ SCENARIO("GetTemperatureDebug parser works") {
         std::string buffer(64, 'c');
         WHEN("filling response") {
             auto written = gcode::GetTemperatureDebug::write_response_into(
-                buffer.begin(), buffer.end(), 10.25, 11.25, 12.25, 10, 11, 12);
+                buffer.begin(), buffer.end(), 10.25, 11.25, 12.25, 10, 11, 12,
+                true);
             THEN("the response should be written in full") {
-                REQUIRE_THAT(
-                    buffer,
-                    Catch::Matchers::StartsWith(
-                        "M105.D AT10.25 BT11.25 OT12.25 AD10 BD11 OD12 OK\n"));
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "M105.D AT10.25 BT11.25 OT12.25 AD10 "
+                                         "BD11 OD12 PG1 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }
@@ -677,7 +677,7 @@ SCENARIO("GetTemperatureDebug parser works") {
         WHEN("filling response") {
             auto written = gcode::GetTemperatureDebug::write_response_into(
                 buffer.begin(), buffer.begin() + 7, 10.01, 11.2, 41.2, 44, 10,
-                4);
+                4, false);
             THEN("the response should write only up to the available space") {
                 std::string response = "M105.Dcccccccccc";
                 response.at(6) = '\0';

--- a/stm32-modules/heater-shaker/tests/test_heater_policy.cpp
+++ b/stm32-modules/heater-shaker/tests/test_heater_policy.cpp
@@ -1,15 +1,18 @@
 #include "test/test_heater_policy.hpp"
 
-TestHeaterPolicy::TestHeaterPolicy(bool pgood, bool can_reset)
-    : power_good_val(pgood), may_reset(can_reset) {}
+#include <cstddef>
 
-TestHeaterPolicy::TestHeaterPolicy() : TestHeaterPolicy(false, false) {}
+TestHeaterPolicy::TestHeaterPolicy(bool pgood, bool can_reset)
+    : power_good_val(pgood), may_reset(can_reset), try_reset_calls(0) {}
+
+TestHeaterPolicy::TestHeaterPolicy() : TestHeaterPolicy(true, true) {}
 
 [[nodiscard]] auto TestHeaterPolicy::power_good() const -> bool {
     return power_good_val;
 }
 
 [[nodiscard]] auto TestHeaterPolicy::try_reset_power_good() -> bool {
+    try_reset_calls++;
     if (may_reset) {
         power_good_val = true;
     }
@@ -22,4 +25,12 @@ auto TestHeaterPolicy::set_power_good(bool pgood) -> void {
 
 auto TestHeaterPolicy::set_can_reset(bool can_reset) -> void {
     may_reset = can_reset;
+}
+
+auto TestHeaterPolicy::try_reset_call_count() const -> size_t {
+    return try_reset_calls;
+}
+
+auto TestHeaterPolicy::reset_try_reset_call_count() -> void {
+    try_reset_calls = 0;
 }

--- a/stm32-modules/heater-shaker/tests/test_heater_policy.cpp
+++ b/stm32-modules/heater-shaker/tests/test_heater_policy.cpp
@@ -1,0 +1,25 @@
+#include "test/test_heater_policy.hpp"
+
+TestHeaterPolicy::TestHeaterPolicy(bool pgood, bool can_reset)
+    : power_good_val(pgood), may_reset(can_reset) {}
+
+TestHeaterPolicy::TestHeaterPolicy() : TestHeaterPolicy(false, false) {}
+
+[[nodiscard]] auto TestHeaterPolicy::power_good() const -> bool {
+    return power_good_val;
+}
+
+[[nodiscard]] auto TestHeaterPolicy::try_reset_power_good() -> bool {
+    if (may_reset) {
+        power_good_val = true;
+    }
+    return power_good_val;
+}
+
+auto TestHeaterPolicy::set_power_good(bool pgood) -> void {
+    power_good_val = pgood;
+}
+
+auto TestHeaterPolicy::set_can_reset(bool can_reset) -> void {
+    may_reset = can_reset;
+}

--- a/stm32-modules/heater-shaker/tests/test_heater_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_heater_task.cpp
@@ -10,13 +10,13 @@ SCENARIO("heater task message passing") {
             .pad_a = ((1U << 9) - 1), .pad_b = (1U << 9), .board = (1U << 11)};
         tasks->get_heater_queue().backing_deque.push_back(
             messages::HeaterMessage(read_message));
-        tasks->get_heater_task().run_once();
+        tasks->run_heater_task();
         WHEN("sending a set-temperature message") {
             auto message = messages::SetTemperatureMessage{
                 .id = 1231, .target_temperature = 45};
             tasks->get_heater_queue().backing_deque.push_back(
                 messages::HeaterMessage(message));
-            tasks->get_heater_task().run_once();
+            tasks->run_heater_task();
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_heater_queue().backing_deque.empty());
                 AND_THEN("the task should respond to the message") {
@@ -38,7 +38,7 @@ SCENARIO("heater task message passing") {
             auto message = messages::GetTemperatureMessage{.id = 999};
             tasks->get_heater_queue().backing_deque.push_back(
                 messages::HeaterMessage(message));
-            tasks->get_heater_task().run_once();
+            tasks->run_heater_task();
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_heater_queue().backing_deque.empty());
                 AND_THEN("the task should respond to the message") {
@@ -62,7 +62,7 @@ SCENARIO("heater task message passing") {
             auto message = messages::GetTemperatureDebugMessage{.id = 123};
             tasks->get_heater_queue().backing_deque.push_back(
                 messages::HeaterMessage(message));
-            tasks->get_heater_task().run_once();
+            tasks->run_heater_task();
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_heater_queue().backing_deque.empty());
                 AND_THEN("the task should respond to the message") {
@@ -95,7 +95,7 @@ SCENARIO("heater task message passing") {
                 .pad_a = (1U << 9), .pad_b = 0, .board = (1U << 11)};
             tasks->get_heater_queue().backing_deque.push_back(
                 messages::HeaterMessage(read_message));
-            tasks->get_heater_task().run_once();
+            tasks->run_heater_task();
             auto error_message =
                 tasks->get_host_comms_queue().backing_deque.front();
             tasks->get_host_comms_queue().backing_deque.pop_front();
@@ -107,7 +107,7 @@ SCENARIO("heater task message passing") {
             AND_WHEN("getting the same conversion again") {
                 tasks->get_heater_queue().backing_deque.push_back(
                     messages::HeaterMessage(read_message));
-                tasks->get_heater_task().run_once();
+                tasks->run_heater_task();
                 THEN("the task should not send another error message") {
                     REQUIRE(
                         tasks->get_host_comms_queue().backing_deque.empty());
@@ -119,8 +119,8 @@ SCENARIO("heater task message passing") {
                     messages::HeaterMessage(message));
                 tasks->get_heater_queue().backing_deque.push_back(
                     messages::HeaterMessage(message));
-                tasks->get_heater_task().run_once();
-                tasks->get_heater_task().run_once();
+                tasks->run_heater_task();
+                tasks->run_heater_task();
                 THEN("the task should return an error both times") {
                     auto first =
                         tasks->get_host_comms_queue().backing_deque.front();
@@ -144,13 +144,13 @@ SCENARIO("heater task message passing") {
                 read_message.pad_b = (1U << 9);
                 tasks->get_heater_queue().backing_deque.push_back(
                     messages::HeaterMessage(read_message));
-                tasks->get_heater_task().run_once();
+                tasks->run_heater_task();
                 CHECK(tasks->get_host_comms_queue().backing_deque.empty());
                 THEN("get-temp messages should return ok") {
                     auto message = messages::GetTemperatureMessage{.id = 999};
                     tasks->get_heater_queue().backing_deque.push_back(
                         messages::HeaterMessage(message));
-                    tasks->get_heater_task().run_once();
+                    tasks->run_heater_task();
                     auto resp =
                         tasks->get_host_comms_queue().backing_deque.front();
                     REQUIRE(std::get<messages::GetTemperatureResponse>(resp)
@@ -166,7 +166,7 @@ SCENARIO("heater task message passing") {
             .pad_a = (1U << 9), .pad_b = 0, .board = (1U << 11)};
         tasks->get_heater_queue().backing_deque.push_back(
             messages::HeaterMessage(read_message));
-        tasks->get_heater_task().run_once();
+        tasks->run_heater_task();
         CHECK(std::holds_alternative<messages::ErrorMessage>(
             tasks->get_host_comms_queue().backing_deque.front()));
         tasks->get_host_comms_queue().backing_deque.pop_front();
@@ -176,7 +176,7 @@ SCENARIO("heater task message passing") {
                 .id = 1231, .target_temperature = 60};
             tasks->get_heater_queue().backing_deque.push_back(
                 messages::HeaterMessage(message));
-            tasks->get_heater_task().run_once();
+            tasks->run_heater_task();
             THEN("the task should respond with an error") {
                 REQUIRE(!tasks->get_host_comms_queue().backing_deque.empty());
                 auto response =
@@ -192,7 +192,7 @@ SCENARIO("heater task message passing") {
             auto message = messages::GetTemperatureMessage{.id = 2222};
             tasks->get_heater_queue().backing_deque.push_back(
                 messages::HeaterMessage(message));
-            tasks->get_heater_task().run_once();
+            tasks->run_heater_task();
             THEN("the task should respond with an error") {
                 REQUIRE(!tasks->get_host_comms_queue().backing_deque.empty());
                 auto response =

--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -437,10 +437,11 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                 REQUIRE(tasks->get_heater_queue().backing_deque.size() != 0);
                 auto heater_message =
                     tasks->get_heater_queue().backing_deque.front();
-                REQUIRE(std::holds_alternative<messages::GetTemperatureDebugMessage>(
-                    heater_message));
+                REQUIRE(std::holds_alternative<
+                        messages::GetTemperatureDebugMessage>(heater_message));
                 auto get_temp_message =
-                    std::get<messages::GetTemperatureDebugMessage>(heater_message);
+                    std::get<messages::GetTemperatureDebugMessage>(
+                        heater_message);
                 tasks->get_heater_queue().backing_deque.pop_front();
                 REQUIRE(written_firstpass == tx_buf.begin());
                 REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
@@ -459,9 +460,13 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     auto written_secondpass =
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
-                    THEN("the task should respond to the get-temp-debug message") {
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "M105.D AT100.00 BT42.00 OT22.00 AD14420 BD0 OD2220 OK\n"));
+                    THEN(
+                        "the task should respond to the get-temp-debug "
+                        "message") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith(
+                                         "M105.D AT100.00 BT42.00 OT22.00 "
+                                         "AD14420 BD0 OD2220 OK\n"));
                         REQUIRE(written_secondpass != tx_buf.begin());
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());

--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -466,7 +466,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                         REQUIRE_THAT(tx_buf,
                                      Catch::Matchers::StartsWith(
                                          "M105.D AT100.00 BT42.00 OT22.00 "
-                                         "AD14420 BD0 OD2220 OK\n"));
+                                         "AD14420 BD0 OD2220 PG0 OK\n"));
                         REQUIRE(written_secondpass != tx_buf.begin());
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());

--- a/stm32-modules/heater-shaker/tests/test_message_passing.cpp
+++ b/stm32-modules/heater-shaker/tests/test_message_passing.cpp
@@ -10,7 +10,7 @@ SCENARIO("testing full message passing integration") {
         tasks->get_heater_queue().backing_deque.push_back(
             messages::HeaterMessage(messages::TemperatureConversionComplete{
                 .pad_a = (1U << 9), .pad_b = (1U << 9), .board = (1U << 11)}));
-        tasks->get_heater_task().run_once();
+        tasks->run_heater_task();
         WHEN("sending a set-rpm message by string to the host comms task") {
             std::string message_str = "M3 S2000\n";
             tasks->get_host_comms_queue().backing_deque.push_back(
@@ -57,7 +57,7 @@ SCENARIO("testing full message passing integration") {
                 auto written = tasks->get_host_comms_task().run_once(
                     response_buffer.begin(), response_buffer.end());
                 REQUIRE(written == response_buffer.begin());
-                tasks->get_heater_task().run_once();
+                tasks->run_heater_task();
                 written = tasks->get_host_comms_task().run_once(
                     response_buffer.begin(), response_buffer.end());
                 REQUIRE_THAT(response_buffer,
@@ -75,7 +75,7 @@ SCENARIO("testing full message passing integration") {
                 auto written = tasks->get_host_comms_task().run_once(
                     response_buffer.begin(), response_buffer.end());
                 REQUIRE(written == response_buffer.begin());
-                tasks->get_heater_task().run_once();
+                tasks->run_heater_task();
                 written = tasks->get_host_comms_task().run_once(
                     response_buffer.begin(), response_buffer.end());
                 REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith(


### PR DESCRIPTION
The heater/shaker has a hardware error detection mechanism which ANDs together in digital logic a whole bunch of error sources (fixed resistor thresholds feeding comparators for thermistor disconnect/short/overtemp) and feeds the result into an SR latch, with the micro having a line on the ~SR line. What all that means is

- We need to read the state of that latch, and feed it into our error detection mechanisms
- When we see that all the errors are gone, or when we want to heat, we should try and reset it, by holding the ~SR asserted (low) for a bit
- If it doesn't reset, we should stay in an error state
This PR basically does that. It adds an error for the hardware error latch, and reads it when it does ADC conversions.

When we go from pad sense error -> no pad sense error, we try and reset the latch. We also try and reset the latch when someone sends a set-temperature command.

Also we need to enable sscanf support for float separately, because of course we do.

## Testing
It's actually pretty hard to test this, because some of the comparators are configured incorrectly on the first-run NFFs and the latch is always locked on. But you can test that you get the appropriate error when you try and set a temperature, or when you disconnect and then reconnect a thermistor. That's about it.