### PR TITLE
chore(heater-shaker): build intel hex

### DIFF
--- a/.github/workflows/heater-shaker.yaml
+++ b/.github/workflows/heater-shaker.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: 'Lint'
         run: cmake --build ./build-stm32-cross --target heater-shaker-lint
       - name: 'Build'
-        run: cmake --build ./build-stm32-cross --target heater-shaker
+        run: cmake --build ./build-stm32-cross --target heater-shaker-hex
   host-compile-test:
     name: 'Host-Compile/Test'
     runs-on: 'ubuntu-20.04'

--- a/stm32-modules/heater-shaker/README.md
+++ b/stm32-modules/heater-shaker/README.md
@@ -12,6 +12,7 @@ When cross-compiling the firmware (using the `stm32-cross` cmake preset, running
 - Format the firmware: `cmake --build ./build-stm32-cross --target heater-shaker-format`
 - Flash the firmware to a board: `cmake --build ./build-stm32-cross --target heater-shaker-flash`
 - Build a .hex file suitable for use with stm's programmer: `cmake --build ./build-stm32-cross --target heater-shaker-hex`
+- Build a .bin file suitable for some other programmers: `cmake --build ./build-stm32-cross --target heater-shaker-bin`
 
 ### Debugging
 There's a target called `heater-shaker-debug` that will build the firmware and then spin up a gdb, spin up an openocd, and connect the two; load some useful python scripts; connect to an st-link that should be already plugged in; automatically upload the firmware, and drop you at a breakpoint at boot time. This should all download itself and be ready as soon as `cmake --preset=stm32-cross .` completes, with one exception: Gdb python support is incredibly weird and will somehow always find your python2 that the system has, no matter how hard you try to avoid this. The scripts should work fine, but you have to install setuptools so `pkg_resources` is available, since this isn't really something we want to "install" by downloading it to some random directory and dropping it in gdb's embedded python interpreter's package path, so do the lovely

--- a/stm32-modules/heater-shaker/README.md
+++ b/stm32-modules/heater-shaker/README.md
@@ -11,6 +11,7 @@ When cross-compiling the firmware (using the `stm32-cross` cmake preset, running
 - Lint the firmware: `cmake --build ./build-stm32-cross --target heater-shaker-lint`
 - Format the firmware: `cmake --build ./build-stm32-cross --target heater-shaker-format`
 - Flash the firmware to a board: `cmake --build ./build-stm32-cross --target heater-shaker-flash`
+- Build a .hex file suitable for use with stm's programmer: `cmake --build ./build-stm32-cross --target heater-shaker-hex`
 
 ### Debugging
 There's a target called `heater-shaker-debug` that will build the firmware and then spin up a gdb, spin up an openocd, and connect the two; load some useful python scripts; connect to an st-link that should be already plugged in; automatically upload the firmware, and drop you at a breakpoint at boot time. This should all download itself and be ready as soon as `cmake --preset=stm32-cross .` completes, with one exception: Gdb python support is incredibly weird and will somehow always find your python2 that the system has, no matter how hard you try to avoid this. The scripts should work fine, but you have to install setuptools so `pkg_resources` is available, since this isn't really something we want to "install" by downloading it to some random directory and dropping it in gdb's embedded python interpreter's package path, so do the lovely

--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -150,6 +150,17 @@ set_target_properties(heater-shaker
   CROSSCOMPILING_EMULATOR
   "${ARM_GDB};--command=${CMAKE_CURRENT_BINARY_DIR}/gdbinit")
 
+find_program(CROSS_OBJCOPY "${CrossGCC_TRIPLE}-objcopy"
+  PATHS "${CrossGCC_BINDIR}"
+  NO_DEFAULT_PATH
+  REQUIRED)
+add_custom_command(OUTPUT heater-shaker.hex
+  COMMAND ${CROSS_OBJCOPY} ARGS heater-shaker "-Oihex" heater-shaker.hex
+  DEPENDS heater-shaker
+  VERBATIM)
+add_custom_target(heater-shaker-hex ALL
+  DEPENDS heater-shaker.hex)
+
 find_package(Clang)
 
 # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html

--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -161,6 +161,13 @@ add_custom_command(OUTPUT heater-shaker.hex
 add_custom_target(heater-shaker-hex ALL
   DEPENDS heater-shaker.hex)
 
+add_custom_command(OUTPUT heater-shaker.bin
+  COMMAND ${CROSS_OBJCOPY} ARGS heater-shaker "-Obinary" heater-shaker.bin
+  DEPENDS heater-shaker
+  VERBATIM)
+add_custom_target(heater-shaker-bin ALL
+  DEPENDS heater-shaker.bin)
+
 find_package(Clang)
 
 # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html


### PR DESCRIPTION
STM's programmer really doesn't like elf outputs, so add a target to
objcopy it into a .hex and add it to default.

## Testing
- Configure: `cmake --preset=stm32-cross .`
- Run a build: `cmake --build ./stm32-cross --target heater-shaker-hex`
- Upload with gdb or stlink or stm32 cube programmer and see if it works