### PR TITLE
feat(heater-shaker): Heater support

### DIFF
--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
@@ -53,7 +53,7 @@ heater_hardware *HEATER_HW_HANDLE = NULL;
 #define HEATER_PGOOD_LATCH_PIN (1<<13)
 #define HEATER_PAD_ENABLE_PORT GPIOD
 #define HEATER_PAD_ENABLE_PIN (1<<14)
-#define HEATER_PAD_ENABLE_TIM_CHANNEL TIM_CHANNEL_4
+#define HEATER_PAD_ENABLE_TIM_CHANNEL TIM_CHANNEL_3
 
 
 static void gpio_setup(void) {
@@ -85,6 +85,7 @@ static void gpio_setup(void) {
     gpio_init.Pin = HEATER_PAD_ENABLE_PIN;
     gpio_init.Mode = GPIO_MODE_AF_PP;
     gpio_init.Alternate = GPIO_AF2_TIM4;
+    gpio_init.Pull = GPIO_NOPULL;
     HAL_GPIO_Init(HEATER_PAD_ENABLE_PORT, &gpio_init);
 }
 
@@ -112,9 +113,10 @@ static void tim_setup(TIM_HandleTypeDef* tim) {
     tim->Init.CounterMode = TIM_COUNTERMODE_UP;
     tim->Init.Prescaler = HEATER_PAD_TIM_PRESCALER;
     tim->Init.RepetitionCounter = 0;
-    tim->Init.AutoReloadPreload = HEATER_PAD_PWM_GRANULARITY;
+    tim->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
+    tim->Init.Period = HEATER_PAD_PWM_GRANULARITY;
     TIM_OC_InitTypeDef channel_config = {
-        .OCMode = TIM_OCMODE_PWM1,
+        .OCMode = TIM_OCMODE_TIMING,
         .Pulse = HEATER_PAD_PWM_GRANULARITY,
         .OCPolarity = TIM_OCPOLARITY_HIGH,
         .OCIdleState = TIM_OCIDLESTATE_RESET

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.h
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.h
@@ -49,6 +49,8 @@ void heater_hardware_begin_conversions(heater_hardware* hardware);
 bool heater_hardware_sense_power_good();
 void heater_hardware_drive_pg_latch_low();
 void heater_hardware_release_pg_latch();
+void heater_hardware_power_disable(heater_hardware* hardware);
+void heater_hardware_power_set(heater_hardware* hardware, uint16_t setting);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.h
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.h
@@ -23,7 +23,6 @@ typedef struct {
 } conversion_results;
 
 typedef struct {
-    ADC_HandleTypeDef ntc_adc;
     void (*conversions_complete)(const conversion_results* results);
     void* hardware_internal;
 } heater_hardware;

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.h
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.h
@@ -10,6 +10,22 @@ extern "C" {
 
 #include "stm32f3xx_hal.h"
 
+// These defines drive the math for setting the PWM clocking parameters.
+// The frequency will be respected as accurately as possible, and is in Hz.
+// Because we only have ints available, the requested granularity will be less
+// than or equal to whatever granularity we end up with - for instance, with
+// 15535 (uint16_t max) requested, the prescaler needs to be 4.6; we'll set it
+// to 4, and then the granularity will be 18000.
+#define HEATER_PAD_PWM_GRANULARITY_REQUESTED 15535uL
+#define HEATER_PAD_PWM_FREQ 1000uL
+#define HEATER_PAD_TIM_CLKDIV 1uL
+#define HEATER_PAD_INPUT_FREQ (72000000uL / HEATER_PAD_TIM_CLKDIV)
+#define HEATER_PAD_TIM_PRESCALER \
+    ((HEATER_PAD_INPUT_FREQ) /   \
+     (HEATER_PAD_PWM_FREQ * HEATER_PAD_PWM_GRANULARITY_REQUESTED))
+#define HEATER_PAD_PWM_GRANULARITY \
+    ((HEATER_PAD_INPUT_FREQ / HEATER_PAD_TIM_PRESCALER) / HEATER_PAD_PWM_FREQ)
+
 typedef enum {
     NTC_PAD_A = 1,
     NTC_PAD_B = 2,

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.cpp
@@ -37,7 +37,16 @@ auto HeaterPolicy::set_power_output(double relative_power) -> void {
     if (relative_power > 1.0 || relative_power < 0.0) {
         return;
     }
+    heater_hardware_power_set(
+        hardware_handle,
+        // The macro HEATER_PAD_PWM_GRANULARITY purposefully uses integer division since the
+        // end goal is in fact an integer
+        // NOLINTNEXTLINE(bugprone-integer-division)
+        static_cast<uint16_t>(static_cast<double>(HEATER_PAD_PWM_GRANULARITY) *
+                              relative_power));
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static,readability-make-member-function-const)
-auto HeaterPolicy::disable_power_output() -> void {}
+auto HeaterPolicy::disable_power_output() -> void {
+    heater_hardware_power_disable(hardware_handle);
+}

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.cpp
@@ -39,8 +39,8 @@ auto HeaterPolicy::set_power_output(double relative_power) -> void {
     }
     heater_hardware_power_set(
         hardware_handle,
-        // The macro HEATER_PAD_PWM_GRANULARITY purposefully uses integer division since the
-        // end goal is in fact an integer
+        // The macro HEATER_PAD_PWM_GRANULARITY purposefully uses integer
+        // division since the end goal is in fact an integer
         // NOLINTNEXTLINE(bugprone-integer-division)
         static_cast<uint16_t>(static_cast<double>(HEATER_PAD_PWM_GRANULARITY) *
                               relative_power));

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.cpp
@@ -31,3 +31,13 @@ HeaterPolicy::HeaterPolicy(heater_hardware* hardware)
     vTaskDelay(HEATER_LATCH_RELEASE_TO_SENSE_DELAY_TICKS);
     return power_good();
 }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static,readability-make-member-function-const)
+auto HeaterPolicy::set_power_output(double relative_power) -> void {
+    if (relative_power > 1.0 || relative_power < 0.0) {
+        return;
+    }
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static,readability-make-member-function-const)
+auto HeaterPolicy::disable_power_output() -> void {}

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.hpp
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.hpp
@@ -11,7 +11,8 @@ class HeaterPolicy {
     explicit HeaterPolicy(heater_hardware* hardware);
     [[nodiscard]] auto power_good() const -> bool;
     [[nodiscard]] auto try_reset_power_good() -> bool;
-
+    auto set_power_output(double relative_power) -> void;
+    auto disable_power_output() -> void;
     // The latch hardware requires some amount of time where the latch is held
     // low. That time isn't very long (it's ns, this is digital logic) but it is
     // non-zero, and this is how long we can delay without busy waiting

--- a/stm32-modules/heater-shaker/include/heater-shaker/errors.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/errors.hpp
@@ -51,6 +51,7 @@ enum class ErrorCode {
     HEATER_THERMISTOR_BOARD_OVERTEMP = 209,
     HEATER_THERMISTOR_BOARD_DISCONNECTED = 210,
     HEATER_HARDWARE_ERROR_LATCH = 211,
+    HEATER_CONSTANT_OUT_OF_RANGE = 212,
 };
 
 auto from_motor_error(uint16_t error_bitmap, MotorErrorOffset which)

--- a/stm32-modules/heater-shaker/include/heater-shaker/heater_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/heater_task.hpp
@@ -336,7 +336,11 @@ requires MessageQueue<QueueImpl<Message>, Message> class HeaterTask {
             response.with_error = most_relevant_error();
         } else {
             double power = std::clamp(msg.power, 0.0, 1.0);
-            policy.set_power_output(power);
+            if (power == 0.0) {
+                policy.disable_power_output();
+            } else {
+                policy.set_power_output(power);
+            }
             setpoint = power;
             state.system_status = State::POWER_TEST;
         }

--- a/stm32-modules/heater-shaker/include/heater-shaker/heater_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/heater_task.hpp
@@ -31,6 +31,14 @@ concept HeaterExecutionPolicy = requires(Policy& p, const Policy& cp) {
     // or if the error condition is still present (false)
     { p.try_reset_power_good() }
     ->std::same_as<bool>;
+
+    // A set_power_output function with inputs between 0 and 1 sets the
+    // relative output of the heater pad
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    {p.set_power_output(0.5)};
+    // disable_power_output should fully turn off the driver (set_power_output
+    // will usually turn it on at least a little bit)
+    {p.disable_power_output()};
 };
 
 struct State {

--- a/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
@@ -36,10 +36,12 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
         gcode::GroupParser<gcode::SetRPM, gcode::SetTemperature, gcode::GetRPM,
                            gcode::GetTemperature, gcode::SetAcceleration,
                            gcode::GetTemperatureDebug,
-                           gcode::SetHeaterPIDConstants>;
+                           gcode::SetHeaterPIDConstants,
+                           gcode::SetHeaterPowerTest>;
     using AckOnlyCache =
         AckCache<8, gcode::SetRPM, gcode::SetTemperature,
-                 gcode::SetAcceleration, gcode::SetHeaterPIDConstants>;
+                 gcode::SetAcceleration, gcode::SetHeaterPIDConstants,
+                 gcode::SetHeaterPowerTest>;
     using GetTempCache = AckCache<8, gcode::GetTemperature>;
     using GetTempDebugCache = AckCache<8, gcode::GetTemperatureDebug>;
     using GetRPMCache = AckCache<8, gcode::GetRPM>;
@@ -462,6 +464,30 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
         }
         auto message = messages::SetPIDConstantsMessage{
             .id = id, .kp = gcode.kp, .ki = gcode.ki, .kd = gcode.kd};
+        if (!task_registry->heater->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt>&&
+        std::sized_sentinel_for<InputLimit, InputIt> auto
+        visit_gcode(const gcode::SetHeaterPowerTest& gcode, InputIt tx_into,
+                    InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message =
+            messages::SetPowerTestMessage{.id = id, .power = gcode.power};
         if (!task_registry->heater->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
@@ -69,6 +69,13 @@ struct TemperatureConversionComplete {
     uint16_t board;
 };
 
+struct SetPIDConstantsMessage {
+    uint32_t id;
+    double kp;
+    double ki;
+    double kd;
+};
+
 // Used internally to the motor task, communicates asynchronous errors to the
 // main controller task
 struct MotorSystemErrorMessage {
@@ -125,7 +132,8 @@ struct IncomingMessageFromHost {
 
 using HeaterMessage =
     ::std::variant<std::monostate, SetTemperatureMessage, GetTemperatureMessage,
-                   TemperatureConversionComplete, GetTemperatureDebugMessage>;
+                   TemperatureConversionComplete, GetTemperatureDebugMessage,
+                   SetPIDConstantsMessage>;
 using MotorMessage =
     ::std::variant<std::monostate, MotorSystemErrorMessage, SetRPMMessage,
                    GetRPMMessage, SetAccelerationMessage>;

--- a/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
@@ -76,6 +76,11 @@ struct SetPIDConstantsMessage {
     double kd;
 };
 
+struct SetPowerTestMessage {
+    uint32_t id;
+    double power;
+};
+
 // Used internally to the motor task, communicates asynchronous errors to the
 // main controller task
 struct MotorSystemErrorMessage {
@@ -133,7 +138,7 @@ struct IncomingMessageFromHost {
 using HeaterMessage =
     ::std::variant<std::monostate, SetTemperatureMessage, GetTemperatureMessage,
                    TemperatureConversionComplete, GetTemperatureDebugMessage,
-                   SetPIDConstantsMessage>;
+                   SetPIDConstantsMessage, SetPowerTestMessage>;
 using MotorMessage =
     ::std::variant<std::monostate, MotorSystemErrorMessage, SetRPMMessage,
                    GetRPMMessage, SetAccelerationMessage>;

--- a/stm32-modules/heater-shaker/include/heater-shaker/pid.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/pid.hpp
@@ -17,11 +17,11 @@ class PID {
     [[nodiscard]] auto last_error() const -> double;
 
   private:
-    const double _kp;
-    const double _ki;
-    const double _kd;
-    const double _windup_limit_high;
-    const double _windup_limit_low;
+    double _kp;
+    double _ki;
+    double _kd;
+    double _windup_limit_high;
+    double _windup_limit_low;
     double _integrator;
     double _last_error;
 };

--- a/stm32-modules/heater-shaker/include/heater-shaker/pid.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/pid.hpp
@@ -3,25 +3,25 @@
 class PID {
   public:
     PID() = delete;
-    PID(float kp, float ki, float kd);
-    PID(float kp, float ki, float kd, float windup_limit_high,
-        float windup_limit_low);
-    auto compute(float error) -> float;
+    PID(double kp, double ki, double kd);
+    PID(double kp, double ki, double kd, double windup_limit_high,
+        double windup_limit_low);
+    auto compute(double error) -> double;
     auto reset() -> void;
-    [[nodiscard]] auto kp() const -> float;
-    [[nodiscard]] auto ki() const -> float;
-    [[nodiscard]] auto kd() const -> float;
-    [[nodiscard]] auto windup_limit_high() const -> float;
-    [[nodiscard]] auto windup_limit_low() const -> float;
-    [[nodiscard]] auto integrator() const -> float;
-    [[nodiscard]] auto last_error() const -> float;
+    [[nodiscard]] auto kp() const -> double;
+    [[nodiscard]] auto ki() const -> double;
+    [[nodiscard]] auto kd() const -> double;
+    [[nodiscard]] auto windup_limit_high() const -> double;
+    [[nodiscard]] auto windup_limit_low() const -> double;
+    [[nodiscard]] auto integrator() const -> double;
+    [[nodiscard]] auto last_error() const -> double;
 
   private:
-    const float _kp;
-    const float _ki;
-    const float _kd;
-    const float _windup_limit_high;
-    const float _windup_limit_low;
-    float _integrator;
-    float _last_error;
+    const double _kp;
+    const double _ki;
+    const double _kd;
+    const double _windup_limit_high;
+    const double _windup_limit_low;
+    double _integrator;
+    double _last_error;
 };

--- a/stm32-modules/heater-shaker/include/test/test_heater_policy.hpp
+++ b/stm32-modules/heater-shaker/include/test/test_heater_policy.hpp
@@ -7,9 +7,14 @@ class TestHeaterPolicy {
     explicit TestHeaterPolicy(bool pgood, bool can_reset);
     [[nodiscard]] auto power_good() const -> bool;
     [[nodiscard]] auto try_reset_power_good() -> bool;
+    auto set_power_output(double output) -> void;
+    auto disable_power_output() -> void;
 
     auto set_power_good(bool pgood) -> void;
     auto set_can_reset(bool can_reset) -> void;
+
+    auto last_power_setting() const -> double;
+    auto last_enable_setting() const -> bool;
 
     auto try_reset_call_count() const -> size_t;
     auto reset_try_reset_call_count() -> void;
@@ -18,4 +23,6 @@ class TestHeaterPolicy {
     bool power_good_val;
     bool may_reset;
     size_t try_reset_calls;
+    double power;
+    bool enabled;
 };

--- a/stm32-modules/heater-shaker/src/errors.cpp
+++ b/stm32-modules/heater-shaker/src/errors.cpp
@@ -44,6 +44,8 @@ const char* const HEATER_THERMISTOR_BOARD_DISCONNECTED =
     "ERR210:heater:board thermistor disconnected\n";
 const char* const HEATER_HARDWARE_ERROR_LATCH =
     "ERR211:heater:hardware error latch set\n";
+const char* const HEATER_CONSTANT_OUT_OF_RANGE =
+    "ERR212:heater:control constant out of range\n";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
@@ -82,6 +84,7 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(HEATER_THERMISTOR_BOARD_OVERTEMP);
         HANDLE_CASE(HEATER_THERMISTOR_BOARD_DISCONNECTED);
         HANDLE_CASE(HEATER_HARDWARE_ERROR_LATCH);
+        HANDLE_CASE(HEATER_CONSTANT_OUT_OF_RANGE);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/heater-shaker/src/pid.cpp
+++ b/stm32-modules/heater-shaker/src/pid.cpp
@@ -3,12 +3,12 @@
 #include <algorithm>
 #include <limits>
 
-PID::PID(float kp, float ki, float kd)
-    : PID(kp, ki, kd, std::numeric_limits<float>::infinity(),
-          -std::numeric_limits<float>::infinity()) {}
+PID::PID(double kp, double ki, double kd)
+    : PID(kp, ki, kd, std::numeric_limits<double>::infinity(),
+          -std::numeric_limits<double>::infinity()) {}
 
-PID::PID(float kp, float ki, float kd, float windup_limit_high,
-         float windup_limit_low)
+PID::PID(double kp, double ki, double kd, double windup_limit_high,
+         double windup_limit_low)
     : _kp(kp),
       _ki(ki),
       _kd(kd),
@@ -17,24 +17,24 @@ PID::PID(float kp, float ki, float kd, float windup_limit_high,
       _integrator(0),
       _last_error(0) {}
 
-auto PID::kp() const -> float { return _kp; }
+auto PID::kp() const -> double { return _kp; }
 
-auto PID::ki() const -> float { return _ki; }
+auto PID::ki() const -> double { return _ki; }
 
-auto PID::kd() const -> float { return _kd; }
+auto PID::kd() const -> double { return _kd; }
 
-auto PID::windup_limit_high() const -> float { return _windup_limit_high; }
+auto PID::windup_limit_high() const -> double { return _windup_limit_high; }
 
-auto PID::windup_limit_low() const -> float { return _windup_limit_low; }
+auto PID::windup_limit_low() const -> double { return _windup_limit_low; }
 
-auto PID::integrator() const -> float { return _integrator; }
+auto PID::integrator() const -> double { return _integrator; }
 
-auto PID::last_error() const -> float { return _last_error; }
+auto PID::last_error() const -> double { return _last_error; }
 
-auto PID::compute(float error) -> float {
+auto PID::compute(double error) -> double {
     _integrator =
         std::clamp(error + _integrator, _windup_limit_low, _windup_limit_high);
-    const float errdiff = error - _last_error;
+    const double errdiff = error - _last_error;
     _last_error = error;
     return (_kp * error) + (_kd * errdiff) + (_ki * _integrator);
 }

--- a/stm32-modules/heater-shaker/tests/test_gcodes.cpp
+++ b/stm32-modules/heater-shaker/tests/test_gcodes.cpp
@@ -1,7 +1,10 @@
 #include <array>
 
 #include "catch2/catch.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
 #include "heater-shaker/gcodes.hpp"
+#pragma GCC diagnostic pop
 
 SCENARIO("SetRPM parser works") {
     GIVEN("an empty string") {

--- a/stm32-modules/heater-shaker/tests/test_heater_policy.cpp
+++ b/stm32-modules/heater-shaker/tests/test_heater_policy.cpp
@@ -3,7 +3,11 @@
 #include <cstddef>
 
 TestHeaterPolicy::TestHeaterPolicy(bool pgood, bool can_reset)
-    : power_good_val(pgood), may_reset(can_reset), try_reset_calls(0) {}
+    : power_good_val(pgood),
+      may_reset(can_reset),
+      try_reset_calls(0),
+      power(0),
+      enabled(false) {}
 
 TestHeaterPolicy::TestHeaterPolicy() : TestHeaterPolicy(true, true) {}
 
@@ -34,3 +38,14 @@ auto TestHeaterPolicy::try_reset_call_count() const -> size_t {
 auto TestHeaterPolicy::reset_try_reset_call_count() -> void {
     try_reset_calls = 0;
 }
+
+auto TestHeaterPolicy::set_power_output(double output) -> void {
+    power = output;
+    enabled = true;
+}
+
+auto TestHeaterPolicy::disable_power_output() -> void { enabled = false; }
+
+auto TestHeaterPolicy::last_power_setting() const -> double { return power; }
+
+auto TestHeaterPolicy::last_enable_setting() const -> bool { return enabled; }

--- a/stm32-modules/heater-shaker/tests/test_message_passing.cpp
+++ b/stm32-modules/heater-shaker/tests/test_message_passing.cpp
@@ -79,7 +79,7 @@ SCENARIO("testing full message passing integration") {
                 written = tasks->get_host_comms_task().run_once(
                     response_buffer.begin(), response_buffer.end());
                 REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith(
-                                                  "M105 C95.20 T48.00 OK\n"));
+                                                  "M105 C95.20 T0.00 OK\n"));
             }
         }
 


### PR DESCRIPTION
Links up the heater and heat control system.

- Brings up the heat pad  driver through a PWM channel
- Links up the control system and the new direct-power-set command to the hardware for heater driving

- New Gcode M104.D Sxx.xx allows direct set of relative heater power on a 0-1 scale; useful for testing. When running in this mode, the setpoint  temperature response from M105 is replaced with the power setpoint.

The control system itself isn't tuned at all yet, because we don't have the heater pads we're looking for, but the drive is verified on the bench using M104.D; the controller is tested and verified; and the thermistors and error  sense  are there.

There's one missing error sense condition, which is using the heater pad switch's current sense output to check for unplugged/short conditions; but we also don't  have the hardware for that on NFF rev A.

## Review Requests
- The whole policy-passed-in-to-run_once thing is still looking good right
- How badly do I need to split up the gcode tests into separate files?  Pretty bad, right?
- 
## Testing
Testing for this is mostly hardware focused. We should use a scope and M104.D to check that we're accurately commanding  heater power from 0-1, and honestly just trust that the controller is vaguely right until we get actual heater pads we can control on.