### PR TITLE
feat(heater-shaker): quick versioning

### DIFF
--- a/.github/workflows/heater-shaker.yaml
+++ b/.github/workflows/heater-shaker.yaml
@@ -2,8 +2,8 @@ name: 'Heater/shaker build/test'
 on:
   pull_request:
     paths:
-      - 'stm32-modules/heater-shaker'
-      - 'cmake/*'
+      - 'stm32-modules/heater-shaker/**/*'
+      - 'cmake/**/*'
       - 'CMakeLists.txt'
       - 'stm32-modules/CMakeLists.txt'
       - 'CMakePresets.json'
@@ -13,8 +13,8 @@ on:
       - 'cmake/Arduino*'
   push:
     paths:
-      - 'stm32-modules/heater-shaker'
-      - 'cmake/*'
+      - 'stm32-modules/heater-shaker/**/*'
+      - 'cmake/**/*'
       - 'CMakeLists.txt'
       - 'stm32-modules/CMakeLists.txt'
       - 'CMakePresets.json'

--- a/stm32-modules/heater-shaker/include/heater-shaker/gcodes.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/gcodes.hpp
@@ -453,12 +453,11 @@ struct EnterBootloader {
 
 struct GetVersion {
     /**
-     * GetVersion keys off the string "version" and returns hardware and
-     * software versions
+     * GetVersion keys off gcode M115 and returns hardware and
+     * software versions and eventually serial numbers
      * */
     using ParseResult = std::optional<GetVersion>;
-    static constexpr auto prefix =
-        std::array{'v', 'e', 'r', 's', 'i', 'o', 'n'};
+    static constexpr auto prefix = std::array{'M', '1', '1', '5'};
 
     template <typename InputIt, typename InLimit>
     requires std::forward_iterator<InputIt>&&
@@ -466,7 +465,7 @@ struct GetVersion {
         write_response_into(InputIt write_to_buf, InLimit write_to_limit,
                             const char* fw_version, const char* hw_version)
             -> InputIt {
-        static constexpr const char* prefix = "version FW:";
+        static constexpr const char* prefix = "M115 FW:";
         auto written =
             write_string_to_iterpair(write_to_buf, write_to_limit, prefix);
         if (written == write_to_limit) {

--- a/stm32-modules/heater-shaker/include/heater-shaker/version.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/version.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace version {
+auto fw_version() -> const char*;
+auto hw_version() -> const char*;
+};  // namespace version

--- a/stm32-modules/heater-shaker/src/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/src/CMakeLists.txt
@@ -3,6 +3,30 @@
 # library. It is included in both host and cross configurations.
 
 find_package(Python)
+find_package(Git QUIET)
+
+# This is like version for project but works when there aren't any tags yet
+execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --match "heater-shaker*"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  OUTPUT_VARIABLE TAGNAME
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+if (NOT TAGNAME)
+  set(TAGNAME "@(dev)-")
+endif()
+
+string(REGEX MATCH "@.*$" PREPENDED_VERSION ${TAGNAME})
+string(SUBSTRING ${PREPENDED_VERSION} 1 -l VERSION)
+if (NOT VERSION)
+  set(VERSION "(dev)")
+endif()
+execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  OUTPUT_VARIABLE HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+set(heater-shaker_VERSION "${VERSION}-${HASH}")
+
+configure_file(./version.cpp.in ./version.cpp)
 
 add_custom_command(
   COMMAND Python::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/generate_thermistor_table.py
@@ -23,13 +47,13 @@ set(CORE_LINTABLE_SOURCES
   )
 
 set(CORE_NONLINTABLE_SOURCES
-  ${CMAKE_CURRENT_BINARY_DIR}/thermistor_lookups.cpp)
+  ${CMAKE_CURRENT_BINARY_DIR}/thermistor_lookups.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/version.cpp)
 
 add_library(heater-shaker-core STATIC
   ${CORE_LINTABLE_SOURCES}
   ${CORE_NONLINTABLE_SOURCES}
 )
-
 
 set_target_properties(heater-shaker-core
   PROPERTIES CXX_STANDARD 20

--- a/stm32-modules/heater-shaker/src/version.cpp.in
+++ b/stm32-modules/heater-shaker/src/version.cpp.in
@@ -1,0 +1,12 @@
+#include "heater-shaker/version.hpp"
+
+static constexpr const char* _FW_VERSION_GENERATED = "${heater-shaker_VERSION}";
+static constexpr const char* _HW_VERSION_GENERATED = "Opentrons Heater-Shaker";
+
+const char* version::fw_version() {
+    return _FW_VERSION_GENERATED;
+}
+
+const char* version::hw_version() {
+    return _HW_VERSION_GENERATED;
+}

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(heater-shaker
   test_m124.cpp
   test_m3.cpp
   test_m301.cpp
+  test_version.cpp
   test_pid.cpp
   test_double_buffer.cpp
   test_host_comms_task.cpp

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(heater-shaker
   test_m124.cpp
   test_m3.cpp
   test_m301.cpp
-  test_version.cpp
+  test_m115.cpp
   test_pid.cpp
   test_double_buffer.cpp
   test_host_comms_task.cpp

--- a/stm32-modules/heater-shaker/tests/test_basic_gcodes.cpp
+++ b/stm32-modules/heater-shaker/tests/test_basic_gcodes.cpp
@@ -15,7 +15,7 @@ TEMPLATE_TEST_CASE("gcode basic parsing", "[gcode][parse]", gcode::SetRPM,
                    gcode::SetTemperature, gcode::GetTemperature, gcode::GetRPM,
                    gcode::SetAcceleration, gcode::GetTemperatureDebug,
                    gcode::SetHeaterPIDConstants, gcode::SetHeaterPowerTest,
-                   gcode::EnterBootloader) {
+                   gcode::EnterBootloader, gcode::GetVersion) {
     SECTION("attempting to parse an empty string fails") {
         std::string to_parse = "";
         auto output = TestType::parse(to_parse.cbegin(), to_parse.cend());
@@ -43,7 +43,8 @@ TEMPLATE_TEST_CASE("gcode basic parsing", "[gcode][parse]", gcode::SetRPM,
 */
 TEMPLATE_TEST_CASE("gcodes without parameters parse", "[gcode][parse]",
                    gcode::GetRPM, gcode::GetTemperature,
-                   gcode::GetTemperatureDebug, gcode::EnterBootloader) {
+                   gcode::GetTemperatureDebug, gcode::EnterBootloader,
+                   gcode::GetVersion) {
     SECTION("parsing the full prefix succeeds") {
         auto output =
             TestType::parse(TestType::prefix.cbegin(), TestType::prefix.cend());

--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -641,3 +641,25 @@ SCENARIO("message handling for other-task-initiated communication") {
         }
     }
 }
+
+SCENARIO("version handling") {
+    GIVEN("a host comms task") {
+        auto tasks = TaskBuilder::build();
+        std::string tx_buf(128, 'c');
+        WHEN("requesting the version") {
+            auto message_text = std::string("version\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            THEN("the task should write out the version") {
+                tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                      tx_buf.end());
+
+                REQUIRE_THAT(tx_buf,
+                             Catch::Matchers::StartsWith("version FW:"));
+                REQUIRE_THAT(tx_buf, Catch::Matchers::Contains("HW:"));
+            }
+        }
+    }
+}

--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -647,7 +647,7 @@ SCENARIO("version handling") {
         auto tasks = TaskBuilder::build();
         std::string tx_buf(128, 'c');
         WHEN("requesting the version") {
-            auto message_text = std::string("version\n");
+            auto message_text = std::string("M115\n");
             auto message_obj =
                 messages::HostCommsMessage(messages::IncomingMessageFromHost(
                     &*message_text.begin(), &*message_text.end()));
@@ -656,8 +656,7 @@ SCENARIO("version handling") {
                 tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                       tx_buf.end());
 
-                REQUIRE_THAT(tx_buf,
-                             Catch::Matchers::StartsWith("version FW:"));
+                REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith("M115 FW:"));
                 REQUIRE_THAT(tx_buf, Catch::Matchers::Contains("HW:"));
             }
         }

--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -655,7 +655,6 @@ SCENARIO("version handling") {
             THEN("the task should write out the version") {
                 tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                       tx_buf.end());
-
                 REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith("M115 FW:"));
                 REQUIRE_THAT(tx_buf, Catch::Matchers::Contains("HW:"));
             }

--- a/stm32-modules/heater-shaker/tests/test_m115.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m115.cpp
@@ -6,14 +6,14 @@
 #include "heater-shaker/gcodes.hpp"
 #pragma GCC diagnostic pop
 
-SCENARIO("GetVersion (version) response works", "[gcode][parse][version]") {
+SCENARIO("GetVersion (M115) response works", "[gcode][parse][m115]") {
     GIVEN("a response buffer large enough for the formatted response") {
         std::string buffer(64, 'c');
         WHEN("filling response") {
             auto written = gcode::GetVersion::write_response_into(
                 buffer.begin(), buffer.end(), "hello", "world");
             THEN("the response should be written in full") {
-                std::string ok = "version FW:hello HW:world OK\n";
+                std::string ok = "M115 FW:hello HW:world OK\n";
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(ok));
                 REQUIRE(written == buffer.begin() + ok.size());
                 std::string suffix(buffer.size() - ok.size(), 'c');
@@ -28,7 +28,7 @@ SCENARIO("GetVersion (version) response works", "[gcode][parse][version]") {
             auto written = gcode::GetVersion::write_response_into(
                 buffer.begin(), buffer.begin() + 16, "hello", "world");
             THEN("the response should write only up to the available space") {
-                std::string response = "version FW:hellocccccccccccccccc";
+                std::string response = "M115 FW:hello HWcccccccccccccccc";
                 REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
                 REQUIRE(written == buffer.begin() + 16);
             }

--- a/stm32-modules/heater-shaker/tests/test_version.cpp
+++ b/stm32-modules/heater-shaker/tests/test_version.cpp
@@ -1,0 +1,37 @@
+#include <array>
+
+#include "catch2/catch.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "heater-shaker/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("GetVersion (version) response works", "[gcode][parse][version]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(64, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetVersion::write_response_into(
+                buffer.begin(), buffer.end(), "hello", "world");
+            THEN("the response should be written in full") {
+                std::string ok = "version FW:hello HW:world OK\n";
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(ok));
+                REQUIRE(written == buffer.begin() + ok.size());
+                std::string suffix(buffer.size() - ok.size(), 'c');
+                REQUIRE_THAT(buffer, Catch::Matchers::EndsWith(suffix));
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(32, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetVersion::write_response_into(
+                buffer.begin(), buffer.begin() + 16, "hello", "world");
+            THEN("the response should write only up to the available space") {
+                std::string response = "version FW:hellocccccccccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written == buffer.begin() + 16);
+            }
+        }
+    }
+}


### PR DESCRIPTION
While we don't want full tag based versioning yet, it's nice to have
something. The heater-shaker now captures the current git
status (unfortunately, you'll need to do a make clean to update it -
this is mostly useful from CI) and put it in the build triggered by a
new gcode called version.