### PR TITLE
chore(heater-shaker): motor  tuning v1

### DIFF
--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -16,7 +16,8 @@ set(MCSDK_LOCATION "${CMAKE_CURRENT_LIST_DIR}/motor_task/MCSDK_v${MCSDK_VERSION}
 
 add_library(_mc_static STATIC IMPORTED)
 set_target_properties(_mc_static
-  PROPERTIES IMPORTED_LOCATION "${MCSDK_LOCATION}/lib/libmc-gcc_M4_NoCCMRAM.lib")
+  PROPERTIES IMPORTED_LOCATION
+  "${MCSDK_LOCATION}/lib/libmc-gcc_M4.lib")
 
 file(GLOB _mcsdk_any_sources "${MCSDK_LOCATION}/MCSDK/MCLib/Any/Src/*.c")
 file(GLOB _mcsdk_f3xx_sources "${MCSDK_LOCATION}/MCSDK/MCLib/F3xx/Src/*.c")
@@ -27,7 +28,8 @@ add_library(mc STATIC
   )
 set_target_properties(mc
   PROPERTIES C_STANDARD 11
-             C_STANDARD_REQUIRED TRUE)
+  C_STANDARD_REQUIRED TRUE)
+target_compile_definitions(mc PUBLIC CCMRAM)
 
 target_include_directories(mc
   PUBLIC "${MCSDK_LOCATION}/MCSDK/MCLib/Any/Inc"

--- a/stm32-modules/heater-shaker/firmware/host_comms_task/usbd_conf.c
+++ b/stm32-modules/heater-shaker/firmware/host_comms_task/usbd_conf.c
@@ -64,7 +64,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
   __HAL_RCC_SYSCFG_CLK_ENABLE();
 
   /* Set USB Default FS Interrupt priority */
-  HAL_NVIC_SetPriority(USB_LP_CAN_RX0_IRQn, 5, 0);
+  HAL_NVIC_SetPriority(USB_LP_CAN_RX0_IRQn, 10, 0);
 
   /* Enable USB FS Interrupt */
   HAL_NVIC_EnableIRQ(USB_LP_CAN_RX0_IRQn);

--- a/stm32-modules/heater-shaker/firmware/motor_task/drive_parameters.h
+++ b/stm32-modules/heater-shaker/firmware/motor_task/drive_parameters.h
@@ -61,7 +61,7 @@ extern "C" {
 /**************************    DRIVE SETTINGS SECTION   **********************/
 /* PWM generation and current reading */
 
-#define PWM_FREQUENCY 10000
+#define PWM_FREQUENCY 30000
 #define PWM_FREQ_SCALING 1
 
 #define LOW_SIDE_SIGNALS_ENABLING ES_GPIO

--- a/stm32-modules/heater-shaker/firmware/motor_task/drive_parameters.h
+++ b/stm32-modules/heater-shaker/firmware/motor_task/drive_parameters.h
@@ -71,18 +71,18 @@ extern "C" {
     1 /*!< FOC execution rate in  \
                       number of PWM cycles */
 /* Gains values for torque and flux control loops */
-#define PID_TORQUE_KP_DEFAULT 3742
-#define PID_TORQUE_KI_DEFAULT 580
+#define PID_TORQUE_KP_DEFAULT 2319
+#define PID_TORQUE_KI_DEFAULT 689
 #define PID_TORQUE_KD_DEFAULT 100
-#define PID_FLUX_KP_DEFAULT 3742
-#define PID_FLUX_KI_DEFAULT 580
+#define PID_FLUX_KP_DEFAULT 2319
+#define PID_FLUX_KI_DEFAULT 689
 #define PID_FLUX_KD_DEFAULT 100
 
 /* Torque/Flux control loop gains dividers*/
-#define TF_KPDIV 4096
+#define TF_KPDIV 2048
 #define TF_KIDIV 16384
 #define TF_KDDIV 8192
-#define TF_KPDIV_LOG LOG2(4096)
+#define TF_KPDIV_LOG LOG2(2048)
 #define TF_KIDIV_LOG LOG2(16384)
 #define TF_KDDIV_LOG LOG2(8192)
 #define TFDIFFERENTIAL_TERM_ENABLING DISABLE
@@ -93,23 +93,23 @@ extern "C" {
                     regulation loop (Hz) */
 
 #define PID_SPEED_KP_DEFAULT \
-    3631 / (SPEED_UNIT / 10) /* Workbench compute the gain for 01Hz unit*/
+    2372 / (SPEED_UNIT / 10) /* Workbench compute the gain for 01Hz unit*/
 #define PID_SPEED_KI_DEFAULT \
-    1536 / (SPEED_UNIT / 10) /* Workbench compute the gain for 01Hz unit*/
+    2624 / (SPEED_UNIT / 10) /* Workbench compute the gain for 01Hz unit*/
 #define PID_SPEED_KD_DEFAULT \
     0 / (SPEED_UNIT / 10) /* Workbench compute the gain for 01Hz unit*/
 /* Speed PID parameter dividers */
 #define SP_KPDIV 16
-#define SP_KIDIV 16384
+#define SP_KIDIV 8192
 #define SP_KDDIV 16
 #define SP_KPDIV_LOG LOG2(16)
-#define SP_KIDIV_LOG LOG2(16384)
+#define SP_KIDIV_LOG LOG2(8192)
 #define SP_KDDIV_LOG LOG2(16)
 
 #define PID_SPEED_INTEGRAL_INIT_DIV 1 /*  */
 
 #define SPD_DIFFERENTIAL_TERM_ENABLING DISABLE
-#define IQMAX 14237
+#define IQMAX 10026
 
 /* Default settings */
 #define DEFAULT_CONTROL_MODE               \

--- a/stm32-modules/heater-shaker/firmware/motor_task/mc_tasks.c
+++ b/stm32-modules/heater-shaker/firmware/motor_task/mc_tasks.c
@@ -489,10 +489,10 @@ bool TSK_StopPermanencyTimeHasElapsedM1(void)
   return (retVal);
 }
 
-#if defined (CCMRAM_ENABLED)
+#if defined (CCMRAM)
 #if defined (__ICCARM__)
 #pragma location = ".ccmram"
-#elif defined (__CC_ARM)
+#elif defined (__CC_ARM) || defined(__GNUC__)
 __attribute__((section (".ccmram")))
 #endif
 #endif

--- a/stm32-modules/heater-shaker/firmware/motor_task/mc_tasks.c
+++ b/stm32-modules/heater-shaker/firmware/motor_task/mc_tasks.c
@@ -622,6 +622,7 @@ uint16_t TSK_SafetyTask_PWMOFF(uint8_t bMotor)
     break;
   case FAULT_OVER:
     PWMC_SwitchOffPWM(pwmcHandle[bMotor]);
+    CodeReturn |= (STM_GetFaultState(&STM[bMotor]) & 0xffff);
     break;
   default:
     break;

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
@@ -21,10 +21,10 @@ static void MX_NVIC_Init(void)
   HAL_NVIC_SetPriority(TIM1_BRK_TIM15_IRQn, 9, 0);
   HAL_NVIC_EnableIRQ(TIM1_BRK_TIM15_IRQn);
   /* TIM1_UP_TIM16_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(TIM1_UP_TIM16_IRQn, 5, 0);
+  HAL_NVIC_SetPriority(TIM1_UP_TIM16_IRQn, 3, 0);
   HAL_NVIC_EnableIRQ(TIM1_UP_TIM16_IRQn);
   /* ADC1_2_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(ADC1_2_IRQn, 7, 0);
+  HAL_NVIC_SetPriority(ADC1_2_IRQn, 4, 0);
   HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
   /* TIM2_IRQn interrupt configuration */
   HAL_NVIC_SetPriority(TIM2_IRQn, 8, 0);
@@ -419,7 +419,6 @@ static void MX_GPIO_Init(void)
   GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStruct);
-
 }
 
 static void DAC_Init(DAC_HandleTypeDef* dac) {

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
@@ -52,11 +52,11 @@ auto MotorPolicy::set_rpm(int16_t rpm) -> ErrorCode {
     }
     int16_t current_speed = get_current_rpm();
     int16_t command_01hz = rpm * _01HZ / _RPM;
-    uint16_t ramp_time = std::max(
+    uint16_t ramp_time_ms = std::max(
         static_cast<uint16_t>(
-            static_cast<int32_t>(std::abs(rpm - current_speed)) / ramp_rate),
+            static_cast<int32_t>(std::abs(rpm - current_speed)) / ramp_rate_rpm_per_ms),
         static_cast<uint16_t>(1));
-    MCI_ExecSpeedRamp(hw_handles->mci[0], -command_01hz, ramp_time);
+    MCI_ExecSpeedRamp(hw_handles->mci[0], -command_01hz, ramp_time_ms);
     if (MCI_GetSTMState(hw_handles->mci[0]) == IDLE) {
         MCI_StartMotor(hw_handles->mci[0]);
     }
@@ -84,7 +84,7 @@ auto MotorPolicy::set_ramp_rate(int32_t rpm_per_s) -> ErrorCode {
         rpm_per_s < MIN_RAMP_RATE_RPM_PER_S) {
         return ErrorCode::MOTOR_ILLEGAL_RAMP_RATE;
     }
-    ramp_rate = rpm_per_s;
+    ramp_rate_rpm_per_ms = std::max(static_cast<double>(rpm_per_s) / 1000.0, 1.0);
     return ErrorCode::NO_ERROR;
 }
 

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
@@ -52,10 +52,11 @@ auto MotorPolicy::set_rpm(int16_t rpm) -> ErrorCode {
     }
     int16_t current_speed = get_current_rpm();
     int16_t command_01hz = rpm * _01HZ / _RPM;
-    uint16_t ramp_time_ms = std::max(
-        static_cast<uint16_t>(
-            static_cast<int32_t>(std::abs(rpm - current_speed)) / ramp_rate_rpm_per_ms),
-        static_cast<uint16_t>(1));
+    uint16_t ramp_time_ms =
+        std::max(static_cast<uint16_t>(
+                     static_cast<int32_t>(std::abs(rpm - current_speed)) /
+                     ramp_rate_rpm_per_ms),
+                 static_cast<uint16_t>(1));
     MCI_ExecSpeedRamp(hw_handles->mci[0], -command_01hz, ramp_time_ms);
     if (MCI_GetSTMState(hw_handles->mci[0]) == IDLE) {
         MCI_StartMotor(hw_handles->mci[0]);
@@ -84,7 +85,9 @@ auto MotorPolicy::set_ramp_rate(int32_t rpm_per_s) -> ErrorCode {
         rpm_per_s < MIN_RAMP_RATE_RPM_PER_S) {
         return ErrorCode::MOTOR_ILLEGAL_RAMP_RATE;
     }
-    ramp_rate_rpm_per_ms = std::max(static_cast<double>(rpm_per_s) / 1000.0, 1.0);
+    ramp_rate_rpm_per_ms =
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        std::max(static_cast<double>(rpm_per_s) / 1000.0, 1.0);
     return ErrorCode::NO_ERROR;
 }
 
@@ -98,4 +101,11 @@ auto MotorPolicy::plate_lock_set_power(float power) -> void {
 
 auto MotorPolicy::plate_lock_disable() -> void {
     motor_hardware_plate_lock_off(&hw_handles->tim3);
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto MotorPolicy::set_pid_constants(double kp, double ki, double kd) -> void {
+    static_cast<void>(kp);
+    static_cast<void>(ki);
+    static_cast<void>(kd);
 }

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
@@ -52,11 +52,10 @@ auto MotorPolicy::set_rpm(int16_t rpm) -> ErrorCode {
     }
     const int16_t current_speed = get_current_rpm();
     const int16_t command_01hz = rpm * _01HZ / _RPM;
-    const uint32_t speed_diff = std::abs(rpm-current_speed);
+    const uint32_t speed_diff = std::abs(rpm - current_speed);
     const uint32_t uncapped_ramp_time_ms = speed_diff / ramp_rate_rpm_per_ms;
-    const uint16_t ramp_time_ms =
-        std::max(static_cast<uint16_t>(uncapped_ramp_time_ms),
-                 static_cast<uint16_t>(1));
+    const uint16_t ramp_time_ms = std::max(
+        static_cast<uint16_t>(uncapped_ramp_time_ms), static_cast<uint16_t>(1));
     MCI_ExecSpeedRamp(hw_handles->mci[0], -command_01hz, ramp_time_ms);
     if (MCI_GetSTMState(hw_handles->mci[0]) == IDLE) {
         MCI_StartMotor(hw_handles->mci[0]);
@@ -104,9 +103,14 @@ auto MotorPolicy::plate_lock_disable() -> void {
 }
 
 auto MotorPolicy::set_pid_constants(double kp, double ki, double kd) -> void {
-    // These conversions match those in drive_parameters.h and therefore let you just look
-    // at the numeric literals there
-    PID_SetKD(hw_handles->mct[0]->pPIDSpeed, static_cast<int16_t>(kd / (SPEED_UNIT / 10)));
-    PID_SetKP(hw_handles->mct[0]->pPIDSpeed, static_cast<int16_t>(kp / (SPEED_UNIT / 10)));
-    PID_SetKI(hw_handles->mct[0]->pPIDSpeed, static_cast<int16_t>(ki / (SPEED_UNIT / 10)));
+    // These conversions match those in drive_parameters.h and therefore let you
+    // just look at the numeric literals there
+    static constexpr const double SPEED_UNIT_CONVERSION_SPC =
+        static_cast<double>(SPEED_UNIT) / 10.0;
+    PID_SetKD(hw_handles->mct[0]->pPIDSpeed,
+              static_cast<int16_t>(kd / SPEED_UNIT_CONVERSION_SPC));
+    PID_SetKP(hw_handles->mct[0]->pPIDSpeed,
+              static_cast<int16_t>(kp / SPEED_UNIT_CONVERSION_SPC));
+    PID_SetKI(hw_handles->mct[0]->pPIDSpeed,
+              static_cast<int16_t>(ki / SPEED_UNIT_CONVERSION_SPC));
 }

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
@@ -50,12 +50,12 @@ auto MotorPolicy::set_rpm(int16_t rpm) -> ErrorCode {
     if (rpm > MAX_APPLICATION_SPEED_RPM || rpm < MIN_APPLICATION_SPEED_RPM) {
         return ErrorCode::MOTOR_ILLEGAL_SPEED;
     }
-    int16_t current_speed = get_current_rpm();
-    int16_t command_01hz = rpm * _01HZ / _RPM;
-    uint16_t ramp_time_ms =
-        std::max(static_cast<uint16_t>(
-                     static_cast<int32_t>(std::abs(rpm - current_speed)) /
-                     ramp_rate_rpm_per_ms),
+    const int16_t current_speed = get_current_rpm();
+    const int16_t command_01hz = rpm * _01HZ / _RPM;
+    const uint32_t speed_diff = std::abs(rpm-current_speed);
+    const uint32_t uncapped_ramp_time_ms = speed_diff / ramp_rate_rpm_per_ms;
+    const uint16_t ramp_time_ms =
+        std::max(static_cast<uint16_t>(uncapped_ramp_time_ms),
                  static_cast<uint16_t>(1));
     MCI_ExecSpeedRamp(hw_handles->mci[0], -command_01hz, ramp_time_ms);
     if (MCI_GetSTMState(hw_handles->mci[0]) == IDLE) {

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
@@ -103,9 +103,10 @@ auto MotorPolicy::plate_lock_disable() -> void {
     motor_hardware_plate_lock_off(&hw_handles->tim3);
 }
 
-// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto MotorPolicy::set_pid_constants(double kp, double ki, double kd) -> void {
-    static_cast<void>(kp);
-    static_cast<void>(ki);
-    static_cast<void>(kd);
+    // These conversions match those in drive_parameters.h and therefore let you just look
+    // at the numeric literals there
+    PID_SetKD(hw_handles->mct[0]->pPIDSpeed, static_cast<int16_t>(kd / (SPEED_UNIT / 10)));
+    PID_SetKP(hw_handles->mct[0]->pPIDSpeed, static_cast<int16_t>(kp / (SPEED_UNIT / 10)));
+    PID_SetKI(hw_handles->mct[0]->pPIDSpeed, static_cast<int16_t>(ki / (SPEED_UNIT / 10)));
 }

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.hpp
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.hpp
@@ -35,6 +35,6 @@ class MotorPolicy {
 
   private:
     static constexpr uint16_t MAX_SOLENOID_CURRENT_MA = 330;
-    int32_t ramp_rate = DEFAULT_RAMP_RATE_RPM_PER_S;
+    double ramp_rate_rpm_per_ms = static_cast<double>(DEFAULT_RAMP_RATE_RPM_PER_S) / 1000.0;
     motor_hardware_handles* hw_handles;
 };

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.hpp
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.hpp
@@ -20,6 +20,7 @@ class MotorPolicy {
     MotorPolicy() = delete;
     explicit MotorPolicy(motor_hardware_handles* handles);
     auto set_rpm(int16_t rpm) -> errors::ErrorCode;
+    auto set_pid_constants(double kp, double ki, double kd) -> void;
     [[nodiscard]] auto get_current_rpm() const -> int16_t;
     [[nodiscard]] auto get_target_rpm() const -> int16_t;
     auto stop() -> void;
@@ -35,6 +36,8 @@ class MotorPolicy {
 
   private:
     static constexpr uint16_t MAX_SOLENOID_CURRENT_MA = 330;
-    double ramp_rate_rpm_per_ms = static_cast<double>(DEFAULT_RAMP_RATE_RPM_PER_S) / 1000.0;
+    double ramp_rate_rpm_per_ms =
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        static_cast<double>(DEFAULT_RAMP_RATE_RPM_PER_S) / 1000.0;
     motor_hardware_handles* hw_handles;
 };

--- a/stm32-modules/heater-shaker/firmware/system/startup_stm32f303xe.s
+++ b/stm32-modules/heater-shaker/firmware/system/startup_stm32f303xe.s
@@ -78,8 +78,25 @@ LoopCopyDataInit:
 	adds	r2, r0, r1
 	cmp	r2, r3
 	bcc	CopyDataInit
+	movs r1, #0
+	ldr	r2, =_sccmram
+	b	LoopCopyCCM
+
+CopyCCM:
+	ldr	r3, =_siccmram
+	ldr	r3, [r3, r1]
+	str	r3, [r0, r1]
+	adds	r1, r1, #4
+
+LoopCopyCCM:
+	ldr	r0, =_sccmram
+	ldr	r3, =_eccmram
+	adds	r2, r0, r1
+	cmp	r2, r3
+	bcc	CopyCCM
 	ldr	r2, =_sbss
 	b	LoopFillZerobss
+
 /* Zero fill the bss segment. */
 FillZerobss:
 	movs	r3, #0

--- a/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
@@ -555,7 +555,7 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
                     task_registry->motor->get_message_queue().try_send(
                         message, TICKS_TO_WAIT_ON_SEND);
         }
-        if (send_result) {
+        if (!send_result) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
             ack_only_cache.remove_if_present(id);

--- a/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/host_comms_task.hpp
@@ -39,12 +39,12 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
     using GCodeParser = gcode::GroupParser<
         gcode::SetRPM, gcode::SetTemperature, gcode::GetRPM,
         gcode::GetTemperature, gcode::SetAcceleration,
-        gcode::GetTemperatureDebug, gcode::SetHeaterPIDConstants,
+        gcode::GetTemperatureDebug, gcode::SetPIDConstants,
         gcode::SetHeaterPowerTest, gcode::EnterBootloader, gcode::GetVersion,
         gcode::Home, gcode::ActuateSolenoid, gcode::DebugControlPlateLockMotor>;
     using AckOnlyCache =
         AckCache<8, gcode::SetRPM, gcode::SetTemperature,
-                 gcode::SetAcceleration, gcode::SetHeaterPIDConstants,
+                 gcode::SetAcceleration, gcode::SetPIDConstants,
                  gcode::SetHeaterPowerTest, gcode::EnterBootloader, gcode::Home,
                  gcode::ActuateSolenoid, gcode::DebugControlPlateLockMotor>;
     using GetTempCache = AckCache<8, gcode::GetTemperature>;
@@ -532,7 +532,7 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt>&&
         std::sized_sentinel_for<InputLimit, InputIt> auto
-        visit_gcode(const gcode::SetHeaterPIDConstants& gcode, InputIt tx_into,
+        visit_gcode(const gcode::SetPIDConstants& gcode, InputIt tx_into,
                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
         auto id = ack_only_cache.add(gcode);
         if (id == 0) {
@@ -543,8 +543,19 @@ requires MessageQueue<QueueImpl<Message>, Message> class HostCommsTask {
 
         auto message = messages::SetPIDConstantsMessage{
             .id = id, .kp = gcode.kp, .ki = gcode.ki, .kd = gcode.kd};
-        if (!task_registry->heater->get_message_queue().try_send(
-                message, TICKS_TO_WAIT_ON_SEND)) {
+        bool send_result = false;
+        switch (gcode.target) {
+            case gcode::SetPIDConstants::HEATER:
+                send_result =
+                    task_registry->heater->get_message_queue().try_send(
+                        message, TICKS_TO_WAIT_ON_SEND);
+                break;
+            case gcode::SetPIDConstants::MOTOR:
+                send_result =
+                    task_registry->motor->get_message_queue().try_send(
+                        message, TICKS_TO_WAIT_ON_SEND);
+        }
+        if (send_result) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
             ack_only_cache.remove_if_present(id);

--- a/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/messages.hpp
@@ -169,11 +169,10 @@ using HeaterMessage =
     ::std::variant<std::monostate, SetTemperatureMessage, GetTemperatureMessage,
                    TemperatureConversionComplete, GetTemperatureDebugMessage,
                    SetPIDConstantsMessage, SetPowerTestMessage>;
-using MotorMessage =
-    ::std::variant<std::monostate, MotorSystemErrorMessage, SetRPMMessage,
-                   GetRPMMessage, SetAccelerationMessage,
-                   CheckHomingStatusMessage, BeginHomingMessage,
-                   ActuateSolenoidMessage, SetPlateLockPowerMessage>;
+using MotorMessage = ::std::variant<
+    std::monostate, MotorSystemErrorMessage, SetRPMMessage, GetRPMMessage,
+    SetAccelerationMessage, CheckHomingStatusMessage, BeginHomingMessage,
+    ActuateSolenoidMessage, SetPlateLockPowerMessage, SetPIDConstantsMessage>;
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious>;
 using HostCommsMessage =

--- a/stm32-modules/heater-shaker/include/test/test_motor_policy.hpp
+++ b/stm32-modules/heater-shaker/include/test/test_motor_policy.hpp
@@ -26,6 +26,8 @@ class TestMotorPolicy {
     [[nodiscard]] auto test_solenoid_engaged() const -> bool;
     [[nodiscard]] auto test_solenoid_current() const -> uint16_t;
 
+    auto set_pid_constants(double kp, double ki, double kd) -> void;
+
     auto test_set_current_rpm(int16_t current_rpm) -> void;
     [[nodiscard]] auto test_get_ramp_rate() -> int32_t;
 
@@ -35,6 +37,10 @@ class TestMotorPolicy {
 
     [[nodiscard]] auto test_plate_lock_get_power() const -> float;
     [[nodiscard]] auto test_plate_lock_enabled() const -> bool;
+
+    [[nodiscard]] auto test_get_overridden_ki() const -> double;
+    [[nodiscard]] auto test_get_overridden_kp() const -> double;
+    [[nodiscard]] auto test_get_overridden_kd() const -> double;
 
   private:
     int16_t target_rpm;
@@ -47,4 +53,7 @@ class TestMotorPolicy {
     uint16_t last_delay = 0;
     float plate_lock_power = 0;
     bool plate_lock_enabled = false;
+    double overridden_ki = 0.0;
+    double overridden_kp = 0.0;
+    double overridden_kd = 0.0;
 };

--- a/stm32-modules/heater-shaker/scripts/.gitignore
+++ b/stm32-modules/heater-shaker/scripts/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+.idea
+*.log
+tmp/
+
+*.py[cod]
+*.egg
+build
+htmlcov
+*.json
+*venv*/**

--- a/stm32-modules/heater-shaker/scripts/.gitignore
+++ b/stm32-modules/heater-shaker/scripts/.gitignore
@@ -9,3 +9,4 @@ build
 htmlcov
 *.json
 *venv*/**
+*.csv

--- a/stm32-modules/heater-shaker/scripts/README.md
+++ b/stm32-modules/heater-shaker/scripts/README.md
@@ -1,0 +1,14 @@
+This directory has some python scripts useful for testing the heater-shaker.
+
+You'll need python 3.
+
+To get setup, create a venv here and install requirements.txt:
+
+```
+virtualenv hs-venv
+. ./hs-venv/activate
+pip install -r requirements.txt
+```
+
+And then you can run the scripts. They should have argparse help and descriptions. 
+

--- a/stm32-modules/heater-shaker/scripts/requirements.txt
+++ b/stm32-modules/heater-shaker/scripts/requirements.txt
@@ -1,0 +1,9 @@
+cycler==0.10.0
+kiwisolver==1.3.1
+matplotlib==3.4.2
+numpy==1.20.3
+Pillow==8.2.0
+pyparsing==2.4.7
+pyserial==3.5
+python-dateutil==2.8.1
+six==1.16.0

--- a/stm32-modules/heater-shaker/scripts/speed_stability.py
+++ b/stm32-modules/heater-shaker/scripts/speed_stability.py
@@ -16,7 +16,7 @@ import serial
 from serial.tools.list_ports import grep
 from matplotlib import pyplot as pp, gridspec
 
-DEFAULT_PID_CONSTANTS = {'kp': 3631, 'ki': 1536, 'kd': 0}
+DEFAULT_PID_CONSTANTS = {'kp': 2372, 'ki': 2624, 'kd': 0}
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description='Test a heater-shaker for stability')
@@ -258,9 +258,11 @@ def plot_data(data: List[Tuple[float, float]], config: RunConfig):
             return sample[1] > config.speed
         else:
             return sample[1] < config.speed
-    crossing = [samp for samp in data if matched(samp)][0]
-    axes.annotate(f'target crossing:\nt={crossing[0]}',
-                  crossing, (0.01, 0.8), 'axes fraction')
+    crossings = [samp for samp in data if matched(samp)]
+    if crossings:
+        crossing = crossings[0]
+        axes.annotate(f'target crossing:\nt={crossing[0]}',
+                      crossing, (0.01, 0.8), 'axes fraction')
 
     # shift right to visible area
     minx, maxx = sorted(box.intervalx)

--- a/stm32-modules/heater-shaker/scripts/speed_stability.py
+++ b/stm32-modules/heater-shaker/scripts/speed_stability.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+import argparse
+import itertools
+import io
+import datetime
+import time
+import json
+import re
+from typing import Tuple, List
+
+import serial
+from serial.tools.list_ports import grep
+from matplotlib import pyplot as pp
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description='Test a heater-shaker for stability')
+    p.add_argument('-o', '--output', choices=['plot','json'],
+                   action='append',
+                   help='Output type; plot draws a matplotlib graph, json dumps a data blob. Pass twice to do both.')
+    p.add_argument('-f', '--file', type=argparse.FileType('w'), help='Path to write the json blob (ignored if not -ojson)',
+                   default=None, dest='output_file')
+    p.add_argument('-p','--port', type=str, help='Path to serial port to open. If not specified, will try to find by usb details', default=None)
+    p.add_argument('speed', metavar='SPEED', type=float, help='Target speed to regulate at')
+    p.add_argument('-w', '--warm-up', type=float, dest='warmup_speed',
+                    help='Speed to hold before going to the speed argument (unplotted)',
+                    default=None)
+    p.add_argument('-t', '--time', type=float, help='Time to sample after setting the target speed. If not specified, tries to await stability',
+                   default=None)
+    p.add_argument('-s', '--sampling-time', dest='sample_time', type=float, help='How frequently to sample speed', default=0.1)
+    p.add_argument('-a', '--acceleration', help='acceleration  (rpm/s)', type=int, default=1000)
+    p.add_argument('--stability-criterion', type=float, default=2, help='square dev from target threshold for stability (rpm^2)')
+    p.add_argument('--stability-window', type=float, default=1, help='trailing window duration for stability check (s)')
+    return p
+
+
+def build_serial(port: str = None) -> serial.Serial:
+    if not port:
+        avail = list(grep('.*eater.*haker.*'))
+        if not avail:
+            raise RuntimeError("could not find heater-shaker")
+        return serial.Serial(avail[0].device, 115200)
+    return serial.Serial(port, 115200)
+
+def guard_error(res: bytes, prefix: bytes=  None):
+    if res.startswith(b'ERR'):
+        raise RuntimeError(res)
+    if prefix and not res.startswith(prefix):
+        raise RuntimeError(f'incorrect response: {res} (expected prefix {prefix})')
+
+
+_SPEED_RE = re.compile('^M123 C(?P<current>.+) T(?P<target>.+) OK\n')
+def get_speed(ser: serial.Serial) -> Tuple[float, float]:
+    ser.write(b'M123\n')
+    res = ser.readline()
+    guard_error(res, b'M123')
+    res_s = res.decode()
+    match = re.match(_SPEED_RE, res_s)
+    return float(match.group('current')), float(match.group('target'))
+
+
+def stable(data: List[Tuple[float, float]],
+           target: float,
+           window: datetime.timedelta,
+           criterion: float):
+    last_timestamp = data[-1][0]
+    if last_timestamp - data[0][0] < window.total_seconds():
+        return False
+    tocheck = list(itertools.takewhile(lambda sample: sample[0] > (last_timestamp - window.total_seconds()), reversed(data)))
+    dev = [(sample[1]-target)**2 for sample in tocheck]
+    if any([d > criterion for d in dev]):
+        return False
+    return True
+
+
+def sample_speed(ser: serial.Serial, target: float,
+                 stab_window: datetime.timedelta,
+                 stab_criterion: float,
+                 sample_time: datetime.timedelta,
+                 timeout: datetime.timedelta = None,
+                 fixed_time: datetime.timedelta = None,
+                 min_time: datetime.timedelta =  None):
+    sample_time = sample_time or datetime.timedelta(milliseconds=100)
+    min_time = min_time or datetime.timedelta(seconds=2)
+    if fixed_time:
+        min_time = min(min_time, fixed_time)
+    if timeout:
+        min_time = min(min_time, timeout)
+    print("Beginning data sampling (ctrl-c ONCE stops early)")
+    running_since = datetime.datetime.now()
+    data = []
+    try:
+        while True:
+            speed, target = get_speed(ser)
+            now = datetime.datetime.now()
+            data.append(((now - running_since).total_seconds(), speed))
+            time.sleep(sample_time.total_seconds())
+            if now - running_since < min_time:
+                continue
+            if timeout and now - running_since > timeout:
+                raise RuntimeError('timeout exceeded')
+            if fixed_time and now - running_since > fixed_time:
+                print(
+                    "Data sampling complete after (fixed time elapsed) {(now-running_since).total_seconds()}s")
+                break
+            if not fixed_time and (abs(speed-target) < 2) and stable(data, target, stab_window, stab_criterion):
+                print(
+                    "Data sampling complete after (speed stable) {(now-running_since).total_seconds()}")
+                break
+
+    except KeyboardInterrupt:
+        now = datetime.datetime.now()
+        print(f"Data sampling complete after (keyboard interrupt) {(now-running_since).total_seconds()}")
+    print(f"Got {len(data)} samples")
+    return data
+
+
+def set_speed(ser: serial.Serial, speed: float):
+    print(f"Setting speed to {speed}RPM")
+    ser.write(f'M3 S{int(speed)}\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M3')
+    print(res)
+
+
+def set_acceleration(ser: serial.Serial, acceleration: float):
+    print(f'Setting acceleration to {acceleration}RPM/s')
+    ser.write(f'M204 S{acceleration}\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M204')
+
+def do_warmup(ser: serial.Serial, speed: float):
+    print(f"Doing warmup phase at {speed}RPM")
+    then = datetime.datetime.now()
+    set_speed(ser, speed)
+    sample_speed(ser, speed, sample_time=datetime.timedelta(seconds=1), stab_window=datetime.timedelta(seconds=0.5), stab_criterion=5)
+    now = datetime.datetime.now()
+    print(f"Warmup phase complete after {(now-then).total_seconds()}")
+
+
+def do_run(ser: serial.Serial,
+           speed: float,
+           stab_window: datetime.timedelta,
+           stab_criterion: float,
+           sampletime: float = None,
+           fixedtime: float = None):
+    print(f"Doing main sample run")
+    then = datetime.datetime.now()
+    set_speed(ser, speed)
+    data = sample_speed(
+        ser,
+        speed,
+        stab_window,
+        stab_criterion,
+        sampletime and datetime.timedelta(seconds=sampletime),
+        None,
+        fixedtime and datetime.timedelta(seconds=fixedtime))
+    now = datetime.datetime.now()
+    set_speed(ser, 0)
+    print(f"Data acquisition complete after {(now-then).total_seconds()}")
+    return data
+
+
+def plot_data(data: List[Tuple[float, float]], speed: float, stab_criterion: float = None):
+    pp.plot([sample[0] for sample in data], [sample[1] for sample in data], label='speed')
+    pp.axhline(speed, color='red', linestyle='-.', label='target speed')
+    if stab_criterion:
+        pp.axhspan(speed - stab_criterion**2, speed + stab_criterion**2,
+                   alpha=0.1, color='r')
+    pp.ylabel('speed (rpm)')
+    pp.xlabel('time (sec)')
+    pp.title(f'Speed/Time (target={args.speed}rpm)')
+    pp.show()
+
+def write_data(data: List[Tuple[float, float]], speed: float, destfile: io.StringIO):
+    timestamp = datetime.datetime.now()
+    output_file = destfile or open(f'./heater-shaker-speed-{timestamp}.json', 'w')
+    json.dump({'meta': {'name': 'heater-shaker motor consistency run',
+                        'format': ['time', 'speed'], 'units': ['s', 'rpm'],
+                        'takenAt': str(timestamp)},
+                   'data': data}, output_file)
+
+
+
+if __name__ == '__main__':
+    parser = build_parser()
+    args = parser.parse_args()
+    port = build_serial(args.port)
+    set_acceleration(port, args.acceleration)
+    if args.warmup_speed:
+        do_warmup(port, args.warmup_speed)
+    data = do_run(port, args.speed,
+                  datetime.timedelta(seconds=args.stability_window),
+                  args.stability_criterion,
+                  args.sample_time, args.time)
+    port.close()
+    if 'json' in args.output:
+        write_data(data, args.speed, args.output_file)
+    if not args.output or 'plot' in args.output:
+        plot_data(data, args.speed, args.stability_criterion)

--- a/stm32-modules/heater-shaker/simulator/motor_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/motor_thread.cpp
@@ -27,6 +27,12 @@ struct SimMotorPolicy {
     [[nodiscard]] auto get_target_rpm() const -> int16_t {
         return rpm_setpoint;
     }
+    auto set_pid_constants(double kp, double ki, double kd) {
+        static_cast<void>(kp);
+        static_cast<void>(ki);
+        static_cast<void>(kd);
+    }
+
     auto stop() -> void {
         rpm_setpoint = 0;
         rpm_current = 0;

--- a/stm32-modules/heater-shaker/tests/test_basic_gcodes.cpp
+++ b/stm32-modules/heater-shaker/tests/test_basic_gcodes.cpp
@@ -14,7 +14,7 @@
 TEMPLATE_TEST_CASE("gcode basic parsing", "[gcode][parse]", gcode::SetRPM,
                    gcode::SetTemperature, gcode::GetTemperature, gcode::GetRPM,
                    gcode::SetAcceleration, gcode::GetTemperatureDebug,
-                   gcode::SetHeaterPIDConstants, gcode::SetHeaterPowerTest,
+                   gcode::SetPIDConstants, gcode::SetHeaterPowerTest,
                    gcode::EnterBootloader, gcode::GetVersion, gcode::Home,
                    gcode::ActuateSolenoid, gcode::DebugControlPlateLockMotor) {
     SECTION("attempting to parse an empty string fails") {
@@ -65,7 +65,7 @@ TEMPLATE_TEST_CASE("gcodes without parameters parse", "[gcode][parse]",
 */
 TEMPLATE_TEST_CASE("gcode responses without parameters generate",
                    "[gcode][response]", gcode::SetRPM, gcode::SetTemperature,
-                   gcode::SetHeaterPowerTest, gcode::SetHeaterPIDConstants,
+                   gcode::SetHeaterPowerTest, gcode::SetPIDConstants,
                    gcode::SetAcceleration, gcode::EnterBootloader, gcode::Home,
                    gcode::ActuateSolenoid, gcode::DebugControlPlateLockMotor) {
     SECTION("responses won't write into zero-size buffers") {

--- a/stm32-modules/heater-shaker/tests/test_m301.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m301.cpp
@@ -4,13 +4,13 @@
 #include "heater-shaker/gcodes.hpp"
 #pragma GCC diagnostic pop
 
-SCENARIO("SetHeaterPIDConstants (M301) parser works", "[gcode][parse][m301]") {
+SCENARIO("SetPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     GIVEN("a string with prefix only") {
-        std::string to_parse = "M301 P\n";
+        std::string to_parse = "M301 T\n";
 
         WHEN("calling parse") {
-            auto result = gcode::SetHeaterPIDConstants::parse(to_parse.cbegin(),
-                                                              to_parse.cend());
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
             THEN("nothing should be parsed") {
                 REQUIRE(!result.first.has_value());
                 REQUIRE(result.second == to_parse.cbegin());
@@ -18,11 +18,50 @@ SCENARIO("SetHeaterPIDConstants (M301) parser works", "[gcode][parse][m301]") {
         }
     }
 
-    GIVEN("a string with a prefix matching but bad data") {
-        std::string to_parse = "M301 Palsjdhas\r\n";
+    GIVEN("a string with a prefix matching but bad target") {
+        std::string to_parse = "M301 Ta\r\n";
         WHEN("calling parse") {
-            auto result = gcode::SetHeaterPIDConstants::parse(to_parse.cbegin(),
-                                                              to_parse.cend());
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
+
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a prefix and target matching but no p") {
+        std::string to_parse = "M301 TH\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
+
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a prefix and target matching and P prefix") {
+        std::string to_parse = "M301 TH P\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
+
+            THEN("nothing should be parsed") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a prefix and target matching and P bad data ") {
+        std::string to_parse = "M301 TH Pfaoiuhsda\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
 
             THEN("nothing should be parsed") {
                 REQUIRE(!result.first.has_value());
@@ -34,8 +73,8 @@ SCENARIO("SetHeaterPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     GIVEN("a string with p ok and no i or d") {
         std::string to_parse = "M301 P22.1\r\n";
         WHEN("calling parse") {
-            auto result = gcode::SetHeaterPIDConstants::parse(to_parse.cbegin(),
-                                                              to_parse.cend());
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
 
             THEN("nothing should be parsed") {
                 REQUIRE(!result.first.has_value());
@@ -47,8 +86,8 @@ SCENARIO("SetHeaterPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     GIVEN("a string with p ok and i prefix only") {
         std::string to_parse = "M301 P22.1 I\r\n";
         WHEN("calling parse") {
-            auto result = gcode::SetHeaterPIDConstants::parse(to_parse.cbegin(),
-                                                              to_parse.cend());
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
 
             THEN("nothing should be parsed") {
                 REQUIRE(!result.first.has_value());
@@ -58,10 +97,10 @@ SCENARIO("SetHeaterPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     }
 
     GIVEN("a string with p ok and i bad data") {
-        std::string to_parse = "M301 P22.1 Isaoihdals\r\n";
+        std::string to_parse = "M301 TM P22.1 Isaoihdals\r\n";
         WHEN("calling parse") {
-            auto result = gcode::SetHeaterPIDConstants::parse(to_parse.cbegin(),
-                                                              to_parse.cend());
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
 
             THEN("nothing should be parsed") {
                 REQUIRE(!result.first.has_value());
@@ -71,10 +110,10 @@ SCENARIO("SetHeaterPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     }
 
     GIVEN("a string with p and i ok and no d") {
-        std::string to_parse = "M301 P22.1 I22.1\r\n";
+        std::string to_parse = "M301 TH P22.1 I22.1\r\n";
         WHEN("calling parse") {
-            auto result = gcode::SetHeaterPIDConstants::parse(to_parse.cbegin(),
-                                                              to_parse.cend());
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
 
             THEN("nothing should be parsed") {
                 REQUIRE(!result.first.has_value());
@@ -84,10 +123,10 @@ SCENARIO("SetHeaterPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     }
 
     GIVEN("a string with p and i ok and d prefix only") {
-        std::string to_parse = "M301 P22.1 I55.1 D\r\n";
+        std::string to_parse = "M301 TM P22.1 I55.1 D\r\n";
         WHEN("calling parse") {
-            auto result = gcode::SetHeaterPIDConstants::parse(to_parse.cbegin(),
-                                                              to_parse.cend());
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
 
             THEN("nothing should be parsed") {
                 REQUIRE(!result.first.has_value());
@@ -97,10 +136,10 @@ SCENARIO("SetHeaterPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     }
 
     GIVEN("a string with p and i ok and d bad data") {
-        std::string to_parse = "M301 P22.1 I55.1 Dasdas\r\n";
+        std::string to_parse = "M301 TH P22.1 I55.1 Dasdas\r\n";
         WHEN("calling parse") {
-            auto result = gcode::SetHeaterPIDConstants::parse(to_parse.cbegin(),
-                                                              to_parse.cend());
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
 
             THEN("nothing should be parsed") {
                 REQUIRE(!result.first.has_value());
@@ -109,20 +148,42 @@ SCENARIO("SetHeaterPIDConstants (M301) parser works", "[gcode][parse][m301]") {
         }
     }
 
-    GIVEN("a correct command") {
-        std::string to_parse = "M301 P22.1 I0.15 D-1.2\r\n";
+    GIVEN("a correct heater target command") {
+        std::string to_parse = "M301 TH P22.1 I0.15 D-1.2\r\n";
         WHEN("calling parse") {
-            auto result = gcode::SetHeaterPIDConstants::parse(to_parse.cbegin(),
-                                                              to_parse.cend());
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
 
             THEN("a value should be parsed") {
                 REQUIRE(result.first.has_value());
+                REQUIRE(result.first.value().target ==
+                        gcode::SetPIDConstants::HEATER);
                 REQUIRE_THAT(result.first.value().kp,
                              Catch::Matchers::WithinAbs(22.1, .01));
                 REQUIRE_THAT(result.first.value().ki,
                              Catch::Matchers::WithinAbs(0.15, 0.001));
                 REQUIRE_THAT(result.first.value().kd,
                              Catch::Matchers::WithinAbs(-1.2, .01));
+                REQUIRE(result.second == (to_parse.cend() - 2));
+            }
+        }
+    }
+    GIVEN("a correct motor target command") {
+        std::string to_parse = "M301 TM P19.1 I1.15 D-4.2\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetPIDConstants::parse(to_parse.cbegin(),
+                                                        to_parse.cend());
+
+            THEN("a value should be parsed") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.first.value().target ==
+                        gcode::SetPIDConstants::MOTOR);
+                REQUIRE_THAT(result.first.value().kp,
+                             Catch::Matchers::WithinAbs(19.1, .01));
+                REQUIRE_THAT(result.first.value().ki,
+                             Catch::Matchers::WithinAbs(1.15, 0.001));
+                REQUIRE_THAT(result.first.value().kd,
+                             Catch::Matchers::WithinAbs(-4.2, .01));
                 REQUIRE(result.second == (to_parse.cend() - 2));
             }
         }

--- a/stm32-modules/heater-shaker/tests/test_motor_policy.cpp
+++ b/stm32-modules/heater-shaker/tests/test_motor_policy.cpp
@@ -88,3 +88,22 @@ auto TestMotorPolicy::test_plate_lock_get_power() const -> float {
 auto TestMotorPolicy::test_plate_lock_enabled() const -> bool {
     return plate_lock_enabled;
 }
+
+auto TestMotorPolicy::set_pid_constants(double kp, double ki, double kd)
+    -> void {
+    overridden_kp = kp;
+    overridden_ki = ki;
+    overridden_kd = kd;
+}
+
+auto TestMotorPolicy::test_get_overridden_kp() const -> double {
+    return overridden_kp;
+}
+
+auto TestMotorPolicy::test_get_overridden_ki() const -> double {
+    return overridden_ki;
+}
+
+auto TestMotorPolicy::test_get_overridden_kd() const -> double {
+    return overridden_kd;
+}


### PR DESCRIPTION
First-pass at motor tuning support, wrapping up a whole bunch of changes and new additions.

- adds the ability to change the motor speed control loop constants using M301, which now has a new target argument: `M301 T[H|P] Pxxx Ixxx Dxxx`.
- adds a scripts/ directory with a `requirements.txt` for making a venv, a readme, and a script for running a motor speed command and capturing the speed readbacks
- swaps some  parameters now
- fixes a mistake I guess I made at some point I can't remember that broke motor control library error detection; we now save errors before resetting them.
- moves the motor control library high-frequency control task, which runs the motor control system, to the [CCMRAM](https://www.st.com/content/ccc/resource/technical/document/application_note/bb/09/ca/83/14/e9/44/c5/DM00083249.pdf/files/DM00083249.pdf/jcr:content/translations/en.DM00083249.pdf). There's more detail at the link, but the short of it is it's a separate RAM area with 1-cycle fetch latencies which therefore makes code in it run faster. In practice, moving the motor control system from execute-from-flash to execute-from-CCMRAM makes the primary control loop task take 11us, whereas on flash it takes 14us. That's nice because the main failure mode of this control system is not finishing the control loop by the time its output is needed, and when it's running at 30KHz from CCMRAM, the standard timings give you about 5us of margin between a normal end-of-task and when the value is needed. So if it's in flash, that margin is gone. End of this post has some scope captures about this. The actual mechanics of the transition are a little fiddly. A different static library version of the motor controller builtins has to be linked in, and a compiler define has to be set, and the startup assembly needs to be changed a little. This is necessary because CCMRAM is ram, not flash, and therefore isn't persistent. During startup, the application has to put the code into CCMRAM every time. That means that it needs to know where the code lives in flash before the copy; this is done by telling the linker to put that code in a special section (which is why all those functions have that preprocessor-logic-gated ``__attribute__((section=".ccmram"))`` - we set the preproc define to make sure those apply), and then the startup assembly has to be changed to use the locations the linker knows about to copy all the data. The startup assembly is taken from [this community post](https://community.arm.com/developer/ip-products/system/f/embedded-forum/4605/how-to-use-ccm-sram-for-cortex-m4); the linker-script stuff was already there. The data is copied in the same way as the way we copy the initial values of initialized data into RAM at the appropriate address. Unlike initialized data, it would probably be fine to do this copy in C as long as we did it before trying to call any of the functions in question, but this keeps the nastiness localized, and prevents any upsetting surprises if we put more stuff in ccmram in the future.
- tweaks the interrupt priorities for pretty much everything that has an interrupt around to keep that 5us margin intact. Because we have an [NVIC](https://developer.arm.com/documentation/ddi0439/b/Nested-Vectored-Interrupt-Controller/NVIC-programmers-model), interrupts at higher priority (Lower priority number (sorry)) can preempt ISRs of lower priority (higher priority number). Interrupts of equal priority are serviced round-robin. In addition to the hardware-handling ISRs we define, for things like the heater ADC, the various timers and ADCs for the motor, and the USB, there's also the ones that FreeRTOS uses internally. FreeRTOSConfig.h [has a value](https://github.com/Opentrons/opentrons-modules/blob/652bbbc848feceba61801114bbc078f6cf341e66/stm32-modules/heater-shaker/firmware/system/FreeRTOSConfig.h#L144) that is a priority-not-to-exceed for internal library methods, for basically exactly this reason. If you make an ISR at a higher priority (lower priority number) than that config value, then it will preempt whatever the RTOS is doing internally. This means you can't use any FreeRTOS methods from ISRs at that priority, but that's fine, we don't need to - the [_other_ motor control task](https://github.com/Opentrons/opentrons-modules/blob/652bbbc848feceba61801114bbc078f6cf341e66/stm32-modules/heater-shaker/firmware/motor_task/freertos_motor_task.cpp#L78-L89), which runs as a normal task rather than in an ISR, handles all that stuff and is safe to do so.
- puts that high-frequency task regulation frequency back at 30KHz 

Running the controller at 20KHz, with the code in flash. Channel 1 goes high at the beginning of the control loop and low at the end. 
![highfrek-20k-noccmram](https://user-images.githubusercontent.com/3091648/121533179-06d4fe00-c9ce-11eb-8e46-85c8086a0141.png)

Running at 20KHz, with the code in CCMRAM. You can see it's a lot faster.
![highfreq-20k-ccmram](https://user-images.githubusercontent.com/3091648/121533267-20764580-c9ce-11eb-88a3-a216bb5e5391.png)

Running at 30KHz. This is a logic analyzer capture rather than a scope. Channel 0 is the same logic with the high-frequency task. Channel 2 is the timer interrupt that the controller is racing; if that goes high while channel 0 is still high (as it does around timing marker 1), there's an error. When an error is present, channel 1 is high. You can ignore Channel 3; I thought the USB interrupt was the main problem, but it's not really related. This capture shows the reason to tweak the interrupts - the variability in the duration and frequency of the peaks on channel 1.
<img width="1103" alt="Screen Shot 2021-06-10 at 9 29 18 AM" src="https://user-images.githubusercontent.com/3091648/121533533-603d2d00-c9ce-11eb-970a-981a61c1c9e7.png">

The logic analyzer capture from the above screenshot. This can be opened with [Saleae Logic 2](https://www.saleae.com/downloads/)
[30khz-failure.sal.zip](https://github.com/Opentrons/opentrons-modules/files/6631755/30khz-failure.sal.zip)



