### PR TITLE
chore(heater-shaker): heater tuning v1

### DIFF
--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
@@ -164,7 +164,7 @@ void heater_hardware_begin_conversions(heater_hardware* hardware) {
     ADC_ChannelConfTypeDef channel_conf = {
         .Channel = NTC_PAD_A,
         .Rank = ADC_REGULAR_RANK_1,
-        .SamplingTime = ADC_SAMPLETIME_19CYCLES_5,
+        .SamplingTime = ADC_SAMPLETIME_601CYCLES_5,
     };
     hw_internal* internal = (hw_internal*)hardware->hardware_internal;
     if (!internal) {
@@ -258,7 +258,7 @@ void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc) {
     ADC_ChannelConfTypeDef channel_conf = {
       .Channel = internal->reading_which,
       .Rank = ADC_REGULAR_RANK_1,
-      .SamplingTime = ADC_SAMPLETIME_19CYCLES_5,
+      .SamplingTime = ADC_SAMPLETIME_601CYCLES_5,
     };
     switch(which) {
         case NTC_PAD_A: {

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
@@ -6,6 +6,7 @@
 #include "stm32f3xx_hal_gpio.h"
 #include "stm32f3xx_hal_cortex.h"
 #include "stm32f3xx_hal_tim.h"
+#include "stm32f3xx_ll_tim.h"
 
 #include "heater_hardware.h"
 
@@ -21,6 +22,7 @@ typedef struct {
     ADC_HandleTypeDef ntc_adc;
     TIM_HandleTypeDef pad_tim;
     TIM_OC_InitTypeDef pwm_config;
+    bool heater_started;
 } hw_internal;
 
 hw_internal _internals = {
@@ -36,7 +38,8 @@ hw_internal _internals = {
 .OCFastMode = TIM_OCFAST_DISABLE,
 .OCIdleState=TIM_OCIDLESTATE_RESET,
 .OCNIdleState=TIM_OCNIDLESTATE_RESET,
-    }
+},
+.heater_started = false,
 };
 
 heater_hardware *HEATER_HW_HANDLE = NULL;
@@ -54,6 +57,7 @@ heater_hardware *HEATER_HW_HANDLE = NULL;
 #define HEATER_PAD_ENABLE_PORT GPIOD
 #define HEATER_PAD_ENABLE_PIN (1<<14)
 #define HEATER_PAD_ENABLE_TIM_CHANNEL TIM_CHANNEL_3
+#define HEATER_PAD_LL_SETCOMPARE LL_TIM_OC_SetCompareCH3
 
 
 static void gpio_setup(void) {
@@ -197,6 +201,7 @@ void heater_hardware_power_disable(heater_hardware* hardware) {
         init_error();
     }
     HAL_TIM_PWM_Stop(&internal->pad_tim, HEATER_PAD_ENABLE_TIM_CHANNEL);
+    internal->heater_started = false;
 }
 
 void heater_hardware_power_set(heater_hardware* hardware, uint16_t setting) {
@@ -205,10 +210,15 @@ void heater_hardware_power_set(heater_hardware* hardware, uint16_t setting) {
         init_error();
     }
     internal->pwm_config.Pulse = setting;
-    HAL_TIM_PWM_Stop(&internal->pad_tim, HEATER_PAD_ENABLE_TIM_CHANNEL);
-    HAL_TIM_PWM_ConfigChannel(
-        &internal->pad_tim, &internal->pwm_config, HEATER_PAD_ENABLE_TIM_CHANNEL);
-    HAL_TIM_PWM_Start(&internal->pad_tim, HEATER_PAD_ENABLE_TIM_CHANNEL);
+    if (!internal->heater_started) {
+        HAL_TIM_PWM_Stop(&internal->pad_tim, HEATER_PAD_ENABLE_TIM_CHANNEL);
+        HAL_TIM_PWM_ConfigChannel(
+            &internal->pad_tim, &internal->pwm_config, HEATER_PAD_ENABLE_TIM_CHANNEL);
+        HAL_TIM_PWM_Start(&internal->pad_tim, HEATER_PAD_ENABLE_TIM_CHANNEL);
+        internal->heater_started = true;
+    } else {
+        HEATER_PAD_LL_SETCOMPARE(internal->pad_tim.Instance, setting);
+    }
 }
 
 

--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_policy.cpp
@@ -1,5 +1,7 @@
 #include "heater_policy.hpp"
 
+#include <algorithm>
+
 #include "FreeRTOS.h"
 #include "task.h"
 
@@ -34,16 +36,14 @@ HeaterPolicy::HeaterPolicy(heater_hardware* hardware)
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static,readability-make-member-function-const)
 auto HeaterPolicy::set_power_output(double relative_power) -> void {
-    if (relative_power > 1.0 || relative_power < 0.0) {
-        return;
-    }
+    const double relative_clamped = std::clamp(relative_power, 0.0, 1.0);
     heater_hardware_power_set(
         hardware_handle,
         // The macro HEATER_PAD_PWM_GRANULARITY purposefully uses integer
         // division since the end goal is in fact an integer
         // NOLINTNEXTLINE(bugprone-integer-division)
         static_cast<uint16_t>(static_cast<double>(HEATER_PAD_PWM_GRANULARITY) *
-                              relative_power));
+                              relative_clamped));
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static,readability-make-member-function-const)

--- a/stm32-modules/heater-shaker/include/heater-shaker/heater_task.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/heater_task.hpp
@@ -91,9 +91,9 @@ requires MessageQueue<QueueImpl<Message>, Message> class HeaterTask {
     static constexpr uint8_t ADC_BIT_DEPTH = 12;
     static constexpr double HEATER_PAD_OVERTEMP_SAFETY_LIMIT_C = 100;
     static constexpr double BOARD_OVERTEMP_SAFETY_LIMIT_C = 60;
-    static constexpr double DEFAULT_KI = 1.0;
-    static constexpr double DEFAULT_KP = 1.0;
-    static constexpr double DEFAULT_KD = 1.0;
+    static constexpr double DEFAULT_KI = 0.102;
+    static constexpr double DEFAULT_KP = 0.97;
+    static constexpr double DEFAULT_KD = 1.901;
     static constexpr double MAX_CONTROLLABLE_TEMPERATURE = 95.0;
     static constexpr double KP_MIN = -200;
     static constexpr double KP_MAX = 200;

--- a/stm32-modules/heater-shaker/include/heater-shaker/pid.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/pid.hpp
@@ -3,25 +3,30 @@
 class PID {
   public:
     PID() = delete;
-    PID(double kp, double ki, double kd);
-    PID(double kp, double ki, double kd, double windup_limit_high,
-        double windup_limit_low);
+    PID(double kp, double ki, double kd, double sampletime);
+    PID(double kp, double ki, double kd, double sampletime,
+        double windup_limit_high, double windup_limit_low);
     auto compute(double error) -> double;
     auto reset() -> void;
     [[nodiscard]] auto kp() const -> double;
     [[nodiscard]] auto ki() const -> double;
     [[nodiscard]] auto kd() const -> double;
+    [[nodiscard]] auto sampletime() const -> double;
     [[nodiscard]] auto windup_limit_high() const -> double;
     [[nodiscard]] auto windup_limit_low() const -> double;
-    [[nodiscard]] auto integrator() const -> double;
     [[nodiscard]] auto last_error() const -> double;
+    [[nodiscard]] auto last_iterm() const -> double;
+    auto arm_integrator_reset(double error) -> void;
 
   private:
+    enum IntegratorResetTrigger { RISING, FALLING, NONE };
     double _kp;
     double _ki;
     double _kd;
+    double _sampletime;
     double _windup_limit_high;
     double _windup_limit_low;
-    double _integrator;
     double _last_error;
+    double _last_iterm;
+    IntegratorResetTrigger _reset_trigger = NONE;
 };

--- a/stm32-modules/heater-shaker/scripts/heater_profiling.py
+++ b/stm32-modules/heater-shaker/scripts/heater_profiling.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from dataclasses import dataclass, asdict
+import datetime
+import serial
+import argparse
+import time
+
+from typing import Any, Dict, List, Tuple
+
+import test_utils
+
+def build_parser():
+    p = test_utils.build_parent_parser(desc='Run a heater profile (step) on a heater-shaker')
+    p.add_argument('power', metavar='POWER', type=float, help='Heater power in [0, 1]')
+    p.add_argument('duration', metavar='DURATION', type=float, help='Time to sample for')
+    p.add_argument('-e', '--until-exceeds', dest='until_exceeds', type=float, help='Stop sampling early if temp exceeds this valuee', default=95)
+    return p
+
+@dataclass
+class PowerConfig(test_utils.RunConfig):
+    power: float
+    duration: datetime.timedelta
+
+    def dict_for_save(self) -> Dict[str, Any]:
+        parent = super().dict_for_save()
+        parent.update(asdict(self))
+        return parent
+
+    def rowiterable_for_save(self) -> List[List[Any]]:
+        return super().rowiterable_for_save() + [
+            ['power', self.power],
+            ['duration', self.duration.total_seconds()]
+        ]
+
+
+if __name__ == '__main__':
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.output and 'json' in args.output and 'csv' in args.output:
+        raise RuntimeError("please pick just one of json or csv")
+    port = test_utils.build_serial(args.port)
+    config = PowerConfig(power=args.power,
+                         duration=datetime.timedelta(seconds=args.duration),
+                         target=args.until_exceeds,
+                         stability_criterion=2,
+                         sampling_time=datetime.timedelta(seconds=args.sampling_time),
+                         process='temperature',
+                         process_unit='C')
+    test_utils.set_heater_power(port, config.power)
+    def done(duration, data):
+        if duration > config.duration:
+            print("sampling done (time expired)")
+            return True
+        if data[-1][1] > config.target:
+            print("sampling done (target reaeched)")
+            return True
+    start = datetime.datetime.now()
+    prefix = []
+    for i in range(10):
+        current, _ = test_utils.get_temperature(port)
+        now = datetime.datetime.now()
+        prefix.append(((now-start).total_seconds(), current))
+        time.sleep(config.sampling_time.total_seconds())
+    prefix_end = datetime.datetime.now()
+    data = test_utils.sample_fixed_time(port, config, config.duration,
+                                        test_utils.get_temperature, done)
+    try:
+        test_utils.set_heater_power(port, 0)
+    except RuntimeError:
+        pass
+    port.close()
+
+    prefix_duration = (prefix_end-start).total_seconds()
+    padded = prefix + [(elem[0] + prefix_duration, elem[1]) for elem in data]
+    output_type = args.output or ['plot']
+    if 'json' in output_type:
+        test_utils.write_json(padded, config, args.output_file)
+    if 'csv' in output_type:
+        test_utils.write_csv(padded, config, args.output_file)
+    if 'plot' in output_type:
+        test_utils.plot_data(padded, config)

--- a/stm32-modules/heater-shaker/scripts/heater_stability.py
+++ b/stm32-modules/heater-shaker/scripts/heater_stability.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+from dataclasses import dataclass, asdict
+import datetime
+import serial
+import argparse
+from copy import copy
+
+from typing import Any, Dict, List, Tuple
+
+import test_utils
+
+DEFAULT_PID_CONSTANTS = {'kp': 1, 'ki': 1, 'kd': 1}
+
+def build_parser():
+    p = test_utils.build_parent_parser(desc='Run a heater profile (step) on a heater-shaker')
+    p.add_argument('temperature', metavar='TEMPERATURe', type=float, help='Target temperature')
+    p.add_argument('-t', '--time', type=float, help='Fixed time to sample for')
+    p.add_argument('--stability-criterion', type=float, default=2, help='square dev from target threshold for stability (rpm^2)')
+    p.add_argument('--stability-window', type=float, default=1, help='trailing window duration for stability check (s)')
+    p.add_argument('-kp', dest='kp_override', type=float, help='Kp override')
+    p.add_argument('-ki', dest='ki_override', type=float, help='Ki override')
+    p.add_argument('-kd', dest='kd_override', type=float, help='Kd override')
+    return p
+
+@dataclass
+class HeaterConfig(test_utils.RunConfig):
+    fixed_time_sample: datetime.timedelta
+    stability_window: datetime.timedelta
+    pid_constants: Dict[str, float]
+    pid_constants_need_setting: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace):
+        pid_constants = copy(DEFAULT_PID_CONSTANTS)
+        needs_setting = False
+        if args.kp_override is not None:
+            pid_constants['kp'] = args.kp_override
+            needs_setting = True
+        if args.ki_override is not None:
+            pid_constants['ki'] = args.ki_override
+            needs_setting = True
+        if args.kd_override is not None:
+            pid_constants['kd'] = args.kd_override
+            needs_setting = True
+        return cls(
+            process='temperature',
+            process_unit='C',
+            target=args.temperature,
+            fixed_time_sample=args.time and datetime.timedelta(seconds=args.time),
+            sampling_time=datetime.timedelta(seconds=args.sampling_time),
+            stability_criterion=args.stability_criterion,
+            stability_window=datetime.timedelta(seconds=args.stability_window),
+            pid_constants=pid_constants,
+            pid_constants_need_setting=needs_setting)
+
+
+    def dict_for_save(self) -> Dict[str, Any]:
+        parent = super().dict_for_save()
+        mydict = asdict(self)
+        for k, v in mydict.items():
+            if isinstance(v, datetime.timedelta):
+                mydict[k] = v.total_seconds()
+        mydict.pop('pid_constants_need_setting')
+        parent.update(mydict)
+        return parent
+
+    def rowiterable_for_save(self) -> List[List[Any]]:
+        return super().rowiterable_for_save() + [
+            ['power', self.power],
+            ['fixed sample time (s)',
+             (self.fixed_time_sample
+              and self.fixed_time_sample.total_seconds()
+              or 'not set')],
+            ['stability window (s)', self.stability_window.total_seconds()],
+            ['kp', self.pid_constants['kp']],
+            ['ki', self.pid_constants['ki']],
+            ['kd', self.pid_constants['kd']],
+            ['duration', self.duration.total_seconds()]
+        ]
+
+def sample_heater(ser: serial.Serial,
+                  config: HeaterConfig,
+                  min_time: datetime.timedelta = None) -> List[Tuple[float, float]]:
+    min_time = min_time or datetime.timedelta(seconds=2)
+    if config.fixed_time_sample:
+        return test_utils.sample_fixed_time(
+            ser, config, config.fixed_time_sample, test_utils.get_temperature)
+    else:
+        return test_utils.sample_until_stable(
+            ser, config, min_time, test_utils.get_temperature)
+
+if __name__ == '__main__':
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.output and 'json' in args.output and 'csv' in args.output:
+        raise RuntimeError("please pick just one of json or csv")
+    port = test_utils.build_serial(args.port)
+    config = HeaterConfig.from_args(args)
+    if config.pid_constants_need_setting:
+        test_utils.set_heater_pid(port, **config.pid_constants)
+    test_utils.set_temperature(port, config.target)
+    data = sample_heater(port, config)
+    try:
+        test_utils.set_temperature(port, 0)
+    except RuntimeError:
+        pass
+    port.close()
+    output_type = args.output or ['plot']
+    if 'json' in output_type:
+        test_utils.write_json(data, config, args.output_file)
+    if 'csv' in output_type:
+        test_utils.write_csv(data, config, args.output_file)
+    if 'plot' in output_type:
+        test_utils.plot_data(data, config)

--- a/stm32-modules/heater-shaker/scripts/speed_stability.py
+++ b/stm32-modules/heater-shaker/scripts/speed_stability.py
@@ -1,38 +1,29 @@
 #!/usr/bin/env python3
 import argparse
-import math
 from copy import copy
-import csv
+
 from dataclasses import dataclass, asdict
-import itertools
-import io
+
 import datetime
 import time
-import json
-import re
+
 from typing import Any, Dict, Tuple, List, Optional
 
 import serial
-from serial.tools.list_ports import grep
-from matplotlib import pyplot as pp, gridspec
+
+import test_utils
+
 
 DEFAULT_PID_CONSTANTS = {'kp': 2372, 'ki': 2624, 'kd': 0}
 
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(description='Test a heater-shaker for stability')
-    p.add_argument('-o', '--output', choices=['plot','json', 'csv'],
-                   action='append',
-                   help='Output type; plot draws a matplotlib graph, json dumps a data blob. Pass twice to do both.')
-    p.add_argument('-f', '--file', type=argparse.FileType('w'), help='Path to write the json blob (ignored if not -ojson)',
-                   default=None, dest='output_file')
-    p.add_argument('-p','--port', type=str, help='Path to serial port to open. If not specified, will try to find by usb details', default=None)
+    p = test_utils.build_parent_parser('Run some motor tests on a heater-shaker')
     p.add_argument('speed', metavar='SPEED', type=float, help='Target speed to regulate at')
     p.add_argument('-w', '--warm-up', type=float, dest='warmup_speed',
                     help='Speed to hold before going to the speed argument (unplotted)',
                     default=None)
     p.add_argument('-t', '--time', type=float, help='Time to sample after setting the target speed. If not specified, tries to await stability',
                    default=None)
-    p.add_argument('-s', '--sampling-time', dest='sampling_time', type=float, help='How frequently to sample speed', default=0.1)
     p.add_argument('-a', '--acceleration', help='acceleration  (rpm/s)', type=int, default=1000)
     p.add_argument('--stability-criterion', type=float, default=2, help='square dev from target threshold for stability (rpm^2)')
     p.add_argument('--stability-window', type=float, default=1, help='trailing window duration for stability check (s)')
@@ -43,13 +34,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 @dataclass
-class RunConfig:
-    speed: float
+class SpeedConfig(test_utils.RunConfig):
     warmup_speed: Optional[float]
     fixed_time_sample: Optional[datetime.timedelta]
-    sampling_time: datetime.timedelta
     acceleration: float
-    stability_criterion: float
     stability_window: datetime.timedelta
     pid_constants: Dict[str, float]
     pid_constants_need_setting: bool
@@ -67,33 +55,36 @@ class RunConfig:
         if args.kd_override:
             pid_constants['kd'] = args.kd_override
             needs_setting = True
-        return cls(speed=args.speed,
-                   warmup_speed=args.warmup_speed,
-                   fixed_time_sample=args.time and datetime.timedelta(seconds=args.time),
-                   sampling_time=datetime.timedelta(seconds=args.sampling_time),
-                   acceleration=args.acceleration,
-                   stability_criterion=args.stability_criterion,
-                   stability_window=datetime.timedelta(seconds=args.stability_window),
-                   pid_constants=pid_constants,
-                   pid_constants_need_setting=needs_setting)
+        return cls(
+            process='speed',
+            process_unit='rpm',
+            target=args.speed,
+            warmup_speed=args.warmup_speed,
+            fixed_time_sample=args.time and datetime.timedelta(seconds=args.time),
+            sampling_time=datetime.timedelta(seconds=args.sampling_time),
+            acceleration=args.acceleration,
+            stability_criterion=args.stability_criterion,
+            stability_window=datetime.timedelta(seconds=args.stability_window),
+            pid_constants=pid_constants,
+            pid_constants_need_setting=needs_setting)
 
     def dict_for_save(self) -> Dict[str, Any]:
+        parent = super().dict_for_save()
         mydict = asdict(self)
         for k, v in mydict.items():
             if isinstance(v, datetime.timedelta):
                 mydict[k] = v.total_seconds()
         mydict.pop('pid_constants_need_setting')
-        return mydict
+        parent.update(mydict)
+        return parent
 
     def rowiterable_for_save(self) -> List[List[Any]]:
-        return [
-            ['speed (rpm)', self.speed],
+        return super().rowiterable_for_save() + [
             ['warmup speed (rpm)',  self.warmup_speed or 0],
             ['fixed sample time  (s)',
              (self.fixed_time_sample and self.fixed_time_sample.total_seconds())
              or 'not set'],
             ['acceleration (rpm/s)', self.acceleration],
-            ['stability criterion (rpm^2)', self.stability_criterion],
             ['stability window (s)',  self.stability_window.total_seconds()],
             ['kp', self.pid_constants['kp']],
             ['ki', self.pid_constants['ki']],
@@ -101,236 +92,56 @@ class RunConfig:
         ]
 
 
-def build_serial(port: str = None) -> serial.Serial:
-    if not port:
-        avail = list(grep('.*eater.*haker.*'))
-        if not avail:
-            raise RuntimeError("could not find heater-shaker")
-        return serial.Serial(avail[0].device, 115200)
-    return serial.Serial(port, 115200)
-
-def guard_error(res: bytes, prefix: bytes=  None):
-    if res.startswith(b'ERR'):
-        raise RuntimeError(res)
-    if prefix and not res.startswith(prefix):
-        raise RuntimeError(f'incorrect response: {res} (expected prefix {prefix})')
-
-
-_SPEED_RE = re.compile('^M123 C(?P<current>.+) T(?P<target>.+) OK\n')
-def get_speed(ser: serial.Serial) -> Tuple[float, float]:
-    ser.write(b'M123\n')
-    res = ser.readline()
-    guard_error(res, b'M123')
-    res_s = res.decode()
-    match = re.match(_SPEED_RE, res_s)
-    return float(match.group('current')), float(match.group('target'))
-
-
-def stable(data: List[Tuple[float, float]],
-           target: float,
-           window: datetime.timedelta,
-           criterion: float):
-    last_timestamp = data[-1][0]
-    if last_timestamp - data[0][0] < window.total_seconds():
-        return False
-    tocheck = list(itertools.takewhile(lambda sample: sample[0] > (last_timestamp - window.total_seconds()), reversed(data)))
-    dev = [(sample[1]-target)**2 for sample in tocheck]
-    if any([d > criterion for d in dev]):
-        return False
-    return True
-
-
-def set_speed_pid(ser: serial.Serial,
-                  kp: float, ki: float, kd: float):
-    print(f'Overriding PID constants to kp={kp}, ki={ki}, kd={kd}')
-    ser.write(f'M301 TM P{kp} I{ki} D{kd}\n'.encode())
-    guard_error(ser.readline(), b'M301')
-
-
-def sample_speed(ser: serial.Serial,
-                 config: RunConfig,
-                 min_time: datetime.timedelta =  None):
+def sample_speed(ser, config: SpeedConfig, min_time: datetime.timedelta = None):
     min_time = min_time or datetime.timedelta(seconds=2)
     if config.fixed_time_sample:
-        min_time = min(min_time, config.fixed_time_sample)
-    print("Beginning data sampling (ctrl-c ONCE stops early)")
-    running_since = datetime.datetime.now()
-    data = []
-    try:
-        while True:
-            speed, target = get_speed(ser)
-            now = datetime.datetime.now()
-            data.append(((now - running_since).total_seconds(), speed))
-            time.sleep(config.sampling_time.total_seconds())
-            if now - running_since < min_time:
-                continue
-            if config.fixed_time_sample and now - running_since > config.fixed_time_sample:
-                print(
-                    "Data sampling complete after (fixed time elapsed) {(now-running_since).total_seconds()}s")
-                break
-            if (not config.fixed_time_sample)\
-               and (abs(speed-target) < 2) \
-               and stable(data, target, config.stability_window, config.stability_criterion):
-                print(
-                    "Data sampling complete after (speed stable) {(now-running_since).total_seconds()}")
-                break
-
-    except KeyboardInterrupt:
-        now = datetime.datetime.now()
-        print(f"Data sampling complete after (keyboard interrupt) {(now-running_since).total_seconds()}")
-    print(f"Got {len(data)} samples")
-    return data
-
-
-def set_speed(ser: serial.Serial, speed: float):
-    print(f"Setting speed to {speed}RPM")
-    ser.write(f'M3 S{int(speed)}\n'.encode())
-    res = ser.readline()
-    guard_error(res, b'M3')
-    print(res)
-
-
-def set_acceleration(ser: serial.Serial, acceleration: float):
-    print(f'Setting acceleration to {acceleration}RPM/s')
-    ser.write(f'M204 S{acceleration}\n'.encode())
-    res = ser.readline()
-    guard_error(res, b'M204')
+        return test_utils.sample_fixed_time(ser, config, config.fixed_time_sample, test_utils.get_speed)
+    else:
+        return test_utils.sample_until_stable(ser, config, min_time, test_utils.get_speed)
 
 def do_warmup(ser: serial.Serial, speed: float):
     print(f"Doing warmup phase at {speed}RPM")
     then = datetime.datetime.now()
-    set_speed(ser, speed)
-    warmup_config = RunConfig(
-        speed=speed,
-        stability_window=datetime.timedelta(seconds=2),
-        stability_criterion=20,
+    test_utils.set_speed(ser, speed)
+    warmup_config = test_utils.RunConfig(
+        process='speed',
+        process_unit='rpm',
+        target=speed,
+        stability_criterion=200,
         sampling_time=datetime.timedelta(milliseconds=500))
     sample_speed(ser, warmup_config)
     now = datetime.datetime.now()
     print(f"Warmup phase complete after {(now-then).total_seconds()}")
 
 
-def do_run(ser: serial.Serial, config: RunConfig):
+def do_run(ser: serial.Serial, config: SpeedConfig):
     print(f"Doing main sample run")
     then = datetime.datetime.now()
-    set_speed(ser, config.speed)
+    test_utils.set_speed(ser, config.target)
     data = sample_speed(ser, config)
+    test_utils.set_speed(ser, 0)
     now = datetime.datetime.now()
-    set_speed(ser, 0)
     print(f"Data acquisition complete after {(now-then).total_seconds()}")
     return data
-
-
-def plot_data(data: List[Tuple[float, float]], config: RunConfig):
-    fig = pp.figure()
-    gs = gridspec.GridSpec(2, 1, height_ratios=[4, 1], hspace=0.5)
-    axes = pp.subplot(gs[0])
-    bwaxes = pp.subplot(gs[1])
-    axes.plot([sample[0] for sample in data], [sample[1] for sample in data], label='speed')
-    axes.axhline(config.speed, color='red', linestyle='-.', label='target speed')
-    axes.axhspan(config.speed - config.stability_criterion**2, config.speed + config.stability_criterion**2,
-                 alpha=0.1, color='r')
-    # options string: we'd like to put the options on the plot mostly so that if
-    # it's saved as an image, we keep them around. it'll be a big chunk of text,
-    # so we autolayout it to either the bottom right or top right depending on
-    # whether most of the data is on the bottom or the top (because we capture
-    # a ramp and then regulation period, it'll usually have a blank space)
-    options_string = '\n'.join(f'{k}: {val}' for k, val in config.dict_for_save().items())
-    yavg = sum([sample[1] for sample in data]) / len(data)
-    ylims = axes.get_ylim()
-    if yavg < sum(ylims)/2:
-        pos = (axes.get_xlim()[1], ylims[1])
-        valign = 'top'
-    else:
-        pos = (axes.get_xlim()[1], ylims[0])
-        valign = 'bottom'
-    # once we render the text we  know what size it is, so we can shift it in
-    # to the visible area
-    text = axes.text(
-        *pos,
-        options_string,
-        verticalalignment=valign,
-        horizontalalignment='left')
-    box = text.get_window_extent(
-        fig.canvas.get_renderer()).transformed(axes.transData.inverted())
-    def matched(sample):
-        if data[0][1] < config.speed:
-            return sample[1] > config.speed
-        else:
-            return sample[1] < config.speed
-    crossings = [samp for samp in data if matched(samp)]
-    if crossings:
-        crossing = crossings[0]
-        axes.annotate(f'target crossing:\nt={crossing[0]}',
-                      crossing, (0.01, 0.8), 'axes fraction')
-
-    # shift right to visible area
-    minx, maxx = sorted(box.intervalx)
-    miny, maxy = sorted(box.intervaly)
-    newx = minx - (maxx-minx)
-    if yavg < sum(ylims)/2:
-        # line is low, text is high
-        newy = miny - (maxy-miny)
-    else:
-        newy = miny
-    text.set_position((newx, newy))
-
-    #filtered_samples  =  list(itertools.dropwhile(
-    #lambda samp: (samp[0] < 0.1 * data[-1][0]) or abs(samp[1]-config.speed) < 0.1*config.speed, data))
-    filtered_samples = data[len(data)//2:-1]
-    box_data = [filtered_samp[1] for filtered_samp in filtered_samples]
-    bwaxes.boxplot(box_data, vert=False)
-    bp = bwaxes.set_xlabel('speed (rpm)')
-    bwaxes.set_title(f'Speed sample data after first target intercept')
-    axes.indicate_inset([filtered_samples[0][0], min(box_data),
-                         filtered_samples[-1][0]-filtered_samples[0][0],
-                         max(box_data)-min(box_data)],
-                        bwaxes)
-
-    axes.set_ylabel('speed (rpm)')
-    axes.set_xlabel('time (sec)')
-    axes.set_title(f'Speed/Time (target={config.speed}rpm)')
-    pp.show()
-
-def write_json(data: List[Tuple[float, float]], config: RunConfig, destfile: io.StringIO):
-    timestamp = datetime.datetime.now()
-    output_file = destfile or open(f'./heater-shaker-speed-{config.speed}rpm-{timestamp}.json', 'w')
-    json.dump({'meta': {'name': 'heater-shaker motor consistency run',
-                        'config': config.dict_for_save(),
-                        'format': ['time', 'speed'], 'units': ['s', 'rpm'],
-                        'takenAt': str(timestamp)},
-                   'data': data}, output_file)
-
-def write_csv(data: List[Tuple[float, float]], config: RunConfig, destfile: io.StringIO):
-    timestamp = datetime.datetime.now()
-    output_file = destfile or open(f'./heater-shaker-speed-{config.speed}rpm-{timestamp}.csv', 'w')
-    writer = csv.writer(output_file)
-    writer.writerows(
-        [['title', 'heater shaker speed'],
-         ['taken at', str(timestamp)]])
-    writer.writerows(config.rowiterable_for_save())
-    writer.writerows([['time', 'speed'],
-                      ['seconds', 'rpm']])
-    writer.writerows(data)
 
 if __name__ == '__main__':
     parser = build_parser()
     args = parser.parse_args()
     if args.output and 'json' in args.output and 'csv' in args.output:
         raise RuntimeError("please pick just one of json or csv")
-    port = build_serial(args.port)
-    config = RunConfig.from_args(args)
-    set_acceleration(port, config.acceleration)
+    port = test_utils.build_serial(args.port)
+    config = SpeedConfig.from_args(args)
+    test_utils.set_acceleration(port, config.acceleration)
     if config.pid_constants_need_setting:
-        set_speed_pid(port, **config.pid_constants)
+        test_utils.set_speed_pid(port, **config.pid_constants)
     if config.warmup_speed:
         do_warmup(port, config.warmup_speed)
     data = do_run(port, config)
     port.close()
     output_type = args.output or ['plot']
     if 'json' in output_type:
-        write_json(data, config, args.output_file)
+        test_utils.write_json(data, config, args.output_file)
     if 'csv' in output_type:
-        write_csv(data, config, args.output_file)
+        test_utils.write_csv(data, config, args.output_file)
     if 'plot' in output_type:
-        plot_data(data, config)
+        test_utils.plot_data(data, config)

--- a/stm32-modules/heater-shaker/scripts/test_utils.py
+++ b/stm32-modules/heater-shaker/scripts/test_utils.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+
+from matplotlib import pyplot as pp, gridspec
+import argparse
+import csv
+import io
+import json
+import re
+import serial
+import datetime
+import time
+
+from serial.tools.list_ports import grep
+from typing import Any, Callable, Dict, Tuple, List, Optional
+
+from dataclasses import dataclass, asdict
+
+def build_parent_parser(desc: str) -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=desc)
+    p.add_argument('-o', '--output', choices=['plot','json', 'csv'],
+                   action='append',
+                   help='Output type; plot draws a matplotlib graph, json dumps a data blob. Pass twice to do both.')
+    p.add_argument('-f', '--file', type=argparse.FileType('w'), help='Path to write the json blob (ignored if not -ojson)',
+                   default=None, dest='output_file')
+    p.add_argument('-p','--port', type=str, help='Path to serial port to open. If not specified, will try to find by usb details', default=None)
+    p.add_argument('-s', '--sampling-time', dest='sampling_time', type=float, help='How frequently to sample in seconds', default=0.1)
+    return p
+
+@dataclass
+class RunConfig:
+    """
+    Dataclass for configuration storage that will also help with displays
+    """
+    process: str
+    process_unit: str
+    target: float
+    stability_criterion: float
+    sampling_time: datetime.timedelta
+
+    def dict_for_save(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def rowiterable_for_save(self) -> List[List[Any]]:
+        return [
+            [f'target {self.process} ({self.process_unit})'],
+            ['sample time (s)', self.sampling_time.total_seconds()],
+            [f'stability criterion ({self.process_unit}^2)', self.stability_criterion]
+        ]
+
+
+def build_serial(port: str = None) -> serial.Serial:
+    if not port:
+        avail = list(grep('.*eater.*haker.*'))
+        if not avail:
+            raise RuntimeError("could not find heater-shaker")
+        return serial.Serial(avail[0].device, 115200)
+    return serial.Serial(port, 115200)
+
+def guard_error(res: bytes, prefix: bytes=  None):
+    if res.startswith(b'ERR'):
+        raise RuntimeError(res)
+    if prefix and not res.startswith(prefix):
+        raise RuntimeError(f'incorrect response: {res} (expected prefix {prefix})')
+
+
+_SPEED_RE = re.compile('^M123 C(?P<current>.+) T(?P<target>.+) OK\n')
+def get_speed(ser: serial.Serial) -> Tuple[float, float]:
+    ser.write(b'M123\n')
+    res = ser.readline()
+    guard_error(res, b'M123')
+    res_s = res.decode()
+    match = re.match(_SPEED_RE, res_s)
+    return float(match.group('current')), float(match.group('target'))
+
+
+_TEMP_RE = re.compile('^M105 C(?P<current>.+) T(?P<target>.+) OK\n')
+def get_temperature(ser: serial.Serial) -> Tuple[float, float]:
+    ser.write(b'M105\n')
+    res = ser.readline()
+    guard_error(res, b'M105')
+    res_s = res.decode()
+    match = re.match(_TEMP_RE, res_s)
+    return float(match.group('current')), float(match.group('target'))
+
+
+def set_speed_pid(ser: serial.Serial,
+                  kp: float, ki: float, kd: float):
+    print(f'Overriding motor PID constants to kp={kp}, ki={ki}, kd={kd}')
+    ser.write(f'M301 TM P{kp} I{ki} D{kd}\n'.encode())
+    guard_error(ser.readline(), b'M301')
+
+
+def set_heater_pid(ser: serial.Serial,
+                   kp: float, ki: float, kd: float):
+    print(f"Overriding heater PID constants to kp={kp}, ki={ki}, kd={kd}")
+    ser.write(f'M301 TH P{kp} I{ki} D{kd}\n'.encode())
+    guard_error(ser.readline(), b'M301')
+
+
+def stable(data: List[Tuple[float, float]],
+           target: float,
+           criterion: float,
+           window: datetime.timedelta = datetime.timedelta(seconds=2)):
+    last_timestamp = data[-1][0]
+    if last_timestamp - data[0][0] < window.total_seconds():
+        return False
+    tocheck = list(itertools.takewhile(lambda sample: sample[0] > (last_timestamp - window.total_seconds()), reversed(data)))
+    dev = [(sample[1]-target)**2 for sample in tocheck]
+    if any([d > criterion for d in dev]):
+        return False
+    return True
+
+
+def set_temperature(ser: serial.Serial, target: float):
+    ser.write(f'M104 S{target}\n'.encode())
+    guard_error(ser.readline(), b'M104')
+
+
+def _do_sample(ser: serial.Serial,
+               config: RunConfig,
+               sampler: Callable[[serial.Serial], Tuple[float, float]],
+               done: Callable[[datetime.timedelta, List[Tuple[float, float]]], bool]) -> List[Tuple[float, float]]:
+    data = []
+    running_since = datetime.datetime.now()
+    try:
+        print("Beginning data sampling (ctrl-c ONCE stops early)")
+        while True:
+            current, target = sampler(ser)
+            now = datetime.datetime.now()
+            data.append(((now - running_since).total_seconds(), current))
+            time.sleep(config.sampling_time.total_seconds())
+            if done(now-running_since, data):
+                break
+    except KeyboardInterrupt:
+        print("Sampling complete (keyboard interrupt)")
+    except RuntimeError as re:
+        print(f"Sampling complete (error from device: {re})")
+    finally:
+        return data
+
+
+def sample_fixed_time(ser: serial.Serial,
+                      config: RunConfig,
+                      duration: datetime.timedelta,
+                      sampler: Callable[[serial.Serial], Tuple[float, float]],
+                      done: Callable[[datetime.timedelta, List[Tuple[float, float]]], bool] = None):
+    def timeonly_done(elapsed: datetime.timedelta, _ignore: Any):
+        if elapsed > duration:
+            print(f"Sampling complete (fixed time over) after {elapsed.total_seconds()}")
+        return elapsed > duration
+
+    return _do_sample(ser, config, sampler, done or timeonly_done)
+
+
+def sample_until_stable(ser: serial.Serial,
+                        config: RunConfig,
+                        min_duration: datetime.timedelta,
+                        sampler: Callable[[serial.Serial], Tuple[float, float]]):
+    def done(elapsed: datetime.timedelta, data: List[Tuple[float, float]]):
+        if elapsed < min_duration:
+            return False
+        if abs(data[-1][1]-config.target) < 2 and stable(data, config.target, config.stability_criterion):
+            print("Sampling complete (speed stable) after {elapsed.total_seconds()}")
+            return True
+
+    return _do_sample(ser, config, sampler, done)
+
+
+def set_speed(ser: serial.Serial, speed: float):
+    print(f"Setting speed to {speed}RPM")
+    ser.write(f'M3 S{int(speed)}\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M3')
+    print(res)
+
+
+def set_heater_power(ser: serial.Serial, power: float):
+    print(f'Setting heater power to {power}/1.0')
+    if power < 0 or power > 1.0:
+        raise RuntimeError("bad power setting must be in [0, 1]")
+    ser.write(f'M104.D S{power}\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M104.D')
+    print(res)
+
+
+def set_acceleration(ser: serial.Serial, acceleration: float):
+    print(f'Setting acceleration to {acceleration}RPM/s')
+    ser.write(f'M204 S{acceleration}\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M204')
+
+
+
+
+def plot_data(data: List[Tuple[float, float]], config: RunConfig):
+    fig = pp.figure()
+    gs = gridspec.GridSpec(2, 1, height_ratios=[4, 1], hspace=0.5)
+    axes = pp.subplot(gs[0])
+    bwaxes = pp.subplot(gs[1])
+    axes.plot([sample[0] for sample in data], [sample[1] for sample in data], label=f'{config.process} ({config.process_unit})')
+    axes.axhline(config.target, color='red', linestyle='-.', label='target')
+    axes.axhspan(config.target - config.stability_criterion**2, config.target + config.stability_criterion**2,
+                 alpha=0.1, color='r')
+    # options string: we'd like to put the options on the plot mostly so that if
+    # it's saved as an image, we keep them around. it'll be a big chunk of text,
+    # so we autolayout it to either the bottom right or top right depending on
+    # whether most of the data is on the bottom or the top (because we capture
+    # a ramp and then regulation period, it'll usually have a blank space)
+    options_string = '\n'.join(f'{k}: {val}' for k, val in config.dict_for_save().items())
+    yavg = sum([sample[1] for sample in data]) / len(data)
+    ylims = axes.get_ylim()
+    if yavg < sum(ylims)/2:
+        pos = (axes.get_xlim()[1], ylims[1])
+        valign = 'top'
+    else:
+        pos = (axes.get_xlim()[1], ylims[0])
+        valign = 'bottom'
+    # once we render the text we  know what size it is, so we can shift it in
+    # to the visible area
+    text = axes.text(
+        *pos,
+        options_string,
+        verticalalignment=valign,
+        horizontalalignment='left')
+    box = text.get_window_extent(
+        fig.canvas.get_renderer()).transformed(axes.transData.inverted())
+    def matched(sample):
+        if data[0][1] < config.target:
+            return sample[1] > config.target
+        else:
+            return sample[1] < config.target
+    crossings = [samp for samp in data if matched(samp)]
+    if crossings:
+        crossing = crossings[0]
+        axes.annotate(f'target crossing:\nt={crossing[0]}',
+                      crossing, (0.01, 0.8), 'axes fraction')
+
+    # shift right to visible area
+    minx, maxx = sorted(box.intervalx)
+    miny, maxy = sorted(box.intervaly)
+    newx = minx - (maxx-minx)
+    if yavg < sum(ylims)/2:
+        # line is low, text is high
+        newy = miny - (maxy-miny)
+    else:
+        newy = miny
+    text.set_position((newx, newy))
+
+    filtered_samples = data[len(data)//2:-1]
+    box_data = [filtered_samp[1] for filtered_samp in filtered_samples]
+    bwaxes.boxplot(box_data, vert=False)
+    bp = bwaxes.set_xlabel(config.process)
+    bwaxes.set_title(f'{config.process} sample data after first target intercept')
+    axes.indicate_inset([filtered_samples[0][0], min(box_data),
+                         filtered_samples[-1][0]-filtered_samples[0][0],
+                         max(box_data)-min(box_data)],
+                        bwaxes)
+
+    axes.set_ylabel(f'{config.process} ({config.process_unit})')
+    axes.set_xlabel('time (sec)')
+    axes.set_title(f'{config.process} ({config.process_unit})/time (sec) (target={config.target})')
+    pp.show()
+
+def write_json(data: List[Tuple[float, float]], config: RunConfig, destfile: io.StringIO):
+    timestamp = datetime.datetime.now()
+    output_file = destfile or open(f'./heater-shaker-{config.process}-{config.target}-{timestamp}.json', 'w')
+    json.dump({'meta': {'name': f'heater-shaker {config.process} run',
+                        'config': config.dict_for_save(),
+                        'format': ['time', config.process], 'units': ['s', 'rpm'],
+                        'takenAt': str(timestamp)},
+                   'data': data}, output_file)
+
+def write_csv(data: List[Tuple[float, float]], config: RunConfig, destfile: io.StringIO):
+    timestamp = datetime.datetime.now()
+    output_file = destfile or open(f'./heater-shaker-{config.process}-{config.target}-{timestamp}.csv', 'w')
+    writer = csv.writer(output_file)
+    writer.writerows(
+        [['title', f'heater shaker {config.process}'],
+         ['taken at', str(timestamp)]])
+    writer.writerows(config.rowiterable_for_save())
+    writer.writerows([['time', config.process],
+                      ['seconds', config.process_unit]])
+    writer.writerows(data)

--- a/stm32-modules/heater-shaker/src/pid.cpp
+++ b/stm32-modules/heater-shaker/src/pid.cpp
@@ -42,7 +42,7 @@ auto PID::compute(double error) -> double {
     }
     const double unclamped_iterm = last_iterm() + sampletime() * ki() * error;
     const double iterm =
-      std::clamp(unclamped_iterm, windup_limit_low(), windup_limit_high());
+        std::clamp(unclamped_iterm, windup_limit_low(), windup_limit_high());
     _last_iterm = iterm;
     const double errdiff = error - last_error();
     _last_error = error;

--- a/stm32-modules/heater-shaker/src/pid.cpp
+++ b/stm32-modules/heater-shaker/src/pid.cpp
@@ -3,19 +3,20 @@
 #include <algorithm>
 #include <limits>
 
-PID::PID(double kp, double ki, double kd)
-    : PID(kp, ki, kd, std::numeric_limits<double>::infinity(),
+PID::PID(double kp, double ki, double kd, double sampletime)
+    : PID(kp, ki, kd, sampletime, std::numeric_limits<double>::infinity(),
           -std::numeric_limits<double>::infinity()) {}
 
-PID::PID(double kp, double ki, double kd, double windup_limit_high,
-         double windup_limit_low)
+PID::PID(double kp, double ki, double kd, double sampletime,
+         double windup_limit_high, double windup_limit_low)
     : _kp(kp),
       _ki(ki),
       _kd(kd),
+      _sampletime(sampletime),
       _windup_limit_high(windup_limit_high),
       _windup_limit_low(windup_limit_low),
-      _integrator(0),
-      _last_error(0) {}
+      _last_error(0),
+      _last_iterm(0) {}
 
 auto PID::kp() const -> double { return _kp; }
 
@@ -23,23 +24,42 @@ auto PID::ki() const -> double { return _ki; }
 
 auto PID::kd() const -> double { return _kd; }
 
+auto PID::sampletime() const -> double { return _sampletime; }
+
+auto PID::last_iterm() const -> double { return _last_iterm; }
+
 auto PID::windup_limit_high() const -> double { return _windup_limit_high; }
 
 auto PID::windup_limit_low() const -> double { return _windup_limit_low; }
 
-auto PID::integrator() const -> double { return _integrator; }
-
 auto PID::last_error() const -> double { return _last_error; }
 
 auto PID::compute(double error) -> double {
-    _integrator =
-        std::clamp(error + _integrator, _windup_limit_low, _windup_limit_high);
-    const double errdiff = error - _last_error;
+    if (((_reset_trigger == FALLING) && (error <= 0)) ||
+        ((_reset_trigger == RISING) && (error > 0))) {
+        _last_iterm = 0;
+        _reset_trigger = NONE;
+    }
+    const double unclamped_iterm = last_iterm() + sampletime() * ki() * error;
+    const double iterm =
+      std::clamp(unclamped_iterm, windup_limit_low(), windup_limit_high());
+    _last_iterm = iterm;
+    const double errdiff = error - last_error();
     _last_error = error;
-    return (_kp * error) + (_kd * errdiff) + (_ki * _integrator);
+    const double pterm = kp() * error;
+    const double dterm = kd() * errdiff / sampletime();
+    return pterm + iterm + dterm;
 }
 
 auto PID::reset() -> void {
-    _integrator = 0;
     _last_error = 0;
+    _last_iterm = 0;
+}
+
+auto PID::arm_integrator_reset(double error) -> void {
+    if (error <= 0) {
+        _reset_trigger = RISING;
+    } else {
+        _reset_trigger = FALLING;
+    }
 }

--- a/stm32-modules/heater-shaker/tests/test_heater_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_heater_task.cpp
@@ -71,6 +71,18 @@ SCENARIO("heater task message passing") {
                                     .setpoint_temperature == 0.125);
                     }
                 }
+                AND_WHEN("continuing to get thermistor readings") {
+                    auto conversion_message =
+                        messages::TemperatureConversionComplete{
+                            .pad_a = ((1U << 9) - 1),
+                            .pad_b = (1U << 9),
+                            .board = (1U << 11)};
+                    tasks->get_heater_queue().backing_deque.push_front(
+                        conversion_message);
+                    tasks->run_heater_task();
+                    REQUIRE(tasks->get_heater_policy().last_power_setting() ==
+                            0.125);
+                }
             }
         }
         WHEN("sending a set-temperature message as if from host comms") {

--- a/stm32-modules/heater-shaker/tests/test_pid.cpp
+++ b/stm32-modules/heater-shaker/tests/test_pid.cpp
@@ -219,7 +219,9 @@ SCENARIO("PID controller") {
         }
     }
 
-    GIVEN("a pid controller with an iterm and integrator reset armed with a positive error value") {
+    GIVEN(
+        "a pid controller with an iterm and integrator reset armed with a "
+        "positive error value") {
         auto p = PID(0, 1, 0, 1);
         p.arm_integrator_reset(25);
         WHEN("repeatedly calculating controls without an error zero-cross") {
@@ -233,31 +235,39 @@ SCENARIO("PID controller") {
                 REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
             }
         }
-        WHEN("repeatedly calculating results that include a single error zero-cross") {
+        WHEN(
+            "repeatedly calculating results that include a single error "
+            "zero-cross") {
             std::vector<float> inputs = {3, 3, 3, 3, -3, -3, -3, -3};
             std::vector<float> results(8);
             std::transform(
                 inputs.cbegin(), inputs.cend(), results.begin(),
-                [&p](const float& error){ return p.compute(error);} );
+                [&p](const float& error) { return p.compute(error); });
             THEN("the integrator should be reset when the error crosses zero") {
                 std::vector<float> intended = {3, 6, 9, 12, -3, -6, -9, -12};
                 REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
             }
         }
-        WHEN("repeatedly calculating results that include multiple error zero-crosses") {
+        WHEN(
+            "repeatedly calculating results that include multiple error "
+            "zero-crosses") {
             std::vector<float> inputs = {3, 3, -3, -3, 1, -1, 2, -2};
             std::vector<float> results(8);
             std::transform(
                 inputs.cbegin(), inputs.cend(), results.begin(),
-                [&p](const float& error){ return p.compute(error);} );
-            THEN("the integrator should be reset only after the first zero cross") {
+                [&p](const float& error) { return p.compute(error); });
+            THEN(
+                "the integrator should be reset only after the first zero "
+                "cross") {
                 std::vector<float> intended = {3, 6, -3, -6, -5, -6, -4, -6};
                 REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
             }
         }
     }
 
-    GIVEN("a pid controller with an iterm and integrator reset armed with a negative error value") {
+    GIVEN(
+        "a pid controller with an iterm and integrator reset armed with a "
+        "negative error value") {
         auto p = PID(0, 1, 0, 1);
         p.arm_integrator_reset(-25);
         WHEN("repeatedly calculating controls without an error zero-cross") {
@@ -267,28 +277,35 @@ SCENARIO("PID controller") {
                 inputs.cbegin(), inputs.cend(), results.begin(),
                 [&p](const float& error) { return p.compute(error); });
             THEN("the integrator term should accumulate") {
-                std::vector<float> intended = {-3, -6, -9, -12, -15, -18, -21, -24};
+                std::vector<float> intended = {-3,  -6,  -9,  -12,
+                                               -15, -18, -21, -24};
                 REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
             }
         }
-        WHEN("repeatedly calculating results that include a single error zero-cross") {
+        WHEN(
+            "repeatedly calculating results that include a single error "
+            "zero-cross") {
             std::vector<float> inputs = {-3, -3, -3, -3, 3, 3, 3, 3};
             std::vector<float> results(8);
             std::transform(
                 inputs.cbegin(), inputs.cend(), results.begin(),
-                [&p](const float& error){ return p.compute(error);} );
+                [&p](const float& error) { return p.compute(error); });
             THEN("the integrator should be reset when the error crosses zero") {
                 std::vector<float> intended = {-3, -6, -9, -12, 3, 6, 9, 12};
                 REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
             }
         }
-        WHEN("repeatedly calculating results that include multiple error zero-crosses") {
+        WHEN(
+            "repeatedly calculating results that include multiple error "
+            "zero-crosses") {
             std::vector<float> inputs = {-3, -3, 3, 3, -1, 1, -2, 2};
             std::vector<float> results(8);
             std::transform(
                 inputs.cbegin(), inputs.cend(), results.begin(),
-                [&p](const float& error){ return p.compute(error);} );
-            THEN("the integrator should be reset only after the first zero cross") {
+                [&p](const float& error) { return p.compute(error); });
+            THEN(
+                "the integrator should be reset only after the first zero "
+                "cross") {
                 std::vector<float> intended = {-3, -6, 3, 6, 5, 6, 4, 6};
                 REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
             }

--- a/stm32-modules/heater-shaker/tests/test_pid.cpp
+++ b/stm32-modules/heater-shaker/tests/test_pid.cpp
@@ -6,7 +6,7 @@
 
 SCENARIO("PID controller") {
     GIVEN("a PID controller initialized with all 0 coeffs") {
-        auto p = PID(0, 0, 0);
+        auto p = PID(0, 0, 0, 1);
         WHEN("calculating a value") {
             auto result = p.compute(12312.0);
             THEN("the result should be 0") { REQUIRE(result == 0.0); }
@@ -17,11 +17,12 @@ SCENARIO("PID controller") {
         }
     }
     GIVEN("a PID controller") {
-        auto p = PID(1.0, 2.0, 3.0, 4.0, -5.0);
+        auto p = PID(1.0, 2.0, 3.0, 1.0, 4.0, -5.0);
         WHEN("querying the accessors for static data") {
             auto kp = p.kp();
             auto ki = p.ki();
             auto kd = p.kd();
+            auto ts = p.sampletime();
             auto windup_high = p.windup_limit_high();
             auto windup_low = p.windup_limit_low();
             THEN("the queried values should match the ctor values") {
@@ -30,6 +31,7 @@ SCENARIO("PID controller") {
                 REQUIRE(kd == 3.0);
                 REQUIRE(windup_high == 4.0);
                 REQUIRE(windup_low == -5.0);
+                REQUIRE(ts == 1.0);
             }
         }
         WHEN("computing values") {
@@ -37,12 +39,12 @@ SCENARIO("PID controller") {
             p.compute(3.0);
             THEN("the updated state should be correct") {
                 REQUIRE(p.last_error() == 3.0);
-                REQUIRE(p.integrator() == 4.0);
+                REQUIRE(p.last_iterm() == 4.0);
             }
         }
     }
     GIVEN("a PID controller with only kp") {
-        auto p = PID(2.0, 0, 0);
+        auto p = PID(2.0, 0, 0, 1.0);
         WHEN("repeatedly calculating controls") {
             std::vector<float> results(8);
             std::vector<float> inputs = {0, 1, 2, 3, 4, 5, 6, 7};
@@ -73,7 +75,7 @@ SCENARIO("PID controller") {
         }
     }
     GIVEN("a PID controller with only kd") {
-        auto p = PID(0, 0, 1.0);
+        auto p = PID(0, 0, 1.0, 1.0);
         WHEN("repeatedly calculating controls") {
             std::vector<float> results(8);
             std::vector<float> inputs = {0, 1, 2, 4, 8, 16, 32, 64};
@@ -116,7 +118,7 @@ SCENARIO("PID controller") {
     }
 
     GIVEN("a PID controller with only ki and no windup limiters") {
-        auto p = PID(0, 1.0, 0);
+        auto p = PID(0, 1.0, 0, 1.0);
         WHEN("repeatedly calculating controls from positive errors") {
             std::vector<float> results(8);
             std::vector<float> inputs = {2, 2, 2, 2, 2, 2, 2, 2};
@@ -162,7 +164,7 @@ SCENARIO("PID controller") {
     }
 
     GIVEN("a PID controller with only ki and a windup limiter") {
-        auto p = PID(0, 2, 0, 16, -12);
+        auto p = PID(0, 2, 0, 1.0, 16, -12);
         WHEN("repeatedly calculating controls from positive errors") {
             std::vector<float> inputs = {3, 3, 3, 3, 3, 3, 3, 3};
             std::vector<float> results(8);
@@ -170,7 +172,7 @@ SCENARIO("PID controller") {
                 inputs.cbegin(), inputs.cend(), results.begin(),
                 [&p](const float& error) { return p.compute(error); });
             THEN("the result should accumulate and clip at bound") {
-                std::vector<float> intended = {6, 12, 18, 24, 30, 32, 32, 32};
+                std::vector<float> intended = {6, 12, 16, 16, 16, 16, 16, 16};
                 REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
             }
         }
@@ -182,37 +184,113 @@ SCENARIO("PID controller") {
                 inputs.cbegin(), inputs.cend(), results.begin(),
                 [&p](const float& error) { return p.compute(error); });
             THEN("the result should accumulate and clip at bound") {
-                std::vector<float> intended = {-4,  -8,  -12, -16,
-                                               -20, -24, -24, -24};
+                std::vector<float> intended = {-4,  -8,  -12, -12,
+                                               -12, -12, -12, -12};
                 REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
             }
         }
 
         WHEN("alternating input signs") {
             std::vector<float> results(6);
-            std::vector<float> inputs = {10, 10, -16, -10, -10, 12};
+            std::vector<float> inputs = {5, 10, -8, -5, -2, 6};
             std::transform(
                 inputs.cbegin(), inputs.cend(), results.begin(),
                 [&p](const float& error) { return p.compute(error); });
             THEN(
                 "the integral term is properly cancelled by negating the "
-                "clip") {
-                std::vector<float> intended = {20, 32, 0, -20, -24, 0};
+                "input") {
+                std::vector<float> intended = {10, 16, 0, -10, -12, 0};
                 REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
             }
         }
     }
 
     GIVEN("a PID controller with all coeffs set and windup limiters present") {
-        auto p = PID(2, -1, 1, 10, -12);
+        auto p = PID(2, -1, 1, 1.0, 10, -12);
         WHEN("repeatedly calculating controls") {
             THEN("the result should behave correctly from first principles") {
                 REQUIRE(p.compute(1) == 2);
                 REQUIRE(p.last_error() == 1);
-                REQUIRE(p.integrator() == 1);
+                REQUIRE(p.last_iterm() == -1);
                 REQUIRE(p.compute(2) == 2);
                 REQUIRE(p.last_error() == 2);
-                REQUIRE(p.integrator() == 3);
+                REQUIRE(p.last_iterm() == -3);
+            }
+        }
+    }
+
+    GIVEN("a pid controller with an iterm and integrator reset armed with a positive error value") {
+        auto p = PID(0, 1, 0, 1);
+        p.arm_integrator_reset(25);
+        WHEN("repeatedly calculating controls without an error zero-cross") {
+            std::vector<float> inputs = {3, 3, 3, 3, 3, 3, 3, 3};
+            std::vector<float> results(8);
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error) { return p.compute(error); });
+            THEN("the integrator term should accumulate") {
+                std::vector<float> intended = {3, 6, 9, 12, 15, 18, 21, 24};
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+        WHEN("repeatedly calculating results that include a single error zero-cross") {
+            std::vector<float> inputs = {3, 3, 3, 3, -3, -3, -3, -3};
+            std::vector<float> results(8);
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error){ return p.compute(error);} );
+            THEN("the integrator should be reset when the error crosses zero") {
+                std::vector<float> intended = {3, 6, 9, 12, -3, -6, -9, -12};
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+        WHEN("repeatedly calculating results that include multiple error zero-crosses") {
+            std::vector<float> inputs = {3, 3, -3, -3, 1, -1, 2, -2};
+            std::vector<float> results(8);
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error){ return p.compute(error);} );
+            THEN("the integrator should be reset only after the first zero cross") {
+                std::vector<float> intended = {3, 6, -3, -6, -5, -6, -4, -6};
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+    }
+
+    GIVEN("a pid controller with an iterm and integrator reset armed with a negative error value") {
+        auto p = PID(0, 1, 0, 1);
+        p.arm_integrator_reset(-25);
+        WHEN("repeatedly calculating controls without an error zero-cross") {
+            std::vector<float> inputs = {-3, -3, -3, -3, -3, -3, -3, -3};
+            std::vector<float> results(8);
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error) { return p.compute(error); });
+            THEN("the integrator term should accumulate") {
+                std::vector<float> intended = {-3, -6, -9, -12, -15, -18, -21, -24};
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+        WHEN("repeatedly calculating results that include a single error zero-cross") {
+            std::vector<float> inputs = {-3, -3, -3, -3, 3, 3, 3, 3};
+            std::vector<float> results(8);
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error){ return p.compute(error);} );
+            THEN("the integrator should be reset when the error crosses zero") {
+                std::vector<float> intended = {-3, -6, -9, -12, 3, 6, 9, 12};
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+            }
+        }
+        WHEN("repeatedly calculating results that include multiple error zero-crosses") {
+            std::vector<float> inputs = {-3, -3, 3, 3, -1, 1, -2, 2};
+            std::vector<float> results(8);
+            std::transform(
+                inputs.cbegin(), inputs.cend(), results.begin(),
+                [&p](const float& error){ return p.compute(error);} );
+            THEN("the integrator should be reset only after the first zero cross") {
+                std::vector<float> intended = {-3, -6, 3, 6, 5, 6, 4, 6};
+                REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
             }
         }
     }


### PR DESCRIPTION
Tunes the heater-shaker heater controller to desired levels of accuracy and fixes some bugs in the hardware configuration.
- ADC needs to have a longer sample time to give the internal capacitor time to charge since the thermistor is so high-impedance that we only get a trickle of current
- Make the PID controller a discrete-time implementation using euler approximation (t -> kTs for integer k and sampling time Ts; dx/dt ~= (x(k)-x(k-1))/Ts)
- Add an integrator reset in addition to an integrator windup limiter for faster response
- Use step response data generated with `M104.D` as an input to https://pidtuner.com/#/UFVRqBHnaf which uses https://www.researchgate.net/publication/254233805_Probably_the_best_simple_PID_tuning_rules_in_the_world (perfect title) to tune the controller for best disturbance rejection and settling times. This overshoots a little  but only by a degree or so for 10 seconds.
- Switch the method for changing the heater drive duty cycle to not have to stop and restart the timing channel every time\
- Add some more python scripts for testing the above
![heater-integrator-lag-detail](https://user-images.githubusercontent.com/3091648/122464323-b7ba3a80-cf84-11eb-9cc9-54f1da4593a7.png)
![heater-integrator-lag-constants](https://user-images.githubusercontent.com/3091648/122464331-ba1c9480-cf84-11eb-81f7-53e27a68dfb0.png)
