### PR TITLE
fix(heater-shaker-sim): Add missing exit catch

### DIFF
--- a/stm32-modules/heater-shaker/simulator/system_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/system_thread.cpp
@@ -27,7 +27,11 @@ auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb) -> void {
     auto policy = SimSystemPolicy();
     tcb->queue.set_stop_token(st);
     while (!st.stop_requested()) {
-        tcb->task.run_once(policy);
+        try {
+            tcb->task.run_once(policy);
+        } catch (const SimSystemTask::Queue::StopDuringMsgWait sdmw) {
+            return;
+        }
     }
 }
 


### PR DESCRIPTION
This exception is raised when we try and quit during a time when we're
not at the top level of the thread, and it has to be in all the threads,
and it was missing in system.