### PR TITLE
feat(heater_shaker): Add socket communication in simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ build-stm32-host/
 
 # Custom CMake Config
 /CMakeUserPresets.json
+
+# Clion Config
+.idea*

--- a/stm32-modules/heater-shaker/include/simulator/cli_parser.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/cli_parser.hpp
@@ -1,0 +1,8 @@
+#include <string>
+
+
+
+namespace cli_parser {
+    enum SimType {STDIN, SOCKET};
+    SimType get_sim_type(int, char**);
+}

--- a/stm32-modules/heater-shaker/include/simulator/cli_parser.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/cli_parser.hpp
@@ -1,8 +1,8 @@
-#include <string>
 #include <memory>
+#include <string>
+
 #include "simulator/sim_driver.hpp"
 
-
 namespace cli_parser {
-    sim_driver::SimDriver* get_sim_driver(int, char**);
+sim_driver::SimDriver* get_sim_driver(int, char**);
 }

--- a/stm32-modules/heater-shaker/include/simulator/cli_parser.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/cli_parser.hpp
@@ -1,8 +1,8 @@
 #include <string>
-
+#include <memory>
+#include "simulator/sim_driver.hpp"
 
 
 namespace cli_parser {
-    enum SimType {STDIN, SOCKET};
-    SimType get_sim_type(int, char**);
+    sim_driver::SimDriver* get_sim_driver(int, char**);
 }

--- a/stm32-modules/heater-shaker/include/simulator/cli_parser.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/cli_parser.hpp
@@ -4,5 +4,5 @@
 #include "simulator/sim_driver.hpp"
 
 namespace cli_parser {
-std::unique_ptr<sim_driver::SimDriver> get_sim_driver(int, char**);
+std::shared_ptr<sim_driver::SimDriver> get_sim_driver(int, char**);
 }

--- a/stm32-modules/heater-shaker/include/simulator/cli_parser.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/cli_parser.hpp
@@ -4,5 +4,5 @@
 #include "simulator/sim_driver.hpp"
 
 namespace cli_parser {
-sim_driver::SimDriver* get_sim_driver(int, char**);
+std::unique_ptr<sim_driver::SimDriver> get_sim_driver(int, char**);
 }

--- a/stm32-modules/heater-shaker/include/simulator/comm_thread.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/comm_thread.hpp
@@ -10,7 +10,8 @@
 namespace comm_thread {
 using SimCommTask = host_comms_task::HostCommsTask<SimulatorMessageQueue>;
 struct TaskControlBlock;
-auto build(std::shared_ptr<sim_driver::SimDriver>&&) -> tasks::Task<std::unique_ptr<std::jthread>, SimCommTask>;
+auto build(std::shared_ptr<sim_driver::SimDriver>&&)
+    -> tasks::Task<std::unique_ptr<std::jthread>, SimCommTask>;
 void handle_input(std::shared_ptr<sim_driver::SimDriver>&& driver,
                   tasks::Tasks<SimulatorMessageQueue>& tasks);
 };  // namespace comm_thread

--- a/stm32-modules/heater-shaker/include/simulator/comm_thread.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/comm_thread.hpp
@@ -10,7 +10,7 @@
 namespace comm_thread {
 using SimCommTask = host_comms_task::HostCommsTask<SimulatorMessageQueue>;
 struct TaskControlBlock;
-auto build() -> tasks::Task<std::unique_ptr<std::jthread>, SimCommTask>;
-void handle_input(std::unique_ptr<sim_driver::SimDriver>&& driver,
+auto build(std::shared_ptr<sim_driver::SimDriver>&&) -> tasks::Task<std::unique_ptr<std::jthread>, SimCommTask>;
+void handle_input(std::shared_ptr<sim_driver::SimDriver>&& driver,
                   tasks::Tasks<SimulatorMessageQueue>& tasks);
 };  // namespace comm_thread

--- a/stm32-modules/heater-shaker/include/simulator/comm_thread.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/comm_thread.hpp
@@ -4,13 +4,13 @@
 
 #include "heater-shaker/host_comms_task.hpp"
 #include "heater-shaker/tasks.hpp"
-#include "simulator/simulator_queue.hpp"
 #include "simulator/sim_driver.hpp"
-
+#include "simulator/simulator_queue.hpp"
 
 namespace comm_thread {
 using SimCommTask = host_comms_task::HostCommsTask<SimulatorMessageQueue>;
 struct TaskControlBlock;
 auto build() -> tasks::Task<std::unique_ptr<std::jthread>, SimCommTask>;
-void handle_input(sim_driver::SimDriver* driver, tasks::Tasks<SimulatorMessageQueue>& tasks);
+void handle_input(sim_driver::SimDriver* driver,
+                  tasks::Tasks<SimulatorMessageQueue>& tasks);
 };  // namespace comm_thread

--- a/stm32-modules/heater-shaker/include/simulator/comm_thread.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/comm_thread.hpp
@@ -5,10 +5,12 @@
 #include "heater-shaker/host_comms_task.hpp"
 #include "heater-shaker/tasks.hpp"
 #include "simulator/simulator_queue.hpp"
+#include "simulator/sim_driver.hpp"
+
 
 namespace comm_thread {
 using SimCommTask = host_comms_task::HostCommsTask<SimulatorMessageQueue>;
 struct TaskControlBlock;
 auto build() -> tasks::Task<std::unique_ptr<std::jthread>, SimCommTask>;
-auto handle_input(tasks::Tasks<SimulatorMessageQueue>& tasks) -> void;
+void handle_input(sim_driver::SimDriver* driver, tasks::Tasks<SimulatorMessageQueue>& tasks);
 };  // namespace comm_thread

--- a/stm32-modules/heater-shaker/include/simulator/comm_thread.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/comm_thread.hpp
@@ -11,6 +11,6 @@ namespace comm_thread {
 using SimCommTask = host_comms_task::HostCommsTask<SimulatorMessageQueue>;
 struct TaskControlBlock;
 auto build() -> tasks::Task<std::unique_ptr<std::jthread>, SimCommTask>;
-void handle_input(sim_driver::SimDriver* driver,
+void handle_input(std::unique_ptr<sim_driver::SimDriver>&& driver,
                   tasks::Tasks<SimulatorMessageQueue>& tasks);
 };  // namespace comm_thread

--- a/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#include "heater-shaker/host_comms_task.hpp"
+#include "heater-shaker/messages.hpp"
+#include "heater-shaker/tasks.hpp"
+
+
+namespace sim_driver {
+    const std::string SOCKET_DRIVER_NAME = "Socket";
+    const std::string STDIN_DRIVER_NAME = "Stdin";
+    class SimDriver {
+        std::string name;
+
+        public:
+            virtual std::string get_name() = 0;
+            virtual void write() = 0;
+            virtual std::string read() = 0;
+    };
+
+    class SocketSimDriver: public SimDriver {
+        std::string name = SOCKET_DRIVER_NAME;
+        std::string host;
+        int port;
+
+        public:
+            SocketSimDriver(std::string);
+            std::string get_host();
+            int get_port();
+            std::string get_name();
+            void write();
+            std::string read();
+    };
+
+    class StdinSimDriver: public SimDriver {
+        std::string name = STDIN_DRIVER_NAME;
+        public:
+            StdinSimDriver();
+            std::string get_name();
+            void write();
+            std::string read();
+    };
+}

--- a/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
@@ -12,4 +12,4 @@ class SimDriver {
     virtual void write(std::string message) = 0;
     virtual void read(tasks::Tasks<SimulatorMessageQueue>& tasks) = 0;
 };
-}
+}  // namespace sim_driver

--- a/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
@@ -12,28 +12,4 @@ class SimDriver {
     virtual void write() = 0;
     virtual void read(tasks::Tasks<SimulatorMessageQueue>& tasks) = 0;
 };
-
-class SocketSimDriver : public SimDriver {
-    static const std::string name;
-    std::string host;
-    int port;
-
-  public:
-    SocketSimDriver(std::string);
-    std::string get_host();
-    int get_port();
-    const std::string& get_name() const;
-    void write();
-    void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
-};
-
-class StdinSimDriver : public SimDriver {
-    static const std::string name;
-
-  public:
-    StdinSimDriver();
-    const std::string& get_name() const;
-    void write();
-    void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
-};
-}  // namespace sim_driver
+}

--- a/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
@@ -7,7 +7,6 @@
 namespace sim_driver {
 
 class SimDriver {
-
   public:
     virtual const std::string& get_name() const = 0;
     virtual void write() = 0;

--- a/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
@@ -4,39 +4,39 @@
 #include "heater-shaker/tasks.hpp"
 #include "simulator/simulator_queue.hpp"
 
-
 namespace sim_driver {
-    const std::string SOCKET_DRIVER_NAME = "Socket";
-    const std::string STDIN_DRIVER_NAME = "Stdin";
-    class SimDriver {
-        std::string name;
+const std::string SOCKET_DRIVER_NAME = "Socket";
+const std::string STDIN_DRIVER_NAME = "Stdin";
+class SimDriver {
+    std::string name;
 
-        public:
-            virtual std::string get_name() = 0;
-            virtual void write() = 0;
-            virtual void read(tasks::Tasks<SimulatorMessageQueue>& tasks) = 0;
-    };
+  public:
+    virtual std::string get_name() = 0;
+    virtual void write() = 0;
+    virtual void read(tasks::Tasks<SimulatorMessageQueue>& tasks) = 0;
+};
 
-    class SocketSimDriver: public SimDriver {
-        std::string name = SOCKET_DRIVER_NAME;
-        std::string host;
-        int port;
+class SocketSimDriver : public SimDriver {
+    std::string name = SOCKET_DRIVER_NAME;
+    std::string host;
+    int port;
 
-        public:
-            SocketSimDriver(std::string);
-            std::string get_host();
-            int get_port();
-            std::string get_name();
-            void write();
-            void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
-    };
+  public:
+    SocketSimDriver(std::string);
+    std::string get_host();
+    int get_port();
+    std::string get_name();
+    void write();
+    void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
+};
 
-    class StdinSimDriver: public SimDriver {
-        std::string name = STDIN_DRIVER_NAME;
-        public:
-            StdinSimDriver();
-            std::string get_name();
-            void write();
-            void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
-    };
-}
+class StdinSimDriver : public SimDriver {
+    std::string name = STDIN_DRIVER_NAME;
+
+  public:
+    StdinSimDriver();
+    std::string get_name();
+    void write();
+    void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
+};
+}  // namespace sim_driver

--- a/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
@@ -5,18 +5,17 @@
 #include "simulator/simulator_queue.hpp"
 
 namespace sim_driver {
-const std::string SOCKET_DRIVER_NAME = "Socket";
-const std::string STDIN_DRIVER_NAME = "Stdin";
+
 class SimDriver {
 
   public:
-    virtual const std::string& get_name() const = 0
+    virtual const std::string& get_name() const = 0;
     virtual void write() = 0;
     virtual void read(tasks::Tasks<SimulatorMessageQueue>& tasks) = 0;
 };
 
 class SocketSimDriver : public SimDriver {
-    std::string name = SOCKET_DRIVER_NAME;
+    static const std::string name;
     std::string host;
     int port;
 
@@ -24,17 +23,17 @@ class SocketSimDriver : public SimDriver {
     SocketSimDriver(std::string);
     std::string get_host();
     int get_port();
-    std::string get_name();
+    const std::string& get_name() const;
     void write();
     void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
 };
 
 class StdinSimDriver : public SimDriver {
-    std::string name = STDIN_DRIVER_NAME;
+    static const std::string name;
 
   public:
     StdinSimDriver();
-    std::string get_name();
+    const std::string& get_name() const;
     void write();
     void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
 };

--- a/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
@@ -8,10 +8,9 @@ namespace sim_driver {
 const std::string SOCKET_DRIVER_NAME = "Socket";
 const std::string STDIN_DRIVER_NAME = "Stdin";
 class SimDriver {
-    std::string name;
 
   public:
-    virtual std::string get_name() = 0;
+    virtual const std::string& get_name() const = 0
     virtual void write() = 0;
     virtual void read(tasks::Tasks<SimulatorMessageQueue>& tasks) = 0;
 };

--- a/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
@@ -2,6 +2,7 @@
 #include "heater-shaker/host_comms_task.hpp"
 #include "heater-shaker/messages.hpp"
 #include "heater-shaker/tasks.hpp"
+#include "simulator/simulator_queue.hpp"
 
 
 namespace sim_driver {
@@ -13,7 +14,7 @@ namespace sim_driver {
         public:
             virtual std::string get_name() = 0;
             virtual void write() = 0;
-            virtual std::string read() = 0;
+            virtual void read(tasks::Tasks<SimulatorMessageQueue>& tasks) = 0;
     };
 
     class SocketSimDriver: public SimDriver {
@@ -27,7 +28,7 @@ namespace sim_driver {
             int get_port();
             std::string get_name();
             void write();
-            std::string read();
+            void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
     };
 
     class StdinSimDriver: public SimDriver {
@@ -36,6 +37,6 @@ namespace sim_driver {
             StdinSimDriver();
             std::string get_name();
             void write();
-            std::string read();
+            void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
     };
 }

--- a/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
@@ -9,7 +9,7 @@ namespace sim_driver {
 class SimDriver {
   public:
     virtual const std::string& get_name() const = 0;
-    virtual void write() = 0;
+    virtual void write(std::string message) = 0;
     virtual void read(tasks::Tasks<SimulatorMessageQueue>& tasks) = 0;
 };
 }

--- a/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/sim_driver.hpp
@@ -9,7 +9,7 @@ namespace sim_driver {
 class SimDriver {
   public:
     virtual const std::string& get_name() const = 0;
-    virtual void write(std::string message) = 0;
+    virtual void write(const std::string& message) = 0;
     virtual void read(tasks::Tasks<SimulatorMessageQueue>& tasks) = 0;
 };
 }  // namespace sim_driver

--- a/stm32-modules/heater-shaker/include/simulator/socket_sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/socket_sim_driver.hpp
@@ -1,10 +1,11 @@
 #pragma once
+#include <boost/asio.hpp>
+
 #include "heater-shaker/host_comms_task.hpp"
 #include "heater-shaker/messages.hpp"
 #include "heater-shaker/tasks.hpp"
 #include "simulator/sim_driver.hpp"
 #include "simulator/simulator_queue.hpp"
-#include <boost/asio.hpp>
 
 namespace socket_sim_driver {
 

--- a/stm32-modules/heater-shaker/include/simulator/socket_sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/socket_sim_driver.hpp
@@ -4,6 +4,7 @@
 #include "heater-shaker/tasks.hpp"
 #include "simulator/sim_driver.hpp"
 #include "simulator/simulator_queue.hpp"
+#include <boost/asio.hpp>
 
 namespace socket_sim_driver {
 
@@ -15,12 +16,15 @@ struct AddressInfo {
 class SocketSimDriver : public sim_driver::SimDriver {
     static const std::string name;
     AddressInfo address_info;
+    std::unique_ptr<boost::asio::ip::tcp::socket> s;
 
   public:
     SocketSimDriver(std::string);
     std::string get_host();
     int get_port();
     const std::string& get_name() const;
+    std::unique_ptr<boost::asio::ip::tcp::socket> get_socket();
+
     void write(std::string message);
     void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
 };

--- a/stm32-modules/heater-shaker/include/simulator/socket_sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/socket_sim_driver.hpp
@@ -21,12 +21,11 @@ class SocketSimDriver : public sim_driver::SimDriver {
 
   public:
     SocketSimDriver(std::string);
-    std::string get_host();
-    int get_port();
+    const std::string& get_host() const;
+    int get_port() const;
     const std::string& get_name() const;
-    std::unique_ptr<boost::asio::ip::tcp::socket> get_socket();
 
-    void write(std::string message);
+    void write(const std::string& message);
     void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
 };
 }  // namespace socket_sim_driver

--- a/stm32-modules/heater-shaker/include/simulator/socket_sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/socket_sim_driver.hpp
@@ -21,7 +21,7 @@ class SocketSimDriver : public sim_driver::SimDriver {
     std::string get_host();
     int get_port();
     const std::string& get_name() const;
-    void write();
+    void write(std::string message);
     void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
 };
 }  // namespace socket_sim_driver

--- a/stm32-modules/heater-shaker/include/simulator/socket_sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/socket_sim_driver.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include "heater-shaker/host_comms_task.hpp"
+#include "heater-shaker/messages.hpp"
+#include "heater-shaker/tasks.hpp"
+#include "simulator/sim_driver.hpp"
+#include "simulator/simulator_queue.hpp"
+
+namespace socket_sim_driver {
+
+class SocketSimDriver : public sim_driver::SimDriver {
+    static const std::string name;
+    std::string host;
+    int port;
+
+  public:
+    SocketSimDriver(std::string);
+    std::string get_host();
+    int get_port();
+    const std::string& get_name() const;
+    void write();
+    void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
+};
+}  // namespace socket_sim_driver

--- a/stm32-modules/heater-shaker/include/simulator/socket_sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/socket_sim_driver.hpp
@@ -7,10 +7,14 @@
 
 namespace socket_sim_driver {
 
-class SocketSimDriver : public sim_driver::SimDriver {
-    static const std::string name;
+struct AddressInfo {
     std::string host;
     int port;
+};
+
+class SocketSimDriver : public sim_driver::SimDriver {
+    static const std::string name;
+    AddressInfo address_info;
 
   public:
     SocketSimDriver(std::string);

--- a/stm32-modules/heater-shaker/include/simulator/stdin_sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/stdin_sim_driver.hpp
@@ -12,7 +12,7 @@ class StdinSimDriver : public sim_driver::SimDriver {
   public:
     StdinSimDriver();
     const std::string& get_name() const;
-    void write();
+    void write(std::string message);
     void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
 };
 }  // namespace stdin_sim_driver

--- a/stm32-modules/heater-shaker/include/simulator/stdin_sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/stdin_sim_driver.hpp
@@ -12,7 +12,7 @@ class StdinSimDriver : public sim_driver::SimDriver {
   public:
     StdinSimDriver();
     const std::string& get_name() const;
-    void write(std::string message);
+    void write(const std::string& message);
     void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
 };
 }  // namespace stdin_sim_driver

--- a/stm32-modules/heater-shaker/include/simulator/stdin_sim_driver.hpp
+++ b/stm32-modules/heater-shaker/include/simulator/stdin_sim_driver.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "heater-shaker/host_comms_task.hpp"
+#include "heater-shaker/messages.hpp"
+#include "heater-shaker/tasks.hpp"
+#include "simulator/sim_driver.hpp"
+#include "simulator/simulator_queue.hpp"
+
+namespace stdin_sim_driver {
+class StdinSimDriver : public sim_driver::SimDriver {
+    static const std::string name;
+
+  public:
+    StdinSimDriver();
+    const std::string& get_name() const;
+    void write();
+    void read(tasks::Tasks<SimulatorMessageQueue>& tasks);
+};
+}  // namespace stdin_sim_driver

--- a/stm32-modules/heater-shaker/simulator/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/simulator/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(heater-shaker-simulator
   system_thread.cpp
   main.cpp)
 
-target_link_libraries(heater-shaker-simulator PRIVATE heater-shaker-core Boost::boost pthread)
+target_link_libraries(heater-shaker-simulator PRIVATE heater-shaker-core Boost::boost Boost::program_options pthread)
 target_include_directories(heater-shaker-simulator PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 

--- a/stm32-modules/heater-shaker/simulator/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/simulator/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(heater-shaker-simulator
   motor_thread.cpp
   heater_thread.cpp
   system_thread.cpp
+  cli_parser.cpp
   main.cpp)
 
 target_link_libraries(heater-shaker-simulator PRIVATE heater-shaker-core Boost::boost Boost::program_options pthread)

--- a/stm32-modules/heater-shaker/simulator/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/simulator/CMakeLists.txt
@@ -1,13 +1,23 @@
 find_package(Boost 1.71.0)
-add_executable(heater-shaker-simulator
-  comm_thread.cpp
-  motor_thread.cpp
-  heater_thread.cpp
-  system_thread.cpp
-  cli_parser.cpp
-  main.cpp)
+add_executable(
+        heater-shaker-simulator
+        comm_thread.cpp
+        motor_thread.cpp
+        heater_thread.cpp
+        system_thread.cpp
+        cli_parser.cpp
+        main.cpp
+        sim_driver.cpp
+)
 
-target_link_libraries(heater-shaker-simulator PRIVATE heater-shaker-core Boost::boost Boost::program_options pthread)
+target_link_libraries(
+        heater-shaker-simulator
+        PRIVATE
+        heater-shaker-core
+        Boost::boost
+        Boost::program_options
+        pthread
+)
 target_include_directories(heater-shaker-simulator PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 

--- a/stm32-modules/heater-shaker/simulator/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/simulator/CMakeLists.txt
@@ -7,7 +7,8 @@ add_executable(
         system_thread.cpp
         cli_parser.cpp
         main.cpp
-        sim_driver.cpp
+        socket_sim_driver.cpp
+        stdin_sim_driver.cpp
 )
 
 target_link_libraries(

--- a/stm32-modules/heater-shaker/simulator/cli_parser.cpp
+++ b/stm32-modules/heater-shaker/simulator/cli_parser.cpp
@@ -5,19 +5,19 @@
 using namespace cli_parser;
 
 void no_options_specified_error(boost::program_options::options_description desc) {
-    std::cout << std::endl << "ERROR: You must provide either the --stdin OR the --socket option." << std::endl << std::endl;
+    std::cerr << std::endl << "ERROR: You must provide either the --stdin OR the --socket option." << std::endl << std::endl;
     std::cout << desc << std::endl;
     exit(1);
 }
 
 void both_drivers_specified_error(boost::program_options::options_description desc) {
-    std::cout << std::endl << "ERROR: You may only provide either the --stdin OR the --socket option, not both." << std::endl << std::endl;
+    std::cerr << std::endl << "ERROR: You may only provide either the --stdin OR the --socket option, not both." << std::endl << std::endl;
     std::cout << desc << std::endl;
     exit(1);
 }
 
 void neither_driver_error(boost::program_options::options_description desc) {
-    std::cout << std::endl << "ERROR: Neither --socket or --stdin was specified";
+    std::cerr << std::endl << "ERROR: Neither --socket or --stdin was specified";
     std::cout << desc << std::endl;
     exit(1);
 }

--- a/stm32-modules/heater-shaker/simulator/cli_parser.cpp
+++ b/stm32-modules/heater-shaker/simulator/cli_parser.cpp
@@ -1,6 +1,8 @@
 #include "simulator/cli_parser.hpp"
 #include <boost/program_options.hpp>
 #include <iostream>
+#include "simulator/sim_driver.hpp"
+
 
 using namespace cli_parser;
 
@@ -22,7 +24,7 @@ void neither_driver_error(boost::program_options::options_description desc) {
     exit(1);
 }
 
-cli_parser::SimType cli_parser::get_sim_type(int num_args, char *args[]) {
+sim_driver::SimDriver* cli_parser::get_sim_driver(int num_args, char *args[]) {
     bool use_stdin = false;
     bool use_socket = false;
     bool options_specified = num_args > 1;
@@ -51,11 +53,12 @@ cli_parser::SimType cli_parser::get_sim_type(int num_args, char *args[]) {
     if (num_args <= 1) { no_options_specified_error(desc); }
     if (use_stdin && use_socket) { both_drivers_specified_error(desc); }
 
-    cli_parser::SimType sim_type;
+    sim_driver::SimDriver* sim_driver;
 
-    if (use_stdin) { sim_type = STDIN; }
-    else if (use_socket) { sim_type = SOCKET; }
-    else { neither_driver_error(); }
+    if (use_stdin) { sim_driver = new sim_driver::StdinSimDriver(); }
+    else if (use_socket) { sim_driver = new sim_driver::SocketSimDriver(vm["socket"].as<std::string>()); }
+    else { neither_driver_error(desc); }
 
-    return sim_type;
+    return sim_driver;
+
 }

--- a/stm32-modules/heater-shaker/simulator/cli_parser.cpp
+++ b/stm32-modules/heater-shaker/simulator/cli_parser.cpp
@@ -4,6 +4,8 @@
 #include <iostream>
 
 #include "simulator/sim_driver.hpp"
+#include "simulator/socket_sim_driver.hpp"
+#include "simulator/stdin_sim_driver.hpp"
 
 using namespace cli_parser;
 
@@ -81,10 +83,10 @@ sim_driver::SimDriver* cli_parser::get_sim_driver(int num_args, char* args[]) {
     sim_driver::SimDriver* sim_driver;
 
     if (use_stdin) {
-        sim_driver = new sim_driver::StdinSimDriver();
+        sim_driver = new stdin_sim_driver::StdinSimDriver();
     } else if (use_socket) {
-        sim_driver =
-            new sim_driver::SocketSimDriver(vm["socket"].as<std::string>());
+        sim_driver = new socket_sim_driver::SocketSimDriver(
+            vm["socket"].as<std::string>());
     } else {
         neither_driver_error(desc);
     }

--- a/stm32-modules/heater-shaker/simulator/cli_parser.cpp
+++ b/stm32-modules/heater-shaker/simulator/cli_parser.cpp
@@ -1,64 +1,92 @@
 #include "simulator/cli_parser.hpp"
+
 #include <boost/program_options.hpp>
 #include <iostream>
-#include "simulator/sim_driver.hpp"
 
+#include "simulator/sim_driver.hpp"
 
 using namespace cli_parser;
 
-void no_options_specified_error(boost::program_options::options_description desc) {
-    std::cerr << std::endl << "ERROR: You must provide either the --stdin OR the --socket option." << std::endl << std::endl;
+void no_options_specified_error(
+    boost::program_options::options_description desc) {
+    std::cerr
+        << std::endl
+        << "ERROR: You must provide either the --stdin OR the --socket option."
+        << std::endl
+        << std::endl;
     std::cout << desc << std::endl;
     exit(1);
 }
 
-void both_drivers_specified_error(boost::program_options::options_description desc) {
-    std::cerr << std::endl << "ERROR: You may only provide either the --stdin OR the --socket option, not both." << std::endl << std::endl;
+void both_drivers_specified_error(
+    boost::program_options::options_description desc) {
+    std::cerr << std::endl
+              << "ERROR: You may only provide either the --stdin OR the "
+                 "--socket option, not both."
+              << std::endl
+              << std::endl;
     std::cout << desc << std::endl;
     exit(1);
 }
 
 void neither_driver_error(boost::program_options::options_description desc) {
-    std::cerr << std::endl << "ERROR: Neither --socket or --stdin was specified";
+    std::cerr << std::endl
+              << "ERROR: Neither --socket or --stdin was specified";
     std::cout << desc << std::endl;
     exit(1);
 }
 
-sim_driver::SimDriver* cli_parser::get_sim_driver(int num_args, char *args[]) {
+sim_driver::SimDriver* cli_parser::get_sim_driver(int num_args, char* args[]) {
     bool use_stdin = false;
     bool use_socket = false;
     bool options_specified = num_args > 1;
 
     boost::program_options::options_description desc("Allowed options");
-    desc.add_options()
-            ("help", "Show this help message")
-            ("stdin", boost::program_options::bool_switch(&use_stdin), "Use stdin to provide G-Codes")
-            ("socket", boost::program_options::value<std::string>(), "Use socket to provide G-Codes")
-            ;
+    desc.add_options()("help", "Show this help message")(
+        "stdin", boost::program_options::bool_switch(&use_stdin),
+        "Use stdin to provide G-Codes")("socket",
+                                        boost::program_options::value<
+                                            std::string>(),
+                                        "Use socket to provide G-Codes");
 
     boost::program_options::variables_map vm;
     /*
-     * Have to do this long crazy parser creation to make sure that partial options are not accepted.
-     * For instance, `--std` was being accepted as --stdin, and that's super confusing
+     * Have to do this long crazy parser creation to make sure that partial
+     * options are not accepted. For instance, `--std` was being accepted as
+     * --stdin, and that's super confusing
      */
-    auto parser = boost::program_options::command_line_parser(num_args, args)
+    auto parser =
+        boost::program_options::command_line_parser(num_args, args)
             .options(desc)
-            .style(boost::program_options::command_line_style::default_style & ~boost::program_options::command_line_style::allow_guessing)
+            .style(boost::program_options::command_line_style::default_style &
+                   ~boost::program_options::command_line_style::allow_guessing)
             .run();
     boost::program_options::store(parser, vm);
     boost::program_options::notify(vm);
 
-    if (vm.count("help")) { std::cout << desc << std::endl; }
-    if (vm.count("socket")) { use_socket = true; }
-    if (num_args <= 1) { no_options_specified_error(desc); }
-    if (use_stdin && use_socket) { both_drivers_specified_error(desc); }
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+    }
+    if (vm.count("socket")) {
+        use_socket = true;
+    }
+    if (num_args <= 1) {
+        no_options_specified_error(desc);
+    }
+    if (use_stdin && use_socket) {
+        both_drivers_specified_error(desc);
+    }
 
     sim_driver::SimDriver* sim_driver;
 
-    if (use_stdin) { sim_driver = new sim_driver::StdinSimDriver(); }
-    else if (use_socket) { sim_driver = new sim_driver::SocketSimDriver(vm["socket"].as<std::string>()); }
-    else { neither_driver_error(desc); }
+    if (use_stdin) {
+        sim_driver = new sim_driver::StdinSimDriver();
+    } else if (use_socket) {
+        sim_driver =
+            new sim_driver::SocketSimDriver(vm["socket"].as<std::string>());
+    } else {
+        neither_driver_error(desc);
+    }
 
     return sim_driver;
-
 }

--- a/stm32-modules/heater-shaker/simulator/cli_parser.cpp
+++ b/stm32-modules/heater-shaker/simulator/cli_parser.cpp
@@ -3,6 +3,7 @@
 #include <boost/program_options.hpp>
 #include <iostream>
 #include <memory>
+
 #include "simulator/sim_driver.hpp"
 #include "simulator/socket_sim_driver.hpp"
 #include "simulator/stdin_sim_driver.hpp"
@@ -39,7 +40,8 @@ using namespace cli_parser;
     exit(1);
 }
 
-std::unique_ptr<sim_driver::SimDriver> cli_parser::get_sim_driver(int num_args, char* args[]) {
+std::unique_ptr<sim_driver::SimDriver> cli_parser::get_sim_driver(
+    int num_args, char* args[]) {
     bool use_stdin = false;
     bool use_socket = false;
     bool options_specified = num_args > 1;
@@ -83,7 +85,8 @@ std::unique_ptr<sim_driver::SimDriver> cli_parser::get_sim_driver(int num_args, 
     if (use_stdin) {
         return std::make_unique<stdin_sim_driver::StdinSimDriver>();
     } else if (use_socket) {
-        return std::make_unique<socket_sim_driver::SocketSimDriver>(vm["socket"].as<std::string>());
+        return std::make_unique<socket_sim_driver::SocketSimDriver>(
+            vm["socket"].as<std::string>());
     } else {
         neither_driver_error(desc);
     }

--- a/stm32-modules/heater-shaker/simulator/cli_parser.cpp
+++ b/stm32-modules/heater-shaker/simulator/cli_parser.cpp
@@ -29,7 +29,8 @@ using namespace cli_parser;
     exit(1);
 }
 
-[[noreturn]] void neither_driver_error(boost::program_options::options_description desc) {
+[[noreturn]] void neither_driver_error(
+    boost::program_options::options_description desc) {
     std::cerr << std::endl
               << "ERROR: Neither --socket or --stdin was specified";
     std::cerr << desc << std::endl;

--- a/stm32-modules/heater-shaker/simulator/cli_parser.cpp
+++ b/stm32-modules/heater-shaker/simulator/cli_parser.cpp
@@ -2,7 +2,7 @@
 
 #include <boost/program_options.hpp>
 #include <iostream>
-
+#include <memory>
 #include "simulator/sim_driver.hpp"
 #include "simulator/socket_sim_driver.hpp"
 #include "simulator/stdin_sim_driver.hpp"
@@ -39,7 +39,7 @@ using namespace cli_parser;
     exit(1);
 }
 
-sim_driver::SimDriver* cli_parser::get_sim_driver(int num_args, char* args[]) {
+std::unique_ptr<sim_driver::SimDriver> cli_parser::get_sim_driver(int num_args, char* args[]) {
     bool use_stdin = false;
     bool use_socket = false;
     bool options_specified = num_args > 1;
@@ -80,16 +80,11 @@ sim_driver::SimDriver* cli_parser::get_sim_driver(int num_args, char* args[]) {
         both_drivers_specified_error(desc);
     }
 
-    sim_driver::SimDriver* sim_driver;
-
     if (use_stdin) {
-        sim_driver = new stdin_sim_driver::StdinSimDriver();
+        return std::make_unique<stdin_sim_driver::StdinSimDriver>();
     } else if (use_socket) {
-        sim_driver = new socket_sim_driver::SocketSimDriver(
-            vm["socket"].as<std::string>());
+        return std::make_unique<socket_sim_driver::SocketSimDriver>(vm["socket"].as<std::string>());
     } else {
         neither_driver_error(desc);
     }
-
-    return sim_driver;
 }

--- a/stm32-modules/heater-shaker/simulator/cli_parser.cpp
+++ b/stm32-modules/heater-shaker/simulator/cli_parser.cpp
@@ -40,7 +40,7 @@ using namespace cli_parser;
     exit(1);
 }
 
-std::unique_ptr<sim_driver::SimDriver> cli_parser::get_sim_driver(
+std::shared_ptr<sim_driver::SimDriver> cli_parser::get_sim_driver(
     int num_args, char* args[]) {
     bool use_stdin = false;
     bool use_socket = false;
@@ -83,9 +83,9 @@ std::unique_ptr<sim_driver::SimDriver> cli_parser::get_sim_driver(
     }
 
     if (use_stdin) {
-        return std::make_unique<stdin_sim_driver::StdinSimDriver>();
+        return std::make_shared<stdin_sim_driver::StdinSimDriver>();
     } else if (use_socket) {
-        return std::make_unique<socket_sim_driver::SocketSimDriver>(
+        return std::make_shared<socket_sim_driver::SocketSimDriver>(
             vm["socket"].as<std::string>());
     } else {
         neither_driver_error(desc);

--- a/stm32-modules/heater-shaker/simulator/cli_parser.cpp
+++ b/stm32-modules/heater-shaker/simulator/cli_parser.cpp
@@ -7,32 +7,32 @@
 
 using namespace cli_parser;
 
-void no_options_specified_error(
+[[noreturn]] void no_options_specified_error(
     boost::program_options::options_description desc) {
     std::cerr
         << std::endl
         << "ERROR: You must provide either the --stdin OR the --socket option."
         << std::endl
         << std::endl;
-    std::cout << desc << std::endl;
+    std::cerr << desc << std::endl;
     exit(1);
 }
 
-void both_drivers_specified_error(
+[[noreturn]] void both_drivers_specified_error(
     boost::program_options::options_description desc) {
     std::cerr << std::endl
               << "ERROR: You may only provide either the --stdin OR the "
                  "--socket option, not both."
               << std::endl
               << std::endl;
-    std::cout << desc << std::endl;
+    std::cerr << desc << std::endl;
     exit(1);
 }
 
-void neither_driver_error(boost::program_options::options_description desc) {
+[[noreturn]] void neither_driver_error(boost::program_options::options_description desc) {
     std::cerr << std::endl
               << "ERROR: Neither --socket or --stdin was specified";
-    std::cout << desc << std::endl;
+    std::cerr << desc << std::endl;
     exit(1);
 }
 

--- a/stm32-modules/heater-shaker/simulator/cli_parser.cpp
+++ b/stm32-modules/heater-shaker/simulator/cli_parser.cpp
@@ -1,0 +1,61 @@
+#include "simulator/cli_parser.hpp"
+#include <boost/program_options.hpp>
+#include <iostream>
+
+using namespace cli_parser;
+
+void no_options_specified_error(boost::program_options::options_description desc) {
+    std::cout << std::endl << "ERROR: You must provide either the --stdin OR the --socket option." << std::endl << std::endl;
+    std::cout << desc << std::endl;
+    exit(1);
+}
+
+void both_drivers_specified_error(boost::program_options::options_description desc) {
+    std::cout << std::endl << "ERROR: You may only provide either the --stdin OR the --socket option, not both." << std::endl << std::endl;
+    std::cout << desc << std::endl;
+    exit(1);
+}
+
+void neither_driver_error(boost::program_options::options_description desc) {
+    std::cout << std::endl << "ERROR: Neither --socket or --stdin was specified";
+    std::cout << desc << std::endl;
+    exit(1);
+}
+
+cli_parser::SimType cli_parser::get_sim_type(int num_args, char *args[]) {
+    bool use_stdin = false;
+    bool use_socket = false;
+    bool options_specified = num_args > 1;
+
+    boost::program_options::options_description desc("Allowed options");
+    desc.add_options()
+            ("help", "Show this help message")
+            ("stdin", boost::program_options::bool_switch(&use_stdin), "Use stdin to provide G-Codes")
+            ("socket", boost::program_options::value<std::string>(), "Use socket to provide G-Codes")
+            ;
+
+    boost::program_options::variables_map vm;
+    /*
+     * Have to do this long crazy parser creation to make sure that partial options are not accepted.
+     * For instance, `--std` was being accepted as --stdin, and that's super confusing
+     */
+    auto parser = boost::program_options::command_line_parser(num_args, args)
+            .options(desc)
+            .style(boost::program_options::command_line_style::default_style & ~boost::program_options::command_line_style::allow_guessing)
+            .run();
+    boost::program_options::store(parser, vm);
+    boost::program_options::notify(vm);
+
+    if (vm.count("help")) { std::cout << desc << std::endl; }
+    if (vm.count("socket")) { use_socket = true; }
+    if (num_args <= 1) { no_options_specified_error(desc); }
+    if (use_stdin && use_socket) { both_drivers_specified_error(desc); }
+
+    cli_parser::SimType sim_type;
+
+    if (use_stdin) { sim_type = STDIN; }
+    else if (use_socket) { sim_type = SOCKET; }
+    else { neither_driver_error(); }
+
+    return sim_type;
+}

--- a/stm32-modules/heater-shaker/simulator/comm_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/comm_thread.cpp
@@ -10,6 +10,8 @@
 #include "heater-shaker/host_comms_task.hpp"
 #include "heater-shaker/messages.hpp"
 #include "heater-shaker/tasks.hpp"
+#include "simulator/sim_driver.hpp"
+
 
 using namespace comm_thread;
 
@@ -21,6 +23,7 @@ struct comm_thread::TaskControlBlock {
 };
 
 auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb) -> void {
+    std::cout << "Running" << std::endl;
     tcb->queue.set_stop_token(st);
     std::string buffer(1024, 'c');
     while (!st.stop_requested()) {
@@ -39,38 +42,6 @@ auto comm_thread::build()
     return tasks::Task{std::make_unique<std::jthread>(run, tcb), &tcb->task};
 }
 
-auto comm_thread::handle_input(tasks::Tasks<SimulatorMessageQueue>& tasks)
--> void {
-    boost::asio::io_service io_context;
-
-    boost::asio::ip::tcp::socket mysocket(io_context);
-    boost::asio::ip::tcp::endpoint endpoint(
-            boost::asio::ip::address::from_string("127.0.0.1"), 9999);
-    boost::system::error_code ec;
-    mysocket.connect(endpoint, ec);
-    if (ec) {
-
-    }
-
-    char pBuff[30];
-    boost::asio::mutable_buffer buff(pBuff, sizeof(pBuff));
-    std::string tot;
-
-    std::size_t l = mysocket.read_some(buff);
-    while (l > 0) {
-        tot.append(static_cast<const char*>(buff.data()), l);
-
-        std::size_t pos = tot.find("\r");
-        while (pos != std::string::npos) {
-            std::string msg = tot.substr(0, pos);
-            tot.erase(0, pos+1);
-            std::cout << "Sending " << msg << " to queue" << std::endl;
-            auto c_string = msg.c_str();
-
-            auto message = messages::IncomingMessageFromHost(c_string, msg.c_str());
-            static_cast<void>(tasks.comms->get_message_queue().try_send(message));
-            pos = tot.find("\r");
-        }
-        l = mysocket.read_some(buff);
-    }
+void comm_thread::handle_input(sim_driver::SimDriver* driver, tasks::Tasks<SimulatorMessageQueue>& tasks){
+    driver->read(tasks);
 }

--- a/stm32-modules/heater-shaker/simulator/comm_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/comm_thread.cpp
@@ -1,17 +1,16 @@
 #include "simulator/comm_thread.hpp"
 
+#include <boost/asio.hpp>
 #include <iostream>
 #include <memory>
 #include <stop_token>
 #include <string_view>
 #include <thread>
-#include <boost/asio.hpp>
 
 #include "heater-shaker/host_comms_task.hpp"
 #include "heater-shaker/messages.hpp"
 #include "heater-shaker/tasks.hpp"
 #include "simulator/sim_driver.hpp"
-
 
 using namespace comm_thread;
 
@@ -41,6 +40,7 @@ auto comm_thread::build()
     return tasks::Task{std::make_unique<std::jthread>(run, tcb), &tcb->task};
 }
 
-void comm_thread::handle_input(sim_driver::SimDriver* driver, tasks::Tasks<SimulatorMessageQueue>& tasks){
+void comm_thread::handle_input(sim_driver::SimDriver* driver,
+                               tasks::Tasks<SimulatorMessageQueue>& tasks) {
     driver->read(tasks);
 }

--- a/stm32-modules/heater-shaker/simulator/comm_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/comm_thread.cpp
@@ -21,6 +21,7 @@ struct comm_thread::TaskControlBlock {
     SimCommTask task;
 };
 
+// TODO: Refactor this into using a driver.write method
 auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb) -> void {
     tcb->queue.set_stop_token(st);
     std::string buffer(1024, 'c');

--- a/stm32-modules/heater-shaker/simulator/comm_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/comm_thread.cpp
@@ -41,7 +41,7 @@ auto comm_thread::build()
     return tasks::Task{std::make_unique<std::jthread>(run, tcb), &tcb->task};
 }
 
-void comm_thread::handle_input(sim_driver::SimDriver* driver,
+void comm_thread::handle_input(std::unique_ptr<sim_driver::SimDriver>&& driver,
                                tasks::Tasks<SimulatorMessageQueue>& tasks) {
     driver->read(tasks);
 }

--- a/stm32-modules/heater-shaker/simulator/comm_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/comm_thread.cpp
@@ -23,7 +23,6 @@ struct comm_thread::TaskControlBlock {
 };
 
 auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb) -> void {
-    std::cout << "Running" << std::endl;
     tcb->queue.set_stop_token(st);
     std::string buffer(1024, 'c');
     while (!st.stop_requested()) {

--- a/stm32-modules/heater-shaker/simulator/comm_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/comm_thread.cpp
@@ -21,7 +21,6 @@ struct comm_thread::TaskControlBlock {
     SimCommTask task;
 };
 
-// TODO: Refactor this into using a driver.write method
 auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb,
          std::shared_ptr<sim_driver::SimDriver> driver) -> void {
     tcb->queue.set_stop_token(st);

--- a/stm32-modules/heater-shaker/simulator/comm_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/comm_thread.cpp
@@ -22,7 +22,8 @@ struct comm_thread::TaskControlBlock {
 };
 
 // TODO: Refactor this into using a driver.write method
-auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb, std::shared_ptr<sim_driver::SimDriver> driver) -> void {
+auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb,
+         std::shared_ptr<sim_driver::SimDriver> driver) -> void {
     tcb->queue.set_stop_token(st);
     std::string buffer(1024, 'c');
     while (!st.stop_requested()) {
@@ -38,7 +39,8 @@ auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb, std::shared_
 auto comm_thread::build(std::shared_ptr<sim_driver::SimDriver>&& driver)
     -> tasks::Task<std::unique_ptr<std::jthread>, comm_thread::SimCommTask> {
     auto tcb = std::make_shared<TaskControlBlock>();
-    return tasks::Task{std::make_unique<std::jthread>(run, tcb, driver), &tcb->task};
+    return tasks::Task{std::make_unique<std::jthread>(run, tcb, driver),
+                       &tcb->task};
 }
 
 void comm_thread::handle_input(std::shared_ptr<sim_driver::SimDriver>&& driver,

--- a/stm32-modules/heater-shaker/simulator/main.cpp
+++ b/stm32-modules/heater-shaker/simulator/main.cpp
@@ -6,24 +6,47 @@
 #include "simulator/motor_thread.hpp"
 #include "simulator/simulator_queue.hpp"
 #include "simulator/system_thread.hpp"
+#include <boost/program_options.hpp>
 
 using namespace std;
 
 int main(int argc, char *argv[]) {
-    auto system = system_thread::build();
-    auto heater = heater_thread::build();
-    auto motor = motor_thread::build();
-    auto comms = comm_thread::build();
-    auto tasks = tasks::Tasks<SimulatorMessageQueue>(heater.task, comms.task,
-                                                     motor.task, system.task);
-    comm_thread::handle_input(tasks);
-    system.handle->request_stop();
-    heater.handle->request_stop();
-    motor.handle->request_stop();
-    comms.handle->request_stop();
-    system.handle->join();
-    heater.handle->join();
-    motor.handle->join();
-    comms.handle->join();
-    return 0;
+    bool use_stdin = false;
+    bool use_socket = false;
+
+    namespace po = boost::program_options;
+
+    po::options_description desc("Allowed options");
+    desc.add_options()
+            ("help", "produce help message")
+            ("stdin", po::bool_switch(&use_stdin), "Use stdin to provide G-Codes")
+            ("socket", po::bool_switch(&use_socket), "Use socket to provide G-Codes")
+            ;
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    bool options_provided = argc > 1;
+    bool both_stdin_and_socket_specified = use_stdin && use_socket;
+
+    if (!options_provided) {
+        cout << endl << "ERROR: You must provide either the --stdin OR the --socket option" << endl << endl;
+        cout << desc << endl;
+        exit(1);
+    }
+
+    if (both_stdin_and_socket_specified) {
+        cout << endl << "ERROR: You may only provide either the --stdin OR the --socket option, not both" << endl << endl;
+        cout << desc << endl;
+        exit(1);
+    }
+
+    if (use_stdin) {
+        cout << "Using stdin" << endl;
+    }
+
+    if (use_socket) {
+        cout << "Using socket" << endl;
+    }
 }

--- a/stm32-modules/heater-shaker/simulator/main.cpp
+++ b/stm32-modules/heater-shaker/simulator/main.cpp
@@ -15,28 +15,21 @@ using namespace std;
 int main(int argc, char *argv[]) {
 
     auto sim_driver = cli_parser::get_sim_driver(argc, argv);
-    cout << sim_driver->get_name() << endl;
-//
-//    auto reader = socket_reader::SocketReader("localhost", 9999);
-//    std::cout << reader.get_host() << std::endl;
-//    std::cout << reader.get_port() << std::endl;
 
-
-
-//    auto system = system_thread::build();
-//    auto heater = heater_thread::build();
-//    auto motor = motor_thread::build();
-//    auto comms = comm_thread::build();
-//    auto tasks = tasks::Tasks<SimulatorMessageQueue>(heater.task, comms.task,
-//                                                     motor.task, system.task);
-//    comm_thread::handle_input(tasks);
-//    system.handle->request_stop();
-//    heater.handle->request_stop();
-//    motor.handle->request_stop();
-//    comms.handle->request_stop();
-//    system.handle->join();
-//    heater.handle->join();
-//    motor.handle->join();
-//    comms.handle->join();
-//    return 0;
+    auto system = system_thread::build();
+    auto heater = heater_thread::build();
+    auto motor = motor_thread::build();
+    auto comms = comm_thread::build();
+    auto tasks = tasks::Tasks<SimulatorMessageQueue>(heater.task, comms.task,
+                                                     motor.task, system.task);
+    comm_thread::handle_input(sim_driver, tasks);
+    system.handle->request_stop();
+    heater.handle->request_stop();
+    motor.handle->request_stop();
+    comms.handle->request_stop();
+    system.handle->join();
+    heater.handle->join();
+    motor.handle->join();
+    comms.handle->join();
+    return 0;
 }

--- a/stm32-modules/heater-shaker/simulator/main.cpp
+++ b/stm32-modules/heater-shaker/simulator/main.cpp
@@ -13,7 +13,6 @@
 using namespace std;
 
 int main(int argc, char *argv[]) {
-    std::unique_ptr<std::array<char, 2048>> pBuff{};
     auto sim_driver = cli_parser::get_sim_driver(argc, argv);
     auto system = system_thread::build();
     auto heater = heater_thread::build();

--- a/stm32-modules/heater-shaker/simulator/main.cpp
+++ b/stm32-modules/heater-shaker/simulator/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
     auto system = system_thread::build();
     auto heater = heater_thread::build();
     auto motor = motor_thread::build();
-    auto comms = comm_thread::build();
+    auto comms = comm_thread::build(std::move(sim_driver));
     auto tasks = tasks::Tasks<SimulatorMessageQueue>(heater.task, comms.task,
                                                      motor.task, system.task);
     comm_thread::handle_input(std::move(sim_driver), tasks);

--- a/stm32-modules/heater-shaker/simulator/main.cpp
+++ b/stm32-modules/heater-shaker/simulator/main.cpp
@@ -13,7 +13,7 @@
 using namespace std;
 
 int main(int argc, char *argv[]) {
-    std::unique_ptr<std::array<char, 2048>> pBuff {};
+    std::unique_ptr<std::array<char, 2048>> pBuff{};
     auto sim_driver = cli_parser::get_sim_driver(argc, argv);
     auto system = system_thread::build();
     auto heater = heater_thread::build();

--- a/stm32-modules/heater-shaker/simulator/main.cpp
+++ b/stm32-modules/heater-shaker/simulator/main.cpp
@@ -1,21 +1,18 @@
 #include <iostream>
 
 #include "heater-shaker/tasks.hpp"
+#include "simulator/cli_parser.hpp"
 #include "simulator/comm_thread.hpp"
 #include "simulator/heater_thread.hpp"
 #include "simulator/motor_thread.hpp"
+#include "simulator/sim_driver.hpp"
 #include "simulator/simulator_queue.hpp"
 #include "simulator/system_thread.hpp"
-#include "simulator/cli_parser.hpp"
-#include "simulator/sim_driver.hpp"
-
 
 using namespace std;
 
 int main(int argc, char *argv[]) {
-
     auto sim_driver = cli_parser::get_sim_driver(argc, argv);
-
     auto system = system_thread::build();
     auto heater = heater_thread::build();
     auto motor = motor_thread::build();

--- a/stm32-modules/heater-shaker/simulator/main.cpp
+++ b/stm32-modules/heater-shaker/simulator/main.cpp
@@ -6,23 +6,16 @@
 #include "simulator/motor_thread.hpp"
 #include "simulator/simulator_queue.hpp"
 #include "simulator/system_thread.hpp"
-#include "simulator/socket_reader.hpp"
 #include "simulator/cli_parser.hpp"
+#include "simulator/sim_driver.hpp"
 
 
 using namespace std;
 
 int main(int argc, char *argv[]) {
-    auto sim_type = cli_parser::get_sim_type(argc, argv);
 
-    if (sim_type == cli_parser::STDIN) {
-        cout << "Using stdin" << endl;
-    }
-
-    if (sim_type == cli_parser::SOCKET) {
-        cout << "Using socket" << endl;
-    }
-
+    auto sim_driver = cli_parser::get_sim_driver(argc, argv);
+    cout << sim_driver->get_name() << endl;
 //
 //    auto reader = socket_reader::SocketReader("localhost", 9999);
 //    std::cout << reader.get_host() << std::endl;

--- a/stm32-modules/heater-shaker/simulator/main.cpp
+++ b/stm32-modules/heater-shaker/simulator/main.cpp
@@ -6,47 +6,44 @@
 #include "simulator/motor_thread.hpp"
 #include "simulator/simulator_queue.hpp"
 #include "simulator/system_thread.hpp"
-#include <boost/program_options.hpp>
+#include "simulator/socket_reader.hpp"
+#include "simulator/cli_parser.hpp"
+
 
 using namespace std;
 
 int main(int argc, char *argv[]) {
-    bool use_stdin = false;
-    bool use_socket = false;
+    auto sim_type = cli_parser::get_sim_type(argc, argv);
 
-    namespace po = boost::program_options;
-
-    po::options_description desc("Allowed options");
-    desc.add_options()
-            ("help", "produce help message")
-            ("stdin", po::bool_switch(&use_stdin), "Use stdin to provide G-Codes")
-            ("socket", po::bool_switch(&use_socket), "Use socket to provide G-Codes")
-            ;
-
-    po::variables_map vm;
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    bool options_provided = argc > 1;
-    bool both_stdin_and_socket_specified = use_stdin && use_socket;
-
-    if (!options_provided) {
-        cout << endl << "ERROR: You must provide either the --stdin OR the --socket option" << endl << endl;
-        cout << desc << endl;
-        exit(1);
-    }
-
-    if (both_stdin_and_socket_specified) {
-        cout << endl << "ERROR: You may only provide either the --stdin OR the --socket option, not both" << endl << endl;
-        cout << desc << endl;
-        exit(1);
-    }
-
-    if (use_stdin) {
+    if (sim_type == cli_parser::STDIN) {
         cout << "Using stdin" << endl;
     }
 
-    if (use_socket) {
+    if (sim_type == cli_parser::SOCKET) {
         cout << "Using socket" << endl;
     }
+
+//
+//    auto reader = socket_reader::SocketReader("localhost", 9999);
+//    std::cout << reader.get_host() << std::endl;
+//    std::cout << reader.get_port() << std::endl;
+
+
+
+//    auto system = system_thread::build();
+//    auto heater = heater_thread::build();
+//    auto motor = motor_thread::build();
+//    auto comms = comm_thread::build();
+//    auto tasks = tasks::Tasks<SimulatorMessageQueue>(heater.task, comms.task,
+//                                                     motor.task, system.task);
+//    comm_thread::handle_input(tasks);
+//    system.handle->request_stop();
+//    heater.handle->request_stop();
+//    motor.handle->request_stop();
+//    comms.handle->request_stop();
+//    system.handle->join();
+//    heater.handle->join();
+//    motor.handle->join();
+//    comms.handle->join();
+//    return 0;
 }

--- a/stm32-modules/heater-shaker/simulator/main.cpp
+++ b/stm32-modules/heater-shaker/simulator/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <memory>
 
 #include "heater-shaker/tasks.hpp"
 #include "simulator/cli_parser.hpp"
@@ -12,6 +13,7 @@
 using namespace std;
 
 int main(int argc, char *argv[]) {
+    std::unique_ptr<std::array<char, 2048>> pBuff {};
     auto sim_driver = cli_parser::get_sim_driver(argc, argv);
     auto system = system_thread::build();
     auto heater = heater_thread::build();
@@ -19,7 +21,7 @@ int main(int argc, char *argv[]) {
     auto comms = comm_thread::build();
     auto tasks = tasks::Tasks<SimulatorMessageQueue>(heater.task, comms.task,
                                                      motor.task, system.task);
-    comm_thread::handle_input(sim_driver, tasks);
+    comm_thread::handle_input(std::move(sim_driver), tasks);
     system.handle->request_stop();
     heater.handle->request_stop();
     motor.handle->request_stop();

--- a/stm32-modules/heater-shaker/simulator/sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/sim_driver.cpp
@@ -1,5 +1,8 @@
 #include <regex>
+#include <boost/asio.hpp>
 #include "simulator/sim_driver.hpp"
+#include "simulator/simulator_queue.hpp"
+
 
 using namespace sim_driver;
 
@@ -21,9 +24,54 @@ std::string sim_driver::SocketSimDriver::get_host() { return this->host; }
 int sim_driver::SocketSimDriver::get_port() { return this->port; }
 std::string sim_driver::SocketSimDriver::get_name() { return this-> name; }
 void sim_driver::SocketSimDriver::write() { }
-std::string sim_driver::SocketSimDriver::read() { return "Hello World"; }
+void sim_driver::SocketSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& tasks) {
+    boost::asio::io_service io_context;
+
+    boost::asio::ip::tcp::socket mysocket(io_context);
+    boost::asio::ip::tcp::endpoint endpoint(
+            boost::asio::ip::address::from_string(this->host), this->port);
+    boost::system::error_code ec;
+    mysocket.connect(endpoint, ec);
+    if (ec) {
+
+    }
+
+    char pBuff[30];
+    boost::asio::mutable_buffer buff(pBuff, sizeof(pBuff));
+    std::string tot;
+
+    std::size_t l = mysocket.read_some(buff);
+    while (l > 0) {
+        tot.append(static_cast<const char*>(buff.data()), l);
+
+        std::size_t pos = tot.find("\r");
+        while (pos != std::string::npos) {
+            std::string msg = tot.substr(0, pos);
+            tot.erase(0, pos+1);
+            std::cout << "Sending " << msg << " to queue" << std::endl;
+            auto c_string = msg.c_str();
+
+            auto message = messages::IncomingMessageFromHost(c_string, msg.c_str());
+            static_cast<void>(tasks.comms->get_message_queue().try_send(message));
+            pos = tot.find("\r");
+        }
+        l = mysocket.read_some(buff);
+    }
+}
 
 sim_driver::StdinSimDriver::StdinSimDriver() { }
 std::string sim_driver::StdinSimDriver::get_name() { return this-> name; }
 void sim_driver::StdinSimDriver::write() { }
-std::string sim_driver::StdinSimDriver::read() { return "Hello World"; }
+void sim_driver::StdinSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& tasks) {
+    auto linebuf = std::make_shared<std::string>(1024, 'c');
+    while (true) {
+        if (!std::cin.getline(linebuf->data(), linebuf->size() - 1, '\n')) {
+            return;
+        }
+        auto wrote_to = std::cin.gcount();
+        linebuf->at(wrote_to - 1) = '\n';
+        auto message = messages::IncomingMessageFromHost(
+                linebuf->data(), linebuf->data() + wrote_to);
+        static_cast<void>(tasks.comms->get_message_queue().try_send(message));
+    }
+}

--- a/stm32-modules/heater-shaker/simulator/sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/sim_driver.cpp
@@ -34,7 +34,7 @@ auto get_socket(std::string host, int port){
     boost::asio::ip::tcp::socket socket(io_context);
     boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::address::from_string(host), port);
     boost::system::error_code ec;
-    socket.connect(endpoint, ec);
+    socket.connect(endpoint, ec);  // TODO: Change this to socket.bind - Derek Maggio 9/30/21
     if (ec) {
         std::cerr << "Failed to create socket: " << ec.category().name() << ": " << ec.value() << std::endl;
         exit(ec.value());
@@ -49,6 +49,11 @@ void sim_driver::SocketSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& task
     boost::asio::mutable_buffer buff(pBuff, sizeof(pBuff));
     std::string read_data;
 
+    /*
+     * TODO: This algorithm starts dropping G-Codes if they are sent faster than once every 0.005 seconds.
+     * Need to handle that
+     * Derek Maggio 9/30/21
+     */
     std::size_t l = socket.read_some(buff);
     while (l > 0) {
 

--- a/stm32-modules/heater-shaker/simulator/sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/sim_driver.cpp
@@ -30,7 +30,9 @@ std::string sim_driver::SocketSimDriver::get_host() { return this->host; }
 
 int sim_driver::SocketSimDriver::get_port() { return this->port; }
 
-const std::string& sim_driver::SocketSimDriver::get_name() const { return this->name; }
+const std::string& sim_driver::SocketSimDriver::get_name() const {
+    return this->name;
+}
 
 void sim_driver::SocketSimDriver::write() {}
 
@@ -66,7 +68,8 @@ void sim_driver::SocketSimDriver::read(
      */
     for (std::size_t l = socket.read_some(buff); l > 0;) {
         read_data.append(static_cast<const char*>(buff.data()), l);
-        for (std::size_t pos = read_data.find("\n"); pos != std::string::npos;) {
+        for (std::size_t pos = read_data.find("\n");
+             pos != std::string::npos;) {
             std::string msg = read_data.substr(0, pos + 1);
             linebuf.replace(0, msg.length(), msg);
 
@@ -85,7 +88,9 @@ void sim_driver::SocketSimDriver::read(
 
 sim_driver::StdinSimDriver::StdinSimDriver() {}
 const std::string sim_driver::StdinSimDriver::name = STDIN_DRIVER_NAME;
-const std::string& sim_driver::StdinSimDriver::get_name() const { return this->name; }
+const std::string& sim_driver::StdinSimDriver::get_name() const {
+    return this->name;
+}
 void sim_driver::StdinSimDriver::write() {}
 void sim_driver::StdinSimDriver::read(
     tasks::Tasks<SimulatorMessageQueue>& tasks) {

--- a/stm32-modules/heater-shaker/simulator/sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/sim_driver.cpp
@@ -1,13 +1,14 @@
-#include <regex>
-#include <boost/asio.hpp>
 #include "simulator/sim_driver.hpp"
-#include "simulator/simulator_queue.hpp"
 
+#include <boost/asio.hpp>
+#include <regex>
+
+#include "simulator/simulator_queue.hpp"
 
 using namespace sim_driver;
 
 sim_driver::SocketSimDriver::SocketSimDriver(std::string url) {
-    std::regex url_regex (":\\/\\/([a-zA-Z0-9.]*):(\\d*)$");
+    std::regex url_regex(":\\/\\/([a-zA-Z0-9.]*):(\\d*)$");
     std::smatch url_match_result;
 
     if (std::regex_search(url, url_match_result, url_regex)) {
@@ -24,25 +25,30 @@ std::string sim_driver::SocketSimDriver::get_host() { return this->host; }
 
 int sim_driver::SocketSimDriver::get_port() { return this->port; }
 
-std::string sim_driver::SocketSimDriver::get_name() { return this-> name; }
+std::string sim_driver::SocketSimDriver::get_name() { return this->name; }
 
-void sim_driver::SocketSimDriver::write() { }
+void sim_driver::SocketSimDriver::write() {}
 
-auto get_socket(std::string host, int port){
+auto get_socket(std::string host, int port) {
     boost::asio::io_service io_context;
 
     boost::asio::ip::tcp::socket socket(io_context);
-    boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::address::from_string(host), port);
+    boost::asio::ip::tcp::endpoint endpoint(
+        boost::asio::ip::address::from_string(host), port);
     boost::system::error_code ec;
-    socket.connect(endpoint, ec);  // TODO: Change this to socket.bind - Derek Maggio 9/30/21
+    socket.connect(
+        endpoint,
+        ec);  // TODO: Change this to socket.bind - Derek Maggio 9/30/21
     if (ec) {
-        std::cerr << "Failed to create socket: " << ec.category().name() << ": " << ec.value() << std::endl;
+        std::cerr << "Failed to create socket: " << ec.category().name() << ": "
+                  << ec.value() << std::endl;
         exit(ec.value());
     }
     return socket;
 }
 
-void sim_driver::SocketSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& tasks) {
+void sim_driver::SocketSimDriver::read(
+    tasks::Tasks<SimulatorMessageQueue>& tasks) {
     char pBuff[30];
     auto socket = get_socket(this->host, this->port);
     auto linebuf = std::string(1024, 'c');
@@ -50,25 +56,24 @@ void sim_driver::SocketSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& task
     std::string read_data;
 
     /*
-     * TODO: This algorithm starts dropping G-Codes if they are sent faster than once every 0.005 seconds.
-     * Need to handle that
-     * Derek Maggio 9/30/21
+     * TODO: This algorithm starts dropping G-Codes if they are sent faster than
+     * once every 0.005 seconds. Need to handle that Derek Maggio 9/30/21
      */
     std::size_t l = socket.read_some(buff);
     while (l > 0) {
-
         read_data.append(static_cast<const char*>(buff.data()), l);
         std::size_t pos = read_data.find("\n");
 
         while (pos != std::string::npos) {
-
             std::string msg = read_data.substr(0, pos + 1);
             linebuf.replace(0, msg.length(), msg);
 
-            auto message = messages::IncomingMessageFromHost(linebuf.data(), linebuf.data() + msg.size());
-            static_cast<void>(tasks.comms->get_message_queue().try_send(message));
+            auto message = messages::IncomingMessageFromHost(
+                linebuf.data(), linebuf.data() + msg.size());
+            static_cast<void>(
+                tasks.comms->get_message_queue().try_send(message));
 
-            read_data.erase(0, pos+1);
+            read_data.erase(0, pos + 1);
             pos = read_data.find("\n");
         }
 
@@ -76,10 +81,11 @@ void sim_driver::SocketSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& task
     }
 }
 
-sim_driver::StdinSimDriver::StdinSimDriver() { }
-std::string sim_driver::StdinSimDriver::get_name() { return this-> name; }
-void sim_driver::StdinSimDriver::write() { }
-void sim_driver::StdinSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& tasks) {
+sim_driver::StdinSimDriver::StdinSimDriver() {}
+std::string sim_driver::StdinSimDriver::get_name() { return this->name; }
+void sim_driver::StdinSimDriver::write() {}
+void sim_driver::StdinSimDriver::read(
+    tasks::Tasks<SimulatorMessageQueue>& tasks) {
     auto linebuf = std::make_shared<std::string>(1024, 'c');
     while (true) {
         if (!std::cin.getline(linebuf->data(), linebuf->size() - 1, '\n')) {
@@ -88,7 +94,8 @@ void sim_driver::StdinSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& tasks
         auto wrote_to = std::cin.gcount();
 
         linebuf->at(wrote_to - 1) = '\n';
-        auto message = messages::IncomingMessageFromHost(linebuf->data(), linebuf->data() + wrote_to);
+        auto message = messages::IncomingMessageFromHost(
+            linebuf->data(), linebuf->data() + wrote_to);
         static_cast<void>(tasks.comms->get_message_queue().try_send(message));
     }
 }

--- a/stm32-modules/heater-shaker/simulator/sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/sim_driver.cpp
@@ -1,0 +1,29 @@
+#include <regex>
+#include "simulator/sim_driver.hpp"
+
+using namespace sim_driver;
+
+sim_driver::SocketSimDriver::SocketSimDriver(std::string url) {
+    std::regex url_regex (":\\/\\/([a-zA-Z0-9.]*):(\\d*)$");
+    std::smatch url_match_result;
+
+    if (std::regex_search(url, url_match_result, url_regex)) {
+        host = url_match_result[1];
+        port = std::stoi(url_match_result[2]);
+
+    } else {
+        std::cerr << "Malformed url." << std::endl;
+        exit(1);
+    }
+}
+
+std::string sim_driver::SocketSimDriver::get_host() { return this->host; }
+int sim_driver::SocketSimDriver::get_port() { return this->port; }
+std::string sim_driver::SocketSimDriver::get_name() { return this-> name; }
+void sim_driver::SocketSimDriver::write() { }
+std::string sim_driver::SocketSimDriver::read() { return "Hello World"; }
+
+sim_driver::StdinSimDriver::StdinSimDriver() { }
+std::string sim_driver::StdinSimDriver::get_name() { return this-> name; }
+void sim_driver::StdinSimDriver::write() { }
+std::string sim_driver::StdinSimDriver::read() { return "Hello World"; }

--- a/stm32-modules/heater-shaker/simulator/sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/sim_driver.cpp
@@ -48,10 +48,9 @@ void sim_driver::SocketSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& task
         while (pos != std::string::npos) {
             std::string msg = tot.substr(0, pos);
             tot.erase(0, pos+1);
-            std::cout << "Sending " << msg << " to queue" << std::endl;
             auto c_string = msg.c_str();
 
-            auto message = messages::IncomingMessageFromHost(c_string, msg.c_str());
+            auto message = messages::IncomingMessageFromHost((c_string, c_string + msg.size()));
             static_cast<void>(tasks.comms->get_message_queue().try_send(message));
             pos = tot.find("\r");
         }
@@ -69,9 +68,10 @@ void sim_driver::StdinSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& tasks
             return;
         }
         auto wrote_to = std::cin.gcount();
+
         linebuf->at(wrote_to - 1) = '\n';
-        auto message = messages::IncomingMessageFromHost(
-                linebuf->data(), linebuf->data() + wrote_to);
+
+        auto message = messages::IncomingMessageFromHost(linebuf->data(), linebuf->data() + wrote_to);
         static_cast<void>(tasks.comms->get_message_queue().try_send(message));
     }
 }

--- a/stm32-modules/heater-shaker/simulator/sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/sim_driver.cpp
@@ -64,12 +64,9 @@ void sim_driver::SocketSimDriver::read(
      * TODO: This algorithm starts dropping G-Codes if they are sent faster than
      * once every 0.005 seconds. Need to handle that Derek Maggio 9/30/21
      */
-    std::size_t l = socket.read_some(buff);
-    while (l > 0) {
+    for (std::size_t l = socket.read_some(buff); l > 0;) {
         read_data.append(static_cast<const char*>(buff.data()), l);
-        std::size_t pos = read_data.find("\n");
-
-        while (pos != std::string::npos) {
+        for (std::size_t pos = read_data.find("\n"); pos != std::string::npos;) {
             std::string msg = read_data.substr(0, pos + 1);
             linebuf.replace(0, msg.length(), msg);
 

--- a/stm32-modules/heater-shaker/simulator/sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/sim_driver.cpp
@@ -28,8 +28,7 @@ void sim_driver::SocketSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& task
     boost::asio::io_service io_context;
 
     boost::asio::ip::tcp::socket mysocket(io_context);
-    boost::asio::ip::tcp::endpoint endpoint(
-            boost::asio::ip::address::from_string(this->host), this->port);
+    boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::address::from_string(this->host), this->port);
     boost::system::error_code ec;
     mysocket.connect(endpoint, ec);
     if (ec) { };
@@ -42,15 +41,14 @@ void sim_driver::SocketSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& task
     do {
         std::size_t l = mysocket.read_some(buff);
         read_data.append(static_cast<const char*>(buff.data()), l);
-
+        auto linebuf = std::string(1024, 'c');
         std::size_t pos = read_data.find("\n");
+
         while (pos != std::string::npos) {
-            auto linebuf = std::string(1024, 'c');
+
             std::string msg = read_data.substr(0, pos + 1);
 
             linebuf.replace(0, msg.length(), msg);
-            std::cout << linebuf.data() << std::endl;
-            std::cout << linebuf.data() + msg.size() << std::endl;
 
             auto message = messages::IncomingMessageFromHost(linebuf.data(), linebuf.data() + msg.size());
             static_cast<void>(tasks.comms->get_message_queue().try_send(message));
@@ -74,8 +72,6 @@ void sim_driver::StdinSimDriver::read(tasks::Tasks<SimulatorMessageQueue>& tasks
         auto wrote_to = std::cin.gcount();
 
         linebuf->at(wrote_to - 1) = '\n';
-        std::cout << linebuf->data() << std::endl;
-        std::cout << linebuf->data() + wrote_to << std::endl;
         auto message = messages::IncomingMessageFromHost(linebuf->data(), linebuf->data() + wrote_to);
         static_cast<void>(tasks.comms->get_message_queue().try_send(message));
     }

--- a/stm32-modules/heater-shaker/simulator/sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/sim_driver.cpp
@@ -7,6 +7,9 @@
 
 using namespace sim_driver;
 
+const std::string SOCKET_DRIVER_NAME = "Socket";
+const std::string STDIN_DRIVER_NAME = "Stdin";
+
 sim_driver::SocketSimDriver::SocketSimDriver(std::string url) {
     std::regex url_regex(":\\/\\/([a-zA-Z0-9.]*):(\\d*)$");
     std::smatch url_match_result;
@@ -21,11 +24,13 @@ sim_driver::SocketSimDriver::SocketSimDriver(std::string url) {
     }
 }
 
+const std::string sim_driver::SocketSimDriver::name = SOCKET_DRIVER_NAME;
+
 std::string sim_driver::SocketSimDriver::get_host() { return this->host; }
 
 int sim_driver::SocketSimDriver::get_port() { return this->port; }
 
-std::string sim_driver::SocketSimDriver::get_name() { return this->name; }
+const std::string& sim_driver::SocketSimDriver::get_name() const { return this->name; }
 
 void sim_driver::SocketSimDriver::write() {}
 
@@ -82,7 +87,8 @@ void sim_driver::SocketSimDriver::read(
 }
 
 sim_driver::StdinSimDriver::StdinSimDriver() {}
-std::string sim_driver::StdinSimDriver::get_name() { return this->name; }
+const std::string sim_driver::StdinSimDriver::name = STDIN_DRIVER_NAME;
+const std::string& sim_driver::StdinSimDriver::get_name() const { return this->name; }
 void sim_driver::StdinSimDriver::write() {}
 void sim_driver::StdinSimDriver::read(
     tasks::Tasks<SimulatorMessageQueue>& tasks) {

--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -59,9 +59,9 @@ auto get_socket(std::string host, int port) {
     return socket;
 }
 
-int get_index(char* char_array, char value_to_find) {
+int has_char(char* char_array, char value_to_find) {
     char* position = std::find(char_array, char_array + strlen(char_array), value_to_find);
-    return (char_array + strlen(char_array) == position) ? -1 : (position - char_array);
+    return char_array + strlen(char_array) != position;
 }
 
 void socket_sim_driver::SocketSimDriver::read(
@@ -80,8 +80,7 @@ void socket_sim_driver::SocketSimDriver::read(
         }
         char* data = write_buffer->accessible()->data();
         end_of_input = std::copy(reinterpret_cast<char*>(buff.data()), reinterpret_cast<char*>(buff.data()) + l, end_of_input);
-        int pos = get_index(data, '\n');
-        if ( pos != -1 ) {
+        if ( has_char(data, '\n') ) {
             auto message = messages::IncomingMessageFromHost(std::begin(*write_buffer->accessible()), end_of_input);
             static_cast<void>(tasks.comms->get_message_queue().try_send(message));
             write_buffer->swap();

--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -18,8 +18,8 @@ socket_sim_driver::SocketSimDriver::SocketSimDriver(std::string url) {
     std::smatch url_match_result;
 
     if (std::regex_search(url, url_match_result, url_regex)) {
-        host = url_match_result[1];
-        port = std::stoi(url_match_result[2]);
+        address_info = socket_sim_driver::AddressInfo{
+            url_match_result[1], std::stoi(url_match_result[2])};
 
     } else {
         std::cerr << "Malformed url." << std::endl;
@@ -30,10 +30,12 @@ socket_sim_driver::SocketSimDriver::SocketSimDriver(std::string url) {
 const std::string socket_sim_driver::SocketSimDriver::name = SOCKET_DRIVER_NAME;
 
 std::string socket_sim_driver::SocketSimDriver::get_host() {
-    return this->host;
+    return this->address_info.host;
 }
 
-int socket_sim_driver::SocketSimDriver::get_port() { return this->port; }
+int socket_sim_driver::SocketSimDriver::get_port() {
+    return this->address_info.port;
+}
 
 const std::string& socket_sim_driver::SocketSimDriver::get_name() const {
     return this->name;
@@ -68,7 +70,7 @@ int has_char(char* char_array, char value_to_find) {
 void socket_sim_driver::SocketSimDriver::read(
     tasks::Tasks<SimulatorMessageQueue>& tasks) {
     char pBuff[30];
-    auto socket = get_socket(this->host, this->port);
+    auto socket = get_socket(this->get_host(), this->get_port());
     boost::asio::mutable_buffer buff(pBuff, sizeof(pBuff));
     auto write_buffer =
         std::make_shared<double_buffer::DoubleBuffer<char, 2048>>();

--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -27,6 +27,24 @@ socket_sim_driver::SocketSimDriver::SocketSimDriver(std::string url) {
     }
 }
 
+auto get_socket(std::string host, int port) {
+    boost::asio::io_service io_context;
+
+    boost::asio::ip::tcp::socket socket(io_context);
+    boost::asio::ip::tcp::endpoint endpoint(
+            boost::asio::ip::address::from_string(host), port);
+    boost::system::error_code ec;
+    socket.connect(
+            endpoint,
+            ec);
+    if (ec) {
+        std::cerr << "Failed to create socket: " << ec.category().name() << ": "
+                  << ec.value() << std::endl;
+        exit(ec.value());
+    }
+    return socket;
+}
+
 const std::string socket_sim_driver::SocketSimDriver::name = SOCKET_DRIVER_NAME;
 
 std::string socket_sim_driver::SocketSimDriver::get_host() {
@@ -41,25 +59,12 @@ const std::string& socket_sim_driver::SocketSimDriver::get_name() const {
     return this->name;
 }
 
-void socket_sim_driver::SocketSimDriver::write() {}
-
-auto get_socket(std::string host, int port) {
-    boost::asio::io_service io_context;
-
-    boost::asio::ip::tcp::socket socket(io_context);
-    boost::asio::ip::tcp::endpoint endpoint(
-        boost::asio::ip::address::from_string(host), port);
-    boost::system::error_code ec;
-    socket.connect(
-        endpoint,
-        ec);  // TODO: Change this to socket.bind - Derek Maggio 9/30/21
-    if (ec) {
-        std::cerr << "Failed to create socket: " << ec.category().name() << ": "
-                  << ec.value() << std::endl;
-        exit(ec.value());
-    }
-    return socket;
+void socket_sim_driver::SocketSimDriver::write(std::string message)  {
+//    auto socket = get_socket(this->get_host(), this->get_port());
+    std::cout << message;
 }
+
+
 
 int has_char(char* char_array, char value_to_find) {
     char* position =

--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -47,11 +47,11 @@ socket_sim_driver::SocketSimDriver::SocketSimDriver(std::string url) {
 
 const std::string socket_sim_driver::SocketSimDriver::name = SOCKET_DRIVER_NAME;
 
-std::string socket_sim_driver::SocketSimDriver::get_host() {
+const std::string& socket_sim_driver::SocketSimDriver::get_host() const {
     return this->address_info.host;
 }
 
-int socket_sim_driver::SocketSimDriver::get_port() {
+int socket_sim_driver::SocketSimDriver::get_port() const {
     return this->address_info.port;
 }
 
@@ -59,7 +59,7 @@ const std::string& socket_sim_driver::SocketSimDriver::get_name() const {
     return this->name;
 }
 
-void socket_sim_driver::SocketSimDriver::write(std::string message) {
+void socket_sim_driver::SocketSimDriver::write(const std::string& message) {
     this->s->write_some(boost::asio::buffer(message));
 }
 

--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -63,8 +63,7 @@ const std::string& socket_sim_driver::SocketSimDriver::get_name() const {
 }
 
 void socket_sim_driver::SocketSimDriver::write(std::string message)  {
-//    auto socket = get_socket(this->get_host(), this->get_port());
-    std::cout << message;
+    this->s->write_some(boost::asio::buffer(message));
 }
 
 int has_char(char* char_array, char value_to_find) {

--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -13,28 +13,14 @@ using namespace socket_sim_driver;
 
 const std::string SOCKET_DRIVER_NAME = "Socket";
 
-socket_sim_driver::SocketSimDriver::SocketSimDriver(std::string url) {
-    std::regex url_regex(":\\/\\/([a-zA-Z0-9.]*):(\\d*)$");
-    std::smatch url_match_result;
-
-    if (std::regex_search(url, url_match_result, url_regex)) {
-        address_info = socket_sim_driver::AddressInfo{
-            url_match_result[1], std::stoi(url_match_result[2])};
-
-    } else {
-        std::cerr << "Malformed url." << std::endl;
-        exit(1);
-    }
-}
-
-auto get_socket(std::string host, int port) {
+std::unique_ptr<boost::asio::ip::tcp::socket> connect_to_socket(std::string host, int port) {
     boost::asio::io_service io_context;
 
-    boost::asio::ip::tcp::socket socket(io_context);
+    auto socket = std::make_unique<boost::asio::ip::tcp::socket>(io_context);
     boost::asio::ip::tcp::endpoint endpoint(
             boost::asio::ip::address::from_string(host), port);
     boost::system::error_code ec;
-    socket.connect(
+    socket->connect(
             endpoint,
             ec);
     if (ec) {
@@ -44,6 +30,23 @@ auto get_socket(std::string host, int port) {
     }
     return socket;
 }
+
+socket_sim_driver::SocketSimDriver::SocketSimDriver(std::string url) {
+    std::regex url_regex(":\\/\\/([a-zA-Z0-9.]*):(\\d*)$");
+    std::smatch url_match_result;
+
+    if (std::regex_search(url, url_match_result, url_regex)) {
+        address_info = socket_sim_driver::AddressInfo{
+            url_match_result[1], std::stoi(url_match_result[2])};
+        s = connect_to_socket(address_info.host, address_info.port);
+
+    } else {
+        std::cerr << "Malformed url." << std::endl;
+        exit(1);
+    }
+}
+
+
 
 const std::string socket_sim_driver::SocketSimDriver::name = SOCKET_DRIVER_NAME;
 
@@ -64,8 +67,6 @@ void socket_sim_driver::SocketSimDriver::write(std::string message)  {
     std::cout << message;
 }
 
-
-
 int has_char(char* char_array, char value_to_find) {
     char* position =
         std::find(char_array, char_array + strlen(char_array), value_to_find);
@@ -75,15 +76,13 @@ int has_char(char* char_array, char value_to_find) {
 void socket_sim_driver::SocketSimDriver::read(
     tasks::Tasks<SimulatorMessageQueue>& tasks) {
     char pBuff[30];
-    auto socket = get_socket(this->get_host(), this->get_port());
     boost::asio::mutable_buffer buff(pBuff, sizeof(pBuff));
     auto write_buffer =
         std::make_shared<double_buffer::DoubleBuffer<char, 2048>>();
-
-    size_t l = socket.read_some(buff);
+    size_t l = this->s->read_some(buff);
     char* end_of_input = std::begin(*write_buffer->accessible());
     char* end_of_buffer = std::end(*write_buffer->accessible());
-    for (; l > 0; l = socket.read_some(buff)) {
+    for (; l > 0; l = this->s->read_some(buff)) {
         if (end_of_input + l > end_of_buffer) {
             end_of_input = std::begin(*write_buffer->accessible());
         }

--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -1,13 +1,13 @@
 #include "simulator/socket_sim_driver.hpp"
 
-#include <boost/asio.hpp>
-#include <regex>
-#include <memory>
 #include <algorithm>
+#include <boost/asio.hpp>
 #include <iterator>
+#include <memory>
+#include <regex>
 
-#include "simulator/simulator_queue.hpp"
 #include "hal/double_buffer.hpp"
+#include "simulator/simulator_queue.hpp"
 
 using namespace socket_sim_driver;
 
@@ -60,7 +60,8 @@ auto get_socket(std::string host, int port) {
 }
 
 int has_char(char* char_array, char value_to_find) {
-    char* position = std::find(char_array, char_array + strlen(char_array), value_to_find);
+    char* position =
+        std::find(char_array, char_array + strlen(char_array), value_to_find);
     return char_array + strlen(char_array) != position;
 }
 
@@ -69,7 +70,8 @@ void socket_sim_driver::SocketSimDriver::read(
     char pBuff[30];
     auto socket = get_socket(this->host, this->port);
     boost::asio::mutable_buffer buff(pBuff, sizeof(pBuff));
-    auto write_buffer = std::make_shared<double_buffer::DoubleBuffer<char, 2048>>();
+    auto write_buffer =
+        std::make_shared<double_buffer::DoubleBuffer<char, 2048>>();
 
     size_t l = socket.read_some(buff);
     char* end_of_input = std::begin(*write_buffer->accessible());
@@ -79,10 +81,14 @@ void socket_sim_driver::SocketSimDriver::read(
             end_of_input = std::begin(*write_buffer->accessible());
         }
         char* data = write_buffer->accessible()->data();
-        end_of_input = std::copy(reinterpret_cast<char*>(buff.data()), reinterpret_cast<char*>(buff.data()) + l, end_of_input);
-        if ( has_char(data, '\n') ) {
-            auto message = messages::IncomingMessageFromHost(std::begin(*write_buffer->accessible()), end_of_input);
-            static_cast<void>(tasks.comms->get_message_queue().try_send(message));
+        end_of_input =
+            std::copy(reinterpret_cast<char*>(buff.data()),
+                      reinterpret_cast<char*>(buff.data()) + l, end_of_input);
+        if (has_char(data, '\n')) {
+            auto message = messages::IncomingMessageFromHost(
+                std::begin(*write_buffer->accessible()), end_of_input);
+            static_cast<void>(
+                tasks.comms->get_message_queue().try_send(message));
             write_buffer->swap();
             end_of_input = std::begin(*write_buffer->accessible());
             end_of_buffer = std::end(*write_buffer->accessible());

--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -13,16 +13,15 @@ using namespace socket_sim_driver;
 
 const std::string SOCKET_DRIVER_NAME = "Socket";
 
-std::unique_ptr<boost::asio::ip::tcp::socket> connect_to_socket(std::string host, int port) {
+std::unique_ptr<boost::asio::ip::tcp::socket> connect_to_socket(
+    std::string host, int port) {
     boost::asio::io_service io_context;
 
     auto socket = std::make_unique<boost::asio::ip::tcp::socket>(io_context);
     boost::asio::ip::tcp::endpoint endpoint(
-            boost::asio::ip::address::from_string(host), port);
+        boost::asio::ip::address::from_string(host), port);
     boost::system::error_code ec;
-    socket->connect(
-            endpoint,
-            ec);
+    socket->connect(endpoint, ec);
     if (ec) {
         std::cerr << "Failed to create socket: " << ec.category().name() << ": "
                   << ec.value() << std::endl;
@@ -46,8 +45,6 @@ socket_sim_driver::SocketSimDriver::SocketSimDriver(std::string url) {
     }
 }
 
-
-
 const std::string socket_sim_driver::SocketSimDriver::name = SOCKET_DRIVER_NAME;
 
 std::string socket_sim_driver::SocketSimDriver::get_host() {
@@ -62,7 +59,7 @@ const std::string& socket_sim_driver::SocketSimDriver::get_name() const {
     return this->name;
 }
 
-void socket_sim_driver::SocketSimDriver::write(std::string message)  {
+void socket_sim_driver::SocketSimDriver::write(std::string message) {
     this->s->write_some(boost::asio::buffer(message));
 }
 

--- a/stm32-modules/heater-shaker/simulator/stdin_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/stdin_sim_driver.cpp
@@ -1,0 +1,32 @@
+#include "simulator/stdin_sim_driver.hpp"
+
+#include <boost/asio.hpp>
+#include <regex>
+
+#include "simulator/simulator_queue.hpp"
+
+using namespace stdin_sim_driver;
+
+const std::string STDIN_DRIVER_NAME = "Stdin";
+
+stdin_sim_driver::StdinSimDriver::StdinSimDriver() {}
+const std::string stdin_sim_driver::StdinSimDriver::name = STDIN_DRIVER_NAME;
+const std::string& stdin_sim_driver::StdinSimDriver::get_name() const {
+    return this->name;
+}
+void stdin_sim_driver::StdinSimDriver::write() {}
+void stdin_sim_driver::StdinSimDriver::read(
+    tasks::Tasks<SimulatorMessageQueue>& tasks) {
+    auto linebuf = std::make_shared<std::string>(1024, 'c');
+    while (true) {
+        if (!std::cin.getline(linebuf->data(), linebuf->size() - 1, '\n')) {
+            return;
+        }
+        auto wrote_to = std::cin.gcount();
+
+        linebuf->at(wrote_to - 1) = '\n';
+        auto message = messages::IncomingMessageFromHost(
+            linebuf->data(), linebuf->data() + wrote_to);
+        static_cast<void>(tasks.comms->get_message_queue().try_send(message));
+    }
+}

--- a/stm32-modules/heater-shaker/simulator/stdin_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/stdin_sim_driver.cpp
@@ -14,7 +14,7 @@ const std::string stdin_sim_driver::StdinSimDriver::name = STDIN_DRIVER_NAME;
 const std::string& stdin_sim_driver::StdinSimDriver::get_name() const {
     return this->name;
 }
-void stdin_sim_driver::StdinSimDriver::write(std::string message) {
+void stdin_sim_driver::StdinSimDriver::write(const std::string& message) {
     std::cout << message;
 }
 void stdin_sim_driver::StdinSimDriver::read(

--- a/stm32-modules/heater-shaker/simulator/stdin_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/stdin_sim_driver.cpp
@@ -14,7 +14,9 @@ const std::string stdin_sim_driver::StdinSimDriver::name = STDIN_DRIVER_NAME;
 const std::string& stdin_sim_driver::StdinSimDriver::get_name() const {
     return this->name;
 }
-void stdin_sim_driver::StdinSimDriver::write() {}
+void stdin_sim_driver::StdinSimDriver::write(std::string message) {
+    std::cout << message;
+}
 void stdin_sim_driver::StdinSimDriver::read(
     tasks::Tasks<SimulatorMessageQueue>& tasks) {
     auto linebuf = std::make_shared<std::string>(1024, 'c');


### PR DESCRIPTION
# Overview

- Add socket communication to heater shaker simulation
- Add ability to specify whether to use stdin or socket for G-Code input through cli options

# Changelog

- Added sim_driver.hpp/cpp
  - Contains `SimDriver` abstract base class
  - Contains `StdinSimDriver` and `SocketSimDriver` which inherit from `SimDriver`
  - Both `StdinSimDriver` and `SocketSimDriver` manage reading and writing to stdin and a socket respectively
  - `SocketSimDriver` handles connecting to socket
- Added cli_parser.hpp/cpp
  - Manages parsing passed cli options and returning the correct `SimDriver`


# Review requests

* This is my first venture into writing C++, hold my code to the same standards as everyone else's and tear it apart
* Note the following TODOs and let me know if it is okay to address these in a subsequent PR
    * [Refactor run function to use a driver.write method](https://github.com/Opentrons/opentrons-modules/pull/203/files#diff-170cba0464601e13288a39ae9871eb0887df83e71211194d443938fccfb31ea2R24)
    * [Change socket code to bind to a socket instead of connecting to it](https://github.com/Opentrons/opentrons-modules/pull/203/files#diff-07b6889b97919fe2f098a8eb9f0d19edc3394c672e25e7c60e5659c5785c174aR41)
    * [Socket read method starts dropping G-Codes if they are sent faster than one every 0.005 seconds](https://github.com/Opentrons/opentrons-modules/pull/203/files#diff-07b6889b97919fe2f098a8eb9f0d19edc3394c672e25e7c60e5659c5785c174aR58-R61)

# Risk assessment

None, stdin functionality was preserved and there is no automation that is dependent on it