### PR TITLE
chore(heater-shaker): Add : separating key and val

### DIFF
--- a/stm32-modules/heater-shaker/include/heater-shaker/gcodes.hpp
+++ b/stm32-modules/heater-shaker/include/heater-shaker/gcodes.hpp
@@ -123,7 +123,7 @@ struct GetTemperature {
     static auto write_response_into(InputIt buf, InLimit limit,
                                     double current_temperature,
                                     double setpoint_temperature) -> InputIt {
-        auto res = snprintf(&*buf, (limit - buf), "M105 C%0.2f T%0.2f OK\n",
+        auto res = snprintf(&*buf, (limit - buf), "M105 C:%0.2f T:%0.2f OK\n",
                             static_cast<float>(current_temperature),
                             static_cast<float>(setpoint_temperature));
         if (res <= 0) {
@@ -164,7 +164,7 @@ struct GetRPM {
     static auto write_response_into(InputIt buf, const InLimit limit,
                                     int16_t current_rpm, int16_t setpoint_rpm)
         -> InputIt {
-        static constexpr const char* prefix = "M123 C";
+        static constexpr const char* prefix = "M123 C:";
         char* char_next = &*buf;
         char* const char_limit = &*limit;
         char_next = write_string_to_iterpair(char_next, char_limit, prefix);
@@ -175,7 +175,7 @@ struct GetRPM {
         }
         char_next = tochars_result.ptr;
 
-        static constexpr const char* setpoint_prefix = " T";
+        static constexpr const char* setpoint_prefix = " T:";
         char_next =
             write_string_to_iterpair(char_next, char_limit, setpoint_prefix);
 
@@ -279,7 +279,7 @@ struct GetTemperatureDebug {
                                     bool power_good) -> InputIt {
         auto res = snprintf(
             &*buf, (limit - buf),
-            "M105.D AT%0.2f BT%0.2f OT%0.2f AD%d BD%d OD%d PG%d OK\n",
+            "M105.D AT:%0.2f BT:%0.2f OT:%0.2f AD:%d BD:%d OD:%d PG:%d OK\n",
             static_cast<float>(pad_a_temp), static_cast<float>(pad_b_temp),
             static_cast<float>(board_temp), pad_a_adc, pad_b_adc, board_adc,
             power_good ? 1 : 0);

--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -433,8 +433,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                                                               tx_buf.end());
                     THEN("the task should respond to the get-temp message") {
                         REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "M105 C47.00 T0.00 OK\n"));
-                        REQUIRE(written_secondpass == tx_buf.begin() + 21);
+                                                 "M105 C:47.00 T:0.00 OK\n"));
+                        REQUIRE(written_secondpass == tx_buf.begin() + 23);
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -546,8 +546,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                         "message") {
                         REQUIRE_THAT(tx_buf,
                                      Catch::Matchers::StartsWith(
-                                         "M105.D AT100.00 BT42.00 OT22.00 "
-                                         "AD14420 BD0 OD2220 PG0 OK\n"));
+                                         "M105.D AT:100.00 BT:42.00 OT:22.00 "
+                                         "AD:14420 BD:0 OD:2220 PG:0 OK\n"));
                         REQUIRE(written_secondpass != tx_buf.begin());
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
@@ -634,8 +634,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                                                               tx_buf.end());
                     THEN("the task should ack the previous message") {
                         REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "M123 C1500 T1750 OK\n"));
-                        REQUIRE(written_secondpass == tx_buf.begin() + 20);
+                                                 "M123 C:1500 T:1750 OK\n"));
+                        REQUIRE(written_secondpass == tx_buf.begin() + 22);
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }

--- a/stm32-modules/heater-shaker/tests/test_m105.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m105.cpp
@@ -14,8 +14,8 @@ SCENARIO("GetTemperature (M105) response works", "[gcode][response][m105]") {
                 buffer.begin(), buffer.end(), 10.25, 25.001);
             THEN("the response should be written in full") {
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
-                                         "M105 C10.25 T25.00 OK\n"));
-                REQUIRE(written == buffer.begin() + 22);
+                                         "M105 C:10.25 T:25.00 OK\n"));
+                REQUIRE(written == buffer.begin() + 24);
             }
         }
     }

--- a/stm32-modules/heater-shaker/tests/test_m105d.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m105d.cpp
@@ -16,8 +16,8 @@ SCENARIO("GetTemperatureDebug (M105.D) parser works",
                 true);
             THEN("the response should be written in full") {
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
-                                         "M105.D AT10.25 BT11.25 OT12.25 AD10 "
-                                         "BD11 OD12 PG1 OK\n"));
+                                         "M105.D AT:10.25 BT:11.25 OT:12.25 AD:10 "
+                                         "BD:11 OD:12 PG:1 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }

--- a/stm32-modules/heater-shaker/tests/test_m105d.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m105d.cpp
@@ -15,9 +15,10 @@ SCENARIO("GetTemperatureDebug (M105.D) parser works",
                 buffer.begin(), buffer.end(), 10.25, 11.25, 12.25, 10, 11, 12,
                 true);
             THEN("the response should be written in full") {
-                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
-                                         "M105.D AT:10.25 BT:11.25 OT:12.25 AD:10 "
-                                         "BD:11 OD:12 PG:1 OK\n"));
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::StartsWith(
+                                 "M105.D AT:10.25 BT:11.25 OT:12.25 AD:10 "
+                                 "BD:11 OD:12 PG:1 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }

--- a/stm32-modules/heater-shaker/tests/test_m123.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m123.cpp
@@ -14,8 +14,8 @@ SCENARIO("GetRPM (M103) response generation works", "[gcode][response][m103]") {
                 buffer.begin(), buffer.end(), 10, 25);
             THEN("the response should be written in full") {
                 REQUIRE_THAT(buffer,
-                             Catch::Matchers::StartsWith("M123 C10 T25 OK\n"));
-                REQUIRE(written == buffer.begin() + 16);
+                             Catch::Matchers::StartsWith("M123 C:10 T:25 OK\n"));
+                REQUIRE(written == buffer.begin() + 18);
             }
         }
     }
@@ -27,7 +27,7 @@ SCENARIO("GetRPM (M103) response generation works", "[gcode][response][m103]") {
                 buffer.begin(), buffer.begin() + 7, 10, 25);
             THEN("the response should write only up to the available space") {
                 REQUIRE_THAT(buffer,
-                             Catch::Matchers::Equals("M123 Ccccccccccc"));
+                             Catch::Matchers::Equals("M123 C:ccccccccc"));
                 REQUIRE(written == buffer.begin() + 7);
             }
         }

--- a/stm32-modules/heater-shaker/tests/test_m123.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m123.cpp
@@ -13,8 +13,8 @@ SCENARIO("GetRPM (M103) response generation works", "[gcode][response][m103]") {
             auto written = gcode::GetRPM::write_response_into(
                 buffer.begin(), buffer.end(), 10, 25);
             THEN("the response should be written in full") {
-                REQUIRE_THAT(buffer,
-                             Catch::Matchers::StartsWith("M123 C:10 T:25 OK\n"));
+                REQUIRE_THAT(
+                    buffer, Catch::Matchers::StartsWith("M123 C:10 T:25 OK\n"));
                 REQUIRE(written == buffer.begin() + 18);
             }
         }

--- a/stm32-modules/heater-shaker/tests/test_message_passing.cpp
+++ b/stm32-modules/heater-shaker/tests/test_message_passing.cpp
@@ -44,7 +44,7 @@ SCENARIO("testing full message passing integration") {
                 written = tasks->get_host_comms_task().run_once(
                     response_buffer.begin(), response_buffer.end());
                 REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith(
-                                                  "M123 C1050 T3500 OK\n"));
+                                                  "M123 C:1050 T:3500 OK\n"));
             }
         }
         WHEN("sending a set-temp message by string to the host comms task") {
@@ -79,7 +79,7 @@ SCENARIO("testing full message passing integration") {
                 written = tasks->get_host_comms_task().run_once(
                     response_buffer.begin(), response_buffer.end());
                 REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith(
-                                                  "M105 C95.20 T0.00 OK\n"));
+                                                  "M105 C:95.20 T:0.00 OK\n"));
             }
         }
 


### PR DESCRIPTION
The OT-2 software is structured to look for response formats like
key:value rather than keyvalue like we have here (and it's nicer this
way anyway). Add a : character in between the key and value; for
instance, a temperature message is now M123 C:10.00 T:20.01 rather than
M123 C10.00 T20.01.