### PR TITLE
fix(heater_shaker): serial numbers up to 23 characters

### DIFF
--- a/stm32-modules/heater-shaker/firmware/system/system_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/system/system_policy.cpp
@@ -19,7 +19,7 @@ auto SystemPolicy::enter_bootloader() -> void {
 auto SystemPolicy::set_serial_number(
     std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> system_serial_number)
     -> errors::ErrorCode {
-    uint64_t to_write_arr [3];
+    uint64_t to_write_arr[3];
     // convert bytes to uint64_t for system_set_serial_number
     // write to 8 chars to each of first 3 addresses on last page of flash
     for (uint8_t address = 0; address < ADDRESSES; address++) {
@@ -30,7 +30,7 @@ auto SystemPolicy::set_serial_number(
              input != limit && byte_index >= 0; input++, byte_index--) {
             to_write |= (static_cast<uint64_t>(*input) << (byte_index * 8));
         }
-        to_write_arr [address] = to_write;
+        to_write_arr[address] = to_write;
     }
     if (!system_set_serial_number(to_write_arr)) {
         return errors::ErrorCode::SYSTEM_SERIAL_NUMBER_HAL_ERROR;

--- a/stm32-modules/heater-shaker/firmware/system/system_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/system/system_policy.cpp
@@ -19,6 +19,7 @@ auto SystemPolicy::enter_bootloader() -> void {
 auto SystemPolicy::set_serial_number(
     std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> system_serial_number)
     -> errors::ErrorCode {
+    uint64_t to_write_arr [3];
     // convert bytes to uint64_t for system_set_serial_number
     // write to 8 chars to each of first 3 addresses on last page of flash
     for (uint8_t address = 0; address < ADDRESSES; address++) {
@@ -29,10 +30,10 @@ auto SystemPolicy::set_serial_number(
              input != limit && byte_index >= 0; input++, byte_index--) {
             to_write |= (static_cast<uint64_t>(*input) << (byte_index * 8));
         }
-
-        if (!system_set_serial_number(to_write, address)) {
-            return errors::ErrorCode::SYSTEM_SERIAL_NUMBER_HAL_ERROR;
-        }
+        to_write_arr [address] = to_write;
+    }
+    if (!system_set_serial_number(to_write_arr)) {
+        return errors::ErrorCode::SYSTEM_SERIAL_NUMBER_HAL_ERROR;
     }
     return errors::ErrorCode::NO_ERROR;
 }

--- a/stm32-modules/heater-shaker/firmware/system/system_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/system/system_policy.cpp
@@ -19,7 +19,7 @@ auto SystemPolicy::enter_bootloader() -> void {
 auto SystemPolicy::set_serial_number(
     std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> system_serial_number)
     -> errors::ErrorCode {
-    uint64_t to_write_arr[3];
+    writable_serial to_write_struct;
     // convert bytes to uint64_t for system_set_serial_number
     // write to 8 chars to each of first 3 addresses on last page of flash
     for (uint8_t address = 0; address < ADDRESSES; address++) {
@@ -30,9 +30,9 @@ auto SystemPolicy::set_serial_number(
              input != limit && byte_index >= 0; input++, byte_index--) {
             to_write |= (static_cast<uint64_t>(*input) << (byte_index * 8));
         }
-        to_write_arr[address] = to_write;
+        to_write_struct.contents[address] = to_write;
     }
-    if (!system_set_serial_number(to_write_arr)) {
+    if (!system_set_serial_number(&to_write_struct)) {
         return errors::ErrorCode::SYSTEM_SERIAL_NUMBER_HAL_ERROR;
     }
     return errors::ErrorCode::NO_ERROR;

--- a/stm32-modules/heater-shaker/firmware/system/system_serial_number.c
+++ b/stm32-modules/heater-shaker/firmware/system/system_serial_number.c
@@ -8,21 +8,22 @@
 #include "system_serial_number.h"
 
 static uint32_t PAGE_ADDRESS = 0x0805F800; //last page in flash memory, 0x0807F800 for 512K FLASH
+static uint8_t ADDRESS_SIZE = 64;
 
-bool system_set_serial_number(uint64_t to_write1, uint64_t to_write2, uint64_t to_write3) {
+bool system_set_serial_number(uint64_t *to_write) {
     FLASH_EraseInitTypeDef pageToErase = {.TypeErase = FLASH_TYPEERASE_PAGES, .PageAddress = PAGE_ADDRESS, .NbPages = 1};
     uint32_t pageErrorPtr = 0; //pointer to variable  that contains the configuration information on faulty page in case of error
     uint32_t ProgramAddress1 = PAGE_ADDRESS;
-    uint32_t ProgramAddress2 = PAGE_ADDRESS + 64;
-    uint32_t ProgramAddress3 = PAGE_ADDRESS + 128;
+    uint32_t ProgramAddress2 = PAGE_ADDRESS + ADDRESS_SIZE;
+    uint32_t ProgramAddress3 = PAGE_ADDRESS + (2 * ADDRESS_SIZE);
 
     HAL_StatusTypeDef status = HAL_FLASH_Unlock();
     if (status == HAL_OK) {
         status = HAL_FLASHEx_Erase(&pageToErase, &pageErrorPtr);
         if (status == HAL_OK) {
-            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress1, to_write1);
-            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress2, to_write2);
-            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress3, to_write3);
+            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress1, to_write[0]);
+            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress2, to_write[1]);
+            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress3, to_write[2]);
             if (status == HAL_OK) {
                 status = HAL_FLASH_Lock();
             }
@@ -32,6 +33,6 @@ bool system_set_serial_number(uint64_t to_write1, uint64_t to_write2, uint64_t t
 }
 
 uint64_t system_get_serial_number(uint8_t address) {
-    uint32_t AddressToRead = PAGE_ADDRESS + (address * 64);
+    uint32_t AddressToRead = PAGE_ADDRESS + (address * ADDRESS_SIZE);
     return *(uint64_t*)AddressToRead;
 }

--- a/stm32-modules/heater-shaker/firmware/system/system_serial_number.c
+++ b/stm32-modules/heater-shaker/firmware/system/system_serial_number.c
@@ -9,16 +9,20 @@
 
 static uint32_t PAGE_ADDRESS = 0x0805F800; //last page in flash memory, 0x0807F800 for 512K FLASH
 
-bool system_set_serial_number(uint64_t to_write, uint8_t address) {
+bool system_set_serial_number(uint64_t to_write1, uint64_t to_write2, uint64_t to_write3) {
     FLASH_EraseInitTypeDef pageToErase = {.TypeErase = FLASH_TYPEERASE_PAGES, .PageAddress = PAGE_ADDRESS, .NbPages = 1};
     uint32_t pageErrorPtr = 0; //pointer to variable  that contains the configuration information on faulty page in case of error
-    uint32_t ProgramAddress = PAGE_ADDRESS + (address * 64);
+    uint32_t ProgramAddress1 = PAGE_ADDRESS;
+    uint32_t ProgramAddress2 = PAGE_ADDRESS + 64;
+    uint32_t ProgramAddress3 = PAGE_ADDRESS + 128;
 
     HAL_StatusTypeDef status = HAL_FLASH_Unlock();
     if (status == HAL_OK) {
         status = HAL_FLASHEx_Erase(&pageToErase, &pageErrorPtr);
         if (status == HAL_OK) {
-            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress, to_write);
+            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress1, to_write1);
+            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress2, to_write2);
+            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress3, to_write3);
             if (status == HAL_OK) {
                 status = HAL_FLASH_Lock();
             }

--- a/stm32-modules/heater-shaker/firmware/system/system_serial_number.c
+++ b/stm32-modules/heater-shaker/firmware/system/system_serial_number.c
@@ -10,7 +10,7 @@
 static uint32_t PAGE_ADDRESS = 0x0805F800; //last page in flash memory, 0x0807F800 for 512K FLASH
 static uint8_t ADDRESS_SIZE = 64;
 
-bool system_set_serial_number(uint64_t *to_write) {
+bool system_set_serial_number(struct writable_serial* to_write) {
     FLASH_EraseInitTypeDef pageToErase = {.TypeErase = FLASH_TYPEERASE_PAGES, .PageAddress = PAGE_ADDRESS, .NbPages = 1};
     uint32_t pageErrorPtr = 0; //pointer to variable  that contains the configuration information on faulty page in case of error
     uint32_t ProgramAddress1 = PAGE_ADDRESS;
@@ -21,9 +21,9 @@ bool system_set_serial_number(uint64_t *to_write) {
     if (status == HAL_OK) {
         status = HAL_FLASHEx_Erase(&pageToErase, &pageErrorPtr);
         if (status == HAL_OK) {
-            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress1, to_write[0]);
-            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress2, to_write[1]);
-            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress3, to_write[2]);
+            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress1, to_write->contents[0]);
+            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress2, to_write->contents[1]);
+            status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, ProgramAddress3, to_write->contents[2]);
             if (status == HAL_OK) {
                 status = HAL_FLASH_Lock();
             }

--- a/stm32-modules/heater-shaker/firmware/system/system_serial_number.h
+++ b/stm32-modules/heater-shaker/firmware/system/system_serial_number.h
@@ -8,7 +8,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stddef.h>
 
-bool system_set_serial_number(uint64_t to_write, uint8_t address);
+bool system_set_serial_number(uint64_t to_write1, uint64_t to_write2, uint64_t to_write3);
 
 uint64_t system_get_serial_number(uint8_t address);
 

--- a/stm32-modules/heater-shaker/firmware/system/system_serial_number.h
+++ b/stm32-modules/heater-shaker/firmware/system/system_serial_number.h
@@ -8,7 +8,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stddef.h>
 
-bool system_set_serial_number(uint64_t to_write1, uint64_t to_write2, uint64_t to_write3);
+bool system_set_serial_number(uint64_t *to_write);
 
 uint64_t system_get_serial_number(uint8_t address);
 

--- a/stm32-modules/heater-shaker/firmware/system/system_serial_number.h
+++ b/stm32-modules/heater-shaker/firmware/system/system_serial_number.h
@@ -8,7 +8,11 @@ extern "C" {
 #include <stdbool.h>
 #include <stddef.h>
 
-bool system_set_serial_number(uint64_t *to_write);
+struct writable_serial {
+    uint64_t contents[3];
+};
+
+bool system_set_serial_number(struct writable_serial* to_write);
 
 uint64_t system_get_serial_number(uint8_t address);
 


### PR DESCRIPTION
first two addresses of serial number flash were getting erased in previous code