### PR TITLE
fix(heater-shaker/simulator): no hardcoded error

### DIFF
--- a/stm32-modules/heater-shaker/simulator/motor_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/motor_thread.cpp
@@ -114,11 +114,6 @@ auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb) -> void {
         } catch (const SimMotorTask::Queue::StopDuringMsgWait& sdmw) {
             return;
         }
-        if (tcb->task.get_state() ==
-            motor_task::State::HOMING_COASTING_TO_STOP) {
-            static_cast<void>(tcb->queue.try_send(
-                messages::MotorSystemErrorMessage{.errors = 2}));
-        }
     }
 }
 


### PR DESCRIPTION
The motor subsystem used to use error detection as a mechanism to know
when it homed. That's not true any more, but we didn't change the simulator.