### PR TITLE
fix(heater-shaker): set usb class in device desc

### DIFF
--- a/stm32-modules/heater-shaker/firmware/host_comms_task/usbd_desc.c
+++ b/stm32-modules/heater-shaker/firmware/host_comms_task/usbd_desc.c
@@ -72,8 +72,8 @@ __ALIGN_BEGIN   uint8_t USBD_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END =
   USB_DESC_TYPE_DEVICE,       /* bDescriptorType */
   0x00,                       /* bcdUSB */
   0x02,
-  0x00,                       /* bDeviceClass */
-  0x00,                       /* bDeviceSubClass */
+  0x02,                       /* bDeviceClass */
+  0x02,                       /* bDeviceSubClass */
   0x00,                       /* bDeviceProtocol */
   USB_MAX_EP0_SIZE,           /* bMaxPacketSize */
   LOBYTE(USBD_VID),           /* idVendor */


### PR DESCRIPTION
The default configuration for the USB descriptors defers the device
class to each interface. USB CDC/ACM has two interfaces - one for
control (the ACM, class 2 subclass 2) and one for data (the CDC, class a
subclass 0). If you don't specify a sub/class in the _device_
descriptor, the spec says hosts look at each interface separately, and
windows serial driver binding is looking for class 2 subclass 2, so it
binds the ACM interface but not the CDC interface, and then fails the
device.

By specifying class and subclass somewhat redundantly in the top level
device descriptor, windows binds the composite device to the cdc/acm
drivers and all is good.