### PR TITLE
feat(thermocycler-refresh): Create thermal tasks

### DIFF
--- a/stm32-modules/CMakeLists.txt
+++ b/stm32-modules/CMakeLists.txt
@@ -3,9 +3,12 @@
 if (${CMAKE_CROSSCOMPILING})
     find_package(CrossGCC)
     find_package(OpenOCD)
+    find_package(GDBSVDTools)
 else()
     find_package(Boost 1.71.0)
 endif()
+
+find_package(Clang)
 
 add_subdirectory(common)
 add_subdirectory(heater-shaker)

--- a/stm32-modules/common/CMakeLists.txt
+++ b/stm32-modules/common/CMakeLists.txt
@@ -12,8 +12,6 @@ else()
   add_subdirectory(tests)
 endif()
 
-find_package(Clang)
-
 file(GLOB_RECURSE ${TARGET_MODULE_NAME}_SOURCES_FOR_FORMAT
   ./*.cpp ./*.hpp ./*.h
   ../include/${TARGET_MODULE_NAME}/*.hpp ../include/${TARGET_MODULE_NAME}/*.h)

--- a/stm32-modules/common/STM32G491/CMakeLists.txt
+++ b/stm32-modules/common/STM32G491/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 find_package(GDBSVDTools)
 
+set(G4_BOARD_FILE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/stm32g4discovery.cfg")
+
 # Fills in the template with values specified by the find_package(OpenOCD) call above
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gdbinit.template ./gdbinit)
 

--- a/stm32-modules/common/src/CMakeLists.txt
+++ b/stm32-modules/common/src/CMakeLists.txt
@@ -57,7 +57,6 @@ target_compile_options(${TARGET_MODULE_NAME}-core
 # in 'common' to be linted. Only want to expose this for cross
 # compilation anyways.
 if (${CMAKE_CROSSCOMPILING})
-  find_package(Clang)
 
   # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html
   # which is a catch-all static analyzer/linter

--- a/stm32-modules/heater-shaker/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/CMakeLists.txt
@@ -9,8 +9,6 @@ else()
   add_subdirectory(simulator)
 endif()
 
-find_package(Clang)
-
 file(GLOB_RECURSE HS_SOURCES_FOR_FORMAT 
   ./*.cpp ./*.hpp ./*.h
   ../include/heater-shaker/*.hpp ../include/heater-shaker/*.h)

--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -10,6 +10,7 @@ set(MOTOR_DIR "${CMAKE_CURRENT_SOURCE_DIR}/motor_task")
 set(COMMS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/host_comms_task")
 set(COMMON_MCU_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../common/STM32F303")
 set(COMMON_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../common/src")
+set(GDBINIT_PATH "${CMAKE_CURRENT_BINARY_DIR}/../../common/STM32F303/gdbinit")
 
 set(MCSDK_VERSION 5.4.4)
 set(MCSDK_LOCATION "${CMAKE_CURRENT_LIST_DIR}/motor_task/MCSDK_v${MCSDK_VERSION}/MotorControl")
@@ -131,8 +132,6 @@ set_target_properties(
   STM32F303BSP_FreeRTOS
   PROPERTIES FREERTOS_HEAP_IMPLEMENTATION "heap_5")
 
-find_package(GDBSVDTools)
-
 find_program(ARM_GDB
   arm-none-eabi-gdb-py
   PATHS "${CrossGCC_BINDIR}"
@@ -144,7 +143,7 @@ message(STATUS "Found svd exe at ${GDBSVDTools_gdbsvd_EXECUTABLE}")
 set_target_properties(heater-shaker
   PROPERTIES
   CROSSCOMPILING_EMULATOR
-  "${ARM_GDB};--command=${COMMON_MCU_DIR}/gdbinit")
+  "${ARM_GDB};--command=${GDBINIT_PATH}")
 
 find_program(CROSS_OBJCOPY "${CrossGCC_TRIPLE}-objcopy"
   PATHS "${CrossGCC_BINDIR}"
@@ -163,8 +162,6 @@ add_custom_command(OUTPUT heater-shaker.bin
   VERBATIM)
 add_custom_target(heater-shaker-bin ALL
   DEPENDS heater-shaker.bin)
-
-find_package(Clang)
 
 # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html
 # which is a catch-all static analyzer/linter

--- a/stm32-modules/include/thermocycler-refresh/firmware/freertos_lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/freertos_lid_heater_task.hpp
@@ -1,0 +1,16 @@
+/*
+ * Interface for the firmware-specific parts of the thermal plate control task
+ */
+#pragma once
+
+#include "FreeRTOS.h"
+#include "firmware/freertos_message_queue.hpp"
+#include "task.h"
+#include "thermocycler-refresh/tasks.hpp"
+
+namespace lid_heater_control_task {
+// Function that starts the task
+auto start()
+    -> tasks::Task<TaskHandle_t,
+                   lid_heater_task::LidHeaterTask<FreeRTOSMessageQueue>>;
+}  // namespace lid_heater_control_task

--- a/stm32-modules/include/thermocycler-refresh/firmware/freertos_thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/freertos_thermal_plate_task.hpp
@@ -5,12 +5,12 @@
 
 #include "FreeRTOS.h"
 #include "firmware/freertos_message_queue.hpp"
-#include "thermocycler-refresh/tasks.hpp"
 #include "task.h"
+#include "thermocycler-refresh/tasks.hpp"
 
 namespace thermal_plate_control_task {
 // Function that starts the task
 auto start()
-    -> tasks::Task<TaskHandle_t, 
-        thermal_plate_task::ThermalPlateTask<FreeRTOSMessageQueue>>;
-} // namespace thermal_plate_control_task
+    -> tasks::Task<TaskHandle_t,
+                   thermal_plate_task::ThermalPlateTask<FreeRTOSMessageQueue>>;
+}  // namespace thermal_plate_control_task

--- a/stm32-modules/include/thermocycler-refresh/firmware/freertos_thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/freertos_thermal_plate_task.hpp
@@ -1,0 +1,16 @@
+/*
+ * Interface for the firmware-specific parts of the thermal plate control task
+ */
+#pragma once
+
+#include "FreeRTOS.h"
+#include "firmware/freertos_message_queue.hpp"
+#include "thermocycler-refresh/tasks.hpp"
+#include "task.h"
+
+namespace thermal_plate_control_task {
+// Function that starts the task
+auto start()
+    -> tasks::Task<TaskHandle_t, 
+        thermal_plate_task::ThermalPlateTask<FreeRTOSMessageQueue>>;
+} // namespace thermal_plate_control_task

--- a/stm32-modules/include/thermocycler-refresh/simulator/lid_heater_thread.hpp
+++ b/stm32-modules/include/thermocycler-refresh/simulator/lid_heater_thread.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <memory>
+#include <thread>
+
+#include "simulator/simulator_queue.hpp"
+#include "thermocycler-refresh/lid_heater_task.hpp"
+#include "thermocycler-refresh/tasks.hpp"
+
+namespace lid_heater_thread {
+using SimLidHeaterTask = lid_heater_task::LidHeaterTask<SimulatorMessageQueue>;
+struct TaskControlBlock;
+auto build() -> tasks::Task<std::unique_ptr<std::jthread>, SimLidHeaterTask>;
+};  // namespace lid_heater_thread

--- a/stm32-modules/include/thermocycler-refresh/simulator/thermal_plate_thread.hpp
+++ b/stm32-modules/include/thermocycler-refresh/simulator/thermal_plate_thread.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <memory>
+#include <thread>
+
+#include "simulator/simulator_queue.hpp"
+#include "thermocycler-refresh/tasks.hpp"
+#include "thermocycler-refresh/thermal_plate_task.hpp"
+
+namespace thermal_plate_thread {
+using SimThermalPlateTask =
+    thermal_plate_task::ThermalPlateTask<SimulatorMessageQueue>;
+struct TaskControlBlock;
+auto build() -> tasks::Task<std::unique_ptr<std::jthread>, SimThermalPlateTask>;
+};  // namespace thermal_plate_thread

--- a/stm32-modules/include/thermocycler-refresh/test/task_builder.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/task_builder.hpp
@@ -4,9 +4,13 @@
 
 #include "test/test_message_queue.hpp"
 #include "test/test_system_policy.hpp"
+#include "test/test_lid_heater_policy.hpp"
+#include "test/test_thermal_plate_policy.hpp"
 #include "thermocycler-refresh/host_comms_task.hpp"
 #include "thermocycler-refresh/system_task.hpp"
 #include "thermocycler-refresh/tasks.hpp"
+#include "thermocycler-refresh/lid_heater_task.hpp"
+#include "thermocycler-refresh/thermal_plate_task.hpp"
 
 struct TaskBuilder {
     ~TaskBuilder() = default;
@@ -46,6 +50,12 @@ struct TaskBuilder {
     host_comms_task::HostCommsTask<TestMessageQueue> host_comms_task;
     TestMessageQueue<system_task::Message> system_queue;
     system_task::SystemTask<TestMessageQueue> system_task;
+    TestMessageQueue<thermal_plate_task::Message> thermal_plate_queue;
+    thermal_plate_task::ThermalPlateTask<TestMessageQueue> thermal_plate_task;
+    TestMessageQueue<lid_heater_task::Message> lid_heater_queue;
+    lid_heater_task::LidHeaterTask<TestMessageQueue> lid_heater_task;
     tasks::Tasks<TestMessageQueue> task_aggregator;
     TestSystemPolicy system_policy;
+    TestThermalPlatePolicy thermal_plate_policy;
+    TestLidHeaterPolicy lid_heater_policy;
 };

--- a/stm32-modules/include/thermocycler-refresh/test/task_builder.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/task_builder.hpp
@@ -2,14 +2,14 @@
 #include <memory>
 #include <utility>
 
+#include "test/test_lid_heater_policy.hpp"
 #include "test/test_message_queue.hpp"
 #include "test/test_system_policy.hpp"
-#include "test/test_lid_heater_policy.hpp"
 #include "test/test_thermal_plate_policy.hpp"
 #include "thermocycler-refresh/host_comms_task.hpp"
+#include "thermocycler-refresh/lid_heater_task.hpp"
 #include "thermocycler-refresh/system_task.hpp"
 #include "thermocycler-refresh/tasks.hpp"
-#include "thermocycler-refresh/lid_heater_task.hpp"
 #include "thermocycler-refresh/thermal_plate_task.hpp"
 
 struct TaskBuilder {

--- a/stm32-modules/include/thermocycler-refresh/test/test_lid_heater_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_lid_heater_policy.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
 class TestLidHeaterPolicy {
-    private:
-        bool _enabled = false;
-    public:
-        auto set_enabled(bool enabled) -> void {
-            _enabled = enabled;
-        }
+  private:
+    bool _enabled = false;
+
+  public:
+    auto set_enabled(bool enabled) -> void { _enabled = enabled; }
 };

--- a/stm32-modules/include/thermocycler-refresh/test/test_lid_heater_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_lid_heater_policy.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+class TestLidHeaterPolicy {
+    private:
+        bool _enabled = false;
+    public:
+        auto set_enabled(bool enabled) -> void {
+            _enabled = enabled;
+        }
+};

--- a/stm32-modules/include/thermocycler-refresh/test/test_thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_thermal_plate_policy.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
 class TestThermalPlatePolicy {
-    private:
-        bool _enabled = false;
-    public:
-        auto set_enabled(bool enabled) -> void {
-            _enabled = enabled;
-        }
+  private:
+    bool _enabled = false;
+
+  public:
+    auto set_enabled(bool enabled) -> void { _enabled = enabled; }
 };

--- a/stm32-modules/include/thermocycler-refresh/test/test_thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_thermal_plate_policy.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+class TestThermalPlatePolicy {
+    private:
+        bool _enabled = false;
+    public:
+        auto set_enabled(bool enabled) -> void {
+            _enabled = enabled;
+        }
+};

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -1,0 +1,143 @@
+/*
+ * the primary interface to the thermal plate task
+ */
+#pragma once
+
+#include <algorithm>
+#include <concepts>
+#include <cstddef>
+#include <variant>
+
+#include "core/pid.hpp"
+#include "core/thermistor_conversion.hpp"
+#include "hal/message_queue.hpp"
+#include "thermocycler-refresh/errors.hpp"
+#include "thermocycler-refresh/messages.hpp"
+#include "thermocycler-refresh/tasks.hpp"
+#include "thermocycler-refresh/thermal_general.hpp"
+
+/* Need a forward declaration for this because of recursive includes */
+namespace tasks {
+template <template <class> class Queue>
+struct Tasks;
+};
+
+namespace lid_heater_task {
+
+template <typename Policy>
+concept LidHeaterExecutionPolicy = requires(Policy& p, const Policy& cp) {
+    // A set_enabled function with inputs of `false` or `true` that
+    // sets the enable pin for the peltiers off or on
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    {p.set_enabled(false)};
+};
+
+struct State {
+    enum Status {
+        IDLE,
+        ERROR,
+        CONTROLLING,
+    };
+    Status system_status;
+    uint16_t error_bitmap;
+    static constexpr uint16_t LID_THERMISTOR_ERROR = (1 << 0);
+    static constexpr uint16_t HEATER_POWER_ERROR = (1 << 1);
+};
+
+// By using a template template parameter here, we allow the code instantiating
+// this template to do so as LidHeaterTask<SomeQueueImpl> rather than
+// LidHeaterTask<SomeQueueImpl<Message>>
+using Message = messages::LidHeaterMessage;
+template <template <class> class QueueImpl>
+requires MessageQueue<QueueImpl<Message>, Message>
+class LidHeaterTask {
+  public:
+    using Queue = QueueImpl<Message>;
+    static constexpr const uint32_t CONTROL_PERIOD_TICKS = 100;
+    static constexpr double THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM = 10.0;
+    static constexpr uint8_t ADC_BIT_DEPTH = 16;
+    // TODO most of these defaults will have to change
+    static constexpr double DEFAULT_KI = 0.102;
+    static constexpr double DEFAULT_KP = 0.97;
+    static constexpr double DEFAULT_KD = 1.901;
+    static constexpr double KP_MIN = -200;
+    static constexpr double KP_MAX = 200;
+    static constexpr double KI_MIN = -200;
+    static constexpr double KI_MAX = 200;
+    static constexpr double KD_MIN = -200;
+    static constexpr double KD_MAX = 200;
+    static constexpr double OVERTEMP_LIMIT_C = 95;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    static constexpr const double CONTROL_PERIOD_SECONDS =
+        CONTROL_PERIOD_TICKS * 0.001;
+
+    explicit LidHeaterTask(Queue& q)
+        : message_queue(q),
+          task_registry(nullptr),
+          thermistor{.overtemp_limit_c = OVERTEMP_LIMIT_C,
+                     .error_bit = State::LID_THERMISTOR_ERROR},
+          state{.system_status = State::IDLE, .error_bitmap = 0},
+          pid(DEFAULT_KP, DEFAULT_KI, DEFAULT_KD, CONTROL_PERIOD_SECONDS,
+                    1.0, -1.0) {}
+    LidHeaterTask(const LidHeaterTask& other) = delete;
+    auto operator=(const LidHeaterTask& other) -> LidHeaterTask& = delete;
+    LidHeaterTask(LidHeaterTask&& other) noexcept = delete;
+    auto operator=(LidHeaterTask&& other) noexcept
+        -> LidHeaterTask& = delete;
+    ~LidHeaterTask() = default;
+    auto get_message_queue() -> Queue& { return message_queue; }
+
+    void provide_tasks(tasks::Tasks<QueueImpl>* other_tasks) {
+        task_registry = other_tasks;
+    }
+
+    /**
+     * run_once() runs one spin of the task. This means it
+     * - Waits for a message, either a thermistor update or
+     *   some other control message
+     * - If there's a message, handles the message
+     *   - which may include altering its controller state
+     *   - which may include sending a response
+     * - Runs its controller
+     *
+     * The passed-in policy is the hardware interface and must fulfill the
+     * LidHeaterExecutionPolicy concept above.
+     * */
+    template <typename Policy>
+    requires LidHeaterExecutionPolicy<Policy>
+    auto run_once(Policy& policy) -> void {
+        auto message = Message(std::monostate());
+
+        // This is the call down to the provided queue. It will block for
+        // anywhere up to the provided timeout, which drives the controller
+        // frequency.
+
+        static_cast<void>(message_queue.recv(&message));
+        std::visit(
+            [this, &policy](const auto& msg) -> void {
+                this->visit_message(msg, policy);
+            },
+            message);
+    }
+
+  private:
+    template <typename Policy>
+    auto visit_message(const std::monostate& _ignore, Policy& policy) -> void {
+        static_cast<void>(policy);
+        static_cast<void>(_ignore);
+    }
+
+    template <typename Policy>
+    auto visit_message(const messages::LidTempReadComplete& msg,
+                       Policy& policy) -> void {
+        // TODO fill out this function
+    }
+
+    Queue& message_queue;
+    tasks::Tasks<QueueImpl>* task_registry;
+    Thermistor thermistor;
+    State state;
+    PID pid;
+};
+
+}  // namespace lid_heater_task

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -77,13 +77,12 @@ class LidHeaterTask {
           thermistor{.overtemp_limit_c = OVERTEMP_LIMIT_C,
                      .error_bit = State::LID_THERMISTOR_ERROR},
           state{.system_status = State::IDLE, .error_bitmap = 0},
-          pid(DEFAULT_KP, DEFAULT_KI, DEFAULT_KD, CONTROL_PERIOD_SECONDS,
-                    1.0, -1.0) {}
+          pid(DEFAULT_KP, DEFAULT_KI, DEFAULT_KD, CONTROL_PERIOD_SECONDS, 1.0,
+              -1.0) {}
     LidHeaterTask(const LidHeaterTask& other) = delete;
     auto operator=(const LidHeaterTask& other) -> LidHeaterTask& = delete;
     LidHeaterTask(LidHeaterTask&& other) noexcept = delete;
-    auto operator=(LidHeaterTask&& other) noexcept
-        -> LidHeaterTask& = delete;
+    auto operator=(LidHeaterTask&& other) noexcept -> LidHeaterTask& = delete;
     ~LidHeaterTask() = default;
     auto get_message_queue() -> Queue& { return message_queue; }
 
@@ -128,8 +127,8 @@ class LidHeaterTask {
     }
 
     template <typename Policy>
-    auto visit_message(const messages::LidTempReadComplete& msg,
-                       Policy& policy) -> void {
+    auto visit_message(const messages::LidTempReadComplete& msg, Policy& policy)
+        -> void {
         // TODO fill out this function
     }
 

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -90,6 +90,10 @@ struct ThermalPlateTempReadComplete {
     uint16_t back_left;
 };
 
+struct LidTempReadComplete {
+    uint16_t temp;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage>;
@@ -99,4 +103,6 @@ using HostCommsMessage =
                    GetSystemInfoResponse>;
 using ThermalPlateMessage =
     ::std::variant<std::monostate, ThermalPlateTempReadComplete>;
+using LidHeaterMessage =
+    ::std::variant<std::monostate, LidTempReadComplete>;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -80,6 +80,16 @@ struct IncomingMessageFromHost {
     const char* limit;
 };
 
+struct ThermalPlateTempReadComplete {
+    uint16_t heat_sink;
+    uint16_t front_right;
+    uint16_t front_center;
+    uint16_t front_left;
+    uint16_t back_right;
+    uint16_t back_center;
+    uint16_t back_left;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage>;
@@ -87,4 +97,6 @@ using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, AcknowledgePrevious,
                    ErrorMessage, ForceUSBDisconnectMessage,
                    GetSystemInfoResponse>;
+using ThermalPlateMessage =
+    ::std::variant<std::monostate, ThermalPlateTempReadComplete>;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -103,6 +103,5 @@ using HostCommsMessage =
                    GetSystemInfoResponse>;
 using ThermalPlateMessage =
     ::std::variant<std::monostate, ThermalPlateTempReadComplete>;
-using LidHeaterMessage =
-    ::std::variant<std::monostate, LidTempReadComplete>;
+using LidHeaterMessage = ::std::variant<std::monostate, LidTempReadComplete>;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tasks.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tasks.hpp
@@ -7,10 +7,10 @@
 
 #include "hal/message_queue.hpp"
 #include "host_comms_task.hpp"
+#include "lid_heater_task.hpp"
 #include "messages.hpp"
 #include "system_task.hpp"
 #include "thermal_plate_task.hpp"
-#include "lid_heater_task.hpp"
 
 namespace host_comms_task {
 template <template <class> class QueueImpl>
@@ -38,7 +38,7 @@ template <template <class> class QueueImpl>
 requires MessageQueue<QueueImpl<messages::LidHeaterMessage>,
                       messages::LidHeaterMessage>
 class LidHeaterTask;
-}  // namespace thermal_plate_task
+}  // namespace lid_heater_task
 
 namespace tasks {
 /* Container relating the RTOSTask for the implementation and the portable task
@@ -58,8 +58,10 @@ struct Tasks {
           system_task::SystemTask<QueueImpl>* system_in,
           thermal_plate_task::ThermalPlateTask<QueueImpl>* thermal_plate_in,
           lid_heater_task::LidHeaterTask<QueueImpl>* lid_heater_in)
-        : comms(nullptr), system(nullptr), 
-          thermal_plate(nullptr), lid_heater(nullptr) {
+        : comms(nullptr),
+          system(nullptr),
+          thermal_plate(nullptr),
+          lid_heater(nullptr) {
         initialize(comms_in, system_in, thermal_plate_in, lid_heater_in);
     }
 
@@ -67,8 +69,7 @@ struct Tasks {
         host_comms_task::HostCommsTask<QueueImpl>* comms_in,
         system_task::SystemTask<QueueImpl>* system_in,
         thermal_plate_task::ThermalPlateTask<QueueImpl>* thermal_plate_in,
-        lid_heater_task::LidHeaterTask<QueueImpl>* lid_heater_in)
-        -> void {
+        lid_heater_task::LidHeaterTask<QueueImpl>* lid_heater_in) -> void {
         comms = comms_in;
         system = system_in;
         thermal_plate = thermal_plate_in;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tasks.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tasks.hpp
@@ -10,6 +10,7 @@
 #include "messages.hpp"
 #include "system_task.hpp"
 #include "thermal_plate_task.hpp"
+#include "lid_heater_task.hpp"
 
 namespace host_comms_task {
 template <template <class> class QueueImpl>
@@ -32,6 +33,13 @@ requires MessageQueue<QueueImpl<messages::ThermalPlateMessage>,
 class ThermalPlateTask;
 }  // namespace thermal_plate_task
 
+namespace lid_heater_task {
+template <template <class> class QueueImpl>
+requires MessageQueue<QueueImpl<messages::LidHeaterMessage>,
+                      messages::LidHeaterMessage>
+class LidHeaterTask;
+}  // namespace thermal_plate_task
+
 namespace tasks {
 /* Container relating the RTOSTask for the implementation and the portable task
  * object */
@@ -48,22 +56,27 @@ struct Tasks {
     Tasks() = default;
     Tasks(host_comms_task::HostCommsTask<QueueImpl>* comms_in,
           system_task::SystemTask<QueueImpl>* system_in,
-          thermal_plate_task::ThermalPlateTask<QueueImpl>* thermal_plate)
-        : comms(nullptr), system(nullptr), thermal_plate(nullptr) {
-        initialize(comms_in, system_in, thermal_plate);
+          thermal_plate_task::ThermalPlateTask<QueueImpl>* thermal_plate_in,
+          lid_heater_task::LidHeaterTask<QueueImpl>* lid_heater_in)
+        : comms(nullptr), system(nullptr), 
+          thermal_plate(nullptr), lid_heater(nullptr) {
+        initialize(comms_in, system_in, thermal_plate_in, lid_heater_in);
     }
 
     auto initialize(
         host_comms_task::HostCommsTask<QueueImpl>* comms_in,
         system_task::SystemTask<QueueImpl>* system_in,
-        thermal_plate_task::ThermalPlateTask<QueueImpl>* thermal_plate_in)
+        thermal_plate_task::ThermalPlateTask<QueueImpl>* thermal_plate_in,
+        lid_heater_task::LidHeaterTask<QueueImpl>* lid_heater_in)
         -> void {
         comms = comms_in;
         system = system_in;
         thermal_plate = thermal_plate_in;
+        lid_heater = lid_heater_in;
         comms->provide_tasks(this);
         system->provide_tasks(this);
         thermal_plate_in->provide_tasks(this);
+        lid_heater->provide_tasks(this);
     }
 
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
@@ -72,5 +85,7 @@ struct Tasks {
     system_task::SystemTask<QueueImpl>* system;
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     thermal_plate_task::ThermalPlateTask<QueueImpl>* thermal_plate;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    lid_heater_task::LidHeaterTask<QueueImpl>* lid_heater;
 };
 }  // namespace tasks

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tasks.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tasks.hpp
@@ -53,10 +53,11 @@ struct Tasks {
         initialize(comms_in, system_in, thermal_plate);
     }
 
-    auto initialize(host_comms_task::HostCommsTask<QueueImpl>* comms_in,
-            system_task::SystemTask<QueueImpl>* system_in,
-            thermal_plate_task::ThermalPlateTask<QueueImpl>* thermal_plate_in)
-            -> void {
+    auto initialize(
+        host_comms_task::HostCommsTask<QueueImpl>* comms_in,
+        system_task::SystemTask<QueueImpl>* system_in,
+        thermal_plate_task::ThermalPlateTask<QueueImpl>* thermal_plate_in)
+        -> void {
         comms = comms_in;
         system = system_in;
         thermal_plate = thermal_plate_in;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tasks.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tasks.hpp
@@ -9,6 +9,7 @@
 #include "host_comms_task.hpp"
 #include "messages.hpp"
 #include "system_task.hpp"
+#include "thermal_plate_task.hpp"
 
 namespace host_comms_task {
 template <template <class> class QueueImpl>
@@ -23,6 +24,13 @@ requires MessageQueue<QueueImpl<messages::SystemMessage>,
                       messages::SystemMessage>
 class SystemTask;
 }  // namespace system_task
+
+namespace thermal_plate_task {
+template <template <class> class QueueImpl>
+requires MessageQueue<QueueImpl<messages::ThermalPlateMessage>,
+                      messages::ThermalPlateMessage>
+class ThermalPlateTask;
+}  // namespace thermal_plate_task
 
 namespace tasks {
 /* Container relating the RTOSTask for the implementation and the portable task
@@ -39,22 +47,29 @@ template <template <class> class QueueImpl>
 struct Tasks {
     Tasks() = default;
     Tasks(host_comms_task::HostCommsTask<QueueImpl>* comms_in,
-          system_task::SystemTask<QueueImpl>* system_in)
-        : comms(nullptr), system(nullptr) {
-        initialize(comms_in, system_in);
+          system_task::SystemTask<QueueImpl>* system_in,
+          thermal_plate_task::ThermalPlateTask<QueueImpl>* thermal_plate)
+        : comms(nullptr), system(nullptr), thermal_plate(nullptr) {
+        initialize(comms_in, system_in, thermal_plate);
     }
 
     auto initialize(host_comms_task::HostCommsTask<QueueImpl>* comms_in,
-                    system_task::SystemTask<QueueImpl>* system_in) -> void {
+            system_task::SystemTask<QueueImpl>* system_in,
+            thermal_plate_task::ThermalPlateTask<QueueImpl>* thermal_plate_in)
+            -> void {
         comms = comms_in;
         system = system_in;
+        thermal_plate = thermal_plate_in;
         comms->provide_tasks(this);
         system->provide_tasks(this);
+        thermal_plate_in->provide_tasks(this);
     }
 
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     host_comms_task::HostCommsTask<QueueImpl>* comms;
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     system_task::SystemTask<QueueImpl>* system;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    thermal_plate_task::ThermalPlateTask<QueueImpl>* thermal_plate;
 };
 }  // namespace tasks

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_general.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_general.hpp
@@ -1,0 +1,58 @@
+/**
+ * This file contains general utilities, structures, and enumerations
+ * for the thermal subsystem of the thermocycler-refresh module
+ */
+#pragma once
+
+#include "thermocycler-refresh/errors.hpp"
+#include "core/thermistor_conversion.hpp"
+
+// Enumeration of peltiers on the board
+enum PeltierID {
+    PELTIER_LEFT,
+    PELTIER_CENTER,
+    PELTIER_RIGHT,
+    PELTIER_COUNT
+};
+
+/** Enumeration of thermistors on the board.
+ * This is specifically arranged to keep all of the plate-related
+ * thermistors before the Lid, so mapping from the thermistors here
+ * to the values in the Thermal Plate Process can be 1:1 indexing
+ */
+enum ThermistorID {
+    THERM_FRONT_RIGHT,
+    THERM_FRONT_LEFT,
+    THERM_FRONT_CENTER,
+    THERM_BACK_RIGHT,
+    THERM_BACK_LEFT,
+    THERM_BACK_CENTER,
+    THERM_HEATSINK,
+    THERM_LID,
+    THERM_COUNT
+};
+
+struct Thermistor {
+    // Last converted temperature (0 if invalid)
+    double temp_c = 0;
+    // Last ADC result
+    uint16_t last_adc = 0;
+    // Current error
+    errors::ErrorCode error = errors::ErrorCode::NO_ERROR;
+    // These constant values should be set when the struct is initialized
+    // in order to capture errors specific to a sensor that require
+    // a system restart to rectify
+    const double overtemp_limit_c;
+    const uint8_t error_bit;
+};
+
+struct Peltier {
+    // ID to match to hardware - set at initialization
+    const PeltierID id;
+    // Whether this is currently enabled
+    bool enabled;
+    // Current temperature
+    double temp_current;
+    // Target temperature
+    double temp_target;
+};

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_general.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_general.hpp
@@ -4,16 +4,11 @@
  */
 #pragma once
 
-#include "thermocycler-refresh/errors.hpp"
 #include "core/thermistor_conversion.hpp"
+#include "thermocycler-refresh/errors.hpp"
 
 // Enumeration of peltiers on the board
-enum PeltierID {
-    PELTIER_LEFT,
-    PELTIER_CENTER,
-    PELTIER_RIGHT,
-    PELTIER_COUNT
-};
+enum PeltierID { PELTIER_LEFT, PELTIER_CENTER, PELTIER_RIGHT, PELTIER_COUNT };
 
 /** Enumeration of thermistors on the board.
  * This is specifically arranged to keep all of the plate-related

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -1,0 +1,204 @@
+/*
+ * the primary interface to the thermal plate task
+ */
+#pragma once
+
+#include <algorithm>
+#include <concepts>
+#include <cstddef>
+#include <variant>
+
+#include "core/pid.hpp"
+#include "core/thermistor_conversion.hpp"
+#include "hal/message_queue.hpp"
+#include "thermocycler-refresh/errors.hpp"
+#include "thermocycler-refresh/messages.hpp"
+#include "thermocycler-refresh/tasks.hpp"
+#include "thermocycler-refresh/thermal_general.hpp"
+
+/* Need a forward declaration for this because of recursive includes */
+namespace tasks {
+template <template <class> class Queue>
+struct Tasks;
+};
+
+namespace thermal_plate_task {
+    
+template <typename Policy>
+concept ThermalPlateExecutionPolicy = requires(Policy& p, const Policy& cp) {
+    // A set_enabled function with inputs of `false` or `true` that
+    // sets the enable pin for the peltiers off or on
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    { p.set_enabled(false)};
+};
+
+constexpr uint16_t thermistorErrorBit(const ThermistorID id) { 
+    if(id > THERM_HEATSINK) { throw std::out_of_range(""); }
+    return (1 << id); 
+}
+
+struct State {
+    enum Status {
+        IDLE,
+        ERROR,
+        CONTROLLING,
+    };
+    Status system_status;
+    uint16_t error_bitmap;
+    // NOTE - these values are defined assuming the max thermistor error is
+    // (1 << 6), for the heat sink
+    static constexpr uint16_t OVERTEMP_PLATE_ERROR = (1 << 7);
+    static constexpr uint16_t OVERTEMP_HEATSINK_ERROR = (1 << 7);
+};
+
+// By using a template template parameter here, we allow the code instantiating
+// this template to do so as ThermalPlateTask<SomeQueueImpl> rather than
+// ThermalPlateTask<SomeQueueImpl<Message>>
+using Message = messages::ThermalPlateMessage;
+template <template <class> class QueueImpl>
+requires MessageQueue<QueueImpl<Message>, Message>
+class ThermalPlateTask {
+
+public:
+    using Queue = QueueImpl<Message>;
+    static constexpr const uint32_t CONTROL_PERIOD_TICKS = 50;
+    static constexpr double THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM = 10.0;
+    static constexpr uint8_t ADC_BIT_DEPTH = 16;
+    static constexpr uint8_t PLATE_THERM_COUNT = 7;
+    // TODO most of these defaults will have to change
+    static constexpr double DEFAULT_KI = 0.102;
+    static constexpr double DEFAULT_KP = 0.97;
+    static constexpr double DEFAULT_KD = 1.901;
+    static constexpr double KP_MIN = -200;
+    static constexpr double KP_MAX = 200;
+    static constexpr double KI_MIN = -200;
+    static constexpr double KI_MAX = 200;
+    static constexpr double KD_MIN = -200;
+    static constexpr double KD_MAX = 200;
+    static constexpr double OVERTEMP_LIMIT_C = 105;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    static constexpr const double CONTROL_PERIOD_SECONDS =
+        CONTROL_PERIOD_TICKS * 0.001;
+
+    explicit ThermalPlateTask(Queue& q) :
+        message_queue(q),
+        task_registry(nullptr),
+        peltier_left{
+            .id = PELTIER_LEFT,
+            .enabled = false,
+            .temp_current = 0.0,
+            .temp_target = 0.0
+        },
+        peltier_right{
+            .id = PELTIER_RIGHT,
+            .enabled = false,
+            .temp_current = 0.0,
+            .temp_target = 0.0
+        },
+        peltier_center{
+            .id = PELTIER_CENTER,
+            .enabled = false,
+            .temp_current = 0.0,
+            .temp_target = 0.0
+        },
+        thermistors{ {
+            {
+                .overtemp_limit_c = OVERTEMP_LIMIT_C,
+                .error_bit = thermistorErrorBit(THERM_FRONT_RIGHT)
+            },
+            {
+                .overtemp_limit_c = OVERTEMP_LIMIT_C,
+                .error_bit = thermistorErrorBit(THERM_FRONT_LEFT)
+            },
+            {
+                .overtemp_limit_c = OVERTEMP_LIMIT_C,
+                .error_bit = thermistorErrorBit(THERM_FRONT_CENTER)
+            },
+            {
+                .overtemp_limit_c = OVERTEMP_LIMIT_C,
+                .error_bit = thermistorErrorBit(THERM_BACK_RIGHT)
+            },
+            {
+                .overtemp_limit_c = OVERTEMP_LIMIT_C,
+                .error_bit = thermistorErrorBit(THERM_BACK_LEFT)
+            },
+            {
+                .overtemp_limit_c = OVERTEMP_LIMIT_C,
+                .error_bit = thermistorErrorBit(THERM_BACK_CENTER)
+            },
+            {
+                .overtemp_limit_c = OVERTEMP_LIMIT_C,
+                .error_bit = thermistorErrorBit(THERM_HEATSINK)
+            }
+        } },
+        state{
+            .system_status = State::IDLE,
+            .error_bitmap = 0
+        },
+        plate_pid(DEFAULT_KP, DEFAULT_KI, DEFAULT_KD, 
+            CONTROL_PERIOD_SECONDS, 1.0, -1.0)
+        {}
+    ThermalPlateTask(const ThermalPlateTask &other) = delete;
+    auto operator=(const ThermalPlateTask &other) -> ThermalPlateTask& = delete;
+    ThermalPlateTask(ThermalPlateTask&& other) noexcept = delete;
+    auto operator=(ThermalPlateTask&& other) noexcept -> ThermalPlateTask& = delete;
+    ~ThermalPlateTask() = default;
+    auto get_message_queue() -> Queue& { return message_queue; }
+
+    void provide_tasks(tasks::Tasks<QueueImpl>* other_tasks) {
+        task_registry = other_tasks;
+    }
+
+    /**
+     * run_once() runs one spin of the task. This means it
+     * - Waits for a message, either a thermistor update or
+     *   some other control message
+     * - If there's a message, handles the message
+     *   - which may include altering its controller state
+     *   - which may include sending a response
+     * - Runs its controller
+     *
+     * The passed-in policy is the hardware interface and must fulfill the
+     * ThermalPlateExecutionPolicy concept above.
+     * */
+    template <typename Policy>
+    requires ThermalPlateExecutionPolicy<Policy>
+    auto run_once(Policy& policy) -> void {
+        auto message = Message(std::monostate());
+
+        // This is the call down to the provided queue. It will block for
+        // anywhere up to the provided timeout, which drives the controller
+        // frequency.
+
+        static_cast<void>(message_queue.recv(&message));
+        std::visit(
+            [this, &policy](const auto& msg) -> void {
+                this->visit_message(msg, policy);
+            },
+            message);
+    }
+private:
+    template <typename Policy>
+    auto visit_message(const std::monostate& _ignore, Policy& policy) -> void {
+        static_cast<void>(policy);
+        static_cast<void>(_ignore);
+    }
+
+    template <typename Policy>
+    auto visit_message(const messages::ThermalPlateTempReadComplete& msg, 
+                       Policy& policy) -> void {
+        // TODO fill out this function
+    }
+
+    Queue& message_queue;
+    tasks::Tasks<QueueImpl>* task_registry;
+    Peltier peltier_left;
+    Peltier peltier_right;
+    Peltier peltier_center;
+    std::array<Thermistor, PLATE_THERM_COUNT> thermistors;
+    State state;
+    PID plate_pid;
+};
+
+
+}

--- a/stm32-modules/thermocycler-refresh/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/CMakeLists.txt
@@ -12,8 +12,6 @@ else()
   add_subdirectory(simulator)
 endif()
 
-find_package(Clang)
-
 file(GLOB_RECURSE ${TARGET_MODULE_NAME}_SOURCES_FOR_FORMAT
   ./*.cpp ./*.hpp ./*.h
   ../include/${TARGET_MODULE_NAME}/*.hpp ../include/${TARGET_MODULE_NAME}/*.h)

--- a/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
@@ -22,6 +22,8 @@ set(${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS
   ${SYSTEM_DIR}/freertos_idle_timer_task.cpp
   ${THERMAL_DIR}/freertos_thermal_plate_task.cpp
   ${THERMAL_DIR}/thermal_plate_policy.cpp
+  ${THERMAL_DIR}/freertos_lid_heater_task.cpp
+  ${THERMAL_DIR}/lid_heater_policy.cpp
   )
 
 # Add source files that should NOT be checked by clang-tidy here

--- a/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
@@ -8,6 +8,7 @@ add_STM32G4_usb(${TARGET_MODULE_NAME})
 
 set(SYSTEM_DIR "${CMAKE_CURRENT_SOURCE_DIR}/system")
 set(COMMS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/host_comms_task")
+set(THERMAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/thermal")
 set(COMMON_MCU_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../common/STM32G491")
 set(COMMON_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../common/src")
 
@@ -17,7 +18,10 @@ set(${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS
   ${SYSTEM_DIR}/freertos_system_task.cpp
   ${SYSTEM_DIR}/system_policy.cpp
   ${COMMS_DIR}/freertos_comms_task.cpp
-  ${SYSTEM_DIR}/freertos_idle_timer_task.cpp)
+  ${SYSTEM_DIR}/freertos_idle_timer_task.cpp
+  ${THERMAL_DIR}/freertos_thermal_plate_task.cpp
+  ${THERMAL_DIR}/thermal_plate_policy.cpp
+  )
 
 # Add source files that should NOT be checked by clang-tidy here
 set(${TARGET_MODULE_NAME}_FW_NONLINTABLE_SRCS

--- a/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
@@ -11,6 +11,7 @@ set(COMMS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/host_comms_task")
 set(THERMAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/thermal")
 set(COMMON_MCU_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../common/STM32G491")
 set(COMMON_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../common/src")
+set(GDBINIT_PATH "${CMAKE_CURRENT_BINARY_DIR}/../../common/STM32G491/gdbinit")
 
 # Add source files that should be checked by clang-tidy here
 set(${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS
@@ -94,7 +95,6 @@ set_target_properties(
   STM32G4xx_FreeRTOS_${TARGET_MODULE_NAME}
   PROPERTIES FREERTOS_HEAP_IMPLEMENTATION "heap_5")
 
-find_package(GDBSVDTools)
 
 find_program(ARM_GDB
   arm-none-eabi-gdb-py
@@ -107,7 +107,7 @@ message(STATUS "Found svd exe at ${GDBSVDTools_gdbsvd_EXECUTABLE}")
 set_target_properties(${TARGET_MODULE_NAME}
   PROPERTIES
   CROSSCOMPILING_EMULATOR
-  "${ARM_GDB};--command=${COMMON_MCU_DIR}/gdbinit")
+  "${ARM_GDB};--command=${GDBINIT_PATH}")
 
 find_program(CROSS_OBJCOPY "${CrossGCC_TRIPLE}-objcopy"
   PATHS "${CrossGCC_BINDIR}"
@@ -126,8 +126,6 @@ add_custom_command(OUTPUT ${TARGET_MODULE_NAME}.bin
   VERBATIM)
 add_custom_target(${TARGET_MODULE_NAME}-bin ALL
   DEPENDS ${TARGET_MODULE_NAME}.bin)
-
-find_package(Clang)
 
 # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html
 # which is a catch-all static analyzer/linter

--- a/stm32-modules/thermocycler-refresh/firmware/system/main.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/main.cpp
@@ -4,6 +4,7 @@
 #include "firmware/freertos_comms_task.hpp"
 #include "firmware/freertos_message_queue.hpp"
 #include "firmware/freertos_system_task.hpp"
+#include "firmware/freertos_thermal_plate_task.hpp"
 #include "system_stm32g4xx.h"
 #include "thermocycler-refresh/tasks.hpp"
 
@@ -20,7 +21,8 @@ auto main() -> int {
 
     auto system = system_control_task::start();
     auto comms = host_comms_control_task::start();
-    tasks_aggregator.initialize(comms.task, system.task);
+    auto thermal_plate = thermal_plate_control_task::start();
+    tasks_aggregator.initialize(comms.task, system.task, thermal_plate.task);
     vTaskStartScheduler();
     return 0;
 }

--- a/stm32-modules/thermocycler-refresh/firmware/system/main.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/main.cpp
@@ -25,7 +25,7 @@ auto main() -> int {
     auto thermal_plate = thermal_plate_control_task::start();
     auto lid_heater = lid_heater_control_task::start();
     tasks_aggregator.initialize(comms.task, system.task, thermal_plate.task,
-        lid_heater.task);
+                                lid_heater.task);
     vTaskStartScheduler();
     return 0;
 }

--- a/stm32-modules/thermocycler-refresh/firmware/system/main.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/main.cpp
@@ -2,6 +2,7 @@
 
 #include "FreeRTOS.h"
 #include "firmware/freertos_comms_task.hpp"
+#include "firmware/freertos_lid_heater_task.hpp"
 #include "firmware/freertos_message_queue.hpp"
 #include "firmware/freertos_system_task.hpp"
 #include "firmware/freertos_thermal_plate_task.hpp"
@@ -22,7 +23,9 @@ auto main() -> int {
     auto system = system_control_task::start();
     auto comms = host_comms_control_task::start();
     auto thermal_plate = thermal_plate_control_task::start();
-    tasks_aggregator.initialize(comms.task, system.task, thermal_plate.task);
+    auto lid_heater = lid_heater_control_task::start();
+    tasks_aggregator.initialize(comms.task, system.task, thermal_plate.task,
+        lid_heater.task);
     vTaskStartScheduler();
     return 0;
 }

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_lid_heater_task.cpp
@@ -17,7 +17,7 @@ enum class Notifications : uint8_t {
 static FreeRTOSMessageQueue<lid_heater_task::Message>
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     _lid_heater_queue(static_cast<uint8_t>(Notifications::INCOMING_MESSAGE),
-                         "Lid Heater Queue");
+                      "Lid Heater Queue");
 
 static auto _task = lid_heater_task::LidHeaterTask(_lid_heater_queue);
 
@@ -43,8 +43,8 @@ static void run(void *param) {
 auto start()
     -> tasks::Task<TaskHandle_t,
                    lid_heater_task::LidHeaterTask<FreeRTOSMessageQueue>> {
-    auto *handle = xTaskCreateStatic(run, "LidHeater", stack.size(), &_task,
-                                     1, stack.data(), &data);
+    auto *handle = xTaskCreateStatic(run, "LidHeater", stack.size(), &_task, 1,
+                                     stack.data(), &data);
     _lid_heater_queue.provide_handle(handle);
     return tasks::Task<TaskHandle_t, decltype(_task)>{.handle = handle,
                                                       .task = &_task};

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_lid_heater_task.cpp
@@ -1,0 +1,52 @@
+/*
+ * firmware-specific internals and hooks for the lid-heater task
+ */
+
+#include "firmware/freertos_lid_heater_task.hpp"
+
+#include "FreeRTOS.h"
+#include "lid_heater_policy.hpp"
+#include "thermocycler-refresh/lid_heater_task.hpp"
+
+namespace lid_heater_control_task {
+
+enum class Notifications : uint8_t {
+    INCOMING_MESSAGE = 1,
+};
+
+static FreeRTOSMessageQueue<lid_heater_task::Message>
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    _lid_heater_queue(static_cast<uint8_t>(Notifications::INCOMING_MESSAGE),
+                         "Lid Heater Queue");
+
+static auto _task = lid_heater_task::LidHeaterTask(_lid_heater_queue);
+
+static constexpr uint32_t stack_size = 500;
+// Stack as a std::array because why not. Quiet lint because, well, we have to
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static std::array<StackType_t, stack_size> stack;
+
+// Internal FreeRTOS data structure for the task
+static StaticTask_t
+    data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+static void run(void *param) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto *task = reinterpret_cast<decltype(_task) *>(param);
+    auto policy = LidHeaterPolicy();
+    while (true) {
+        task->run_once(policy);
+    }
+}
+
+// Function that spins up the task
+auto start()
+    -> tasks::Task<TaskHandle_t,
+                   lid_heater_task::LidHeaterTask<FreeRTOSMessageQueue>> {
+    auto *handle = xTaskCreateStatic(run, "LidHeater", stack.size(), &_task,
+                                     1, stack.data(), &data);
+    _lid_heater_queue.provide_handle(handle);
+    return tasks::Task<TaskHandle_t, decltype(_task)>{.handle = handle,
+                                                      .task = &_task};
+}
+}  // namespace lid_heater_control_task

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -2,14 +2,14 @@
  * firmware-specific internals and hooks for the plate task
  */
 
-#include "FreeRTOS.h"
 #include "firmware/freertos_thermal_plate_task.hpp"
 
-#include "thermocycler-refresh/thermal_plate_task.hpp"
+#include "FreeRTOS.h"
 #include "thermal_plate_policy.hpp"
+#include "thermocycler-refresh/thermal_plate_task.hpp"
 
 namespace thermal_plate_control_task {
-    
+
 enum class Notifications : uint8_t {
     INCOMING_MESSAGE = 1,
 };
@@ -17,7 +17,7 @@ enum class Notifications : uint8_t {
 static FreeRTOSMessageQueue<thermal_plate_task::Message>
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     _thermal_plate_queue(static_cast<uint8_t>(Notifications::INCOMING_MESSAGE),
-                  "Thermal Plate Queue");
+                         "Thermal Plate Queue");
 
 static auto _task = thermal_plate_task::ThermalPlateTask(_thermal_plate_queue);
 
@@ -31,22 +31,22 @@ static StaticTask_t
     data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 static void run(void *param) {
-
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto *task = reinterpret_cast<decltype(_task) *>(param);
     auto policy = ThermalPlatePolicy();
-    while(true) {
+    while (true) {
         task->run_once(policy);
     }
 }
 
 // Function that spins up the task
-auto start() -> tasks::Task<TaskHandle_t,
-            thermal_plate_task::ThermalPlateTask<FreeRTOSMessageQueue>> {
+auto start()
+    -> tasks::Task<TaskHandle_t,
+                   thermal_plate_task::ThermalPlateTask<FreeRTOSMessageQueue>> {
     auto *handle = xTaskCreateStatic(run, "ThermalPlate", stack.size(), &_task,
-                        1, stack.data(), &data);
+                                     1, stack.data(), &data);
     _thermal_plate_queue.provide_handle(handle);
     return tasks::Task<TaskHandle_t, decltype(_task)>{.handle = handle,
                                                       .task = &_task};
 }
-} // namespace thermal_plate_control_task
+}  // namespace thermal_plate_control_task

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -1,0 +1,52 @@
+/*
+ * firmware-specific internals and hooks for the plate task
+ */
+
+#include "FreeRTOS.h"
+#include "firmware/freertos_thermal_plate_task.hpp"
+
+#include "thermocycler-refresh/thermal_plate_task.hpp"
+#include "thermal_plate_policy.hpp"
+
+namespace thermal_plate_control_task {
+    
+enum class Notifications : uint8_t {
+    INCOMING_MESSAGE = 1,
+};
+
+static FreeRTOSMessageQueue<thermal_plate_task::Message>
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    _thermal_plate_queue(static_cast<uint8_t>(Notifications::INCOMING_MESSAGE),
+                  "Thermal Plate Queue");
+
+static auto _task = thermal_plate_task::ThermalPlateTask(_thermal_plate_queue);
+
+static constexpr uint32_t stack_size = 500;
+// Stack as a std::array because why not. Quiet lint because, well, we have to
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static std::array<StackType_t, stack_size> stack;
+
+// Internal FreeRTOS data structure for the task
+static StaticTask_t
+    data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+static void run(void *param) {
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto *task = reinterpret_cast<decltype(_task) *>(param);
+    auto policy = ThermalPlatePolicy();
+    while(true) {
+        task->run_once(policy);
+    }
+}
+
+// Function that spins up the task
+auto start() -> tasks::Task<TaskHandle_t,
+            thermal_plate_task::ThermalPlateTask<FreeRTOSMessageQueue>> {
+    auto *handle = xTaskCreateStatic(run, "ThermalPlate", stack.size(), &_task,
+                        1, stack.data(), &data);
+    _thermal_plate_queue.provide_handle(handle);
+    return tasks::Task<TaskHandle_t, decltype(_task)>{.handle = handle,
+                                                      .task = &_task};
+}
+} // namespace thermal_plate_control_task

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.cpp
@@ -1,0 +1,8 @@
+#include "lid_heater_policy.hpp"
+
+LidHeaterPolicy::LidHeaterPolicy() {}
+
+auto LidHeaterPolicy::set_enabled(bool enabled) -> void {
+    // TODO - stub right now just to be able to set up concept requirements
+    return;
+}

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.hpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.hpp
@@ -1,0 +1,13 @@
+/**
+ * The LidHeaterPolicy class provides firmware implementation
+ * of any stubbable hardware interactions needed in the Thermal
+ * Plate Task.
+ */
+#pragma once
+
+class LidHeaterPolicy {
+  public:
+    LidHeaterPolicy();
+
+    auto set_enabled(bool enabled) -> void;
+};

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
@@ -1,0 +1,9 @@
+#include "thermal_plate_policy.hpp"
+
+ThermalPlatePolicy::ThermalPlatePolicy() {}
+
+auto ThermalPlatePolicy::set_enabled(bool enabled) -> void
+{
+    // TODO - stub right now just to be able to set up concept requirements
+    return;
+}

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
@@ -2,8 +2,7 @@
 
 ThermalPlatePolicy::ThermalPlatePolicy() {}
 
-auto ThermalPlatePolicy::set_enabled(bool enabled) -> void
-{
+auto ThermalPlatePolicy::set_enabled(bool enabled) -> void {
     // TODO - stub right now just to be able to set up concept requirements
     return;
 }

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.hpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.hpp
@@ -1,0 +1,13 @@
+/**
+ * The ThermalPlatePolicy class provides firmware implementation
+ * of any stubbable hardware interactions needed in the Thermal
+ * Plate Task.
+ */
+#pragma once
+
+class ThermalPlatePolicy {
+public:
+    ThermalPlatePolicy();
+
+    auto set_enabled(bool enabled) -> void;
+};

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.hpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.hpp
@@ -6,7 +6,7 @@
 #pragma once
 
 class ThermalPlatePolicy {
-public:
+  public:
     ThermalPlatePolicy();
 
     auto set_enabled(bool enabled) -> void;

--- a/stm32-modules/thermocycler-refresh/simulator/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/simulator/CMakeLists.txt
@@ -2,9 +2,11 @@ add_executable(
   ${TARGET_MODULE_NAME}-simulator
   cli_parser.cpp
   comm_thread.cpp
+  lid_heater_thread.cpp
   socket_sim_driver.cpp
   stdin_sim_driver.cpp
   system_thread.cpp 
+  thermal_plate_thread.cpp
   main.cpp
 )
 

--- a/stm32-modules/thermocycler-refresh/simulator/lid_heater_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/lid_heater_thread.cpp
@@ -1,0 +1,44 @@
+#include "simulator/lid_heater_thread.hpp"
+
+#include <chrono>
+#include <stop_token>
+
+#include "systemwide.hpp"
+#include "thermocycler-refresh/errors.hpp"
+#include "thermocycler-refresh/tasks.hpp"
+
+using namespace lid_heater_thread;
+
+struct SimLidHeaterPolicy {
+  private:
+    bool _enabled = false;
+
+  public:
+    auto set_enabled(bool enabled) -> void { _enabled = enabled; }
+};
+
+struct lid_heater_thread::TaskControlBlock {
+    TaskControlBlock()
+        : queue(SimLidHeaterTask::Queue()), task(SimLidHeaterTask(queue)) {}
+    SimLidHeaterTask::Queue queue;
+    SimLidHeaterTask task;
+};
+
+auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb) -> void {
+    using namespace std::literals::chrono_literals;
+    auto policy = SimLidHeaterPolicy();
+    tcb->queue.set_stop_token(st);
+    while (!st.stop_requested()) {
+        try {
+            tcb->task.run_once(policy);
+        } catch (const SimLidHeaterTask::Queue::StopDuringMsgWait sdmw) {
+            return;
+        }
+    }
+}
+
+auto lid_heater_thread::build()
+    -> tasks::Task<std::unique_ptr<std::jthread>, SimLidHeaterTask> {
+    auto tcb = std::make_shared<TaskControlBlock>();
+    return tasks::Task(std::make_unique<std::jthread>(run, tcb), &tcb->task);
+}

--- a/stm32-modules/thermocycler-refresh/simulator/main.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/main.cpp
@@ -3,9 +3,11 @@
 
 #include "simulator/cli_parser.hpp"
 #include "simulator/comm_thread.hpp"
+#include "simulator/lid_heater_thread.hpp"
 #include "simulator/sim_driver.hpp"
 #include "simulator/simulator_queue.hpp"
 #include "simulator/system_thread.hpp"
+#include "simulator/thermal_plate_thread.hpp"
 #include "thermocycler-refresh/tasks.hpp"
 
 using namespace std;
@@ -13,16 +15,23 @@ using namespace std;
 int main(int argc, char *argv[]) {
     auto sim_driver = cli_parser::get_sim_driver(argc, argv);
     auto system = system_thread::build();
+    auto thermal_plate = thermal_plate_thread::build();
+    auto lid_heater = lid_heater_thread::build();
     auto comms = comm_thread::build(std::move(sim_driver));
-    auto tasks = tasks::Tasks<SimulatorMessageQueue>(comms.task, system.task);
+    auto tasks = tasks::Tasks<SimulatorMessageQueue>(
+        comms.task, system.task, thermal_plate.task, lid_heater.task);
 
     comm_thread::handle_input(std::move(sim_driver), tasks);
 
     system.handle->request_stop();
     comms.handle->request_stop();
+    thermal_plate.handle->request_stop();
+    lid_heater.handle->request_stop();
 
     system.handle->join();
     comms.handle->join();
+    thermal_plate.handle->join();
+    lid_heater.handle->join();
 
     return 0;
 }

--- a/stm32-modules/thermocycler-refresh/simulator/thermal_plate_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/thermal_plate_thread.cpp
@@ -1,0 +1,45 @@
+#include "simulator/thermal_plate_thread.hpp"
+
+#include <chrono>
+#include <stop_token>
+
+#include "systemwide.hpp"
+#include "thermocycler-refresh/errors.hpp"
+#include "thermocycler-refresh/tasks.hpp"
+
+using namespace thermal_plate_thread;
+
+struct SimThermalPlatePolicy {
+  private:
+    bool _enabled = false;
+
+  public:
+    auto set_enabled(bool enabled) -> void { _enabled = enabled; }
+};
+
+struct thermal_plate_thread::TaskControlBlock {
+    TaskControlBlock()
+        : queue(SimThermalPlateTask::Queue()),
+          task(SimThermalPlateTask(queue)) {}
+    SimThermalPlateTask::Queue queue;
+    SimThermalPlateTask task;
+};
+
+auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb) -> void {
+    using namespace std::literals::chrono_literals;
+    auto policy = SimThermalPlatePolicy();
+    tcb->queue.set_stop_token(st);
+    while (!st.stop_requested()) {
+        try {
+            tcb->task.run_once(policy);
+        } catch (const SimThermalPlateTask::Queue::StopDuringMsgWait sdmw) {
+            return;
+        }
+    }
+}
+
+auto thermal_plate_thread::build()
+    -> tasks::Task<std::unique_ptr<std::jthread>, SimThermalPlateTask> {
+    auto tcb = std::make_shared<TaskControlBlock>();
+    return tasks::Task(std::make_unique<std::jthread>(run, tcb), &tcb->task);
+}

--- a/stm32-modules/thermocycler-refresh/tests/task_builder.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/task_builder.cpp
@@ -9,8 +9,8 @@ TaskBuilder::TaskBuilder()
       thermal_plate_task(thermal_plate_queue),
       lid_heater_queue("lid heater"),
       lid_heater_task(lid_heater_queue),
-      task_aggregator(&host_comms_task, &system_task,
-                      &thermal_plate_task, &lid_heater_task),
+      task_aggregator(&host_comms_task, &system_task, &thermal_plate_task,
+                      &lid_heater_task),
       system_policy(),
       thermal_plate_policy(),
       lid_heater_policy() {}

--- a/stm32-modules/thermocycler-refresh/tests/task_builder.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/task_builder.cpp
@@ -5,8 +5,15 @@ TaskBuilder::TaskBuilder()
       host_comms_task(host_comms_queue),
       system_queue("system"),
       system_task(system_queue),
-      task_aggregator(&host_comms_task, &system_task),
-      system_policy() {}
+      thermal_plate_queue("thermal plate"),
+      thermal_plate_task(thermal_plate_queue),
+      lid_heater_queue("lid heater"),
+      lid_heater_task(lid_heater_queue),
+      task_aggregator(&host_comms_task, &system_task,
+                      &thermal_plate_task, &lid_heater_task),
+      system_policy(),
+      thermal_plate_policy(),
+      lid_heater_policy() {}
 
 auto TaskBuilder::build() -> std::shared_ptr<TaskBuilder> {
     return std::shared_ptr<TaskBuilder>(new TaskBuilder());


### PR DESCRIPTION
Adds two tasks to the TCR project. One task is for the thermal plate (aka the peltier subsystem), and the other for the lid heater (the heat pad). These are separated into two distinct tasks even though they'll share a bit of the same hardware control code because they are logically separate control loops.

Code is added for basic testing policy support for the new tasks, but no tests are added because there isn't anything (usefully) testable - will include test code with the thermistor code.

Also includes some cmake edits
- In #216 I messed up the variables pointing towards gdbinit
- Consolidated the _many_ calls to `find_package(clang)`

