### PR TITLE
chore(thermocycler-refresh): Fix Lint configuration

### DIFF
--- a/stm32-modules/common/src/CMakeLists.txt
+++ b/stm32-modules/common/src/CMakeLists.txt
@@ -77,10 +77,11 @@ if (${CMAKE_CROSSCOMPILING})
   list(TRANSFORM CLANG_EXTRA_ARGS PREPEND --extra-arg=-I)
   # This helps with clang accepting what GCC accepts around the implementations of the message queue
   list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-frelaxed-template-template-args")
+  list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-Werror=implicit-fallthrough")
   add_custom_target(${TARGET_MODULE_NAME}-lint
     COMMENT "Linting"
     ALL
-    COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${CORE_LINTABLE_SOURCES} --config=
+    COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${CORE_LINTABLE_SOURCES}
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thermistor_lookups.hpp
     )
   

--- a/stm32-modules/common/src/generate_thermistor_table.py
+++ b/stm32-modules/common/src/generate_thermistor_table.py
@@ -121,7 +121,8 @@ class KS103J2Generator:
     def generate_header(self):
         return '\n'.join([
             f'{self._incremental_space}struct {self.name()}{{',
-            f'{self._incremental_space}{self._incremental_space}[[nodiscard]] auto operator()(void) -> const {self.array_type()}&;',
+            f'{self._incremental_space}// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)',
+            f'{self._incremental_space}{self._incremental_space}[[nodiscard]] auto operator()() -> const {self.array_type()}&;',
             f'{self._incremental_space}}};'
         ])
     
@@ -140,7 +141,7 @@ class KS103J2Generator:
     
     def generate_function(self):
         return '\n'.join([
-            f'[[nodiscard]] auto lookups::{self.name()}::operator()(void) -> const {self.array_type()}& {{',
+            f'[[nodiscard]] auto lookups::{self.name()}::operator()() -> const {self.array_type()}& {{',
             f'{self._incremental_space}return {self.tablename()};',
             '}'
             ])

--- a/stm32-modules/include/common/firmware/freertos_synchronization.hpp
+++ b/stm32-modules/include/common/firmware/freertos_synchronization.hpp
@@ -33,8 +33,10 @@ class FreeRTOSMutexFromISR {
     }
     FreeRTOSMutexFromISR(const FreeRTOSMutexFromISR &) = delete;
     FreeRTOSMutexFromISR(const FreeRTOSMutexFromISR &&) = delete;
-    auto operator=(const FreeRTOSMutexFromISR &) -> FreeRTOSMutexFromISR & = delete;
-    auto operator=(const FreeRTOSMutexFromISR &&) -> FreeRTOSMutexFromISR && = delete;
+    auto operator=(const FreeRTOSMutexFromISR &)
+        -> FreeRTOSMutexFromISR & = delete;
+    auto operator=(const FreeRTOSMutexFromISR &&)
+        -> FreeRTOSMutexFromISR && = delete;
 
     ~FreeRTOSMutexFromISR() { vSemaphoreDelete(handle); }
 
@@ -42,7 +44,7 @@ class FreeRTOSMutexFromISR {
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
         xSemaphoreTakeFromISR(handle, &xHigherPriorityTaskWoken);
         if (xHigherPriorityTaskWoken != pdFALSE) {
-            //NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
             taskYIELD();
         }
     }
@@ -51,7 +53,7 @@ class FreeRTOSMutexFromISR {
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
         xSemaphoreGiveFromISR(handle, &xHigherPriorityTaskWoken);
         if (xHigherPriorityTaskWoken != pdFALSE) {
-            //NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
             taskYIELD();
         }
     }
@@ -68,19 +70,21 @@ class FreeRTOSCriticalSection {
     FreeRTOSCriticalSection() = default;
     FreeRTOSCriticalSection(const FreeRTOSCriticalSection &) = delete;
     FreeRTOSCriticalSection(const FreeRTOSCriticalSection &&) = delete;
-    auto operator=(const FreeRTOSCriticalSection &) -> FreeRTOSCriticalSection & = delete;
-    auto operator=(const FreeRTOSCriticalSection &&) -> FreeRTOSCriticalSection && = delete;
+    auto operator=(const FreeRTOSCriticalSection &)
+        -> FreeRTOSCriticalSection & = delete;
+    auto operator=(const FreeRTOSCriticalSection &&)
+        -> FreeRTOSCriticalSection && = delete;
 
     ~FreeRTOSCriticalSection() = default;
 
-    // Silence warnings about these functions being static because that would obscure the use
-    // of this object, which is to act as a sort of lock around parts of code that need to
-    // disable interrupts.
+    // Silence warnings about these functions being static because that would
+    // obscure the use of this object, which is to act as a sort of lock around
+    // parts of code that need to disable interrupts.
 
-    //NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     void acquire() { taskENTER_CRITICAL(); }
 
-    //NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     void release() { taskEXIT_CRITICAL(); }
 };
 

--- a/stm32-modules/include/common/firmware/freertos_synchronization.hpp
+++ b/stm32-modules/include/common/firmware/freertos_synchronization.hpp
@@ -10,8 +10,8 @@ class FreeRTOSMutex {
     FreeRTOSMutex() { handle = xSemaphoreCreateMutexStatic(&static_data); }
     FreeRTOSMutex(const FreeRTOSMutex &) = delete;
     FreeRTOSMutex(const FreeRTOSMutex &&) = delete;
-    FreeRTOSMutex &operator=(const FreeRTOSMutex &) = delete;
-    FreeRTOSMutex &&operator=(const FreeRTOSMutex &&) = delete;
+    auto operator=(const FreeRTOSMutex &) -> FreeRTOSMutex & = delete;
+    auto operator=(const FreeRTOSMutex &&) -> FreeRTOSMutex && = delete;
 
     ~FreeRTOSMutex() { vSemaphoreDelete(handle); }
 
@@ -19,7 +19,7 @@ class FreeRTOSMutex {
 
     void release() { xSemaphoreGive(handle); }
 
-    int get_count() { return uxSemaphoreGetCount(handle); }
+    auto get_count() -> int { return uxSemaphoreGetCount(handle); }
 
   private:
     SemaphoreHandle_t handle{};
@@ -33,8 +33,8 @@ class FreeRTOSMutexFromISR {
     }
     FreeRTOSMutexFromISR(const FreeRTOSMutexFromISR &) = delete;
     FreeRTOSMutexFromISR(const FreeRTOSMutexFromISR &&) = delete;
-    FreeRTOSMutexFromISR &operator=(const FreeRTOSMutexFromISR &) = delete;
-    FreeRTOSMutexFromISR &&operator=(const FreeRTOSMutexFromISR &&) = delete;
+    auto operator=(const FreeRTOSMutexFromISR &) -> FreeRTOSMutexFromISR & = delete;
+    auto operator=(const FreeRTOSMutexFromISR &&) -> FreeRTOSMutexFromISR && = delete;
 
     ~FreeRTOSMutexFromISR() { vSemaphoreDelete(handle); }
 
@@ -42,6 +42,7 @@ class FreeRTOSMutexFromISR {
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
         xSemaphoreTakeFromISR(handle, &xHigherPriorityTaskWoken);
         if (xHigherPriorityTaskWoken != pdFALSE) {
+            //NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
             taskYIELD();
         }
     }
@@ -50,11 +51,12 @@ class FreeRTOSMutexFromISR {
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
         xSemaphoreGiveFromISR(handle, &xHigherPriorityTaskWoken);
         if (xHigherPriorityTaskWoken != pdFALSE) {
+            //NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
             taskYIELD();
         }
     }
 
-    int get_count() { return uxSemaphoreGetCount(handle); }
+    auto get_count() -> int { return uxSemaphoreGetCount(handle); }
 
   private:
     SemaphoreHandle_t handle{};
@@ -63,16 +65,22 @@ class FreeRTOSMutexFromISR {
 
 class FreeRTOSCriticalSection {
   public:
-    FreeRTOSCriticalSection() {}
+    FreeRTOSCriticalSection() = default;
     FreeRTOSCriticalSection(const FreeRTOSCriticalSection &) = delete;
     FreeRTOSCriticalSection(const FreeRTOSCriticalSection &&) = delete;
-    FreeRTOSCriticalSection &operator=(const FreeRTOSCriticalSection &) =
-        delete;
-    FreeRTOSCriticalSection &&operator=(const FreeRTOSCriticalSection &&) =
-        delete;
+    auto operator=(const FreeRTOSCriticalSection &) -> FreeRTOSCriticalSection & = delete;
+    auto operator=(const FreeRTOSCriticalSection &&) -> FreeRTOSCriticalSection && = delete;
 
+    ~FreeRTOSCriticalSection() = default;
+
+    // Silence warnings about these functions being static because that would obscure the use
+    // of this object, which is to act as a sort of lock around parts of code that need to
+    // disable interrupts.
+
+    //NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     void acquire() { taskENTER_CRITICAL(); }
 
+    //NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     void release() { taskEXIT_CRITICAL(); }
 };
 

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -152,33 +152,29 @@ struct SetSerialNumber {
 
         auto after = working;
         bool found = false;
-        for (int index = 0; (index != (limit - working + 1)) && (!found);
-             index++) {
-            if (std::isspace(*(working + index)) ||
-                ((*(working + index)) == '\0')) {
-                after = (working + index);
+        for (auto index = working; index != limit && (!found); index++) {
+            if (std::isspace(*index) || (*index == '\0')) {
+                after = index;
                 found = true;
             }
         }
-        if (((after - working) > 0) &&
-            ((after - working) < static_cast<int>(SERIAL_NUMBER_LENGTH))) {
+        if ((after != working) && (std::distance(working, after) <
+                                   static_cast<int>(SERIAL_NUMBER_LENGTH))) {
             std::array<char, SERIAL_NUMBER_LENGTH> serial_number_res = {};
-            std::copy(working, (working + (after - working)),
-                      serial_number_res.begin());
+            std::copy(working, after, serial_number_res.begin());
             return std::make_pair(ParseResult(SetSerialNumber{
                                       .serial_number = serial_number_res}),
                                   after);
-        } else if (((after - working) > 0) &&
-                   ((after - working) >=
-                    static_cast<int>(SERIAL_NUMBER_LENGTH))) {
+        }
+        if (std::distance(working, after) >
+            static_cast<int>(SERIAL_NUMBER_LENGTH)) {
             return std::make_pair(
                 ParseResult(SetSerialNumber{
                     .with_error =
                         errors::ErrorCode::SYSTEM_SERIAL_NUMBER_INVALID}),
                 input);
-        } else {
-            return std::make_pair(ParseResult(), input);
         }
+        return std::make_pair(ParseResult(), input);
     }
 };
 

--- a/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
@@ -151,7 +151,7 @@ list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-Werror=implicit-fallthrough")
 add_custom_target(${TARGET_MODULE_NAME}-lint
   COMMENT "Linting"
   ALL
-  COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS} ${CORE_LINTABLE_SOURCES} --config=
+  COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS} ${CORE_LINTABLE_SOURCES}
   DEPENDS thermocycler-refresh-core # Required to include the thermistor_lookups file, and possibly generate it if not present
 )
 

--- a/stm32-modules/thermocycler-refresh/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/host_comms_task/freertos_comms_task.cpp
@@ -98,15 +98,17 @@ void run(void *param) {  // NOLINT(misc-unused-parameters)
     // stm32g4xx-bsp/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c:159
     // for annotated descriptor definitions
 
-    uint16_t len;
+    uint16_t len = 0;
     auto *usb_hs_desc = USBD_CDC.GetHSConfigDescriptor(&len);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     if ((usb_hs_desc != nullptr) && (len > 30)) {
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-pro-bounds-pointer-arithmetic)
         usb_hs_desc[30] = 0;
     }
     auto *usb_fs_desc = USBD_CDC.GetFSConfigDescriptor(&len);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     if ((usb_fs_desc != nullptr) && (len > 30)) {
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-pro-bounds-pointer-arithmetic)
         usb_fs_desc[30] = 0;
     }
     USBD_Init(&local_task->usb_handle, &CDC_Desc, 0);

--- a/stm32-modules/thermocycler-refresh/firmware/system/system_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/system_policy.cpp
@@ -16,20 +16,24 @@ auto SystemPolicy::enter_bootloader() -> void {
     system_hardware_enter_bootloader();
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto SystemPolicy::set_serial_number(
     std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> system_serial_number)
     -> errors::ErrorCode {
-    writable_serial to_write_struct;
+    writable_serial to_write_struct = {0};
     // convert bytes to uint64_t for system_set_serial_number
     // write to 8 chars to each of first 3 addresses on last page of flash
     for (uint8_t address = 0; address < ADDRESSES; address++) {
-        auto input = system_serial_number.begin() + (address * ADDRESS_LENGTH);
-        auto limit = input + ADDRESS_LENGTH;
+        auto *input =
+            std::next(system_serial_number.begin(), address * ADDRESS_LENGTH);
+        auto *limit = std::next(input, ADDRESS_LENGTH);
         uint64_t to_write = 0;
         for (ssize_t byte_index = sizeof(to_write) - 1;
-             input != limit && byte_index >= 0; input++, byte_index--) {
+             input != limit && byte_index >= 0;
+             std::advance(input, 1), byte_index--) {
             to_write |= (static_cast<uint64_t>(*input) << (byte_index * 8));
         }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
         to_write_struct.contents[address] = to_write;
     }
     if (!system_set_serial_number(&to_write_struct)) {
@@ -38,17 +42,19 @@ auto SystemPolicy::set_serial_number(
     return errors::ErrorCode::NO_ERROR;
 }
 
-auto SystemPolicy::get_serial_number(void)
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto SystemPolicy::get_serial_number()
     -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> {
     std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> serial_number_array = {
         "EMPTYSN"};
     for (uint8_t address = 0; address < ADDRESSES; address++) {
         uint64_t written_serial_number = system_get_serial_number(address);
         // int to bytes
-        auto output = serial_number_array.begin() + (address * ADDRESS_LENGTH);
-        auto limit = output + ADDRESS_LENGTH;
+        auto *output =
+            std::next(serial_number_array.begin(), address * ADDRESS_LENGTH);
+        auto *limit = std::next(output, ADDRESS_LENGTH);
         for (ssize_t iter = sizeof(written_serial_number) - 1;
-             iter >= 0 && output != limit; iter--, output++) {
+             iter >= 0 && output != limit; iter--, std::advance(output, 1)) {
             *output = (written_serial_number >> (iter * 8));
         }
     }

--- a/stm32-modules/thermocycler-refresh/firmware/system/system_policy.hpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/system_policy.hpp
@@ -24,6 +24,5 @@ class SystemPolicy {
     auto set_serial_number(
         std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> system_serial_number)
         -> errors::ErrorCode;
-    auto get_serial_number(void)
-        -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH>;
+    auto get_serial_number() -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH>;
 };

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_lid_heater_task.cpp
@@ -25,6 +25,7 @@ static FreeRTOSMessageQueue<lid_heater_task::Message>
     _lid_heater_queue(static_cast<uint8_t>(Notifications::INCOMING_MESSAGE),
                       "Lid Heater Queue");
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _main_task = lid_heater_task::LidHeaterTask(_lid_heater_queue);
 
 static constexpr uint32_t _stack_size = 500;
@@ -59,11 +60,12 @@ static void run(void *param) {
  * the message sent by updating its control loop.
  */
 static void run_thermistor_task(void *param) {
+    static_cast<void>(param);
     thermal_hardware_setup();
     ADS1115::ADC adc(_adc_address, ADC2_ITR);
     adc.initialize();
     auto last_wake_time = xTaskGetTickCount();
-    messages::LidTempReadComplete readings;
+    messages::LidTempReadComplete readings{};
     while (true) {
         vTaskDelayUntil(
             &last_wake_time,

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.cpp
@@ -1,8 +1,7 @@
 #include "lid_heater_policy.hpp"
 
-LidHeaterPolicy::LidHeaterPolicy() {}
-
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto LidHeaterPolicy::set_enabled(bool enabled) -> void {
     // TODO - stub right now just to be able to set up concept requirements
-    return;
+    static_cast<void>(enabled);
 }

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.hpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.hpp
@@ -7,7 +7,7 @@
 
 class LidHeaterPolicy {
   public:
-    LidHeaterPolicy();
+    LidHeaterPolicy() = default;
 
     auto set_enabled(bool enabled) -> void;
 };

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
@@ -1,8 +1,7 @@
 #include "thermal_plate_policy.hpp"
 
-ThermalPlatePolicy::ThermalPlatePolicy() {}
-
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPlatePolicy::set_enabled(bool enabled) -> void {
     // TODO - stub right now just to be able to set up concept requirements
-    return;
+    static_cast<void>(enabled);
 }

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.hpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.hpp
@@ -7,7 +7,7 @@
 
 class ThermalPlatePolicy {
   public:
-    ThermalPlatePolicy();
+    ThermalPlatePolicy() = default;
 
     auto set_enabled(bool enabled) -> void;
 };


### PR DESCRIPTION
Changes to cmake configuration in order to actually use our `.clang-tidy` configuration file, and changes to the thermocycler-refresh code to comply with our new linting policies.

Heater/Shaker configuration still needs to be fixed