### PR TITLE
chore(thermocycler-refresh, heater-shaker): update CMakePresets to version 2

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -117,9 +117,20 @@
         },
         {
             "name": "format-firmware",
-            "displayName": "format all firmware",
+            "displayName": "format  firmware",
             "description": "Runs clang-format on all targets",
             "configurePreset": "stm32-cross",
+            "targets": [
+                "heater-shaker-format",
+                "common-format",
+                "thermocycler-refresh-format"
+            ]
+        },
+        {
+            "name": "format-host",
+            "displayName": "format host",
+            "description": "Runs clang-format on all targets",
+            "configurePreset": "stm32-host",
             "targets": [
                 "heater-shaker-format",
                 "common-format",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -73,6 +73,7 @@
             "displayName": "thermocycler refresh binary",
             "description": "Build the thermocycler-refresh cross binary",
             "configurePreset": "stm32-cross",
+            "jobs": 4,
             "targets": [
                 "thermocycler-refresh"
             ]
@@ -82,6 +83,7 @@
             "displayName": "thermocycler refresh debug",
             "description": "Build the thermocycler-refresh cross debug",
             "configurePreset": "stm32-cross",
+            "jobs": 4,
             "targets": [
                 "thermocycler-refresh-debug"
             ]
@@ -91,6 +93,7 @@
             "displayName": "heater/shaker binary",
             "description": "Build the heater-shaker cross binary",
             "configurePreset": "stm32-cross",
+            "jobs": 4,
             "targets": [
                 "heater-shaker"
             ]
@@ -109,6 +112,7 @@
             "displayName": "lint all",
             "description": "Runs clang-tidy on all targets",
             "configurePreset": "stm32-cross",
+            "jobs": 4,
             "targets": [
                 "heater-shaker-lint",
                 "common-lint",
@@ -120,6 +124,7 @@
             "displayName": "format  firmware",
             "description": "Runs clang-format on all targets",
             "configurePreset": "stm32-cross",
+            "jobs": 4,
             "targets": [
                 "heater-shaker-format",
                 "common-format",
@@ -131,6 +136,7 @@
             "displayName": "format host",
             "description": "Runs clang-format on all targets",
             "configurePreset": "stm32-host",
+            "jobs": 4,
             "targets": [
                 "heater-shaker-format",
                 "common-format",
@@ -142,6 +148,7 @@
             "displayName": "tests",
             "description": "Runs build-and-test target for all subprojects",
             "configurePreset": "stm32-host",
+            "jobs": 4,
             "targets": [
                 "heater-shaker-build-and-test",
                 "common-build-and-test",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,70 +1,141 @@
 {
-  "version": 1,
-  "cmakeMinimumRequired": {
-    "major": 3,
-    "minor": 19,
-    "patch": 0
-  },
-  "configurePresets": [
-    {
-      "name": "arduino",
-      "displayName": "Arduino modules",
-      "description": "Build modules firmwares that use Arduino compilers (tempdeck, magdeck, thermocycler)",
-      "generator": "Unix Makefiles",
-      "binaryDir": "${sourceDir}/build-arduino/",
-      "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/ArduinoToolchain.cmake",
-        "ARDUINO_IDE_VERSION": "1.8.10",
-        "OPENTRONS_BOARDS_VERSION": "1.3.0",
-        "OPENTRONS_SAMD_BOARDS_VERSION": "1.1.0",
-        "ARDUINO_SAMD_VESION": "1.6.21",
-        "CMAKE_FIND_APPBUNDLE": "NEVER",
-        "TC_DUMMY_BOARD": false,
-        "TC_LID_WARNING": false,
-        "TC_HFQ_PWM": false,
-        "TC_HW_VERSION": "4",
-        "TC_RGBW_NEO": true,
-        "TC_VOLUME_DEPENDENCY": true,
-        "TC_LID_TESTING": false,
-        "MODULE_TYPE": "arduino",
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/dist"
-      }
+    "version": 2,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 20,
+        "patch": 0
     },
-    {
-      "name": "stm32-cross",
-      "displayName": "STM32 module cross-compilation",
-      "description": "Build module application firmware for modules that use STM32, for flashing onto boards",
-      "generator": "Unix Makefiles",
-      "binaryDir": "${sourceDir}/build-stm32-cross",
-      "cacheVariables": {
-        "CMAKE_EXPORT_COMPILE_COMMANDS": true,
-        "CMAKE_MODULE_PATH": "${sourceDir}/cmake",
-        "MODULE_TYPE": "stm32",
-        "CMAKE_FIND_APPBUNDLE": "NEVER",
-        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/STM32CortexM4GCCCrossToolchain.cmake",
-        "CMAKE_BUILD_CONFIG": "MinSizeRel"
-      }
-    },
-    {
-      "name": "stm32-host",
-      "displayName": "STM32 module host compilation for tests",
-      "description": "Build module libraries and test executables for modules that use STM32",
-      "generator": "Unix Makefiles",
-      "binaryDir": "${sourceDir}/build-stm32-host",
-      "cacheVariables": {
-        "MODULE_TYPE": "stm32",
-        "CMAKE_FIND_APPBUNDLE": "NEVER",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": true
-      }
-    },
-    {
-      "name": "stm32-host-gcc10",
-      "inherits": "stm32-host",
-      "displayName": "STM32 module host builds forcing g++",
-      "cacheVariables": {
-        "CMAKE_C_COMPILER": "gcc-10",
-        "CMAKE_CXX_COMPILER": "g++-10"
-      }
-    }
-  ]
+    "configurePresets": [
+        {
+            "name": "arduino",
+            "displayName": "Arduino modules",
+            "description": "Build modules firmwares that use Arduino compilers (tempdeck, magdeck, thermocycler)",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build-arduino/",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/ArduinoToolchain.cmake",
+                "ARDUINO_IDE_VERSION": "1.8.10",
+                "OPENTRONS_BOARDS_VERSION": "1.3.0",
+                "OPENTRONS_SAMD_BOARDS_VERSION": "1.1.0",
+                "ARDUINO_SAMD_VESION": "1.6.21",
+                "CMAKE_FIND_APPBUNDLE": "NEVER",
+                "TC_DUMMY_BOARD": false,
+                "TC_LID_WARNING": false,
+                "TC_HFQ_PWM": false,
+                "TC_HW_VERSION": "4",
+                "TC_RGBW_NEO": true,
+                "TC_VOLUME_DEPENDENCY": true,
+                "TC_LID_TESTING": false,
+                "MODULE_TYPE": "arduino",
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/dist"
+            }
+        },
+        {
+            "name": "stm32-cross",
+            "displayName": "STM32 module cross-compilation",
+            "description": "Build module application firmware for modules that use STM32, for flashing onto boards",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build-stm32-cross",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+                "CMAKE_MODULE_PATH": "${sourceDir}/cmake",
+                "MODULE_TYPE": "stm32",
+                "CMAKE_FIND_APPBUNDLE": "NEVER",
+                "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/STM32CortexM4GCCCrossToolchain.cmake",
+                "CMAKE_BUILD_CONFIG": "MinSizeRel"
+            }
+        },
+        {
+            "name": "stm32-host",
+            "displayName": "STM32 module host compilation for tests",
+            "description": "Build module libraries and test executables for modules that use STM32",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build-stm32-host",
+            "cacheVariables": {
+                "MODULE_TYPE": "stm32",
+                "CMAKE_FIND_APPBUNDLE": "NEVER",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": true
+            }
+        },
+        {
+            "name": "stm32-host-gcc10",
+            "inherits": "stm32-host",
+            "displayName": "STM32 module host builds forcing g++",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "gcc-10",
+                "CMAKE_CXX_COMPILER": "g++-10"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "thermocycler-refresh-binary",
+            "displayName": "thermocycler refresh binary",
+            "description": "Build the thermocycler-refresh cross binary",
+            "configurePreset": "stm32-cross",
+            "targets": [
+                "thermocycler-refresh"
+            ]
+        },
+        {
+            "name": "thermocycler-refresh-debug",
+            "displayName": "thermocycler refresh debug",
+            "description": "Build the thermocycler-refresh cross debug",
+            "configurePreset": "stm32-cross",
+            "targets": [
+                "thermocycler-refresh-debug"
+            ]
+        },
+        {
+            "name": "heater-shaker-binary",
+            "displayName": "heater/shaker binary",
+            "description": "Build the heater-shaker cross binary",
+            "configurePreset": "stm32-cross",
+            "targets": [
+                "heater-shaker"
+            ]
+        },
+        {
+            "name": "heater-shaker-debug",
+            "displayName": "heater/shaker debug",
+            "description": "Build the heater-shaker cross debug",
+            "configurePreset": "stm32-cross",
+            "targets": [
+                "heater-shaker-debug"
+            ]
+        },
+        {
+            "name": "lint",
+            "displayName": "lint all",
+            "description": "Runs clang-tidy on all targets",
+            "configurePreset": "stm32-cross",
+            "targets": [
+                "heater-shaker-lint",
+                "common-lint",
+                "thermocycler-refresh-lint"
+            ]
+        },
+        {
+            "name": "format-firmware",
+            "displayName": "format all firmware",
+            "description": "Runs clang-format on all targets",
+            "configurePreset": "stm32-cross",
+            "targets": [
+                "heater-shaker-format",
+                "common-format",
+                "thermocycler-refresh-format"
+            ]
+        },
+        {
+            "name": "tests",
+            "displayName": "tests",
+            "description": "Runs build-and-test target for all subprojects",
+            "configurePreset": "stm32-host",
+            "targets": [
+                "heater-shaker-build-and-test",
+                "common-build-and-test",
+                "thermocycler-refresh-build-and-test"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
Updated CMakePresets.json to use the cmake 3.20 preset file version, and added build presets on top of the configure presets. This also allows nice integration with vscode (although the debug targets don't really work from vscode's terminal...)