### PR TITLE
feat: Add host name resolving to heater-shaker and thermocycler

### DIFF
--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -17,9 +17,16 @@ std::unique_ptr<boost::asio::ip::tcp::socket> connect_to_socket(
     std::string host, int port) {
     boost::asio::io_service io_context;
     boost::asio::ip::tcp::resolver resolver(io_context);
-    auto endpoints = resolver.resolve(host, std::to_string(port));
-    std::string parsed_host =
-        endpoints.begin()->endpoint().address().to_string();
+    std::string parsed_host;
+    try {
+        auto endpoints = resolver.resolve(host, std::to_string(port));
+        parsed_host =
+                endpoints.begin()->endpoint().address().to_string();
+    }
+    catch (const boost::system::system_error& ex ) {
+        std::cerr << "Failed to resolve passed host/ip: \"" << host << "\"" << std::endl;
+        exit(1);
+    }
 
     auto socket = std::make_unique<boost::asio::ip::tcp::socket>(io_context);
     boost::asio::ip::tcp::endpoint endpoint(

--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -17,8 +17,9 @@ std::unique_ptr<boost::asio::ip::tcp::socket> connect_to_socket(
     std::string host, int port) {
     boost::asio::io_service io_context;
     boost::asio::ip::tcp::resolver resolver(io_context);
-    auto endpoints  = resolver.resolve(host, std::to_string(port));
-    std::string parsed_host = endpoints.begin()->endpoint().address().to_string();
+    auto endpoints = resolver.resolve(host, std::to_string(port));
+    std::string parsed_host =
+        endpoints.begin()->endpoint().address().to_string();
 
     auto socket = std::make_unique<boost::asio::ip::tcp::socket>(io_context);
     boost::asio::ip::tcp::endpoint endpoint(

--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -16,10 +16,13 @@ const std::string SOCKET_DRIVER_NAME = "Socket";
 std::unique_ptr<boost::asio::ip::tcp::socket> connect_to_socket(
     std::string host, int port) {
     boost::asio::io_service io_context;
+    boost::asio::ip::tcp::resolver resolver(io_context);
+    auto endpoints  = resolver.resolve(host, std::to_string(port));
+    std::string parsed_host = endpoints.begin()->endpoint().address().to_string();
 
     auto socket = std::make_unique<boost::asio::ip::tcp::socket>(io_context);
     boost::asio::ip::tcp::endpoint endpoint(
-        boost::asio::ip::address::from_string(host), port);
+        boost::asio::ip::address::from_string(parsed_host), port);
     boost::system::error_code ec;
     socket->connect(endpoint, ec);
     if (ec) {

--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -20,11 +20,10 @@ std::unique_ptr<boost::asio::ip::tcp::socket> connect_to_socket(
     std::string parsed_host;
     try {
         auto endpoints = resolver.resolve(host, std::to_string(port));
-        parsed_host =
-                endpoints.begin()->endpoint().address().to_string();
-    }
-    catch (const boost::system::system_error& ex ) {
-        std::cerr << "Failed to resolve passed host/ip: \"" << host << "\"" << std::endl;
+        parsed_host = endpoints.begin()->endpoint().address().to_string();
+    } catch (const boost::system::system_error& ex) {
+        std::cerr << "Failed to resolve passed host/ip: \"" << host << "\""
+                  << std::endl;
         exit(1);
     }
 

--- a/stm32-modules/thermocycler-refresh/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/socket_sim_driver.cpp
@@ -17,9 +17,16 @@ std::unique_ptr<boost::asio::ip::tcp::socket> connect_to_socket(
     std::string host, int port) {
     boost::asio::io_service io_context;
     boost::asio::ip::tcp::resolver resolver(io_context);
-    auto endpoints = resolver.resolve(host, std::to_string(port));
-    std::string parsed_host =
-        endpoints.begin()->endpoint().address().to_string();
+    std::string parsed_host;
+    try {
+        auto endpoints = resolver.resolve(host, std::to_string(port));
+        parsed_host =
+                endpoints.begin()->endpoint().address().to_string();
+    }
+    catch (const boost::system::system_error& ex ) {
+        std::cerr << "Failed to resolve passed host/ip: \"" << host << "\"" << std::endl;
+        exit(1);
+    }
 
     auto socket = std::make_unique<boost::asio::ip::tcp::socket>(io_context);
     boost::asio::ip::tcp::endpoint endpoint(

--- a/stm32-modules/thermocycler-refresh/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/socket_sim_driver.cpp
@@ -17,8 +17,9 @@ std::unique_ptr<boost::asio::ip::tcp::socket> connect_to_socket(
     std::string host, int port) {
     boost::asio::io_service io_context;
     boost::asio::ip::tcp::resolver resolver(io_context);
-    auto endpoints  = resolver.resolve(host, std::to_string(port));
-    std::string parsed_host = endpoints.begin()->endpoint().address().to_string();
+    auto endpoints = resolver.resolve(host, std::to_string(port));
+    std::string parsed_host =
+        endpoints.begin()->endpoint().address().to_string();
 
     auto socket = std::make_unique<boost::asio::ip::tcp::socket>(io_context);
     boost::asio::ip::tcp::endpoint endpoint(

--- a/stm32-modules/thermocycler-refresh/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/socket_sim_driver.cpp
@@ -16,10 +16,13 @@ const std::string SOCKET_DRIVER_NAME = "Socket";
 std::unique_ptr<boost::asio::ip::tcp::socket> connect_to_socket(
     std::string host, int port) {
     boost::asio::io_service io_context;
+    boost::asio::ip::tcp::resolver resolver(io_context);
+    auto endpoints  = resolver.resolve(host, std::to_string(port));
+    std::string parsed_host = endpoints.begin()->endpoint().address().to_string();
 
     auto socket = std::make_unique<boost::asio::ip::tcp::socket>(io_context);
     boost::asio::ip::tcp::endpoint endpoint(
-        boost::asio::ip::address::from_string(host), port);
+        boost::asio::ip::address::from_string(parsed_host), port);
     boost::system::error_code ec;
     socket->connect(endpoint, ec);
     if (ec) {

--- a/stm32-modules/thermocycler-refresh/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/socket_sim_driver.cpp
@@ -20,11 +20,10 @@ std::unique_ptr<boost::asio::ip::tcp::socket> connect_to_socket(
     std::string parsed_host;
     try {
         auto endpoints = resolver.resolve(host, std::to_string(port));
-        parsed_host =
-                endpoints.begin()->endpoint().address().to_string();
-    }
-    catch (const boost::system::system_error& ex ) {
-        std::cerr << "Failed to resolve passed host/ip: \"" << host << "\"" << std::endl;
+        parsed_host = endpoints.begin()->endpoint().address().to_string();
+    } catch (const boost::system::system_error& ex) {
+        std::cerr << "Failed to resolve passed host/ip: \"" << host << "\""
+                  << std::endl;
         exit(1);
     }
 


### PR DESCRIPTION
Add ability to use a hostname when using `--socket` cli option

`socket://myhostname:8000` and `socket://172.0.21.2:8000` will now both be able to be parsed