### PR TITLE
chore(thermocycler-refresh): Remove HAL from all C++ code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Magnetic Module (Magdeck) and Thermocycler.
 ## setup
 
 This repo uses [CMake](https://cmake.org) as a configuration and build management tool. It requires
-CMake 3.19 since it uses [presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
+CMake 3.20 since it uses [presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
 to manage cross-compilation and project configuration options. If you want to interact with the STM32 hardware, you should also install [st-link](https://github.com/stlink-org/stlink). 
 
 First, clone the repository and change into the directory:

--- a/stm32-modules/include/thermocycler-refresh/firmware/usb_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/usb_hardware.h
@@ -1,0 +1,71 @@
+/**
+ * @file usb_hardware.h
+ * @author Frank Sinapi (frank.sinapi@opentrons.com)
+ * @brief Header with forward definitions of functions
+ * for firmware-specific USB control code.
+ */
+
+#ifndef _USB_HARDWARE_C_
+#define _USB_HARDWARE_C_
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#include <stdint.h>
+
+/**
+ * @brief Function pointer type to be invoked when a new
+ * packet is received.
+ * @details
+ * - First parameter contains a pointer to the buffer of
+ * data returned
+ * - Second parameter contains the length of the data
+ * returned
+ * - The return value should be a pointer to the buffer
+ * where the next packet of RX data shall be stored
+ */
+typedef uint8_t *(*usb_rx_callback_t)(uint8_t *, uint32_t *);
+
+/**
+ * @brief Function pointer used for specifying callback
+ * for CDC initialization
+ * @details
+ * - Should return a pointer to the buffer to store RX packets
+ */
+typedef uint8_t *(*usb_cdc_init_callback_t)();
+
+/**
+ * @brief Function pointer used for specifying callback
+ * for CDC deinitialization
+ */
+typedef void (*usb_cdc_deinit_callback_t)();
+
+/**
+ * @brief Initializes the USB hardware on the system
+ * @param[in] cb The function to call when a USB packet arrives
+ */
+void usb_hw_init(usb_rx_callback_t rx_cb, usb_cdc_init_callback_t cdc_init_cb,
+                 usb_cdc_deinit_callback_t cdc_deinit_cb);
+
+/**
+ * @brief Starts USB CDC on the system
+ */
+void usb_hw_start();
+
+/**
+ * @brief Stop USB
+ */
+void usb_hw_stop();
+
+/**
+ * @brief Send a packet over USB CDC
+ * @param[in] buf The buffer to send
+ * @param[in] len The length of the buffer to be sent
+ */
+void usb_hw_send(uint8_t *buf, uint16_t len);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  /* _USB_HARDWARE_C_ */

--- a/stm32-modules/include/thermocycler-refresh/firmware/usb_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/usb_hardware.h
@@ -44,7 +44,7 @@ typedef void (*usb_cdc_deinit_callback_t)();
  * @brief Initializes the USB hardware on the system. Provides function
  * pointers to the C code that will be invoked upon certain USB CDC events.
  * @param[in] rx_cb The function to call when a USB packet arrives
- * @param[in] cdc_init_cb Function to call when initializing CDC 
+ * @param[in] cdc_init_cb Function to call when initializing CDC
  * @param[in] cdc_deinit_cb Function to call when deinitializing CDC
  */
 void usb_hw_init(usb_rx_callback_t rx_cb, usb_cdc_init_callback_t cdc_init_cb,

--- a/stm32-modules/include/thermocycler-refresh/firmware/usb_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/usb_hardware.h
@@ -31,7 +31,7 @@ typedef uint8_t *(*usb_rx_callback_t)(uint8_t *, uint32_t *);
  * @brief Function pointer used for specifying callback
  * for CDC initialization
  * @details
- * - Should return a pointer to the buffer to store RX packets
+ * - Should return a pointer to a buffer to store RX packets
  */
 typedef uint8_t *(*usb_cdc_init_callback_t)();
 
@@ -42,8 +42,11 @@ typedef uint8_t *(*usb_cdc_init_callback_t)();
 typedef void (*usb_cdc_deinit_callback_t)();
 
 /**
- * @brief Initializes the USB hardware on the system
- * @param[in] cb The function to call when a USB packet arrives
+ * @brief Initializes the USB hardware on the system. Provides function
+ * pointers to the C code that will be invoked upon certain USB CDC events.
+ * @param[in] rx_cb The function to call when a USB packet arrives
+ * @param[in] cdc_init_cb Function to call when initializing CDC 
+ * @param[in] cdc_deinit_cb Function to call when deinitializing CDC
  */
 void usb_hw_init(usb_rx_callback_t rx_cb, usb_cdc_init_callback_t cdc_init_cb,
                  usb_cdc_deinit_callback_t cdc_deinit_cb);

--- a/stm32-modules/include/thermocycler-refresh/firmware/usb_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/usb_hardware.h
@@ -1,6 +1,5 @@
 /**
  * @file usb_hardware.h
- * @author Frank Sinapi (frank.sinapi@opentrons.com)
  * @brief Header with forward definitions of functions
  * for firmware-specific USB control code.
  */

--- a/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
@@ -37,6 +37,7 @@ set(${TARGET_MODULE_NAME}_FW_NONLINTABLE_SRCS
   ${SYSTEM_DIR}/system_serial_number.c
   ${COMMS_DIR}/usbd_conf.c
   ${COMMS_DIR}/usbd_desc.c
+  ${COMMS_DIR}/usb_hardware.c
   ${THERMAL_DIR}/thermal_hardware.c
   )
 

--- a/stm32-modules/thermocycler-refresh/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/host_comms_task/freertos_comms_task.cpp
@@ -8,38 +8,27 @@
 #include <utility>
 
 #include "FreeRTOS.h"
-#include "task.h"
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wvolatile"
-#include "usbd_cdc.h"
-#include "usbd_core.h"
-#include "usbd_desc.h"
-#pragma GCC diagnostic pop
-
 #include "firmware/freertos_message_queue.hpp"
+#include "firmware/usb_hardware.h"
 #include "hal/double_buffer.hpp"
+#include "task.h"
 #include "thermocycler-refresh/host_comms_task.hpp"
 #include "thermocycler-refresh/messages.hpp"
 #include "thermocycler-refresh/tasks.hpp"
 
-struct CommsTaskFreeRTOS {
-    USBD_CDC_ItfTypeDef cdc_class_fops;
-    USBD_HandleTypeDef usb_handle;
-    USBD_CDC_LineCodingTypeDef linecoding;
+/** Sadly this must be manually duplicated from usbd_cdc.h */
+constexpr size_t CDC_BUFFER_SIZE = 512U;
 
-    double_buffer::DoubleBuffer<char, CDC_DATA_HS_MAX_PACKET_SIZE * 4> rx_buf;
-    double_buffer::DoubleBuffer<char, CDC_DATA_HS_MAX_PACKET_SIZE * 4> tx_buf;
+struct CommsTaskFreeRTOS {
+    double_buffer::DoubleBuffer<char, CDC_BUFFER_SIZE * 4> rx_buf;
+    double_buffer::DoubleBuffer<char, CDC_BUFFER_SIZE * 4> tx_buf;
     char *committed_rx_buf_ptr;
 };
 
-static auto CDC_Init() -> int8_t;
-static auto CDC_DeInit() -> int8_t;
-
+static auto cdc_init_handler() -> uint8_t *;
+static auto cdc_deinit_handler() -> void;
 // NOLINTNEXTLINE(readability-named-parameter)
-static auto CDC_Control(uint8_t, uint8_t *, uint16_t) -> int8_t;
-// NOLINTNEXTLINE(readability-named-parameter)
-static auto CDC_Receive(uint8_t *, uint32_t *) -> int8_t;
+static auto cdc_rx_handler(uint8_t *, uint32_t *) -> uint8_t *;
 
 namespace host_comms_control_task {
 
@@ -54,24 +43,7 @@ static FreeRTOSMessageQueue<host_comms_task::Message>
                  "Comms Message Queue");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static CommsTaskFreeRTOS _local_task = {
-    .cdc_class_fops =
-        {
-            .Init = CDC_Init,
-            .DeInit = CDC_DeInit,
-            .Control = CDC_Control,
-            .Receive = CDC_Receive,
-        },
-    .usb_handle = {},
-
-    .linecoding =
-        {.bitrate =
-             115200,  // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
-         .format = 0x00,
-         .paritytype = 0x00,
-         .datatype = 0x08},
-    .rx_buf = {},
-    .tx_buf = {},
-    .committed_rx_buf_ptr = nullptr};
+    .rx_buf = {}, .tx_buf = {}, .committed_rx_buf_ptr = nullptr};
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _top_task = host_comms_task::HostCommsTask(_comms_queue);
@@ -92,47 +64,23 @@ void run(void *param) {  // NOLINT(misc-unused-parameters)
     auto *task_pair = static_cast<decltype(_tasks) *>(param);
     auto *local_task = task_pair->second;
     auto *top_task = task_pair->first;
-    // This clears the capability bit that would be other sent upstream
-    // indicating we handle flow control line setting from host, which we don't,
-    // which leads to delays and annoying kernel messages. See
-    // stm32g4xx-bsp/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c:159
-    // for annotated descriptor definitions
 
-    uint16_t len = 0;
-    auto *usb_hs_desc = USBD_CDC.GetHSConfigDescriptor(&len);
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    if ((usb_hs_desc != nullptr) && (len > 30)) {
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        usb_hs_desc[30] = 0;
-    }
-    auto *usb_fs_desc = USBD_CDC.GetFSConfigDescriptor(&len);
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    if ((usb_fs_desc != nullptr) && (len > 30)) {
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        usb_fs_desc[30] = 0;
-    }
-    USBD_Init(&local_task->usb_handle, &CDC_Desc, 0);
-    USBD_RegisterClass(&local_task->usb_handle, USBD_CDC_CLASS);
-    USBD_CDC_RegisterInterface(&local_task->usb_handle,
-                               &local_task->cdc_class_fops);
-    USBD_SetClassConfig(&local_task->usb_handle, 0);
-    USBD_Start(&local_task->usb_handle);
+    usb_hw_init(&cdc_rx_handler, &cdc_init_handler, &cdc_deinit_handler);
+    usb_hw_start();
     local_task->committed_rx_buf_ptr = local_task->rx_buf.committed()->data();
     while (true) {
         char *tx_end =
             top_task->run_once(local_task->tx_buf.accessible()->begin(),
                                local_task->tx_buf.accessible()->end());
         if (!top_task->may_connect()) {
-            USBD_Stop(&_local_task.usb_handle);
+            usb_hw_stop();
         } else if (tx_end != local_task->tx_buf.accessible()->data()) {
             local_task->tx_buf.swap();
-            USBD_CDC_SetTxBuffer(
-                &_local_task.usb_handle,
+            usb_hw_send(
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
                 reinterpret_cast<uint8_t *>(
                     local_task->tx_buf.committed()->data()),
                 tx_end - local_task->tx_buf.committed()->data());
-            USBD_CDC_TransmitPacket(&_local_task.usb_handle);
         }
     }
 }
@@ -149,87 +97,16 @@ auto start()
 }
 }  // namespace host_comms_control_task
 
-static auto CDC_Init() -> int8_t {
+static auto cdc_init_handler() -> uint8_t * {
     using namespace host_comms_control_task;
     _local_task.committed_rx_buf_ptr = _local_task.rx_buf.committed()->data();
-    USBD_CDC_SetRxBuffer(
-        &_local_task.usb_handle,
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        reinterpret_cast<uint8_t *>(_local_task.committed_rx_buf_ptr));
-    USBD_CDC_ReceivePacket(&_local_task.usb_handle);
-    return (0);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<uint8_t *>(_local_task.committed_rx_buf_ptr);
 }
 
-static auto CDC_DeInit() -> int8_t {
-    /*
-       Add your deinitialization code here
-    */
+static auto cdc_deinit_handler() -> void {
     using namespace host_comms_control_task;
     _local_task.committed_rx_buf_ptr = _local_task.rx_buf.committed()->data();
-    return (0);
-}
-
-static auto CDC_Control(uint8_t cmd, uint8_t *pbuf, uint16_t length) -> int8_t {
-    using namespace host_comms_control_task;
-    static_cast<void>(length);
-    switch (cmd) {
-        case CDC_SEND_ENCAPSULATED_COMMAND:  // NOLINT(bugprone-branch-clone)
-            break;
-
-        case CDC_GET_ENCAPSULATED_RESPONSE:
-            break;
-
-        case CDC_SET_COMM_FEATURE:
-            break;
-
-        case CDC_GET_COMM_FEATURE:
-            break;
-
-        case CDC_CLEAR_COMM_FEATURE:
-            break;
-
-        case CDC_SET_LINE_CODING:
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            _local_task.linecoding.bitrate = (uint32_t)(
-                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-                pbuf[0] | (pbuf[1] << 8) | (pbuf[2] << 16) | (pbuf[3] << 24));
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            _local_task.linecoding.format = pbuf[4];
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-avoid-magic-numbers)
-            _local_task.linecoding.paritytype = pbuf[5];
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-avoid-magic-numbers)
-            _local_task.linecoding.datatype = pbuf[6];
-            break;
-
-        case CDC_GET_LINE_CODING:
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            pbuf[0] = (uint8_t)(_local_task.linecoding.bitrate);
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            pbuf[1] = (uint8_t)(_local_task.linecoding.bitrate >> 8);
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            pbuf[2] = (uint8_t)(_local_task.linecoding.bitrate >> 16);
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            pbuf[3] = (uint8_t)(_local_task.linecoding.bitrate >> 24);
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            pbuf[4] = _local_task.linecoding.format;
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-avoid-magic-numbers)
-            pbuf[5] = _local_task.linecoding.paritytype;
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-avoid-magic-numbers)
-            pbuf[6] = _local_task.linecoding.datatype;
-
-            break;
-
-        case CDC_SET_CONTROL_LINE_STATE:  // NOLINT(bugprone-branch-clone)
-            break;
-
-        case CDC_SEND_BREAK:
-            break;
-
-        default:
-            break;
-    }
-
-    return (0);
 }
 
 /*
@@ -266,7 +143,7 @@ static auto CDC_Control(uint8_t cmd, uint8_t *pbuf, uint16_t length) -> int8_t {
 */
 
 // NOLINTNEXTLINE(readability-non-const-parameter)
-static auto CDC_Receive(uint8_t *Buf, uint32_t *Len) -> int8_t {
+static auto cdc_rx_handler(uint8_t *Buf, uint32_t *Len) -> uint8_t * {
     using namespace host_comms_control_task;
     ssize_t remaining_buffer_count =
         (_local_task.rx_buf.committed()->data()
@@ -280,8 +157,7 @@ static auto CDC_Receive(uint8_t *Buf, uint32_t *Len) -> int8_t {
                       [](auto ch) { return ch == '\n' || ch == '\r'; }) !=
          (Buf +  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
           *Len)) ||
-        remaining_buffer_count <
-            static_cast<ssize_t>(CDC_DATA_HS_MAX_PACKET_SIZE)) {
+        remaining_buffer_count < static_cast<ssize_t>(CDC_BUFFER_SIZE)) {
         // there was a newline in this message, can pass on
         auto message =
             messages::HostCommsMessage(messages::IncomingMessageFromHost{
@@ -301,11 +177,6 @@ static auto CDC_Receive(uint8_t *Buf, uint32_t *Len) -> int8_t {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         _local_task.committed_rx_buf_ptr += *Len;
     }
-
-    USBD_CDC_SetRxBuffer(
-        &_local_task.usb_handle,
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        reinterpret_cast<uint8_t *>(_local_task.committed_rx_buf_ptr));
-    USBD_CDC_ReceivePacket(&_local_task.usb_handle);
-    return USBD_OK;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<uint8_t *>(_local_task.committed_rx_buf_ptr);
 }

--- a/stm32-modules/thermocycler-refresh/firmware/host_comms_task/usb_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/host_comms_task/usb_hardware.c
@@ -151,11 +151,13 @@ static int8_t CDC_Control(uint8_t cmd, uint8_t *pbuf, uint16_t length) {
 }
 
 static int8_t CDC_Receive(uint8_t *Buf, uint32_t *Len) {
-    uint8_t *new_buf = _local_config.rx_callback(Buf, Len); // C++ handles most logic here
-    USBD_CDC_SetRxBuffer(
-        &_local_config.usb_handle,
-        new_buf);
-    USBD_CDC_ReceivePacket(&_local_config.usb_handle);
+    if(_local_config.rx_callback != NULL) {
+        uint8_t *new_buf = _local_config.rx_callback(Buf, Len); // C++ handles most logic here
+        USBD_CDC_SetRxBuffer(
+            &_local_config.usb_handle,
+            new_buf);
+        USBD_CDC_ReceivePacket(&_local_config.usb_handle);        
+    }
 
     return USBD_OK;
 }

--- a/stm32-modules/thermocycler-refresh/firmware/host_comms_task/usb_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/host_comms_task/usb_hardware.c
@@ -1,0 +1,218 @@
+/**
+ * @file usb_hardware.c
+ * @author Frank Sinapi (frank.sinapi@opentrons.com)
+ * @brief Firmware-specific USB HAL control code
+ * @details This file exists to act as a thin wrapper around STM32 HAL
+ * libraries for USB control. The goal is for each function to handle
+ * \e only whatever functionality needs access to the usbd_*.h headers,
+ * and leave the rest of the higher level logic to the \c freertos_comms_task
+ * or other C++ code.
+ */
+
+// My header
+#include "firmware/usb_hardware.h"
+
+// System headers
+#include <stdbool.h>
+#include <stdint.h>
+
+// HAL headers
+#include "FreeRTOS.h"
+#include "task.h"
+#include "usbd_def.h"
+#include "usbd_cdc.h"
+#include "usbd_core.h"
+#include "usbd_desc.h"
+
+/** Local typedef */
+
+struct UsbHardwareConfig {
+    USBD_CDC_ItfTypeDef cdc_class_fops;
+    USBD_HandleTypeDef usb_handle;
+    USBD_CDC_LineCodingTypeDef linecoding;
+
+    usb_rx_callback_t rx_callback;
+    usb_cdc_init_callback_t cdc_init_callback;
+    usb_cdc_deinit_callback_t cdc_deinit_callback;
+
+    bool initialized;
+};
+
+/** Static function declaration*/
+
+static int8_t CDC_Init();
+static int8_t CDC_DeInit();
+static int8_t CDC_Control(uint8_t, uint8_t *, uint16_t);
+static int8_t CDC_Receive(uint8_t *, uint32_t *);
+
+/** Local variables */
+
+struct UsbHardwareConfig _local_config = {
+    .cdc_class_fops =
+        {
+            .Init = CDC_Init,
+            .DeInit = CDC_DeInit,
+            .Control = CDC_Control,
+            .Receive = CDC_Receive,
+        },
+    .usb_handle = {},
+
+    .linecoding =
+        {.bitrate = 115200,
+         .format = 0x00,
+         .paritytype = 0x00,
+         .datatype = 0x08},
+    
+    .rx_callback = NULL,
+    .cdc_init_callback = NULL,
+    .cdc_deinit_callback = NULL,
+    
+    .initialized = false
+};
+
+/** Static function instantiation.*/
+static int8_t CDC_Init() {
+    if(_local_config.cdc_init_callback != NULL) {
+        uint8_t *new_buf = _local_config.cdc_init_callback();
+        USBD_CDC_SetRxBuffer(
+            &_local_config.usb_handle, new_buf);
+        USBD_CDC_ReceivePacket(&_local_config.usb_handle);
+    }
+    return 0;
+}
+
+static int8_t CDC_DeInit() {
+    if(_local_config.cdc_deinit_callback != NULL) {
+        _local_config.cdc_deinit_callback();
+    }
+    return 0;
+}
+
+static int8_t CDC_Control(uint8_t cmd, uint8_t *pbuf, uint16_t length) {
+    (void)length;
+    switch (cmd) {
+        case CDC_SEND_ENCAPSULATED_COMMAND:  // NOLINT(bugprone-branch-clone)
+            break;
+
+        case CDC_GET_ENCAPSULATED_RESPONSE:
+            break;
+
+        case CDC_SET_COMM_FEATURE:
+            break;
+
+        case CDC_GET_COMM_FEATURE:
+            break;
+
+        case CDC_CLEAR_COMM_FEATURE:
+            break;
+
+        case CDC_SET_LINE_CODING:
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            _local_config.linecoding.bitrate = (uint32_t)(
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                pbuf[0] | (pbuf[1] << 8) | (pbuf[2] << 16) | (pbuf[3] << 24));
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            _local_config.linecoding.format = pbuf[4];
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-avoid-magic-numbers)
+            _local_config.linecoding.paritytype = pbuf[5];
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-avoid-magic-numbers)
+            _local_config.linecoding.datatype = pbuf[6];
+            break;
+
+        case CDC_GET_LINE_CODING:
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            pbuf[0] = (uint8_t)(_local_config.linecoding.bitrate);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            pbuf[1] = (uint8_t)(_local_config.linecoding.bitrate >> 8);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            pbuf[2] = (uint8_t)(_local_config.linecoding.bitrate >> 16);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            pbuf[3] = (uint8_t)(_local_config.linecoding.bitrate >> 24);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            pbuf[4] = _local_config.linecoding.format;
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-avoid-magic-numbers)
+            pbuf[5] = _local_config.linecoding.paritytype;
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-avoid-magic-numbers)
+            pbuf[6] = _local_config.linecoding.datatype;
+
+            break;
+
+        case CDC_SET_CONTROL_LINE_STATE:  // NOLINT(bugprone-branch-clone)
+            break;
+
+        case CDC_SEND_BREAK:
+            break;
+
+        default:
+            break;
+    }
+
+    return (0);
+}
+
+static int8_t CDC_Receive(uint8_t *Buf, uint32_t *Len) {
+    uint8_t *new_buf = _local_config.rx_callback(Buf, Len); // C++ handles most logic here
+    USBD_CDC_SetRxBuffer(
+        &_local_config.usb_handle,
+        new_buf);
+    USBD_CDC_ReceivePacket(&_local_config.usb_handle);
+
+    return USBD_OK;
+}
+
+/** Public function instantiation.*/
+
+void usb_hw_init(usb_rx_callback_t rx_cb,
+                 usb_cdc_init_callback_t cdc_init_cb,
+                 usb_cdc_deinit_callback_t cdc_deinit_cb) {
+    _local_config.rx_callback = rx_cb;
+    configASSERT(_local_config.rx_callback != NULL);
+    _local_config.cdc_init_callback = cdc_init_cb;
+    configASSERT(_local_config.cdc_init_callback != NULL);
+    _local_config.cdc_deinit_callback = cdc_deinit_cb;
+    configASSERT(_local_config.cdc_deinit_callback != NULL);
+
+    // This clears the capability bit that would be other sent upstream
+    // indicating we handle flow control line setting from host, which we don't,
+    // which leads to delays and annoying kernel messages. See
+    // stm32g4xx-bsp/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c:159
+    // for annotated descriptor definitions
+    uint16_t len = 0;
+    uint8_t *usb_hs_desc = USBD_CDC.GetHSConfigDescriptor(&len);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    if ((usb_hs_desc != NULL) && (len > 30)) {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        usb_hs_desc[30] = 0;
+    }
+    uint8_t *usb_fs_desc = USBD_CDC.GetFSConfigDescriptor(&len);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    if ((usb_fs_desc != NULL) && (len > 30)) {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        usb_fs_desc[30] = 0;
+    }
+
+    USBD_Init(&_local_config.usb_handle, &CDC_Desc, 0);
+    USBD_RegisterClass(&_local_config.usb_handle, USBD_CDC_CLASS);
+    USBD_CDC_RegisterInterface(&_local_config.usb_handle,
+                               &_local_config.cdc_class_fops);
+    USBD_SetClassConfig(&_local_config.usb_handle, 0);
+
+    _local_config.initialized = true;
+}
+
+void usb_hw_start() {
+    configASSERT(_local_config.initialized);
+    USBD_Start(&_local_config.usb_handle);
+}
+
+void usb_hw_stop() {
+    configASSERT(_local_config.initialized);
+    USBD_Stop(&_local_config.usb_handle);
+}
+
+void usb_hw_send(uint8_t *buf, uint16_t len) {
+    USBD_CDC_SetTxBuffer(
+        &_local_config.usb_handle,
+        buf, len);
+    USBD_CDC_TransmitPacket(&_local_config.usb_handle);
+}

--- a/stm32-modules/thermocycler-refresh/firmware/host_comms_task/usb_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/host_comms_task/usb_hardware.c
@@ -1,6 +1,5 @@
 /**
  * @file usb_hardware.c
- * @author Frank Sinapi (frank.sinapi@opentrons.com)
  * @brief Firmware-specific USB HAL control code
  * @details This file exists to act as a thin wrapper around STM32 HAL
  * libraries for USB control. The goal is for each function to handle

--- a/stm32-modules/thermocycler-refresh/firmware/system/freertos_system_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/freertos_system_task.cpp
@@ -7,16 +7,11 @@
 
 #include "FreeRTOS.h"
 #include "firmware/freertos_message_queue.hpp"
+#include "system_hardware.h"
 #include "system_policy.hpp"
 #include "task.h"
 #include "thermocycler-refresh/system_task.hpp"
 #include "thermocycler-refresh/tasks.hpp"
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wvolatile"
-#include "stm32g4xx_hal.h"
-#include "system_hardware.h"
-#pragma GCC diagnostic pop
 
 namespace system_control_task {
 

--- a/stm32-modules/thermocycler-refresh/firmware/system/main.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/main.cpp
@@ -6,13 +6,9 @@
 #include "firmware/freertos_message_queue.hpp"
 #include "firmware/freertos_system_task.hpp"
 #include "firmware/freertos_thermal_plate_task.hpp"
+#include "system_hardware.h"
 #include "system_stm32g4xx.h"
 #include "thermocycler-refresh/tasks.hpp"
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wvolatile"
-#include "system_hardware.h"
-#pragma GCC diagnostic pop
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 tasks::Tasks<FreeRTOSMessageQueue> tasks_aggregator;

--- a/stm32-modules/thermocycler-refresh/firmware/system/system_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/system/system_hardware.c
@@ -4,6 +4,10 @@
 #include "system_hardware.h"
 #include "stm32g4xx_hal_tim.h"
 
+/** Private definitions.*/
+#define DBG_LED_PIN GPIO_PIN_6
+#define DBG_LED_PORT GPIOE
+
 /** Global variable instantiation */
 
 /** PUBLIC FUNCTION IMPLEMENTATION */

--- a/stm32-modules/thermocycler-refresh/firmware/system/system_hardware.h
+++ b/stm32-modules/thermocycler-refresh/firmware/system/system_hardware.h
@@ -1,12 +1,8 @@
 #ifndef SYSTEM_HARDWARE_H__
 #define SYSTEM_HARDWARE_H__
-#include "stm32g4xx_hal_gpio.h"
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-#define DBG_LED_PIN GPIO_PIN_6
-#define DBG_LED_PORT GPIOE
 
 void system_hardware_setup(void);
 void system_debug_led(int set);

--- a/stm32-modules/thermocycler-refresh/firmware/system/system_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/system_policy.cpp
@@ -1,14 +1,11 @@
+#include "system_policy.hpp"
+
 #include <array>
 #include <iterator>
 #include <ranges>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wvolatile"
 #include "system_hardware.h"
 #include "system_serial_number.h"
-#pragma GCC diagnostic pop
-
-#include "system_policy.hpp"
 #include "thermocycler-refresh/errors.hpp"
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/stm32-modules/thermocycler-refresh/firmware/system/system_policy.hpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/system_policy.hpp
@@ -2,14 +2,10 @@
 
 #include <array>
 
-#include "systemwide.h"
-#include "thermocycler-refresh/errors.hpp"
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wvolatile"
 #include "system_hardware.h"
 #include "system_serial_number.h"
-#pragma GCC diagnostic pop
+#include "systemwide.h"
+#include "thermocycler-refresh/errors.hpp"
 
 class SystemPolicy {
   private:

--- a/stm32-modules/thermocycler-refresh/firmware/system/system_serial_number.h
+++ b/stm32-modules/thermocycler-refresh/firmware/system/system_serial_number.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 struct writable_serial {
     uint64_t contents[3];


### PR DESCRIPTION
All my homies hate `#pragma GCC diagnostic ignored "-Wvolatile"`

Mostly small changes, with the exception of a new `usb_hardware.c/h` file that acts as a glue layer over the STM32 USB CDC libraries. Tested on my board that USB still works fine.