### PR TITLE
feat(thermocycler-refresh): Add fan driver

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/firmware/thermal_fan_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/thermal_fan_hardware.h
@@ -1,0 +1,28 @@
+#ifndef THERMAL_FAN_HARDWARE_H__
+#define THERMAL_FAN_HARDWARE_H__
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#include <stdbool.h>
+
+/**
+ * @brief Initialize the fans on the board. This is a prerequisite
+ * for controlling any fans.
+ */
+void thermal_fan_initialize(void);
+
+/**
+ * @brief Set the power level of the fans
+ *
+ * @param[in] power The power to set, as a percentage from 0.0F to 1.0F
+ * inclusive. Values outside of this range will be clamped
+ * @return True if the fan could be set to \p power, false if an error
+ * occurred.
+ */
+bool thermal_fan_set_power(double power);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  /* THERMAL_FAN_HARDWARE_H__ */

--- a/stm32-modules/include/thermocycler-refresh/firmware/thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/thermal_plate_policy.hpp
@@ -17,4 +17,6 @@ class ThermalPlatePolicy {
                      PeltierDirection direction) -> bool;
 
     auto get_peltier(PeltierID peltier) -> std::pair<PeltierDirection, double>;
+
+    auto set_fan(double power) -> bool;
 };

--- a/stm32-modules/include/thermocycler-refresh/test/test_thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_thermal_plate_policy.hpp
@@ -48,10 +48,17 @@ class TestThermalPlatePolicy {
         return RT(handle.value().get().direction, handle.value().get().power);
     }
 
+    auto set_fan(double power) -> bool {
+        power = std::clamp(power, (double)0.0F, (double)1.0F);
+        _fan_power = power;
+        return true;
+    }
+
     bool _enabled = false;
     TestPeltier _left = TestPeltier();
     TestPeltier _center = TestPeltier();
     TestPeltier _right = TestPeltier();
+    double _fan_power = 0.0F;
 
   private:
     using GetPeltierT = std::optional<std::reference_wrapper<TestPeltier>>;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/errors.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/errors.hpp
@@ -45,6 +45,7 @@ enum class ErrorCode {
     // 4xx - Thermal subsystem errors
     THERMAL_PLATE_BUSY = 401,
     THERMAL_PELTIER_ERROR = 402,
+    THERMAL_HEATSINK_FAN_ERROR = 403,
 };
 
 auto errorstring(ErrorCode code) -> const char*;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -182,9 +182,9 @@ struct SetFanManual {
     /**
      * SetFanManual uses M106. Sets the PWM of the fans as a percentage
      * between 0 and 1.
-     * 
+     *
      * M106 S[power]
-     * 
+     *
      * Power will be maintained at the specified level until:
      * - An error occurs
      * - Another M106 is set
@@ -192,8 +192,7 @@ struct SetFanManual {
      * - The heatsink temperature exceeds the safety limit
      */
     using ParseResult = std::optional<SetFanManual>;
-    static constexpr auto prefix =
-        std::array{'M', '1', '0', '6', ' ', 'S'};
+    static constexpr auto prefix = std::array{'M', '1', '0', '6', ' ', 'S'};
     static constexpr const char* response = "M106 OK\n";
 
     double power;
@@ -210,15 +209,14 @@ struct SetFanManual {
         std::sized_sentinel_for<Limit, InputIt>
     static auto parse(const InputIt& input, Limit limit)
         -> std::pair<ParseResult, InputIt> {
-
         auto working = prefix_matches(input, limit, prefix);
-        if(working == input) {
+        if (working == input) {
             return std::make_pair(ParseResult(), input);
         }
 
         auto power_res = parse_value<float>(working, limit);
 
-        if(!power_res.first.has_value()) {
+        if (!power_res.first.has_value()) {
             return std::make_pair(ParseResult(), input);
         }
         auto power_val = power_res.first.value();
@@ -226,9 +224,8 @@ struct SetFanManual {
             return std::make_pair(ParseResult(), input);
         }
         working = power_res.second;
-        return std::make_pair(
-            ParseResult(SetFanManual{.power = power_val}),
-            working);
+        return std::make_pair(ParseResult(SetFanManual{.power = power_val}),
+                              working);
     }
 };
 

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -135,6 +135,11 @@ struct SetPeltierDebugMessage {
     PeltierSelection selection;
 };
 
+struct SetFanManualMessage {
+    uint32_t id;
+    double power;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage>;
@@ -145,7 +150,8 @@ using HostCommsMessage =
                    GetPlateTemperatureDebugResponse>;
 using ThermalPlateMessage =
     ::std::variant<std::monostate, ThermalPlateTempReadComplete,
-                   GetPlateTemperatureDebugMessage, SetPeltierDebugMessage>;
+                   GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,
+                   SetFanManualMessage>;
 using LidHeaterMessage = ::std::variant<std::monostate, LidTempReadComplete,
                                         GetLidTemperatureDebugMessage>;
 };  // namespace messages

--- a/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
@@ -40,6 +40,7 @@ set(${TARGET_MODULE_NAME}_FW_NONLINTABLE_SRCS
   ${COMMS_DIR}/usb_hardware.c
   ${THERMAL_DIR}/thermal_hardware.c
   ${THERMAL_DIR}/thermal_peltier_hardware.c
+  ${THERMAL_DIR}/thermal_fan_hardware.c
   )
 
 add_executable(${TARGET_MODULE_NAME}

--- a/stm32-modules/thermocycler-refresh/firmware/README.md
+++ b/stm32-modules/thermocycler-refresh/firmware/README.md
@@ -20,6 +20,7 @@ Timer | Use | Notes
 TIM1 | Peltier PWM (CH1, CH2, and CH3) | 25kHz
 TIM7 | System base timer | 1000Hz (milliseconds timer)
 TIM15 | Heater PWM (CH1) | 25kHz
+TIM16 | Fan PWM (Ch1) | 25kHz
 
 ### USB
 Pin | Use
@@ -43,6 +44,8 @@ PB1 | GPIO Out | Left Peltier Direction
 PE7 | GPIO Out | Peltier enable (active __high__)
 PA2 | TIM15 CH1 PWM | Heater Drive
 PD7 | GPIO Out | Heater enable (active __high__)
+PD1 | GPIO Out | Fan 12V Buck Enable (active __high__)
+PA6 | TIM16 CH1 PWM | Fan Drive
 
 ### Misc
 Pin | Use

--- a/stm32-modules/thermocycler-refresh/firmware/system/stm32g4xx_hal_msp.c
+++ b/stm32-modules/thermocycler-refresh/firmware/system/stm32g4xx_hal_msp.c
@@ -189,6 +189,50 @@ void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef* htim_pwm)
 
 }
 
+/**
+* @brief TIM_Base MSP Initialization
+* This function configures the hardware resources used in this example
+* @param htim_base: TIM_Base handle pointer
+* @retval None
+*/
+void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim_base)
+{
+  if(htim_base->Instance==TIM16)
+  {
+  /* USER CODE BEGIN TIM16_MspInit 0 */
+
+  /* USER CODE END TIM16_MspInit 0 */
+    /* Peripheral clock enable */
+    __HAL_RCC_TIM16_CLK_ENABLE();
+  /* USER CODE BEGIN TIM16_MspInit 1 */
+
+  /* USER CODE END TIM16_MspInit 1 */
+  }
+
+}
+
+/**
+* @brief TIM_Base MSP De-Initialization
+* This function freeze the hardware resources used in this example
+* @param htim_base: TIM_Base handle pointer
+* @retval None
+*/
+void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* htim_base)
+{
+  if(htim_base->Instance==TIM16)
+  {
+  /* USER CODE BEGIN TIM16_MspDeInit 0 */
+
+  /* USER CODE END TIM16_MspDeInit 0 */
+    /* Peripheral clock disable */
+    __HAL_RCC_TIM16_CLK_DISABLE();
+  /* USER CODE BEGIN TIM16_MspDeInit 1 */
+
+  /* USER CODE END TIM16_MspDeInit 1 */
+  }
+
+}
+
 /* USER CODE BEGIN 1 */
 
 /* USER CODE END 1 */

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_fan_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_fan_hardware.c
@@ -1,0 +1,168 @@
+#include "firmware/thermal_fan_hardware.h"
+
+
+#include "FreeRTOS.h"
+#include "stm32g4xx_hal_def.h"
+#include "stm32g4xx_hal.h"
+#include "stm32g4xx_hal_gpio.h"
+#include "stm32g4xx_hal_tim.h"
+#include "task.h"
+
+// Private definitions
+#define SINK_FAN_PWM_Pin (GPIO_PIN_6)
+#define SINK_FAN_PWM_GPIO_Port (GPIOA)
+
+#define PULSE_WIDTH_FREQ (25000)
+#define TIMER_CLOCK_FREQ (170000000)
+// These two together give a 25kHz pulse width, and the ARR value
+// of 99 gives us a nice scale of 0-100 for the pulse width.
+// A finer scale is possible by reducing the prescale value and
+// adjusting the reload to match.
+#define TIM16_PRESCALER (67)
+//#define TIM1_RELOAD    (99)
+#define TIM16_RELOAD ((TIMER_CLOCK_FREQ / (PULSE_WIDTH_FREQ * (TIM16_PRESCALER + 1))) - 1)
+// PWM should be scaled from 0 to MAX_PWM, inclusive
+#define MAX_PWM (TIM16_RELOAD + 1)
+
+// Private typedefs
+
+struct Fans {
+    // Configuration
+    GPIO_TypeDef *enable_port;
+    const uint16_t enable_pin;
+    const uint16_t pwm_channel;
+    // Current status
+    bool initialized;
+    double power;
+    TIM_HandleTypeDef timer;
+};
+
+// Local variables
+
+static struct Fans _fans = {
+    .enable_port = GPIOD,
+    .enable_pin  = GPIO_PIN_1,
+    .pwm_channel = TIM_CHANNEL_1,
+    .initialized = false,
+    .power = 0.0F,
+    .timer = {}
+};
+
+// Private function declarations
+
+/**
+ * @brief Enable or disable the fans (12v power supply)
+ * 
+ * @param[in] enabled True to enable the fans, false to turn them off
+ * @return True on success, false if \p enabled could not be written
+ */
+static bool thermal_fan_set_enable(bool enabled);
+
+// Public function implementations
+
+void thermal_fan_initialize(void) {
+    HAL_StatusTypeDef hal_ret = HAL_ERROR;
+    TIM_OC_InitTypeDef sConfigOC = {0};
+    TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+
+    __GPIOA_CLK_ENABLE();
+    __GPIOD_CLK_ENABLE();
+
+    // Disable the 12v converter first
+    GPIO_InitStruct.Pin = _fans.enable_pin;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+    HAL_GPIO_Init(_fans.enable_port, &GPIO_InitStruct);
+    HAL_GPIO_WritePin(_fans.enable_port, _fans.enable_pin, GPIO_PIN_RESET);
+
+    // Configure timer 16 for PWMN control on channel 1
+    _fans.timer.Instance = TIM16;
+    _fans.timer.Init.Prescaler = TIM16_PRESCALER;
+    _fans.timer.Init.CounterMode = TIM_COUNTERMODE_UP;
+    _fans.timer.Init.Period = TIM16_RELOAD;
+    _fans.timer.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    _fans.timer.Init.RepetitionCounter = 0;
+    _fans.timer.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    hal_ret = HAL_TIM_Base_Init(&_fans.timer);
+    configASSERT(hal_ret == HAL_OK);
+    hal_ret = HAL_TIM_PWM_Init(&_fans.timer);
+    configASSERT(hal_ret == HAL_OK);
+    sConfigOC.OCMode = TIM_OCMODE_PWM1;
+    sConfigOC.Pulse = 0;
+    sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+    sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
+    sConfigOC.OCFastMode = TIM_OCFAST_ENABLE;
+    sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
+    sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
+    hal_ret = HAL_TIM_PWM_ConfigChannel(&_fans.timer, &sConfigOC, _fans.pwm_channel);
+    configASSERT(hal_ret == HAL_OK);
+    sBreakDeadTimeConfig.OffStateRunMode = TIM_OSSR_DISABLE;
+    sBreakDeadTimeConfig.OffStateIDLEMode = TIM_OSSI_DISABLE;
+    sBreakDeadTimeConfig.LockLevel = TIM_LOCKLEVEL_OFF;
+    sBreakDeadTimeConfig.DeadTime = 0;
+    sBreakDeadTimeConfig.BreakState = TIM_BREAK_DISABLE;
+    sBreakDeadTimeConfig.BreakPolarity = TIM_BREAKPOLARITY_HIGH;
+    sBreakDeadTimeConfig.BreakFilter = 0;
+    sBreakDeadTimeConfig.AutomaticOutput = TIM_AUTOMATICOUTPUT_DISABLE;
+    hal_ret = HAL_TIMEx_ConfigBreakDeadTime(&_fans.timer, &sBreakDeadTimeConfig);
+    configASSERT(hal_ret == HAL_OK);
+
+    // This is a copy+paste of the HAL_TIM_MspPostInit implementation because
+    // there's no actual reason for it to live in that function
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    /**TIM16 GPIO Configuration
+    PA6     ------> TIM16_CH1
+    */
+    GPIO_InitStruct.Pin = SINK_FAN_PWM_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Alternate = GPIO_AF1_TIM16;
+    HAL_GPIO_Init(SINK_FAN_PWM_GPIO_Port, &GPIO_InitStruct);
+
+    _fans.initialized = true;
+}
+
+
+bool thermal_fan_set_power(double power) {
+    if(!_fans.initialized) { return false; }
+    if(power > 1.0F) { power = 1.0F; }
+    if(power < 0.0F) { power = 0.0F; }
+
+    double old_power = _fans.power;
+    _fans.power = power;
+
+    if(power == 0.0F) {
+        if(!thermal_fan_set_enable(false)) { return false; }
+        return HAL_TIM_PWM_Stop(&_fans.timer, _fans.pwm_channel) == HAL_OK;
+    }
+
+    uint32_t pwm = _fans.power * (double)MAX_PWM;
+    if(!thermal_fan_set_enable(true)) { return false; }
+    __HAL_TIM_SET_COMPARE(&_fans.timer, _fans.pwm_channel, pwm);
+    // PWM_Start will fail if we call it twice, so make sure the fan is 
+    // off before calling it
+    if(old_power == 0.0F) {
+        if(HAL_TIM_PWM_Start(&_fans.timer, _fans.pwm_channel) != HAL_OK) {
+            // Disable 12v if we couldn't set the PWM
+            thermal_fan_set_enable(false);
+            return false;
+        }
+    }
+    
+
+    return true;
+}
+
+// Local function implementations
+
+static bool thermal_fan_set_enable(bool enabled) {
+    if(!_fans.initialized) { return false; }
+
+    GPIO_PinState state = (enabled) ? GPIO_PIN_SET : GPIO_PIN_RESET;
+    HAL_GPIO_WritePin(_fans.enable_port, _fans.enable_pin, state);
+
+    return true;
+}

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_hardware.c
@@ -39,6 +39,7 @@
 #include "task.h"
 
 // Local includes
+#include "firmware/thermal_fan_hardware.h"
 #include "firmware/thermal_peltier_hardware.h"
 
 /** Private definitions */
@@ -143,6 +144,7 @@ void thermal_hardware_setup(void) {
         thermal_gpio_init();
         thermal_i2c_init();
         thermal_peltier_initialize();
+        thermal_fan_initialize();
 
         _initialization_done = true;
     }

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
@@ -1,5 +1,6 @@
 #include "firmware/thermal_plate_policy.hpp"
 
+#include "firmware/thermal_fan_hardware.h"
 #include "firmware/thermal_peltier_hardware.h"
 #include "systemwide.h"
 
@@ -33,4 +34,10 @@ auto ThermalPlatePolicy::get_peltier(PeltierID peltier)
     }
 
     return RT(PeltierDirection::PELTIER_HEATING, 0.0F);
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto ThermalPlatePolicy::set_fan(double power) -> bool {
+    power = std::clamp(power, (double)0.0F, (double)1.0F);
+    return thermal_fan_set_power(power);
 }

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -77,3 +77,14 @@ def set_peltier_debug(power: float, direction: str, peltiers: str, ser: serial.S
     res = ser.readline()
     guard_error(res, b'M104.D OK')
     print(res)
+
+# Sets fan PWM as a percentage. Loud.
+def set_fans_manual(power: float, ser: serial.Serial):
+    if(power< 0.0 or power > 1.0):
+        raise RuntimeError(f'Invalid power input: {power}')
+    
+    print(f'Setting fan PWM to {power}%')
+    ser.write(f'M106 S{power}\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M106 OK')
+    print(res)

--- a/stm32-modules/thermocycler-refresh/simulator/thermal_plate_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/thermal_plate_thread.cpp
@@ -27,6 +27,7 @@ struct SimThermalPlatePolicy {
     SimPeltier _left = SimPeltier();
     SimPeltier _center = SimPeltier();
     SimPeltier _right = SimPeltier();
+    double _fan_power = 0.0F;
 
     using GetPeltierT = std::optional<std::reference_wrapper<SimPeltier>>;
     auto get_peltier_from_id(PeltierID peltier) -> GetPeltierT {
@@ -73,6 +74,12 @@ struct SimThermalPlatePolicy {
             return RT(PeltierDirection::PELTIER_COOLING, 0.0F);
         }
         return RT(handle.value().get().direction, handle.value().get().power);
+    }
+
+    auto set_fan(double power) -> bool {
+        power = std::clamp(power, (double)0.0F, (double)1.0F);
+        _fan_power = power;
+        return true;
     }
 };
 

--- a/stm32-modules/thermocycler-refresh/src/errors.cpp
+++ b/stm32-modules/thermocycler-refresh/src/errors.cpp
@@ -62,6 +62,8 @@ const char* const SYSTEM_SERIAL_NUMBER_HAL_ERROR =
 const char* const THERMAL_PLATE_BUSY = "ERR401:thermal:Thermal plate busy\n";
 const char* const THERMAL_PELTIER_ERROR =
     "ERR402:thermal:Could not activate peltier\n";
+const char* const THERMAL_HEATSINK_FAN_ERROR =
+    "ERR403:thermal:Could not control heatsink fan\n";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
@@ -106,6 +108,7 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(SYSTEM_SERIAL_NUMBER_HAL_ERROR);
         HANDLE_CASE(THERMAL_PLATE_BUSY);
         HANDLE_CASE(THERMAL_PELTIER_ERROR);
+        HANDLE_CASE(THERMAL_HEATSINK_FAN_ERROR);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_m105d.cpp
     test_m141d.cpp
     test_m104d.cpp
+    test_m106.cpp
 )
 
 target_include_directories(${TARGET_MODULE_NAME} 

--- a/stm32-modules/thermocycler-refresh/tests/test_m106.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m106.cpp
@@ -1,0 +1,63 @@
+#include "catch2/catch.hpp"
+#include "thermocycler-refresh/gcodes.hpp"
+
+SCENARIO("SetFanManual (M106) parser works", "[gcode][parse][m106]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(64, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetFanManual::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::StartsWith("M106 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetFanManual::write_response_into(
+                buffer.begin(), buffer.begin() + 3);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M10ccccccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("Valid parameters") {
+        WHEN("Setting power to 1.0") {
+            std::string buffer = "M106 S1.0\n";
+            auto parsed = gcode::SetFanManual::parse(buffer.begin(), buffer.end());
+            THEN("the power should be 1.0") {
+                auto &val = parsed.first;
+                REQUIRE(parsed.second != buffer.begin());
+                REQUIRE(val.has_value());
+                REQUIRE(val.value().power == 1.0F);
+            }
+        }
+        WHEN("Setting power to 0.0") {
+            std::string buffer = "M106 S0\n";
+            auto parsed = gcode::SetFanManual::parse(buffer.begin(), buffer.end());
+            THEN("the power should be 0.0") {
+                auto &val = parsed.first;
+                REQUIRE(parsed.second != buffer.begin());
+                REQUIRE(val.has_value());
+                REQUIRE(val.value().power == 0.0F);
+            }
+        }
+    }
+    GIVEN("Invalid power") {
+        WHEN("Setting power to 2.0") {
+            std::string buffer = "M106 S2.0\n";
+            auto parsed = gcode::SetFanManual::parse(buffer.begin(), buffer.end());
+            THEN("parsing should fail") {
+                auto &val = parsed.first;
+                REQUIRE(!val.has_value());
+                REQUIRE(parsed.second == buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_m106.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m106.cpp
@@ -8,8 +8,7 @@ SCENARIO("SetFanManual (M106) parser works", "[gcode][parse][m106]") {
             auto written = gcode::SetFanManual::write_response_into(
                 buffer.begin(), buffer.end());
             THEN("the response should be written in full") {
-                REQUIRE_THAT(buffer,
-                             Catch::Matchers::StartsWith("M106 OK\n"));
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M106 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }
@@ -30,7 +29,8 @@ SCENARIO("SetFanManual (M106) parser works", "[gcode][parse][m106]") {
     GIVEN("Valid parameters") {
         WHEN("Setting power to 1.0") {
             std::string buffer = "M106 S1.0\n";
-            auto parsed = gcode::SetFanManual::parse(buffer.begin(), buffer.end());
+            auto parsed =
+                gcode::SetFanManual::parse(buffer.begin(), buffer.end());
             THEN("the power should be 1.0") {
                 auto &val = parsed.first;
                 REQUIRE(parsed.second != buffer.begin());
@@ -40,7 +40,8 @@ SCENARIO("SetFanManual (M106) parser works", "[gcode][parse][m106]") {
         }
         WHEN("Setting power to 0.0") {
             std::string buffer = "M106 S0\n";
-            auto parsed = gcode::SetFanManual::parse(buffer.begin(), buffer.end());
+            auto parsed =
+                gcode::SetFanManual::parse(buffer.begin(), buffer.end());
             THEN("the power should be 0.0") {
                 auto &val = parsed.first;
                 REQUIRE(parsed.second != buffer.begin());
@@ -52,7 +53,8 @@ SCENARIO("SetFanManual (M106) parser works", "[gcode][parse][m106]") {
     GIVEN("Invalid power") {
         WHEN("Setting power to 2.0") {
             std::string buffer = "M106 S2.0\n";
-            auto parsed = gcode::SetFanManual::parse(buffer.begin(), buffer.end());
+            auto parsed =
+                gcode::SetFanManual::parse(buffer.begin(), buffer.end());
             THEN("parsing should fail") {
                 auto &val = parsed.first;
                 REQUIRE(!val.has_value());


### PR DESCRIPTION
Adds PWM driver support for the system fans. They are incredibly loud.

- M106 sets the power of the fans as a percentage from 0 to 1.0
- Fan PWM uses the same timing configuration as the peltiers (25kHz, counts from 0 to 99)
- Unit tests included for gcode parsing and message handling in the Thermal Plate task

Tested on a unit by hooking up the fans and setting PWM through the gcode.