### PR TITLE
feat(thermocycler-refresh): add heat pad driver

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/firmware/lid_heater_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/lid_heater_policy.hpp
@@ -9,5 +9,5 @@ class LidHeaterPolicy {
   public:
     LidHeaterPolicy() = default;
 
-    auto set_enabled(bool enabled) -> void;
+    auto set_heater_power(double power) -> bool;
 };

--- a/stm32-modules/include/thermocycler-refresh/firmware/thermal_heater_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/thermal_heater_hardware.h
@@ -1,0 +1,29 @@
+#ifndef THERMAL_HEATER_HARDWARE_H__
+#define THERMAL_HEATER_HARDWARE_H__
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#include <stdbool.h>
+
+/**
+ * @brief Initialize the heater on the board. This is a prerequisite
+ * for controlling the heater.
+ */
+void thermal_heater_initialize(void);
+
+/**
+ * @brief Set the power level of the heater. Automatically updates
+ * the enable pin.
+ *
+ * @param[in] power The power to set, as a percentage from 0.0F to 1.0F
+ * inclusive. Values outside of this range will be clamped
+ * @return True if the fan could be set to \p power, false if an error
+ * occurred.
+ */
+bool thermal_heater_set_power(double power);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  /* THERMAL_HEATER_HARDWARE_H__ */

--- a/stm32-modules/include/thermocycler-refresh/test/test_lid_heater_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_lid_heater_policy.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-class TestLidHeaterPolicy {
-  private:
-    bool _enabled = false;
+#include <algorithm>
 
+class TestLidHeaterPolicy {
   public:
-    auto set_enabled(bool enabled) -> void { _enabled = enabled; }
+    double _power = 0.0F;
+    auto set_heater_power(double power) -> bool {
+        _power = std::clamp(power, (double)0.0F, (double)1.0F);
+        return true;
+    }
 };

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/errors.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/errors.hpp
@@ -46,6 +46,8 @@ enum class ErrorCode {
     THERMAL_PLATE_BUSY = 401,
     THERMAL_PELTIER_ERROR = 402,
     THERMAL_HEATSINK_FAN_ERROR = 403,
+    THERMAL_LID_BUSY = 404,
+    THERMAL_HEATER_ERROR = 405,
 };
 
 auto errorstring(ErrorCode code) -> const char*;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -231,7 +231,7 @@ struct SetFanManual {
 
 struct SetHeaterDebug {
     /**
-     * SetHeaterDebug uses M140.D, debug version of M140. 
+     * SetHeaterDebug uses M140.D, debug version of M140.
      * Sets the PWM of the heater as a percentage between 0 and 1.
      *
      * M140.D S[power]
@@ -242,7 +242,8 @@ struct SetHeaterDebug {
      * - A SetLid command is sent
      */
     using ParseResult = std::optional<SetHeaterDebug>;
-    static constexpr auto prefix = std::array{'M', '1', '4', '0', '.', 'D', ' ', 'S'};
+    static constexpr auto prefix =
+        std::array{'M', '1', '4', '0', '.', 'D', ' ', 'S'};
     static constexpr const char* response = "M140.D OK\n";
 
     double power;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -229,6 +229,56 @@ struct SetFanManual {
     }
 };
 
+struct SetHeaterDebug {
+    /**
+     * SetHeaterDebug uses M140.D, debug version of M140. 
+     * Sets the PWM of the heater as a percentage between 0 and 1.
+     *
+     * M140.D S[power]
+     *
+     * Power will be maintained at the specified level until:
+     * - An error occurs
+     * - Another M140.D is set
+     * - A SetLid command is sent
+     */
+    using ParseResult = std::optional<SetHeaterDebug>;
+    static constexpr auto prefix = std::array{'M', '1', '4', '0', '.', 'D', ' ', 'S'};
+    static constexpr const char* response = "M140.D OK\n";
+
+    double power;
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+
+    template <typename InputIt, typename Limit>
+    requires std::contiguous_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+
+        auto power_res = parse_value<float>(working, limit);
+
+        if (!power_res.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+        auto power_val = power_res.first.value();
+        if ((power_val < 0.0) || (power_val > 1.0)) {
+            return std::make_pair(ParseResult(), input);
+        }
+        working = power_res.second;
+        return std::make_pair(ParseResult(SetHeaterDebug{.power = power_val}),
+                              working);
+    }
+};
+
 struct SetPeltierDebug {
     /**
      * SetPeltierDebug uses M104.D, debug version of M104. Sets the

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
@@ -40,10 +40,11 @@ class HostCommsTask {
     using GCodeParser = gcode::GroupParser<
         gcode::EnterBootloader, gcode::GetSystemInfo, gcode::SetSerialNumber,
         gcode::GetLidTemperatureDebug, gcode::GetPlateTemperatureDebug,
-        gcode::SetPeltierDebug, gcode::SetFanManual>;
+        gcode::SetPeltierDebug, gcode::SetFanManual, gcode::SetHeaterDebug>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
-                 gcode::SetPeltierDebug, gcode::SetFanManual>;
+                 gcode::SetPeltierDebug, gcode::SetFanManual,
+                 gcode::SetHeaterDebug>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetLidTempDebugCache = AckCache<8, gcode::GetLidTemperatureDebug>;
     using GetPlateTempDebugCache = AckCache<8, gcode::GetPlateTemperatureDebug>;
@@ -501,6 +502,31 @@ class HostCommsTask {
         auto message =
             messages::SetFanManualMessage{.id = id, .power = gcode.power};
         if (!task_registry->thermal_plate->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::SetHeaterDebug& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+
+        auto message =
+            messages::SetHeaterDebugMessage{.id = id, .power = gcode.power};
+        if (!task_registry->lid_heater->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -27,10 +27,11 @@ namespace lid_heater_task {
 
 template <typename Policy>
 concept LidHeaterExecutionPolicy = requires(Policy& p, const Policy& cp) {
-    // A set_enabled function with inputs of `false` or `true` that
-    // sets the enable pin for the peltiers off or on
+    // A set_heater_power function to set the power of the heater as
+    // a percentage from 0 to 1.0. Automatically toggles the Enable
+    // pin.
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    {p.set_enabled(false)};
+    {p.set_heater_power(1.0)} -> std::same_as<bool>;
 };
 
 struct State {
@@ -139,9 +140,18 @@ class LidHeaterTask {
     requires LidHeaterExecutionPolicy<Policy>
     auto visit_message(const messages::LidTempReadComplete& msg, Policy& policy)
         -> void {
-        static_cast<void>(policy);
-
+        auto old_error_bitmap = _state.error_bitmap;
         handle_temperature_conversion(msg.lid_temp, _thermistor);
+        if(old_error_bitmap != _state.error_bitmap) {
+            if(_state.error_bitmap != 0) {
+                // We entered an error state. Disable power output.
+                _state.system_status = State::ERROR;
+                policy.set_heater_power(0.0F);
+            } else {
+                // We went from an error state to no error state... so go idle
+                _state.system_status = State::IDLE;
+            }
+        }
     }
 
     template <typename Policy>
@@ -156,6 +166,32 @@ class LidHeaterTask {
             .lid_adc = _thermistor.last_adc};
         static_cast<void>(_task_registry->comms->get_message_queue().try_send(
             messages::HostCommsMessage(response)));
+    }
+
+    template <LidHeaterExecutionPolicy Policy> 
+    auto visit_message(const messages::SetHeaterDebugMessage& msg,
+                       Policy& policy) -> void {
+        auto response = messages::AcknowledgePrevious{.responding_to_id = msg.id};
+        if(_state.system_status == State::ERROR) {
+            response.with_error = most_relevant_error();
+            static_cast<void>(
+                _task_registry->comms->get_message_queue().try_send(response));
+            return;
+        }
+        if (_state.system_status == State::CONTROLLING) {
+            // Send busy error
+            response.with_error = errors::ErrorCode::THERMAL_LID_BUSY;
+            static_cast<void>(
+                _task_registry->comms->get_message_queue().try_send(response));
+            return;
+        }
+
+        if(!policy.set_heater_power(msg.power)) {
+            response.with_error = errors::ErrorCode::THERMAL_HEATER_ERROR;
+        }
+
+        static_cast<void>(
+            _task_registry->comms->get_message_queue().try_send(response));
     }
 
     auto handle_temperature_conversion(uint16_t conversion_result,
@@ -203,6 +239,20 @@ class LidHeaterTask {
             therm.error = errors::ErrorCode::NO_ERROR;
         }
         therm.temp_c = temp;
+    }
+
+    [[nodiscard]] auto most_relevant_error() const -> errors::ErrorCode {
+        // Sometimes more than one error can occur at the same time; sometimes,
+        // that means that one has caused the other. We want to track them
+        // separately, but we also sometimes want to respond with just one error
+        // condition that sums everything up. This method is used by code that
+        // wants the single most relevant code for the current error condition.
+        if((_state.error_bitmap & _thermistor.error_bit) 
+                == _thermistor.error_bit) {
+            return _thermistor.error;
+        }
+
+        return errors::ErrorCode::NO_ERROR;
     }
 
     Queue& _message_queue;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -31,7 +31,7 @@ concept LidHeaterExecutionPolicy = requires(Policy& p, const Policy& cp) {
     // a percentage from 0 to 1.0. Automatically toggles the Enable
     // pin.
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    {p.set_heater_power(1.0)} -> std::same_as<bool>;
+    { p.set_heater_power(1.0) } -> std::same_as<bool>;
 };
 
 struct State {
@@ -142,8 +142,8 @@ class LidHeaterTask {
         -> void {
         auto old_error_bitmap = _state.error_bitmap;
         handle_temperature_conversion(msg.lid_temp, _thermistor);
-        if(old_error_bitmap != _state.error_bitmap) {
-            if(_state.error_bitmap != 0) {
+        if (old_error_bitmap != _state.error_bitmap) {
+            if (_state.error_bitmap != 0) {
                 // We entered an error state. Disable power output.
                 _state.system_status = State::ERROR;
                 policy.set_heater_power(0.0F);
@@ -168,11 +168,12 @@ class LidHeaterTask {
             messages::HostCommsMessage(response)));
     }
 
-    template <LidHeaterExecutionPolicy Policy> 
+    template <LidHeaterExecutionPolicy Policy>
     auto visit_message(const messages::SetHeaterDebugMessage& msg,
                        Policy& policy) -> void {
-        auto response = messages::AcknowledgePrevious{.responding_to_id = msg.id};
-        if(_state.system_status == State::ERROR) {
+        auto response =
+            messages::AcknowledgePrevious{.responding_to_id = msg.id};
+        if (_state.system_status == State::ERROR) {
             response.with_error = most_relevant_error();
             static_cast<void>(
                 _task_registry->comms->get_message_queue().try_send(response));
@@ -186,7 +187,7 @@ class LidHeaterTask {
             return;
         }
 
-        if(!policy.set_heater_power(msg.power)) {
+        if (!policy.set_heater_power(msg.power)) {
             response.with_error = errors::ErrorCode::THERMAL_HEATER_ERROR;
         }
 
@@ -247,8 +248,8 @@ class LidHeaterTask {
         // separately, but we also sometimes want to respond with just one error
         // condition that sums everything up. This method is used by code that
         // wants the single most relevant code for the current error condition.
-        if((_state.error_bitmap & _thermistor.error_bit) 
-                == _thermistor.error_bit) {
+        if ((_state.error_bitmap & _thermistor.error_bit) ==
+            _thermistor.error_bit) {
             return _thermistor.error;
         }
 

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -157,7 +157,7 @@ using ThermalPlateMessage =
     ::std::variant<std::monostate, ThermalPlateTempReadComplete,
                    GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,
                    SetFanManualMessage>;
-using LidHeaterMessage = ::std::variant<std::monostate, LidTempReadComplete,
-                                        GetLidTemperatureDebugMessage,
-                                        SetHeaterDebugMessage>;
+using LidHeaterMessage =
+    ::std::variant<std::monostate, LidTempReadComplete,
+                   GetLidTemperatureDebugMessage, SetHeaterDebugMessage>;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -140,6 +140,11 @@ struct SetFanManualMessage {
     double power;
 };
 
+struct SetHeaterDebugMessage {
+    uint32_t id;
+    double power;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage>;
@@ -153,5 +158,6 @@ using ThermalPlateMessage =
                    GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,
                    SetFanManualMessage>;
 using LidHeaterMessage = ::std::variant<std::monostate, LidTempReadComplete,
-                                        GetLidTemperatureDebugMessage>;
+                                        GetLidTemperatureDebugMessage,
+                                        SetHeaterDebugMessage>;
 };  // namespace messages

--- a/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
@@ -41,6 +41,7 @@ set(${TARGET_MODULE_NAME}_FW_NONLINTABLE_SRCS
   ${THERMAL_DIR}/thermal_hardware.c
   ${THERMAL_DIR}/thermal_peltier_hardware.c
   ${THERMAL_DIR}/thermal_fan_hardware.c
+  ${THERMAL_DIR}/thermal_heater_hardware.c
   )
 
 add_executable(${TARGET_MODULE_NAME}

--- a/stm32-modules/thermocycler-refresh/firmware/system/stm32g4xx_hal_msp.c
+++ b/stm32-modules/thermocycler-refresh/firmware/system/stm32g4xx_hal_msp.c
@@ -164,6 +164,17 @@ void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef* htim_pwm)
 
   /* USER CODE END TIM1_MspInit 1 */
   }
+  else if(htim_pwm->Instance==TIM15)
+  {
+  /* USER CODE BEGIN TIM15_MspInit 0 */
+
+  /* USER CODE END TIM15_MspInit 0 */
+    /* Peripheral clock enable */
+    __HAL_RCC_TIM15_CLK_ENABLE();
+  /* USER CODE BEGIN TIM15_MspInit 1 */
+
+  /* USER CODE END TIM15_MspInit 1 */
+  }
 
 }
 
@@ -185,6 +196,17 @@ void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef* htim_pwm)
   /* USER CODE BEGIN TIM1_MspDeInit 1 */
 
   /* USER CODE END TIM1_MspDeInit 1 */
+  }
+  else if(htim_pwm->Instance==TIM15)
+  {
+  /* USER CODE BEGIN TIM15_MspDeInit 0 */
+
+  /* USER CODE END TIM15_MspDeInit 0 */
+    /* Peripheral clock disable */
+    __HAL_RCC_TIM15_CLK_DISABLE();
+  /* USER CODE BEGIN TIM15_MspDeInit 1 */
+
+  /* USER CODE END TIM15_MspDeInit 1 */
   }
 
 }

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.cpp
@@ -1,7 +1,12 @@
 #include "firmware/lid_heater_policy.hpp"
 
+#include <algorithm>
+
+#include "firmware/thermal_heater_hardware.h"
+
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-auto LidHeaterPolicy::set_enabled(bool enabled) -> void {
-    // TODO - stub right now just to be able to set up concept requirements
-    static_cast<void>(enabled);
+auto LidHeaterPolicy::set_heater_power(double power) -> bool {
+    // Set the power of the heater between 0 and 1
+    power = std::clamp(power, (double)0.0F, (double)1.0F);
+    return thermal_heater_set_power(power);
 }

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_hardware.c
@@ -40,6 +40,7 @@
 
 // Local includes
 #include "firmware/thermal_fan_hardware.h"
+#include "firmware/thermal_heater_hardware.h"
 #include "firmware/thermal_peltier_hardware.h"
 
 /** Private definitions */
@@ -145,6 +146,7 @@ void thermal_hardware_setup(void) {
         thermal_i2c_init();
         thermal_peltier_initialize();
         thermal_fan_initialize();
+        thermal_heater_initialize();
 
         _initialization_done = true;
     }

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_heater_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_heater_hardware.c
@@ -1,0 +1,174 @@
+#include "firmware/thermal_heater_hardware.h"
+
+
+#include "FreeRTOS.h"
+#include "stm32g4xx_hal_def.h"
+#include "stm32g4xx_hal.h"
+#include "stm32g4xx_hal_gpio.h"
+#include "stm32g4xx_hal_tim.h"
+#include "task.h"
+
+// Private definitions
+#define HEATER_PWM_Pin (GPIO_PIN_2)
+#define HEATER_PWM_GPIO_Port (GPIOA)
+
+#define PULSE_WIDTH_FREQ (25000)
+#define TIMER_CLOCK_FREQ (170000000)
+// These two together give a 25kHz pulse width, and the ARR value
+// of 99 gives us a nice scale of 0-100 for the pulse width.
+// A finer scale is possible by reducing the prescale value and
+// adjusting the reload to match.
+#define TIM15_PRESCALER (67)
+//#define TIM1_RELOAD    (99)
+#define TIM15_RELOAD ((TIMER_CLOCK_FREQ / (PULSE_WIDTH_FREQ * (TIM15_PRESCALER + 1))) - 1)
+// PWM should be scaled from 0 to MAX_PWM, inclusive
+#define MAX_PWM (TIM15_RELOAD + 1)
+
+// Private typedefs
+
+struct Heater {
+    // Configuration
+    GPIO_TypeDef *enable_port;
+    const uint16_t enable_pin;
+    const uint16_t pwm_channel;
+    // Current status
+    bool initialized;
+    double power;
+    TIM_HandleTypeDef timer;
+};
+
+// Local variables
+
+static struct Heater _heater = {
+    .enable_port = GPIOD,
+    .enable_pin  = GPIO_PIN_7,
+    .pwm_channel = TIM_CHANNEL_1,
+    .initialized = false,
+    .power = 0.0F,
+    .timer = {}
+};
+
+// Private function declarations
+
+/**
+ * @brief Enable or disable the fans (12v power supply)
+ * 
+ * @param[in] enabled True to enable the fans, false to turn them off
+ * @return True on success, false if \p enabled could not be written
+ */
+static bool thermal_heater_set_enable(bool enabled);
+
+// Public function implementations
+
+void thermal_heater_initialize(void) {
+    HAL_StatusTypeDef hal_ret = HAL_ERROR;
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    TIM_OC_InitTypeDef sConfigOC = {0};
+    TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+
+    __GPIOA_CLK_ENABLE();
+    __GPIOD_CLK_ENABLE();
+
+    // Disable the enable pin first
+    GPIO_InitStruct.Pin = _heater.enable_pin;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+    HAL_GPIO_Init(_heater.enable_port, &GPIO_InitStruct);
+    HAL_GPIO_WritePin(_heater.enable_port, _heater.enable_pin, GPIO_PIN_RESET);
+
+    // Configure timer 15 for PWMN control on channel 1
+    _heater.timer.Instance = TIM15;
+    _heater.timer.Init.Prescaler = TIM15_PRESCALER;
+    _heater.timer.Init.CounterMode = TIM_COUNTERMODE_UP;
+    _heater.timer.Init.Period = TIM15_RELOAD;
+    _heater.timer.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    _heater.timer.Init.RepetitionCounter = 0;
+    _heater.timer.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    hal_ret = HAL_TIM_PWM_Init(&_heater.timer);
+    configASSERT(hal_ret == HAL_OK);
+        
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    hal_ret = HAL_TIMEx_MasterConfigSynchronization(&_heater.timer, &sMasterConfig);
+    configASSERT(hal_ret == HAL_OK);
+
+    sConfigOC.OCMode = TIM_OCMODE_PWM1;
+    sConfigOC.Pulse = 0;
+    sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+    sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
+    sConfigOC.OCFastMode = TIM_OCFAST_ENABLE;
+    sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
+    sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
+    hal_ret = HAL_TIM_PWM_ConfigChannel(&_heater.timer, &sConfigOC, _heater.pwm_channel);
+    configASSERT(hal_ret == HAL_OK);
+
+    sBreakDeadTimeConfig.OffStateRunMode = TIM_OSSR_DISABLE;
+    sBreakDeadTimeConfig.OffStateIDLEMode = TIM_OSSI_DISABLE;
+    sBreakDeadTimeConfig.LockLevel = TIM_LOCKLEVEL_OFF;
+    sBreakDeadTimeConfig.DeadTime = 0;
+    sBreakDeadTimeConfig.BreakState = TIM_BREAK_DISABLE;
+    sBreakDeadTimeConfig.BreakPolarity = TIM_BREAKPOLARITY_HIGH;
+    sBreakDeadTimeConfig.BreakFilter = 0;
+    sBreakDeadTimeConfig.AutomaticOutput = TIM_AUTOMATICOUTPUT_DISABLE;
+    hal_ret = HAL_TIMEx_ConfigBreakDeadTime(&_heater.timer, &sBreakDeadTimeConfig);
+    configASSERT(hal_ret == HAL_OK);
+
+    // This is a copy+paste of the HAL_TIM_MspPostInit implementation because
+    // there's no actual reason for it to live in that function
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    /**TIM15 GPIO Configuration
+    PA2     ------> TIM15_CH1
+    */
+    GPIO_InitStruct.Pin = HEATER_PWM_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Alternate = GPIO_AF9_TIM15;
+    HAL_GPIO_Init(HEATER_PWM_GPIO_Port, &GPIO_InitStruct);
+
+    _heater.initialized = true;
+}
+
+
+bool thermal_heater_set_power(double power) {
+    if(!_heater.initialized) { return false; }
+    if(power > 1.0F) { power = 1.0F; }
+    if(power < 0.0F) { power = 0.0F; }
+
+    double old_power = _heater.power;
+    _heater.power = power;
+
+    if(power == 0.0F) {
+        if(!thermal_heater_set_enable(false)) { return false; }
+        return HAL_TIM_PWM_Stop(&_heater.timer, _heater.pwm_channel) == HAL_OK;
+    }
+
+    uint32_t pwm = _heater.power * (double)MAX_PWM;
+    if(!thermal_heater_set_enable(true)) { return false; }
+    __HAL_TIM_SET_COMPARE(&_heater.timer, _heater.pwm_channel, pwm);
+    // PWM_Start will fail if we call it twice, so make sure the heater is 
+    // off before calling it
+    if(old_power == 0.0F) {
+        if(HAL_TIM_PWM_Start(&_heater.timer, _heater.pwm_channel) != HAL_OK) {
+            // Disable 12v if we couldn't set the PWM
+            thermal_heater_set_enable(false);
+            return false;
+        }
+    }
+    
+
+    return true;
+}
+
+// Local function implementations
+
+static bool thermal_heater_set_enable(bool enabled) {
+    if(!_heater.initialized) { return false; }
+
+    GPIO_PinState state = (enabled) ? GPIO_PIN_SET : GPIO_PIN_RESET;
+    HAL_GPIO_WritePin(_heater.enable_port, _heater.enable_pin, state);
+
+    return true;
+}

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -88,3 +88,14 @@ def set_fans_manual(power: float, ser: serial.Serial):
     res = ser.readline()
     guard_error(res, b'M106 OK')
     print(res)
+
+# Sets heater PWM as a percentage.
+def set_heater_debug(power: float, ser: serial.Serial):
+    if(power< 0.0 or power > 1.0):
+        raise RuntimeError(f'Invalid power input: {power}')
+    
+    print(f'Setting heater PWM to {power}%')
+    ser.write(f'M140.D S{power}\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M140.D OK')
+    print(res)

--- a/stm32-modules/thermocycler-refresh/simulator/lid_heater_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/lid_heater_thread.cpp
@@ -9,12 +9,15 @@
 
 using namespace lid_heater_thread;
 
-struct SimLidHeaterPolicy {
+class SimLidHeaterPolicy {
   private:
-    bool _enabled = false;
+    double _power = 0.0F;
 
   public:
-    auto set_enabled(bool enabled) -> void { _enabled = enabled; }
+    auto set_heater_power(double power) -> bool {
+        _power = std::clamp(power, (double)0.0F, (double)1.0F);
+        return true;
+    }
 };
 
 struct lid_heater_thread::TaskControlBlock {

--- a/stm32-modules/thermocycler-refresh/src/errors.cpp
+++ b/stm32-modules/thermocycler-refresh/src/errors.cpp
@@ -64,6 +64,10 @@ const char* const THERMAL_PELTIER_ERROR =
     "ERR402:thermal:Could not activate peltier\n";
 const char* const THERMAL_HEATSINK_FAN_ERROR =
     "ERR403:thermal:Could not control heatsink fan\n";
+const char* const THERMAL_LID_BUSY =
+    "ERR404:thermal:Lid heater is busy\n";
+const char* const THERMAL_HEATER_ERROR = 
+    "ERR405:thermal:Error controlling lid heater";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
@@ -109,6 +113,8 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(THERMAL_PLATE_BUSY);
         HANDLE_CASE(THERMAL_PELTIER_ERROR);
         HANDLE_CASE(THERMAL_HEATSINK_FAN_ERROR);
+        HANDLE_CASE(THERMAL_LID_BUSY);
+        HANDLE_CASE(THERMAL_HEATER_ERROR);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/thermocycler-refresh/src/errors.cpp
+++ b/stm32-modules/thermocycler-refresh/src/errors.cpp
@@ -64,9 +64,8 @@ const char* const THERMAL_PELTIER_ERROR =
     "ERR402:thermal:Could not activate peltier\n";
 const char* const THERMAL_HEATSINK_FAN_ERROR =
     "ERR403:thermal:Could not control heatsink fan\n";
-const char* const THERMAL_LID_BUSY =
-    "ERR404:thermal:Lid heater is busy\n";
-const char* const THERMAL_HEATER_ERROR = 
+const char* const THERMAL_LID_BUSY = "ERR404:thermal:Lid heater is busy\n";
+const char* const THERMAL_HEATER_ERROR =
     "ERR405:thermal:Error controlling lid heater";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_m141d.cpp
     test_m104d.cpp
     test_m106.cpp
+    test_m140d.cpp
 )
 
 target_include_directories(${TARGET_MODULE_NAME} 

--- a/stm32-modules/thermocycler-refresh/tests/test_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_lid_heater_task.cpp
@@ -46,21 +46,25 @@ SCENARIO("lid heater task message passing") {
             }
         }
         WHEN("Sending a SetHeaterDebug message to enable the heater") {
-            auto message = messages::SetHeaterDebugMessage{.id = 123, .power = 0.65};
+            auto message =
+                messages::SetHeaterDebugMessage{.id = 123, .power = 0.65};
             tasks->get_lid_heater_queue().backing_deque.push_back(
                 messages::LidHeaterMessage(message));
             tasks->run_lid_heater_task();
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
                 AND_THEN("the task should act on the message") {
-                    REQUIRE(tasks->get_thermal_plate_queue().backing_deque.empty());
+                    REQUIRE(
+                        tasks->get_thermal_plate_queue().backing_deque.empty());
 
-                    REQUIRE(!tasks->get_host_comms_queue().backing_deque.empty());
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
                     auto response =
                         tasks->get_host_comms_queue().backing_deque.front();
                     tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(std::holds_alternative<messages::AcknowledgePrevious>(
-                        response));
+                    REQUIRE(
+                        std::holds_alternative<messages::AcknowledgePrevious>(
+                            response));
                     auto response_msg =
                         std::get<messages::AcknowledgePrevious>(response);
                     REQUIRE(response_msg.responding_to_id == 123);
@@ -87,21 +91,25 @@ SCENARIO("lid heater task message passing") {
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
 
         WHEN("Sending a SetHeaterDebug message to enable the heater") {
-            auto message = messages::SetHeaterDebugMessage{.id = 124, .power = 0.65};
+            auto message =
+                messages::SetHeaterDebugMessage{.id = 124, .power = 0.65};
             tasks->get_lid_heater_queue().backing_deque.push_back(
                 messages::LidHeaterMessage(message));
             tasks->run_lid_heater_task();
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
                 AND_THEN("the task should respond with an error") {
-                    REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
+                    REQUIRE(
+                        tasks->get_lid_heater_queue().backing_deque.empty());
 
-                    REQUIRE(!tasks->get_host_comms_queue().backing_deque.empty());
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
                     auto response =
                         tasks->get_host_comms_queue().backing_deque.front();
                     tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(std::holds_alternative<messages::AcknowledgePrevious>(
-                        response));
+                    REQUIRE(
+                        std::holds_alternative<messages::AcknowledgePrevious>(
+                            response));
                     auto response_msg =
                         std::get<messages::AcknowledgePrevious>(response);
                     REQUIRE(response_msg.responding_to_id == 124);
@@ -128,21 +136,25 @@ SCENARIO("lid heater task message passing") {
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
 
         WHEN("Sending a SetHeaterDebug message to enable the heater") {
-            auto message = messages::SetHeaterDebugMessage{.id = 124, .power = 0.65};
+            auto message =
+                messages::SetHeaterDebugMessage{.id = 124, .power = 0.65};
             tasks->get_lid_heater_queue().backing_deque.push_back(
                 messages::LidHeaterMessage(message));
             tasks->run_lid_heater_task();
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
                 AND_THEN("the task should respond with an error") {
-                    REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
+                    REQUIRE(
+                        tasks->get_lid_heater_queue().backing_deque.empty());
 
-                    REQUIRE(!tasks->get_host_comms_queue().backing_deque.empty());
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
                     auto response =
                         tasks->get_host_comms_queue().backing_deque.front();
                     tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(std::holds_alternative<messages::AcknowledgePrevious>(
-                        response));
+                    REQUIRE(
+                        std::holds_alternative<messages::AcknowledgePrevious>(
+                            response));
                     auto response_msg =
                         std::get<messages::AcknowledgePrevious>(response);
                     REQUIRE(response_msg.responding_to_id == 124);

--- a/stm32-modules/thermocycler-refresh/tests/test_m140d.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m140d.cpp
@@ -8,7 +8,8 @@ SCENARIO("SetHeaterDebug (M140.D) parser works", "[gcode][parse][m140d]") {
             auto written = gcode::SetHeaterDebug::write_response_into(
                 buffer.begin(), buffer.end());
             THEN("the response should be written in full") {
-                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M140.D OK\n"));
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::StartsWith("M140.D OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }

--- a/stm32-modules/thermocycler-refresh/tests/test_m140d.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m140d.cpp
@@ -1,0 +1,77 @@
+#include "catch2/catch.hpp"
+#include "thermocycler-refresh/gcodes.hpp"
+
+SCENARIO("SetHeaterDebug (M140.D) parser works", "[gcode][parse][m140d]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(64, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetHeaterDebug::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M140.D OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetHeaterDebug::write_response_into(
+                buffer.begin(), buffer.begin() + 6);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M140.Dcccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("Valid parameters") {
+        WHEN("Setting power to 1.0") {
+            std::string buffer = "M140.D S1.0\n";
+            auto parsed =
+                gcode::SetHeaterDebug::parse(buffer.begin(), buffer.end());
+            THEN("the power should be 1.0") {
+                auto &val = parsed.first;
+                REQUIRE(parsed.second != buffer.begin());
+                REQUIRE(val.has_value());
+                REQUIRE(val.value().power == 1.0F);
+            }
+        }
+        WHEN("Setting power to 0.0") {
+            std::string buffer = "M140.D S0\n";
+            auto parsed =
+                gcode::SetHeaterDebug::parse(buffer.begin(), buffer.end());
+            THEN("the power should be 0.0") {
+                auto &val = parsed.first;
+                REQUIRE(parsed.second != buffer.begin());
+                REQUIRE(val.has_value());
+                REQUIRE(val.value().power == 0.0F);
+            }
+        }
+    }
+    GIVEN("Invalid power") {
+        WHEN("Setting power to 2.0") {
+            std::string buffer = "M140.D S2.0\n";
+            auto parsed =
+                gcode::SetHeaterDebug::parse(buffer.begin(), buffer.end());
+            THEN("parsing should fail") {
+                auto &val = parsed.first;
+                REQUIRE(!val.has_value());
+                REQUIRE(parsed.second == buffer.begin());
+            }
+        }
+    }
+    GIVEN("Invalid message") {
+        WHEN("Setting power to 1.0") {
+            std::string buffer = "M140 S2.0\n";
+            auto parsed =
+                gcode::SetHeaterDebug::parse(buffer.begin(), buffer.end());
+            THEN("parsing should fail") {
+                auto &val = parsed.first;
+                REQUIRE(!val.has_value());
+                REQUIRE(parsed.second == buffer.begin());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a driver for the thermal heating pad in the lid. 

- Controls heater with a PWM line from TIM15 and an enable pin. 
- Includes a debug gcode for setting the PWM of the heater directly (M140.D)

Tested by sending M140.D with a few different powers (0.2, 0.5, 0.75) and watching the temperature increase at different rates. Also tested that sending power of 0.0 makes the temperature stop going up.

