### PR TITLE
feat(thermocycler-refresh): heat pad closed loop control

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/firmware/lid_heater_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/lid_heater_policy.hpp
@@ -11,5 +11,5 @@ class LidHeaterPolicy {
 
     auto set_heater_power(double power) -> bool;
 
-    auto get_heater_power() const -> double;
+    [[nodiscard]] auto get_heater_power() const -> double;
 };

--- a/stm32-modules/include/thermocycler-refresh/firmware/lid_heater_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/lid_heater_policy.hpp
@@ -10,4 +10,6 @@ class LidHeaterPolicy {
     LidHeaterPolicy() = default;
 
     auto set_heater_power(double power) -> bool;
+
+    auto get_heater_power() const -> double;
 };

--- a/stm32-modules/include/thermocycler-refresh/firmware/thermal_heater_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/thermal_heater_hardware.h
@@ -23,6 +23,13 @@ void thermal_heater_initialize(void);
  */
 bool thermal_heater_set_power(double power);
 
+/**
+ * @brief Returns the power level of the heater
+ *
+ * @return The thermal heater power as a percentage from 0 to 1.0
+ */
+double thermal_heater_get_power(void);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/stm32-modules/include/thermocycler-refresh/systemwide.h
+++ b/stm32-modules/include/thermocycler-refresh/systemwide.h
@@ -20,3 +20,5 @@ typedef enum PeltierDirection {
 } PeltierDirection;
 
 enum PeltierSelection { LEFT, CENTER, RIGHT, ALL };
+
+enum PidSelection { HEATER, PELTIERS, FANS };

--- a/stm32-modules/include/thermocycler-refresh/test/test_lid_heater_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_lid_heater_policy.hpp
@@ -4,9 +4,12 @@
 
 class TestLidHeaterPolicy {
   public:
-    double _power = 0.0F;
     auto set_heater_power(double power) -> bool {
         _power = std::clamp(power, (double)0.0F, (double)1.0F);
         return true;
     }
+    auto get_heater_power() const -> double { return _power; }
+
+  private:
+    double _power = 0.0F;
 };

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/errors.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/errors.hpp
@@ -48,6 +48,7 @@ enum class ErrorCode {
     THERMAL_HEATSINK_FAN_ERROR = 403,
     THERMAL_LID_BUSY = 404,
     THERMAL_HEATER_ERROR = 405,
+    THERMAL_CONSTANT_OUT_OF_RANGE = 406,
 };
 
 auto errorstring(ErrorCode code) -> const char*;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
@@ -330,8 +330,8 @@ class HostCommsTask {
         std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_message(const messages::GetLidTempResponse& response,
                        InputIt tx_into, InputLimit tx_limit) -> InputIt {
-        auto cache_entry = get_lid_temp_debug_cache.remove_if_present(
-            response.responding_to_id);
+        auto cache_entry =
+            get_lid_temp_cache.remove_if_present(response.responding_to_id);
         return std::visit(
             [tx_into, tx_limit, response](auto cache_element) {
                 using T = std::decay_t<decltype(cache_element)>;
@@ -353,8 +353,8 @@ class HostCommsTask {
         std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_message(const messages::GetPlateTempResponse& response,
                        InputIt tx_into, InputLimit tx_limit) -> InputIt {
-        auto cache_entry = get_lid_temp_debug_cache.remove_if_present(
-            response.responding_to_id);
+        auto cache_entry =
+            get_plate_temp_cache.remove_if_present(response.responding_to_id);
         return std::visit(
             [tx_into, tx_limit, response](auto cache_element) {
                 using T = std::decay_t<decltype(cache_element)>;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
@@ -40,7 +40,8 @@ class HostCommsTask {
     using GCodeParser = gcode::GroupParser<
         gcode::EnterBootloader, gcode::GetSystemInfo, gcode::SetSerialNumber,
         gcode::GetLidTemperatureDebug, gcode::GetPlateTemperatureDebug,
-        gcode::SetPeltierDebug, gcode::SetFanManual, gcode::SetHeaterDebug>;
+        gcode::SetPeltierDebug, gcode::SetFanManual, gcode::SetHeaterDebug,
+        gcode::GetPlateTemp, gcode::GetLidTemp>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::SetPeltierDebug, gcode::SetFanManual,
@@ -48,6 +49,8 @@ class HostCommsTask {
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetLidTempDebugCache = AckCache<8, gcode::GetLidTemperatureDebug>;
     using GetPlateTempDebugCache = AckCache<8, gcode::GetPlateTemperatureDebug>;
+    using GetPlateTempCache = AckCache<8, gcode::GetPlateTemp>;
+    using GetLidTempCache = AckCache<8, gcode::GetLidTemp>;
 
   public:
     static constexpr size_t TICKS_TO_WAIT_ON_SEND = 10;
@@ -62,7 +65,11 @@ class HostCommsTask {
           // NOLINTNEXTLINE(readability-redundant-member-init)
           get_lid_temp_debug_cache(),
           // NOLINTNEXTLINE(readability-redundant-member-init)
-          get_plate_temp_debug_cache() {}
+          get_plate_temp_debug_cache(),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
+          get_plate_temp_cache(),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
+          get_lid_temp_cache() {}
     HostCommsTask(const HostCommsTask& other) = delete;
     auto operator=(const HostCommsTask& other) -> HostCommsTask& = delete;
     HostCommsTask(HostCommsTask&& other) noexcept = delete;
@@ -315,6 +322,53 @@ class HostCommsTask {
             },
             cache_entry);
     }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(const messages::GetLidTempResponse& response,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto cache_entry = get_lid_temp_debug_cache.remove_if_present(
+            response.responding_to_id);
+        return std::visit(
+            [tx_into, tx_limit, response](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (std::is_same_v<std::monostate, T>) {
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                } else {
+                    return cache_element.write_response_into(
+                        tx_into, tx_limit, response.current_temp,
+                        response.set_temp);
+                }
+            },
+            cache_entry);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(const messages::GetPlateTempResponse& response,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto cache_entry = get_lid_temp_debug_cache.remove_if_present(
+            response.responding_to_id);
+        return std::visit(
+            [tx_into, tx_limit, response](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (std::is_same_v<std::monostate, T>) {
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                } else {
+                    return cache_element.write_response_into(
+                        tx_into, tx_limit, response.current_temp,
+                        response.set_temp);
+                }
+            },
+            cache_entry);
+    }
+
     /**
      * visit_gcode() is a set of member function overloads, each of which is
      * called when we parse the appropriate gcode out of the receive buffer.
@@ -437,6 +491,30 @@ class HostCommsTask {
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::GetLidTemp& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = get_lid_temp_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+
+        auto message = messages::GetLidTempMessage{.id = id};
+        if (!task_registry->lid_heater->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_gcode(const gcode::GetPlateTemperatureDebug& gcode,
                      InputIt tx_into, InputLimit tx_limit)
         -> std::pair<bool, InputIt> {
@@ -448,6 +526,30 @@ class HostCommsTask {
         }
 
         auto message = messages::GetPlateTemperatureDebugMessage{.id = id};
+        if (!task_registry->thermal_plate->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::GetPlateTemp& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = get_plate_temp_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+
+        auto message = messages::GetPlateTempMessage{.id = id};
         if (!task_registry->thermal_plate->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
@@ -555,6 +657,8 @@ class HostCommsTask {
     GetSystemInfoCache get_system_info_cache;
     GetLidTempDebugCache get_lid_temp_debug_cache;
     GetPlateTempDebugCache get_plate_temp_debug_cache;
+    GetPlateTempCache get_plate_temp_cache;
+    GetLidTempCache get_lid_temp_cache;
     bool may_connect_latch = true;
 };
 

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
@@ -702,12 +702,12 @@ class HostCommsTask {
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
 
-        auto message = messages::SetPIDConstantsMessage{
-            .id = id,
-            .selection = gcode.selection,
-            .p = gcode.const_p,
-            .i = gcode.const_i,
-            .d = gcode.const_d};
+        auto message =
+            messages::SetPIDConstantsMessage{.id = id,
+                                             .selection = gcode.selection,
+                                             .p = gcode.const_p,
+                                             .i = gcode.const_i,
+                                             .d = gcode.const_d};
         // TODO when PID is added to the peltiers and fans, will have to
         // switch the target queue based on the selection in the message.
         if (!task_registry->lid_heater->get_message_queue().try_send(
@@ -720,7 +720,6 @@ class HostCommsTask {
 
         return std::make_pair(true, tx_into);
     }
-
 
     // Our error handler just writes an error and bails
     template <typename InputIt, typename InputLimit>

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
@@ -41,11 +41,13 @@ class HostCommsTask {
         gcode::EnterBootloader, gcode::GetSystemInfo, gcode::SetSerialNumber,
         gcode::GetLidTemperatureDebug, gcode::GetPlateTemperatureDebug,
         gcode::SetPeltierDebug, gcode::SetFanManual, gcode::SetHeaterDebug,
-        gcode::GetPlateTemp, gcode::GetLidTemp>;
+        gcode::GetPlateTemp, gcode::GetLidTemp, gcode::SetLidTemperature,
+        gcode::DeactivateLidHeating>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::SetPeltierDebug, gcode::SetFanManual,
-                 gcode::SetHeaterDebug>;
+                 gcode::SetHeaterDebug, gcode::SetLidTemperature,
+                 gcode::DeactivateLidHeating>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetLidTempDebugCache = AckCache<8, gcode::GetLidTemperatureDebug>;
     using GetPlateTempDebugCache = AckCache<8, gcode::GetPlateTemperatureDebug>;
@@ -628,6 +630,55 @@ class HostCommsTask {
 
         auto message =
             messages::SetHeaterDebugMessage{.id = id, .power = gcode.power};
+        if (!task_registry->lid_heater->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::SetLidTemperature& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+
+        auto message = messages::SetLidTemperatureMessage{
+            .id = id, .setpoint = gcode.setpoint};
+        if (!task_registry->lid_heater->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::DeactivateLidHeating& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+
+        auto message = messages::DeactivateLidHeatingMessage{.id = id};
         if (!task_registry->lid_heater->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -72,7 +72,7 @@ class LidHeaterTask {
     static constexpr double KI_MAX = 200;
     static constexpr double KD_MIN = -200;
     static constexpr double KD_MAX = 200;
-    static constexpr double OVERTEMP_LIMIT_C = 95;
+    static constexpr double OVERTEMP_LIMIT_C = 115;
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     static constexpr const double CONTROL_PERIOD_SECONDS =
         CONTROL_PERIOD_TICKS * 0.001;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -300,6 +300,7 @@ class LidHeaterTask {
     template <LidHeaterExecutionPolicy Policy>
     auto visit_message(const messages::SetPIDConstantsMessage& msg,
                        Policy& policy) -> void {
+        static_cast<void>(policy);
         auto response =
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
 

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -298,10 +298,12 @@ class LidHeaterTask {
     }
 
     template <LidHeaterExecutionPolicy Policy>
-    auto visit_message(const messages::SetPIDConstantsMessage& msg, Policy& policy) -> void {
-        auto response = messages::AcknowledgePrevious{.responding_to_id = msg.id};
-        
-        if(_state.system_status == State::CONTROLLING) {
+    auto visit_message(const messages::SetPIDConstantsMessage& msg,
+                       Policy& policy) -> void {
+        auto response =
+            messages::AcknowledgePrevious{.responding_to_id = msg.id};
+
+        if (_state.system_status == State::CONTROLLING) {
             response.with_error = errors::ErrorCode::THERMAL_LID_BUSY;
             static_cast<void>(
                 _task_registry->comms->get_message_queue().try_send(response));
@@ -314,7 +316,7 @@ class LidHeaterTask {
             static_cast<void>(
                 _task_registry->comms->get_message_queue().try_send(response));
             return;
-        } 
+        }
 
         _pid = PID(msg.p, msg.i, msg.d, CONTROL_PERIOD_SECONDS, 1.0, -1.0);
         static_cast<void>(

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -104,6 +104,16 @@ struct GetLidTemperatureDebugResponse {
     uint16_t lid_adc;
 };
 
+struct GetLidTempMessage {
+    uint32_t id;
+};
+
+struct GetLidTempResponse {
+    uint32_t responding_to_id;
+    double current_temp;
+    double set_temp;
+};
+
 struct GetPlateTemperatureDebugMessage {
     uint32_t id;
 };
@@ -125,6 +135,16 @@ struct GetPlateTemperatureDebugResponse {
     uint16_t back_right_adc;
     uint16_t back_center_adc;
     uint16_t back_left_adc;
+};
+
+struct GetPlateTempMessage {
+    uint32_t id;
+};
+
+struct GetPlateTempResponse {
+    uint32_t responding_to_id;
+    double current_temp;
+    double set_temp;
 };
 
 struct SetPeltierDebugMessage {
@@ -152,12 +172,14 @@ using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, AcknowledgePrevious,
                    ErrorMessage, ForceUSBDisconnectMessage,
                    GetSystemInfoResponse, GetLidTemperatureDebugResponse,
-                   GetPlateTemperatureDebugResponse>;
+                   GetPlateTemperatureDebugResponse, GetPlateTempResponse,
+                   GetLidTempResponse>;
 using ThermalPlateMessage =
     ::std::variant<std::monostate, ThermalPlateTempReadComplete,
                    GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,
-                   SetFanManualMessage>;
+                   SetFanManualMessage, GetPlateTempMessage>;
 using LidHeaterMessage =
     ::std::variant<std::monostate, LidTempReadComplete,
-                   GetLidTemperatureDebugMessage, SetHeaterDebugMessage>;
+                   GetLidTemperatureDebugMessage, SetHeaterDebugMessage,
+                   GetLidTempMessage>;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -165,6 +165,15 @@ struct SetHeaterDebugMessage {
     double power;
 };
 
+struct SetLidTemperatureMessage {
+    uint32_t id;
+    double setpoint;
+};
+
+struct DeactivateLidHeatingMessage {
+    uint32_t id;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage>;
@@ -181,5 +190,6 @@ using ThermalPlateMessage =
 using LidHeaterMessage =
     ::std::variant<std::monostate, LidTempReadComplete,
                    GetLidTemperatureDebugMessage, SetHeaterDebugMessage,
-                   GetLidTempMessage>;
+                   GetLidTempMessage, SetLidTemperatureMessage,
+                   DeactivateLidHeatingMessage>;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -174,6 +174,14 @@ struct DeactivateLidHeatingMessage {
     uint32_t id;
 };
 
+struct SetPIDConstantsMessage {
+    uint32_t id;
+    PidSelection selection;
+    double p;
+    double i;
+    double d;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage>;
@@ -191,5 +199,5 @@ using LidHeaterMessage =
     ::std::variant<std::monostate, LidTempReadComplete,
                    GetLidTemperatureDebugMessage, SetHeaterDebugMessage,
                    GetLidTempMessage, SetLidTemperatureMessage,
-                   DeactivateLidHeatingMessage>;
+                   DeactivateLidHeatingMessage, SetPIDConstantsMessage>;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -278,6 +278,7 @@ class ThermalPlateTask {
     template <ThermalPlateExecutionPolicy Policy>
     auto visit_message(const messages::GetPlateTempMessage& msg, Policy& policy)
         -> void {
+        static_cast<void>(policy);
         auto response =
             messages::GetPlateTempResponse{.responding_to_id = msg.id,
                                            .current_temp = average_plate_temp(),
@@ -438,7 +439,7 @@ class ThermalPlateTask {
                 _thermistors[THERM_BACK_LEFT].temp_c +
                 _thermistors[THERM_FRONT_CENTER].temp_c +
                 _thermistors[THERM_BACK_CENTER].temp_c) /
-               6.0F;
+               ((double)(PLATE_THERM_COUNT - 1));
     }
 
     Queue& _message_queue;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -165,7 +165,8 @@ class ThermalPlateTask {
                 .error_bit = thermistorErrorBit(THERM_HEATSINK)}}},
           _converter(THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM, ADC_BIT_MAX,
                      false),
-          _state{.system_status = State::IDLE, .error_bitmap = 0} {}
+          _state{.system_status = State::IDLE, .error_bitmap = 0},
+          _setpoint_c(0) {}
     ThermalPlateTask(const ThermalPlateTask& other) = delete;
     auto operator=(const ThermalPlateTask& other) -> ThermalPlateTask& = delete;
     ThermalPlateTask(ThermalPlateTask&& other) noexcept = delete;
@@ -270,6 +271,20 @@ class ThermalPlateTask {
             .back_right_adc = _thermistors[THERM_BACK_RIGHT].last_adc,
             .back_center_adc = _thermistors[THERM_BACK_CENTER].last_adc,
             .back_left_adc = _thermistors[THERM_BACK_LEFT].last_adc};
+        static_cast<void>(_task_registry->comms->get_message_queue().try_send(
+            messages::HostCommsMessage(response)));
+    }
+
+    template <ThermalPlateExecutionPolicy Policy>
+    auto visit_message(const messages::GetPlateTempMessage& msg, Policy& policy)
+        -> void {
+        auto response =
+            messages::GetPlateTempResponse{.responding_to_id = msg.id,
+                                           .current_temp = average_plate_temp(),
+                                           .set_temp = _setpoint_c};
+        if (_state.system_status != State::CONTROLLING) {
+            response.set_temp = 0.0F;
+        }
         static_cast<void>(_task_registry->comms->get_message_queue().try_send(
             messages::HostCommsMessage(response)));
     }
@@ -416,6 +431,16 @@ class ThermalPlateTask {
         return errors::ErrorCode::NO_ERROR;
     }
 
+    [[nodiscard]] auto average_plate_temp() const -> double {
+        return (_thermistors[THERM_FRONT_RIGHT].temp_c +
+                _thermistors[THERM_BACK_RIGHT].temp_c +
+                _thermistors[THERM_FRONT_LEFT].temp_c +
+                _thermistors[THERM_BACK_LEFT].temp_c +
+                _thermistors[THERM_FRONT_CENTER].temp_c +
+                _thermistors[THERM_BACK_CENTER].temp_c) /
+               6.0F;
+    }
+
     Queue& _message_queue;
     tasks::Tasks<QueueImpl>* _task_registry;
     Peltier _peltier_left;
@@ -424,6 +449,7 @@ class ThermalPlateTask {
     std::array<Thermistor, PLATE_THERM_COUNT> _thermistors;
     thermistor_conversion::Conversion<lookups::KS103J2G> _converter;
     State _state;
+    double _setpoint_c;
 };
 
 }  // namespace thermal_plate_task

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -90,7 +90,7 @@ class ThermalPlateTask {
     static constexpr double KI_MAX = 200;
     static constexpr double KD_MIN = -200;
     static constexpr double KD_MAX = 200;
-    static constexpr double OVERTEMP_LIMIT_C = 105;
+    static constexpr double OVERTEMP_LIMIT_C = 115;
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     static constexpr const double CONTROL_PERIOD_SECONDS =
         CONTROL_PERIOD_TICKS * 0.001;

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.cpp
@@ -10,3 +10,8 @@ auto LidHeaterPolicy::set_heater_power(double power) -> bool {
     power = std::clamp(power, (double)0.0F, (double)1.0F);
     return thermal_heater_set_power(power);
 }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto LidHeaterPolicy::get_heater_power() const -> double {
+    return thermal_heater_get_power();
+}

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/lid_heater_policy.cpp
@@ -12,6 +12,6 @@ auto LidHeaterPolicy::set_heater_power(double power) -> bool {
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-auto LidHeaterPolicy::get_heater_power() const -> double {
+[[nodiscard]] auto LidHeaterPolicy::get_heater_power() const -> double {
     return thermal_heater_get_power();
 }

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_heater_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_heater_hardware.c
@@ -162,6 +162,10 @@ bool thermal_heater_set_power(double power) {
     return true;
 }
 
+double thermal_heater_get_power(void) {
+    return _heater.power;
+}
+
 // Local function implementations
 
 static bool thermal_heater_set_enable(bool enabled) {

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -82,8 +82,8 @@ def set_peltier_debug(power: float, direction: str, peltiers: str, ser: serial.S
 def set_fans_manual(power: float, ser: serial.Serial):
     if(power< 0.0 or power > 1.0):
         raise RuntimeError(f'Invalid power input: {power}')
-    
-    print(f'Setting fan PWM to {power}%')
+    percent = power * 100
+    print(f'Setting fan PWM to {percent}%')
     ser.write(f'M106 S{power}\n'.encode())
     res = ser.readline()
     guard_error(res, b'M106 OK')
@@ -93,8 +93,8 @@ def set_fans_manual(power: float, ser: serial.Serial):
 def set_heater_debug(power: float, ser: serial.Serial):
     if(power< 0.0 or power > 1.0):
         raise RuntimeError(f'Invalid power input: {power}')
-    
-    print(f'Setting heater PWM to {power}%')
+    percent = power * 100
+    print(f'Setting heater PWM to {percent}%')
     ser.write(f'M140.D S{power}\n'.encode())
     res = ser.readline()
     guard_error(res, b'M140.D OK')

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -126,3 +126,11 @@ def deactivate_lid(ser: serial.Serial):
     res = ser.readline()
     guard_error(res, b'M108 OK')
     print(res)
+
+# Set the heater PID constants
+def set_heater_pid(p: float, i: float, d: float, ser: serial.Serial):
+    print(f'Setting heater PID to P={p} I={i} D={d}')
+    ser.write(f'M301 SH P{p} I{i} D{d}\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M301 OK')
+    print(res)

--- a/stm32-modules/thermocycler-refresh/simulator/lid_heater_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/lid_heater_thread.cpp
@@ -18,6 +18,8 @@ class SimLidHeaterPolicy {
         _power = std::clamp(power, (double)0.0F, (double)1.0F);
         return true;
     }
+
+    auto get_heater_power() const -> double { return _power; }
 };
 
 struct lid_heater_thread::TaskControlBlock {

--- a/stm32-modules/thermocycler-refresh/src/errors.cpp
+++ b/stm32-modules/thermocycler-refresh/src/errors.cpp
@@ -67,6 +67,8 @@ const char* const THERMAL_HEATSINK_FAN_ERROR =
 const char* const THERMAL_LID_BUSY = "ERR404:thermal:Lid heater is busy\n";
 const char* const THERMAL_HEATER_ERROR =
     "ERR405:thermal:Error controlling lid heater";
+const char* const THERMAL_CONSTANT_OUT_OF_RANGE =
+    "ERR406:thermal:PID constant(s) out of range";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
@@ -114,6 +116,7 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(THERMAL_HEATSINK_FAN_ERROR);
         HANDLE_CASE(THERMAL_LID_BUSY);
         HANDLE_CASE(THERMAL_HEATER_ERROR);
+        HANDLE_CASE(THERMAL_CONSTANT_OUT_OF_RANGE);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_m140.cpp
     test_m140d.cpp
     test_m141.cpp
+    test_m301.cpp
 )
 
 target_include_directories(${TARGET_MODULE_NAME} 

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -13,11 +13,13 @@ add_executable(${TARGET_MODULE_NAME}
     test_system_task.cpp
     test_thermal_plate_task.cpp
     # GCode parse tests
+    test_m105.cpp
     test_m105d.cpp
     test_m141d.cpp
     test_m104d.cpp
     test_m106.cpp
     test_m140d.cpp
+    test_m141.cpp
 )
 
 target_include_directories(${TARGET_MODULE_NAME} 

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -18,6 +18,8 @@ add_executable(${TARGET_MODULE_NAME}
     test_m141d.cpp
     test_m104d.cpp
     test_m106.cpp
+    test_m108.cpp
+    test_m140.cpp
     test_m140d.cpp
     test_m141.cpp
 )

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -160,13 +160,248 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                 }
             }
         }
+        WHEN("sending a SetFanManual message") {
+            std::string message_text = std::string("M106 S0.5\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the thermal plate task "
+                "and not immediately ack") {
+                REQUIRE(tasks->get_thermal_plate_queue().backing_deque.size() !=
+                        0);
+                auto plate_message =
+                    tasks->get_thermal_plate_queue().backing_deque.front();
+                auto set_fan_manual_message =
+                    std::get<messages::SetFanManualMessage>(plate_message);
+                tasks->get_system_queue().backing_deque.pop_front();
+                constexpr double test_power = 0.5F;
+                REQUIRE(set_fan_manual_message.power == test_power);
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = set_fan_manual_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("M106 OK\n"));
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending a bad response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = set_fan_manual_message.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending an ack with error back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = set_fan_manual_message.id,
+                            .with_error = errors::ErrorCode::
+                                SYSTEM_SERIAL_NUMBER_HAL_ERROR});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should print the error rather than ack") {
+                        REQUIRE_THAT(
+                            tx_buf,
+                            Catch::Matchers::StartsWith(
+                                "ERR302:system:HAL error, busy, or timeout\n"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                    }
+                }
+            }
+        }
+        WHEN("sending a SetLidTemperature message") {
+            std::string message_text = std::string("M140 S101.0\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the lid heater task "
+                "and not immediately ack") {
+                REQUIRE(tasks->get_lid_heater_queue().backing_deque.size() !=
+                        0);
+                auto lid_message =
+                    tasks->get_lid_heater_queue().backing_deque.front();
+                auto set_lid_temp_message =
+                    std::get<messages::SetLidTemperatureMessage>(lid_message);
+                tasks->get_system_queue().backing_deque.pop_front();
+                constexpr double test_temp = 101.0F;
+                REQUIRE(set_lid_temp_message.setpoint == test_temp);
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = set_lid_temp_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("M140 OK\n"));
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending a bad response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = set_lid_temp_message.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending an ack with error back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = set_lid_temp_message.id,
+                            .with_error =
+                                errors::ErrorCode::THERMAL_HEATER_ERROR});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should print the error rather than ack") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR405:"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                    }
+                }
+            }
+        }
+        WHEN("sending a DeactivateLidHeating message") {
+            std::string message_text = std::string("M108\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the lid heater task "
+                "and not immediately ack") {
+                REQUIRE(tasks->get_lid_heater_queue().backing_deque.size() !=
+                        0);
+                auto lid_message =
+                    tasks->get_lid_heater_queue().backing_deque.front();
+                auto deactivate_lid_message =
+                    std::get<messages::DeactivateLidHeatingMessage>(
+                        lid_message);
+                tasks->get_system_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = deactivate_lid_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("M108 OK\n"));
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending a bad response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = deactivate_lid_message.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending an ack with error back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = deactivate_lid_message.id,
+                            .with_error =
+                                errors::ErrorCode::THERMAL_HEATER_ERROR});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should print the error rather than ack") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR405:"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                    }
+                }
+            }
+        }
     }
 }
 
 SCENARIO("message passing for response-carrying gcodes from usb input") {
     GIVEN("a host_comms task") {
         auto tasks = TaskBuilder::build();
-        std::string tx_buf(128, 'c');
+        std::string tx_buf(256, 'c');
         WHEN("sending a get-system-info") {
             auto message_text = std::string("M115\n");
             auto message_obj =
@@ -243,6 +478,376 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     auto response = messages::HostCommsMessage(
                         messages::AcknowledgePrevious{
                             .responding_to_id = get_system_info_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
+        WHEN("sending a get-lid-temp message") {
+            auto message_text = std::string("M141\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the lid and not "
+                "immediately ack") {
+                REQUIRE(tasks->get_lid_heater_queue().backing_deque.size() !=
+                        0);
+                auto lid_message =
+                    tasks->get_lid_heater_queue().backing_deque.front();
+                REQUIRE(std::holds_alternative<messages::GetLidTempMessage>(
+                    lid_message));
+                auto get_lid_temp_message =
+                    std::get<messages::GetLidTempMessage>(lid_message);
+                tasks->get_lid_heater_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response =
+                        messages::HostCommsMessage(messages::GetLidTempResponse{
+                            .responding_to_id = get_lid_temp_message.id,
+                            .current_temp = 30.0F,
+                            .set_temp = 35.0F});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "M141 T:35.00 C:30.00 OK\n"));
+                        REQUIRE(written_secondpass == tx_buf.begin() + 24);
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN(
+                    "sending a response with wrong id back to the comms task") {
+                    auto response =
+                        messages::HostCommsMessage(messages::GetLidTempResponse{
+                            .responding_to_id = get_lid_temp_message.id + 1,
+                            .current_temp = 30.0F,
+                            .set_temp = 35.0F});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN(
+                    "sending a response with wrong message type back to the "
+                    "comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = get_lid_temp_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
+        WHEN("sending a get-plate-temp message") {
+            auto message_text = std::string("M105\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the plate task and not "
+                "immediately ack") {
+                REQUIRE(tasks->get_thermal_plate_queue().backing_deque.size() !=
+                        0);
+                auto plate_message =
+                    tasks->get_thermal_plate_queue().backing_deque.front();
+                REQUIRE(std::holds_alternative<messages::GetPlateTempMessage>(
+                    plate_message));
+                auto get_plate_temp_message =
+                    std::get<messages::GetPlateTempMessage>(plate_message);
+                tasks->get_thermal_plate_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::GetPlateTempResponse{
+                            .responding_to_id = get_plate_temp_message.id,
+                            .current_temp = 30.0F,
+                            .set_temp = 35.0F});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "M105 T:35.00 C:30.00 OK\n"));
+                        REQUIRE(written_secondpass == tx_buf.begin() + 24);
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN(
+                    "sending a response with wrong id back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::GetPlateTempResponse{
+                            .responding_to_id = get_plate_temp_message.id + 1,
+                            .current_temp = 30.0F,
+                            .set_temp = 35.0F});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN(
+                    "sending a response with wrong message type back to the "
+                    "comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = get_plate_temp_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
+        WHEN("sending a get-lid-debug-temp message") {
+            auto message_text = std::string("M141.D\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the lid and not "
+                "immediately ack") {
+                REQUIRE(tasks->get_lid_heater_queue().backing_deque.size() !=
+                        0);
+                auto lid_message =
+                    tasks->get_lid_heater_queue().backing_deque.front();
+                REQUIRE(std::holds_alternative<
+                        messages::GetLidTemperatureDebugMessage>(lid_message));
+                auto get_lid_temp_message =
+                    std::get<messages::GetLidTemperatureDebugMessage>(
+                        lid_message);
+                tasks->get_lid_heater_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::GetLidTemperatureDebugResponse{
+                            .responding_to_id = get_lid_temp_message.id,
+                            .lid_temp = 30.0F,
+                            .lid_adc = 123});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith(
+                                         "M141.D LT:30.00 LA:123 OK\n"));
+                        REQUIRE(written_secondpass == tx_buf.begin() + 26);
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN(
+                    "sending a response with wrong id back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::GetLidTemperatureDebugResponse{
+                            .responding_to_id = get_lid_temp_message.id + 1,
+                            .lid_temp = 30.0F,
+                            .lid_adc = 123});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN(
+                    "sending a response with wrong message type back to the "
+                    "comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = get_lid_temp_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
+        WHEN("sending a get-plate-temp-debug message") {
+            auto message_text = std::string("M105.D\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the plate task and not "
+                "immediately ack") {
+                REQUIRE(tasks->get_thermal_plate_queue().backing_deque.size() !=
+                        0);
+                auto plate_message =
+                    tasks->get_thermal_plate_queue().backing_deque.front();
+                REQUIRE(std::holds_alternative<
+                        messages::GetPlateTemperatureDebugMessage>(
+                    plate_message));
+                auto get_plate_temp_message =
+                    std::get<messages::GetPlateTemperatureDebugMessage>(
+                        plate_message);
+                tasks->get_thermal_plate_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::GetPlateTemperatureDebugResponse{
+                            .responding_to_id = get_plate_temp_message.id,
+                            .heat_sink_temp = 30,
+                            .front_right_temp = 30,
+                            .front_center_temp = 30,
+                            .front_left_temp = 30,
+                            .back_right_temp = 30,
+                            .back_center_temp = 30,
+                            .back_left_temp = 30,
+                            .heat_sink_adc = 123,
+                            .front_right_adc = 123,
+                            .front_center_adc = 123,
+                            .front_left_adc = 123,
+                            .back_right_adc = 123,
+                            .back_center_adc = 123,
+                            .back_left_adc = 123});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(
+                            tx_buf,
+                            Catch::Matchers::StartsWith(
+                                "M105.D HST:30.00 FRT:30.00 FLT:30.00 "
+                                "FCT:30.00 "
+                                "BRT:30.00 BLT:30.00 BCT:30.00 HSA:123 FRA:123 "
+                                "FLA:123 FCA:123 BRA:123 BLA:123 BCA:123 "
+                                "OK\n"));
+                        REQUIRE(written_secondpass == tx_buf.begin() + 136);
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN(
+                    "sending a response with wrong id back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::GetPlateTemperatureDebugResponse{
+                            .responding_to_id = get_plate_temp_message.id + 1,
+                            .heat_sink_temp = 30,
+                            .front_right_temp = 30,
+                            .front_center_temp = 30,
+                            .front_left_temp = 30,
+                            .back_right_temp = 30,
+                            .back_center_temp = 30,
+                            .back_left_temp = 30,
+                            .heat_sink_adc = 123,
+                            .front_right_adc = 123,
+                            .front_center_adc = 123,
+                            .front_left_adc = 123,
+                            .back_right_adc = 123,
+                            .back_center_adc = 123,
+                            .back_left_adc = 123});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN(
+                    "sending a response with wrong message type back to the "
+                    "comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = get_plate_temp_message.id});
                     tasks->get_host_comms_queue().backing_deque.push_back(
                         response);
                     auto written_secondpass =

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -457,8 +457,7 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     auto response = messages::HostCommsMessage(
                         messages::AcknowledgePrevious{
                             .responding_to_id = set_lid_temp_message.id,
-                            .with_error =
-                                errors::ErrorCode::THERMAL_LID_BUSY});
+                            .with_error = errors::ErrorCode::THERMAL_LID_BUSY});
                     tasks->get_host_comms_queue().backing_deque.push_back(
                         response);
                     auto written_secondpass =

--- a/stm32-modules/thermocycler-refresh/tests/test_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_lid_heater_task.cpp
@@ -102,58 +102,66 @@ SCENARIO("lid heater task message passing") {
             }
         }
         WHEN("Sending a SetPIDConstants to configure the lid constants") {
-            auto message = 
-            messages::SetPIDConstantsMessage{.id = 123, .selection = PidSelection::HEATER,
-                .p = 1, .i = 1, .d = 1};
-            tasks->get_lid_heater_queue().backing_deque.push_back(messages::LidHeaterMessage(message));
+            auto message = messages::SetPIDConstantsMessage{
+                .id = 123,
+                .selection = PidSelection::HEATER,
+                .p = 1,
+                .i = 1,
+                .d = 1};
+            tasks->get_lid_heater_queue().backing_deque.push_back(
+                messages::LidHeaterMessage(message));
             tasks->run_lid_heater_task();
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
                 AND_THEN("the task should act on the message") {
-                REQUIRE(
-                    tasks->get_thermal_plate_queue().backing_deque.empty());
+                    REQUIRE(
+                        tasks->get_thermal_plate_queue().backing_deque.empty());
 
-                REQUIRE(
-                    !tasks->get_host_comms_queue().backing_deque.empty());
-                auto response =
-                    tasks->get_host_comms_queue().backing_deque.front();
-                tasks->get_host_comms_queue().backing_deque.pop_front();
-                REQUIRE(
-                    std::holds_alternative<messages::AcknowledgePrevious>(
-                        response));
-                auto response_msg =
-                    std::get<messages::AcknowledgePrevious>(response);
-                REQUIRE(response_msg.responding_to_id == 123);
-                REQUIRE(response_msg.with_error ==
-                        errors::ErrorCode::NO_ERROR);
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
+                    auto response =
+                        tasks->get_host_comms_queue().backing_deque.front();
+                    tasks->get_host_comms_queue().backing_deque.pop_front();
+                    REQUIRE(
+                        std::holds_alternative<messages::AcknowledgePrevious>(
+                            response));
+                    auto response_msg =
+                        std::get<messages::AcknowledgePrevious>(response);
+                    REQUIRE(response_msg.responding_to_id == 123);
+                    REQUIRE(response_msg.with_error ==
+                            errors::ErrorCode::NO_ERROR);
                 }
             }
         }
         WHEN("Sending a SetPIDConstants with invalid constants") {
-            auto message = 
-            messages::SetPIDConstantsMessage{.id = 555, .selection = PidSelection::HEATER,
-                .p = 1000, .i = 1, .d = 1};
-            tasks->get_lid_heater_queue().backing_deque.push_back(messages::LidHeaterMessage(message));
+            auto message = messages::SetPIDConstantsMessage{
+                .id = 555,
+                .selection = PidSelection::HEATER,
+                .p = 1000,
+                .i = 1,
+                .d = 1};
+            tasks->get_lid_heater_queue().backing_deque.push_back(
+                messages::LidHeaterMessage(message));
             tasks->run_lid_heater_task();
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
                 AND_THEN("the task should act on the message") {
-                REQUIRE(
-                    tasks->get_thermal_plate_queue().backing_deque.empty());
+                    REQUIRE(
+                        tasks->get_thermal_plate_queue().backing_deque.empty());
 
-                REQUIRE(
-                    !tasks->get_host_comms_queue().backing_deque.empty());
-                auto response =
-                    tasks->get_host_comms_queue().backing_deque.front();
-                tasks->get_host_comms_queue().backing_deque.pop_front();
-                REQUIRE(
-                    std::holds_alternative<messages::AcknowledgePrevious>(
-                        response));
-                auto response_msg =
-                    std::get<messages::AcknowledgePrevious>(response);
-                REQUIRE(response_msg.responding_to_id == 555);
-                REQUIRE(response_msg.with_error ==
-                        errors::ErrorCode::THERMAL_CONSTANT_OUT_OF_RANGE);
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
+                    auto response =
+                        tasks->get_host_comms_queue().backing_deque.front();
+                    tasks->get_host_comms_queue().backing_deque.pop_front();
+                    REQUIRE(
+                        std::holds_alternative<messages::AcknowledgePrevious>(
+                            response));
+                    auto response_msg =
+                        std::get<messages::AcknowledgePrevious>(response);
+                    REQUIRE(response_msg.responding_to_id == 555);
+                    REQUIRE(response_msg.with_error ==
+                            errors::ErrorCode::THERMAL_CONSTANT_OUT_OF_RANGE);
                 }
             }
         }
@@ -228,32 +236,37 @@ SCENARIO("lid heater task message passing") {
                     }
                 }
             }
-            AND_WHEN("Sending a SetPIDConstants to configure the lid constants") {
+            AND_WHEN(
+                "Sending a SetPIDConstants to configure the lid constants") {
                 tasks->get_host_comms_queue().backing_deque.pop_front();
-                auto message = 
-                    messages::SetPIDConstantsMessage{.id = 808, .selection = PidSelection::HEATER,
-                        .p = 1, .i = 1, .d = 1};
-                tasks->get_lid_heater_queue().backing_deque.push_back(messages::LidHeaterMessage(message));
+                auto message = messages::SetPIDConstantsMessage{
+                    .id = 808,
+                    .selection = PidSelection::HEATER,
+                    .p = 1,
+                    .i = 1,
+                    .d = 1};
+                tasks->get_lid_heater_queue().backing_deque.push_back(
+                    messages::LidHeaterMessage(message));
                 tasks->run_lid_heater_task();
                 THEN("the task should get the message") {
-                    REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
+                    REQUIRE(
+                        tasks->get_lid_heater_queue().backing_deque.empty());
                     AND_THEN("the task should respond with a busy error") {
-                    REQUIRE(
-                        tasks->get_thermal_plate_queue().backing_deque.empty());
+                        REQUIRE(tasks->get_thermal_plate_queue()
+                                    .backing_deque.empty());
 
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 808);
-                    REQUIRE(response_msg.with_error ==
-                            errors::ErrorCode::THERMAL_LID_BUSY);
+                        REQUIRE(!tasks->get_host_comms_queue()
+                                     .backing_deque.empty());
+                        auto response =
+                            tasks->get_host_comms_queue().backing_deque.front();
+                        tasks->get_host_comms_queue().backing_deque.pop_front();
+                        REQUIRE(std::holds_alternative<
+                                messages::AcknowledgePrevious>(response));
+                        auto response_msg =
+                            std::get<messages::AcknowledgePrevious>(response);
+                        REQUIRE(response_msg.responding_to_id == 808);
+                        REQUIRE(response_msg.with_error ==
+                                errors::ErrorCode::THERMAL_LID_BUSY);
                     }
                 }
             }

--- a/stm32-modules/thermocycler-refresh/tests/test_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_lid_heater_task.cpp
@@ -148,11 +148,11 @@ SCENARIO("lid heater task message passing") {
                     messages::LidHeaterMessage(tempMessage));
                 tasks->run_lid_heater_task();
                 THEN("the task should respond to the message") {
-                    REQUIRE(!tasks->get_host_comms_queue()
-                            .backing_deque.empty());
-                    REQUIRE(std::get<messages::AcknowledgePrevious>(
-                            tasks->get_host_comms_queue()
-                                .backing_deque.front())
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
+                    REQUIRE(
+                        std::get<messages::AcknowledgePrevious>(
+                            tasks->get_host_comms_queue().backing_deque.front())
                             .responding_to_id == 321);
                     tasks->get_host_comms_queue().backing_deque.pop_front();
                     AND_WHEN("sending a GetLidTemp query") {

--- a/stm32-modules/thermocycler-refresh/tests/test_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_lid_heater_task.cpp
@@ -101,6 +101,62 @@ SCENARIO("lid heater task message passing") {
                 }
             }
         }
+        WHEN("Sending a SetPIDConstants to configure the lid constants") {
+            auto message = 
+            messages::SetPIDConstantsMessage{.id = 123, .selection = PidSelection::HEATER,
+                .p = 1, .i = 1, .d = 1};
+            tasks->get_lid_heater_queue().backing_deque.push_back(messages::LidHeaterMessage(message));
+            tasks->run_lid_heater_task();
+            THEN("the task should get the message") {
+                REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
+                AND_THEN("the task should act on the message") {
+                REQUIRE(
+                    tasks->get_thermal_plate_queue().backing_deque.empty());
+
+                REQUIRE(
+                    !tasks->get_host_comms_queue().backing_deque.empty());
+                auto response =
+                    tasks->get_host_comms_queue().backing_deque.front();
+                tasks->get_host_comms_queue().backing_deque.pop_front();
+                REQUIRE(
+                    std::holds_alternative<messages::AcknowledgePrevious>(
+                        response));
+                auto response_msg =
+                    std::get<messages::AcknowledgePrevious>(response);
+                REQUIRE(response_msg.responding_to_id == 123);
+                REQUIRE(response_msg.with_error ==
+                        errors::ErrorCode::NO_ERROR);
+                }
+            }
+        }
+        WHEN("Sending a SetPIDConstants with invalid constants") {
+            auto message = 
+            messages::SetPIDConstantsMessage{.id = 555, .selection = PidSelection::HEATER,
+                .p = 1000, .i = 1, .d = 1};
+            tasks->get_lid_heater_queue().backing_deque.push_back(messages::LidHeaterMessage(message));
+            tasks->run_lid_heater_task();
+            THEN("the task should get the message") {
+                REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
+                AND_THEN("the task should act on the message") {
+                REQUIRE(
+                    tasks->get_thermal_plate_queue().backing_deque.empty());
+
+                REQUIRE(
+                    !tasks->get_host_comms_queue().backing_deque.empty());
+                auto response =
+                    tasks->get_host_comms_queue().backing_deque.front();
+                tasks->get_host_comms_queue().backing_deque.pop_front();
+                REQUIRE(
+                    std::holds_alternative<messages::AcknowledgePrevious>(
+                        response));
+                auto response_msg =
+                    std::get<messages::AcknowledgePrevious>(response);
+                REQUIRE(response_msg.responding_to_id == 555);
+                REQUIRE(response_msg.with_error ==
+                        errors::ErrorCode::THERMAL_CONSTANT_OUT_OF_RANGE);
+                }
+            }
+        }
         WHEN("Sending a SetLidTemperature message to enable the lid") {
             auto message = messages::SetLidTemperatureMessage{
                 .id = 123, .setpoint = 100.0F};
@@ -169,6 +225,35 @@ SCENARIO("lid heater task message passing") {
                                             .backing_deque.front())
                                         .set_temp == 0.0F);
                         }
+                    }
+                }
+            }
+            AND_WHEN("Sending a SetPIDConstants to configure the lid constants") {
+                tasks->get_host_comms_queue().backing_deque.pop_front();
+                auto message = 
+                    messages::SetPIDConstantsMessage{.id = 808, .selection = PidSelection::HEATER,
+                        .p = 1, .i = 1, .d = 1};
+                tasks->get_lid_heater_queue().backing_deque.push_back(messages::LidHeaterMessage(message));
+                tasks->run_lid_heater_task();
+                THEN("the task should get the message") {
+                    REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
+                    AND_THEN("the task should respond with a busy error") {
+                    REQUIRE(
+                        tasks->get_thermal_plate_queue().backing_deque.empty());
+
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
+                    auto response =
+                        tasks->get_host_comms_queue().backing_deque.front();
+                    tasks->get_host_comms_queue().backing_deque.pop_front();
+                    REQUIRE(
+                        std::holds_alternative<messages::AcknowledgePrevious>(
+                            response));
+                    auto response_msg =
+                        std::get<messages::AcknowledgePrevious>(response);
+                    REQUIRE(response_msg.responding_to_id == 808);
+                    REQUIRE(response_msg.with_error ==
+                            errors::ErrorCode::THERMAL_LID_BUSY);
                     }
                 }
             }

--- a/stm32-modules/thermocycler-refresh/tests/test_m105.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m105.cpp
@@ -7,8 +7,7 @@
 #include "thermocycler-refresh/gcodes.hpp"
 #pragma GCC diagnostic pop
 
-SCENARIO("GetPlateTemperature (M105) parser works",
-         "[gcode][parse][M105]") {
+SCENARIO("GetPlateTemperature (M105) parser works", "[gcode][parse][M105]") {
     GIVEN("a response buffer large enough for the formatted response") {
         std::string buffer(256, 'c');
         WHEN("filling response") {

--- a/stm32-modules/thermocycler-refresh/tests/test_m105.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m105.cpp
@@ -1,0 +1,47 @@
+#include "catch2/catch.hpp"
+
+// Push this diagnostic to avoid a compiler error about printing to too
+// small of a buffer... which we're doing on purpose!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-refresh/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("GetPlateTemperature (M105) parser works",
+         "[gcode][parse][M105]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetPlateTemp::write_response_into(
+                buffer.begin(), buffer.end(), 10.0, 40);
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "M105 T:40.00 C:10.00 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+        WHEN("filling response with no target temp") {
+            auto written = gcode::GetPlateTemp::write_response_into(
+                buffer.begin(), buffer.end(), 10.0, 0);
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "M105 T:none C:10.00 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetPlateTemp::write_response_into(
+                buffer.begin(), buffer.begin() + 7, 10.0, 40);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M105 Tcccccccccc";
+                response[6] = '\0';
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_m108.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m108.cpp
@@ -1,0 +1,58 @@
+#include "catch2/catch.hpp"
+
+// Push this diagnostic to avoid a compiler error about printing to too
+// small of a buffer... which we're doing on purpose!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-refresh/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("DeactivateLidHeating (M108) parser works", "[gcode][parse][m108]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::DeactivateLidHeating::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M108 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::DeactivateLidHeating::write_response_into(
+                buffer.begin(), buffer.begin() + 5);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M108 ccccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a valid input") {
+        std::string buffer = "M108\n";
+        WHEN("parsing") {
+            auto res = gcode::DeactivateLidHeating::parse(buffer.begin(),
+                                                          buffer.end());
+            THEN("a valid gcode should be produced") {
+                REQUIRE(res.first.has_value());
+                REQUIRE(res.second != buffer.begin());
+            }
+        }
+    }
+    GIVEN("an invalid input") {
+        std::string buffer = "M 108\n";
+        WHEN("parsing") {
+            auto res = gcode::DeactivateLidHeating::parse(buffer.begin(),
+                                                          buffer.end());
+            THEN("an error should be produced") {
+                REQUIRE(!res.first.has_value());
+                REQUIRE(res.second == buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_m140.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m140.cpp
@@ -1,0 +1,64 @@
+#include "catch2/catch.hpp"
+#include "thermocycler-refresh/gcodes.hpp"
+
+SCENARIO("SetLidTemperature (M140) parser works", "[gcode][parse][m140]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(64, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetLidTemperature::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M140 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetLidTemperature::write_response_into(
+                buffer.begin(), buffer.begin() + 6);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M140 Occcccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("valid parameters") {
+        WHEN("Setting target to 100C") {
+            std::string buffer = "M140 S100\n";
+            auto parsed =
+                gcode::SetLidTemperature::parse(buffer.begin(), buffer.end());
+            THEN("the target should be 100") {
+                auto &val = parsed.first;
+                REQUIRE(parsed.second != buffer.begin());
+                REQUIRE(val.has_value());
+                REQUIRE(val.value().setpoint == 100.0F);
+            }
+        }
+        WHEN("Setting target to 0.0") {
+            std::string buffer = "M140 S0.0\n";
+            auto parsed =
+                gcode::SetLidTemperature::parse(buffer.begin(), buffer.end());
+            THEN("the target should be 0.0") {
+                auto &val = parsed.first;
+                REQUIRE(parsed.second != buffer.begin());
+                REQUIRE(val.has_value());
+                REQUIRE(val.value().setpoint == 0.0F);
+            }
+        }
+    }
+    GIVEN("invalid input") {
+        std::string buffer = "M1 40 S 1 00\n";
+        WHEN("parsing") {
+            auto parsed =
+                gcode::SetLidTemperature::parse(buffer.begin(), buffer.end());
+            THEN("parsing fails") {
+                REQUIRE(parsed.second == buffer.begin());
+                REQUIRE(!parsed.first.has_value());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_m141.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m141.cpp
@@ -1,0 +1,47 @@
+#include "catch2/catch.hpp"
+
+// Push this diagnostic to avoid a compiler error about printing to too
+// small of a buffer... which we're doing on purpose!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-refresh/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("GetLidTemperature (M141) parser works",
+         "[gcode][parse][M141]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetLidTemp::write_response_into(
+                buffer.begin(), buffer.end(), 10.0, 40);
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "M141 T:40.00 C:10.00 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+        WHEN("filling response with no target temp") {
+            auto written = gcode::GetLidTemp::write_response_into(
+                buffer.begin(), buffer.end(), 10.0, 0);
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "M141 T:none C:10.00 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetLidTemp::write_response_into(
+                buffer.begin(), buffer.begin() + 7, 10.0, 40);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M141 Tcccccccccc";
+                response[6] = '\0';
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_m141.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m141.cpp
@@ -7,8 +7,7 @@
 #include "thermocycler-refresh/gcodes.hpp"
 #pragma GCC diagnostic pop
 
-SCENARIO("GetLidTemperature (M141) parser works",
-         "[gcode][parse][M141]") {
+SCENARIO("GetLidTemperature (M141) parser works", "[gcode][parse][M141]") {
     GIVEN("a response buffer large enough for the formatted response") {
         std::string buffer(256, 'c');
         WHEN("filling response") {

--- a/stm32-modules/thermocycler-refresh/tests/test_m301.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m301.cpp
@@ -1,5 +1,4 @@
 #include "catch2/catch.hpp"
-
 #include "systemwide.h"
 // Push this diagnostic to avoid a compiler error about printing to too
 // small of a buffer... which we're doing on purpose!
@@ -15,8 +14,7 @@ SCENARIO("SetPIDConstants (M301) parser works", "[gcode][parse][m301]") {
             auto written = gcode::SetPIDConstants::write_response_into(
                 buffer.begin(), buffer.end());
             THEN("the response should be written in full") {
-                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
-                                         "M301 OK\n"));
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M301 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }
@@ -36,7 +34,8 @@ SCENARIO("SetPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     GIVEN("valid input without a target specifier") {
         std::string buffer = "M301 P10.0 I-4 D75\n";
         WHEN("parsing the command") {
-            auto parsed = gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
+            auto parsed =
+                gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
             THEN("a valid command is produced") {
                 REQUIRE(parsed.first.has_value());
                 REQUIRE(parsed.second != buffer.begin());
@@ -51,7 +50,8 @@ SCENARIO("SetPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     GIVEN("valid input specifying the peltiers") {
         std::string buffer = "M301 SP P10.0 I-4 D75\n";
         WHEN("parsing the command") {
-            auto parsed = gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
+            auto parsed =
+                gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
             THEN("a valid command is produced") {
                 REQUIRE(parsed.first.has_value());
                 REQUIRE(parsed.second != buffer.begin());
@@ -66,7 +66,8 @@ SCENARIO("SetPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     GIVEN("valid input specifying the fans") {
         std::string buffer = "M301 SF P10.0 I-4 D75\n";
         WHEN("parsing the command") {
-            auto parsed = gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
+            auto parsed =
+                gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
             THEN("a valid command is produced") {
                 REQUIRE(parsed.first.has_value());
                 REQUIRE(parsed.second != buffer.begin());
@@ -81,7 +82,8 @@ SCENARIO("SetPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     GIVEN("valid input specifying the heater") {
         std::string buffer = "M301 SH P10.0 I-4 D75\n";
         WHEN("parsing the command") {
-            auto parsed = gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
+            auto parsed =
+                gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
             THEN("a valid command is produced") {
                 REQUIRE(parsed.first.has_value());
                 REQUIRE(parsed.second != buffer.begin());
@@ -96,7 +98,8 @@ SCENARIO("SetPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     GIVEN("input with invalid target specifier") {
         std::string buffer = "M301 SW P10.0 I-4 D75\n";
         WHEN("parsing the command") {
-            auto parsed = gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
+            auto parsed =
+                gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
             THEN("no valid command is produced") {
                 REQUIRE(!parsed.first.has_value());
                 REQUIRE(parsed.second == buffer.begin());
@@ -106,7 +109,8 @@ SCENARIO("SetPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     GIVEN("invalid input") {
         std::string buffer = "M301 Px IW ABCDEFG\n";
         WHEN("parsing the command") {
-            auto parsed = gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
+            auto parsed =
+                gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
             THEN("no valid command is produced") {
                 REQUIRE(!parsed.first.has_value());
                 REQUIRE(parsed.second == buffer.begin());

--- a/stm32-modules/thermocycler-refresh/tests/test_m301.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m301.cpp
@@ -1,0 +1,116 @@
+#include "catch2/catch.hpp"
+
+#include "systemwide.h"
+// Push this diagnostic to avoid a compiler error about printing to too
+// small of a buffer... which we're doing on purpose!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-refresh/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("SetPIDConstants (M301) parser works", "[gcode][parse][m301]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetPIDConstants::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "M301 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetPIDConstants::write_response_into(
+                buffer.begin(), buffer.begin() + 6);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M301 Occcccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("valid input without a target specifier") {
+        std::string buffer = "M301 P10.0 I-4 D75\n";
+        WHEN("parsing the command") {
+            auto parsed = gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
+            THEN("a valid command is produced") {
+                REQUIRE(parsed.first.has_value());
+                REQUIRE(parsed.second != buffer.begin());
+                auto val = parsed.first.value();
+                REQUIRE(val.const_p == 10.0F);
+                REQUIRE(val.const_i == -4.0F);
+                REQUIRE(val.const_d == 75.0F);
+                REQUIRE(val.selection == PidSelection::PELTIERS);
+            }
+        }
+    }
+    GIVEN("valid input specifying the peltiers") {
+        std::string buffer = "M301 SP P10.0 I-4 D75\n";
+        WHEN("parsing the command") {
+            auto parsed = gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
+            THEN("a valid command is produced") {
+                REQUIRE(parsed.first.has_value());
+                REQUIRE(parsed.second != buffer.begin());
+                auto val = parsed.first.value();
+                REQUIRE(val.const_p == 10.0F);
+                REQUIRE(val.const_i == -4.0F);
+                REQUIRE(val.const_d == 75.0F);
+                REQUIRE(val.selection == PidSelection::PELTIERS);
+            }
+        }
+    }
+    GIVEN("valid input specifying the fans") {
+        std::string buffer = "M301 SF P10.0 I-4 D75\n";
+        WHEN("parsing the command") {
+            auto parsed = gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
+            THEN("a valid command is produced") {
+                REQUIRE(parsed.first.has_value());
+                REQUIRE(parsed.second != buffer.begin());
+                auto val = parsed.first.value();
+                REQUIRE(val.const_p == 10.0F);
+                REQUIRE(val.const_i == -4.0F);
+                REQUIRE(val.const_d == 75.0F);
+                REQUIRE(val.selection == PidSelection::FANS);
+            }
+        }
+    }
+    GIVEN("valid input specifying the heater") {
+        std::string buffer = "M301 SH P10.0 I-4 D75\n";
+        WHEN("parsing the command") {
+            auto parsed = gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
+            THEN("a valid command is produced") {
+                REQUIRE(parsed.first.has_value());
+                REQUIRE(parsed.second != buffer.begin());
+                auto val = parsed.first.value();
+                REQUIRE(val.const_p == 10.0F);
+                REQUIRE(val.const_i == -4.0F);
+                REQUIRE(val.const_d == 75.0F);
+                REQUIRE(val.selection == PidSelection::HEATER);
+            }
+        }
+    }
+    GIVEN("input with invalid target specifier") {
+        std::string buffer = "M301 SW P10.0 I-4 D75\n";
+        WHEN("parsing the command") {
+            auto parsed = gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
+            THEN("no valid command is produced") {
+                REQUIRE(!parsed.first.has_value());
+                REQUIRE(parsed.second == buffer.begin());
+            }
+        }
+    }
+    GIVEN("invalid input") {
+        std::string buffer = "M301 Px IW ABCDEFG\n";
+        WHEN("parsing the command") {
+            auto parsed = gcode::SetPIDConstants::parse(buffer.begin(), buffer.end());
+            THEN("no valid command is produced") {
+                REQUIRE(!parsed.first.has_value());
+                REQUIRE(parsed.second == buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_thermal_plate_task.cpp
@@ -97,12 +97,11 @@ SCENARIO("thermal plate task message passing") {
                     auto response =
                         tasks->get_host_comms_queue().backing_deque.front();
                     tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(std::holds_alternative<
-                            messages::GetPlateTempResponse>(
-                        response));
+                    REQUIRE(
+                        std::holds_alternative<messages::GetPlateTempResponse>(
+                            response));
                     auto gettemp =
-                        std::get<messages::GetPlateTempResponse>(
-                            response);
+                        std::get<messages::GetPlateTempResponse>(response);
                     REQUIRE(gettemp.responding_to_id == message.id);
                     REQUIRE_THAT(gettemp.current_temp,
                                  Catch::Matchers::WithinAbs(_valid_temp, 0.1));
@@ -277,12 +276,11 @@ SCENARIO("thermal plate task message passing") {
                     auto response =
                         tasks->get_host_comms_queue().backing_deque.front();
                     tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(std::holds_alternative<
-                            messages::GetPlateTempResponse>(
-                        response));
+                    REQUIRE(
+                        std::holds_alternative<messages::GetPlateTempResponse>(
+                            response));
                     auto gettemp =
-                        std::get<messages::GetPlateTempResponse>(
-                            response);
+                        std::get<messages::GetPlateTempResponse>(response);
                     REQUIRE(gettemp.responding_to_id == message.id);
                     REQUIRE_THAT(gettemp.current_temp,
                                  Catch::Matchers::WithinAbs(0.0, 0.1));


### PR DESCRIPTION
### Summary
Adds a few different gcodes:

- GetPlateTemp and GetLidTemp for non-debugging temperature information (average value of the plate, includes target temp if defined)
- SetLidTemperature to set the target temperature of the lid
- DeactivateLidHeating to turn off the lid heater
- SetPIDConstants to reconfigure the PID constants for the heater

Also adds support for the closed-loop heater control. Tested controlling the heater up to 90C, it moves up nice and steady and then settles. The PID constants are just pulled from the heater-shaker so we will still have to tune the loop, but that can wait for a full hardware system.