### PR TITLE
feat(thermocycler-refresh): add automatic fan control

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/systemwide.h
+++ b/stm32-modules/include/thermocycler-refresh/systemwide.h
@@ -7,9 +7,6 @@
 /* size of array for setting serial number */
 #define SYSTEM_WIDE_SERIAL_NUMBER_LENGTH 24
 
-/* Uncomment this to include aynchronous error messages */
-//#define SYSTEM_ALLOW_ASYNC_ERRORS
-
 typedef enum PeltierID {
     PELTIER_RIGHT,
     PELTIER_CENTER,

--- a/stm32-modules/include/thermocycler-refresh/systemwide.h
+++ b/stm32-modules/include/thermocycler-refresh/systemwide.h
@@ -7,6 +7,9 @@
 /* size of array for setting serial number */
 #define SYSTEM_WIDE_SERIAL_NUMBER_LENGTH 24
 
+/* Uncomment this to include aynchronous error messages */
+//#define SYSTEM_ALLOW_ASYNC_ERRORS
+
 typedef enum PeltierID {
     PELTIER_RIGHT,
     PELTIER_CENTER,

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/errors.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/errors.hpp
@@ -49,6 +49,7 @@ enum class ErrorCode {
     THERMAL_LID_BUSY = 404,
     THERMAL_HEATER_ERROR = 405,
     THERMAL_CONSTANT_OUT_OF_RANGE = 406,
+    THERMAL_TARGET_BAD = 407,
 };
 
 auto errorstring(ErrorCode code) -> const char*;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -331,6 +331,35 @@ struct SetFanManual {
     }
 };
 
+struct SetFanAutomatic {
+    /**
+     * SetFanAutomatic uses M107. It has no parameters and just
+     * activates automatic fan control.
+     */
+    using ParseResult = std::optional<SetFanAutomatic>;
+    static constexpr auto prefix = std::array{'M', '1', '0', '7'};
+    static constexpr const char* response = "M107 OK\n";
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(SetFanAutomatic()), working);
+    }
+};
+
 struct SetHeaterDebug {
     /**
      * SetHeaterDebug uses M140.D, debug version of M140.

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
@@ -43,13 +43,15 @@ class HostCommsTask {
         gcode::SetPeltierDebug, gcode::SetFanManual, gcode::SetHeaterDebug,
         gcode::GetPlateTemp, gcode::GetLidTemp, gcode::SetLidTemperature,
         gcode::DeactivateLidHeating, gcode::SetPIDConstants,
-        gcode::SetPlateTemperature, gcode::DeactivatePlate>;
+        gcode::SetPlateTemperature, gcode::DeactivatePlate,
+        gcode::SetFanAutomatic>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::SetPeltierDebug, gcode::SetFanManual,
                  gcode::SetHeaterDebug, gcode::SetLidTemperature,
                  gcode::DeactivateLidHeating, gcode::SetPIDConstants,
-                 gcode::SetPlateTemperature, gcode::DeactivatePlate>;
+                 gcode::SetPlateTemperature, gcode::DeactivatePlate,
+                 gcode::SetFanAutomatic>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetLidTempDebugCache = AckCache<8, gcode::GetLidTemperatureDebug>;
     using GetPlateTempDebugCache = AckCache<8, gcode::GetPlateTemperatureDebug>;
@@ -607,6 +609,30 @@ class HostCommsTask {
 
         auto message =
             messages::SetFanManualMessage{.id = id, .power = gcode.power};
+        if (!task_registry->thermal_plate->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::SetFanAutomatic& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+
+        auto message = messages::SetFanAutomaticMessage{.id = id};
         if (!task_registry->thermal_plate->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -337,11 +337,13 @@ class LidHeaterTask {
         if (old_error != thermistor.error) {
             if (thermistor.error != errors::ErrorCode::NO_ERROR) {
                 _state.error_bitmap |= thermistor.error_bit;
+#if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
                 auto error_message = messages::HostCommsMessage(
                     messages::ErrorMessage{.code = thermistor.error});
                 static_cast<void>(
                     _task_registry->comms->get_message_queue().try_send(
                         error_message));
+#endif
             } else {
                 _state.error_bitmap &= ~thermistor.error_bit;
             }

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -25,6 +25,8 @@ struct Tasks;
 
 namespace lid_heater_task {
 
+using namespace thermal_general;
+
 template <typename Policy>
 concept LidHeaterExecutionPolicy = requires(Policy& p, const Policy& cp) {
     // A set_heater_power function to set the power of the heater as

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -180,6 +180,10 @@ struct SetPlateTemperatureMessage {
     double hold_time;
 };
 
+struct SetFanAutomaticMessage {
+    uint32_t id;
+};
+
 struct DeactivatePlateMessage {
     uint32_t id;
 };
@@ -206,7 +210,7 @@ using ThermalPlateMessage =
                    GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,
                    SetFanManualMessage, GetPlateTempMessage,
                    SetPlateTemperatureMessage, DeactivatePlateMessage,
-                   SetPIDConstantsMessage>;
+                   SetPIDConstantsMessage, SetFanAutomaticMessage>;
 using LidHeaterMessage =
     ::std::variant<std::monostate, LidTempReadComplete,
                    GetLidTemperatureDebugMessage, SetHeaterDebugMessage,

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/plate_control.hpp
@@ -47,6 +47,8 @@ class PlateControl {
     static constexpr double FAN_SETPOINT_OFFSET = (-2.0F);
 
     PlateControl() = delete;
+    PlateControl(PlateControl &) = delete;
+    PlateControl(PlateControl &&) = delete;
     /**
      * @brief Construct a new Plate Control object
      * @param[in] left Left peltier reference

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/plate_control.hpp
@@ -1,0 +1,166 @@
+/**
+ * @file plate_control.hpp
+ * @brief Defines the PlateControl class, which implements control logic for
+ * the thermal plate elements on the Thermocycler.
+ *
+ */
+#pragma once
+
+#include "core/pid.hpp"
+#include "thermocycler-refresh/thermal_general.hpp"
+
+namespace plate_control {
+
+/** Enumeration of the control statuses the plate may be in*/
+enum class PlateStatus { INITIAL_HEAT, INITIAL_COOL, OVERSHOOT, STEADY_STATE };
+
+enum class TemperatureZone { COLD = 23, WARM = 31, HOT };
+
+struct PlateControlVals {
+    double left_power, right_power, center_power, fan_power;
+};
+
+// A TemperatureElement is a struct that has a current temperature,
+// a goal temperature, and a PID controller.
+template <typename E>
+concept TemperatureElement = requires(E &e, double err) {
+    requires std::same_as<decltype(e.temp_target), double>;
+    requires std::same_as<decltype(e.pid), PID>;
+    {e.temp_target};
+    {e.pid};
+    { e.current_temp() } -> std::same_as<double>;
+};
+
+class PlateControl {
+  public:
+    using UpdateRet = std::optional<PlateControlVals>;
+
+    /** This ramp rate value will cause ramped target to immediately become the
+     * target.*/
+    static constexpr double RAMP_INFINITE = (0.0F);
+    /** This hold time means there's no timer for holding.*/
+    static constexpr double HOLD_INFINITE = (0.0F);
+    static constexpr double PELTIER_COUNT = 3.0F;
+    // Max ∆T to be considered "at" the setpoint
+    static constexpr double SETPOINT_THRESHOLD = 0.5F;
+    // Degrees C *under* the threshold to set the fan
+    static constexpr double FAN_SETPOINT_OFFSET = (-2.0F);
+
+    PlateControl() = delete;
+    /**
+     * @brief Construct a new Plate Control object
+     * @param[in] left Left peltier reference
+     * @param[in] right Right peltier reference
+     * @param[in] center Center peltier reference
+     * @param[in] fan Fan control reference
+     * @param[in] update_rate Expected number of seconds between each call to
+     * \c update_control()
+     */
+    PlateControl(thermal_general::Peltier &left,
+                 thermal_general::Peltier &right,
+                 thermal_general::Peltier &center,
+                 thermal_general::HeatsinkFan &fan, double update_rate)
+        : _left(left),
+          _right(right),
+          _center(center),
+          _fan(fan),
+          _update_rate(update_rate) {}
+
+    /**
+     * @brief Updates the power settings for the peltiers fans. The current
+     * temperature of each Peltier & the Heatsink should be set \b before
+     * calling this function, and then the power variables for each element
+     * will be updated accordingly.
+     * @pre Update the current temperature of each thermistor for each peltier
+     * @param setpoint The setpoint to drive the peltiers towards
+     * @return A set of updated power outputs, or nothing if an error occurs
+     */
+    auto update_control() -> UpdateRet;
+    /**
+     * @brief Set a new target temperature
+     *
+     * @param setpoint the temperature to drive to
+     * @return True if the temperature target could be updated
+     */
+    auto set_new_target(double setpoint) -> bool {
+        return set_new_target(setpoint, RAMP_INFINITE, HOLD_INFINITE);
+    }
+    /**
+     * @brief Set a new target temperature, with configurable ramp rate
+     * and hold times
+     *
+     * @param[in] setpoint The temperature to drive to
+     * @param[in] ramp_rate The rate to drive the peltiers at, in degrees
+     * celsius per second.
+     * @param[in] hold_time The amount of time to hold at the target
+     * temperature before the step is considered done, in seconds.
+     * @return True if the temperature target could be updated
+     */
+    auto set_new_target(double setpoint, double ramp_rate, double hold_time)
+        -> bool;
+
+    /** Return the current temperature target.*/
+    [[nodiscard]] auto setpoint() const -> double { return _setpoint; }
+    /** Return the current average temperature of the plate.*/
+    [[nodiscard]] auto plate_temp() const -> double;
+
+  private:
+    /**
+     * @brief Apply a ramp to the target temperature of an element.
+     * @param[in] element The element to ramp target temperature of
+     */
+    template <TemperatureElement Element>
+    auto update_ramp(Element &element) -> void {
+        if (_ramp_rate == RAMP_INFINITE) {
+            element.temp_target = _setpoint;
+        }
+        if (element.temp_target < _setpoint) {
+            element.temp_target =
+                std::min(element.temp_target + _ramp_rate, _setpoint);
+        } else if (element.temp_target > _setpoint) {
+            element.temp_target =
+                std::max(element.temp_target - _ramp_rate, _setpoint);
+        }
+    }
+    /**
+     * @brief Update the PID control of a single temperature element
+     * (fan or peltier).
+     * @param[in] element The temperature element (peltier or fan) to update
+     * @return The new power value for the element
+     */
+    template <TemperatureElement Element>
+    auto update_pid(Element &element) -> double {
+        return element.pid.compute(element.temp_target -
+                                   element.current_temp());
+    }
+    /**
+     * @brief Reset a temperature element for a new setpoint
+     * @param[in] element The element to reset control for
+     */
+    template <TemperatureElement Element>
+    auto reset_control(Element &element) -> void {
+        element.pid.arm_integrator_reset(element.temp_target -
+                                         element.current_temp);
+    }
+    /**
+     * @brief Checks if the current plate temperature is within the acceptable
+     * bounds for the setpoint
+     * @return True if the temperature average is within \ref setpoint_range
+     * degrees of the setpoint, false otherwise
+     */
+    [[nodiscard]] auto temp_within_setpoint() const -> bool;
+
+    PlateStatus _status = PlateStatus::STEADY_STATE;
+    thermal_general::Peltier &_left;
+    thermal_general::Peltier &_right;
+    thermal_general::Peltier &_center;
+    thermal_general::HeatsinkFan &_fan;
+    // This is the update rate in seconds/tick
+    const double _update_rate;
+
+    double _setpoint = 0.0F;
+    double _ramp_rate = 0.0F;
+    double _hold_time = 0.0F;
+};
+
+}  // namespace plate_control

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_general.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_general.hpp
@@ -54,40 +54,41 @@ struct Thermistor {
 
 struct Peltier {
     using ThermistorPair = std::pair<Thermistor &, Thermistor &>;
-    // Target temperature
-    double temp_target = 0.0F;
-    // ID to match to hardware - set at initialization
-    const PeltierID id;
-    // Links to the front & back thermistors
-    ThermistorPair thermistors;
-    // Current PID loop
-    PID pid;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    double temp_target = 0.0F;  // Target temperature
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    const PeltierID id;  // ID to match to hardware - set at initialization
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    ThermistorPair thermistors;  // Links to the front & back thermistors
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    PID pid;  // Current PID loop
 
     /** Get the current temperature of this peltier.*/
-    auto current_temp() -> double {
+    [[nodiscard]] auto current_temp() const -> double {
         return (thermistors.first.temp_c + thermistors.second.temp_c) / 2;
     }
     /**
      * Get the difference in temperature between the front/back thermistors
      * for this peltier.
      */
-    auto current_temp_delta() -> double {
+    [[nodiscard]] auto current_temp_delta() const -> double {
         return std::abs(thermistors.first.temp_c + thermistors.second.temp_c);
     }
 };
 
 struct HeatsinkFan {
-    // Target temperature
-    double temp_target = 0.0F;
-    // Current state (manual or automatic)
-    bool manual_control = false;
-    // Thermistor for reading temperature
-    Thermistor &thermistor;
-    // Current PID loop
-    PID pid;
-
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    double temp_target = 0.0F;  // Target temperature
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    bool manual_control = false;  // Current state (manual or automatic)
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    Thermistor &thermistor;  // Thermistor for reading temperature
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    PID pid;  // Current PID loop
     /** Get the current temperature of the heatsink.*/
-    auto current_temp() -> double { return thermistor.temp_c; }
+    [[nodiscard]] auto current_temp() const -> double {
+        return thermistor.temp_c;
+    }
 };
 
 }  // namespace thermal_general

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -646,6 +646,7 @@ class ThermalPlateTask {
                                     values.value().center_power, policy);
         }
         if (!ret) {
+            policy.set_enabled(false);
             _state.system_status = State::ERROR;
             _state.error_bitmap |= State::PELTIER_ERROR;
             return false;
@@ -654,6 +655,7 @@ class ThermalPlateTask {
             ret = policy.set_fan(values.value().fan_power);
 
             if (!ret) {
+                policy.set_enabled(false);
                 _state.system_status = State::ERROR;
                 _state.error_bitmap |= State::FAN_ERROR;
                 return false;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -409,7 +409,7 @@ class ThermalPlateTask {
             return;
         }
         if (policy.set_fan(msg.power)) {
-            _fans.manual_control = (msg.power > 0.0F) ? true : false;
+            _fans.manual_control = (msg.power > 0.0F);
         } else {
             response.with_error = errors::ErrorCode::THERMAL_HEATSINK_FAN_ERROR;
         }

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -56,16 +56,17 @@ static std::array<ADS1115::ADC, ADC_ITR_NUM> _adc = {
     ADS1115::ADC(static_cast<uint8_t>(ADCAddress::ADC_REAR), ADC2_ITR)};
 
 // This array follows the definition of the ThermistorID enumeration
-static constexpr std::array<ADCPinMap, ThermistorID::THERM_LID> _adc_map = {{
-    // On rev1 boards, net names for right/left are swapped
-    {ADC_FRONT, 3},  // Front right
-    {ADC_FRONT, 1},  // Front left
-    {ADC_FRONT, 2},  // Front center
-    {ADC_REAR, 2},   // Back right
-    {ADC_REAR, 0},   // Back left
-    {ADC_REAR, 3},   // Back center
-    {ADC_FRONT, 0}   // Heat sink
-}};
+static constexpr std::array<ADCPinMap, thermal_general::ThermistorID::THERM_LID>
+    _adc_map = {{
+        // On rev1 boards, net names for right/left are swapped
+        {ADC_FRONT, 3},  // Front right
+        {ADC_FRONT, 1},  // Front left
+        {ADC_FRONT, 2},  // Front center
+        {ADC_REAR, 2},   // Back right
+        {ADC_REAR, 0},   // Back left
+        {ADC_REAR, 3},   // Back center
+        {ADC_FRONT, 0}   // Heat sink
+    }};
 
 // Internal FreeRTOS data structure for the task
 static StaticTask_t
@@ -114,13 +115,20 @@ static void run_thermistor_task(void *param) {
             // NOLINTNEXTLINE(readability-static-accessed-through-instance)
             _main_task.CONTROL_PERIOD_TICKS);
 
-        readings.front_right = read_thermistor(_adc_map[THERM_FRONT_RIGHT]);
-        readings.front_left = read_thermistor(_adc_map[THERM_FRONT_LEFT]);
-        readings.front_center = read_thermistor(_adc_map[THERM_FRONT_CENTER]);
-        readings.back_left = read_thermistor(_adc_map[THERM_BACK_LEFT]);
-        readings.back_right = read_thermistor(_adc_map[THERM_BACK_RIGHT]);
-        readings.back_center = read_thermistor(_adc_map[THERM_BACK_CENTER]);
-        readings.heat_sink = read_thermistor(_adc_map[THERM_HEATSINK]);
+        readings.front_right = read_thermistor(
+            _adc_map[thermal_general::ThermistorID::THERM_FRONT_RIGHT]);
+        readings.front_left = read_thermistor(
+            _adc_map[thermal_general::ThermistorID::THERM_FRONT_LEFT]);
+        readings.front_center = read_thermistor(
+            _adc_map[thermal_general::ThermistorID::THERM_FRONT_CENTER]);
+        readings.back_left = read_thermistor(
+            _adc_map[thermal_general::ThermistorID::THERM_BACK_LEFT]);
+        readings.back_right = read_thermistor(
+            _adc_map[thermal_general::ThermistorID::THERM_BACK_RIGHT]);
+        readings.back_center = read_thermistor(
+            _adc_map[thermal_general::ThermistorID::THERM_BACK_CENTER]);
+        readings.heat_sink = read_thermistor(
+            _adc_map[thermal_general::ThermistorID::THERM_HEATSINK]);
 
         auto send_ret = _main_task.get_message_queue().try_send(readings);
         static_cast<void>(

--- a/stm32-modules/thermocycler-refresh/scripts/test_plate_pid.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_plate_pid.py
@@ -22,11 +22,7 @@ if __name__ == '__main__':
                 test_utils.set_plate_temperature(temperature=HEAT_TARGET, ser=ser)
                 direction = 1
     
-
-    test_utils.set_peltier_pid(0.97, 0.102, 1.901, ser)
-    test_utils.set_fans_manual(0.35, ser)
     test_utils.set_plate_temperature(temperature = HEAT_TARGET, ser=ser)
     plot_temp.graphTemperatures(ser, update_cb)
 
     test_utils.deactivate_plate(ser)
-    test_utils.set_fans_manual(0, ser)

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -100,6 +100,14 @@ def set_fans_manual(power: float, ser: serial.Serial):
     guard_error(res, b'M106 OK')
     print(res)
 
+# Turns fans to automatic mode
+def set_fans_automatic(ser: serial.Serial):
+    print(f'Setting fans to automatic mode')
+    ser.write(f'M107\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M107 OK')
+    print(res)
+
 # Sets heater PWM as a percentage.
 def set_heater_debug(power: float, ser: serial.Serial):
     if(power< 0.0 or power > 1.0):

--- a/stm32-modules/thermocycler-refresh/src/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/src/CMakeLists.txt
@@ -47,6 +47,12 @@ set(${TARGET_MODULE_NAME}_VERSION "${VERSION}-${HASH}")
 
 configure_file(./version.cpp.in ./version.cpp)
 
+option(ALLOW_ASYNC_ERRORS "Select whether asynchronous errors are sent by firmware")
+
+if(ALLOW_ASYNC_ERRORS) 
+    add_definitions(-DSYSTEM_ALLOW_ASYNC_ERRORS)
+endif()
+
 # Configure lintable/nonlintable sources here
 set(CORE_LINTABLE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/errors.cpp

--- a/stm32-modules/thermocycler-refresh/src/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/src/CMakeLists.txt
@@ -50,6 +50,7 @@ configure_file(./version.cpp.in ./version.cpp)
 # Configure lintable/nonlintable sources here
 set(CORE_LINTABLE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/errors.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/plate_control.cpp
   )
 set(CORE_NONLINTABLE_SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/thermistor_lookups.cpp

--- a/stm32-modules/thermocycler-refresh/src/errors.cpp
+++ b/stm32-modules/thermocycler-refresh/src/errors.cpp
@@ -69,6 +69,8 @@ const char* const THERMAL_HEATER_ERROR =
     "ERR405:thermal:Error controlling lid heater";
 const char* const THERMAL_CONSTANT_OUT_OF_RANGE =
     "ERR406:thermal:PID constant(s) out of range";
+const char* const THERMAL_TARGET_BAD =
+    "ERR407:thermal:Invalid target temperature";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
@@ -117,6 +119,7 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(THERMAL_LID_BUSY);
         HANDLE_CASE(THERMAL_HEATER_ERROR);
         HANDLE_CASE(THERMAL_CONSTANT_OUT_OF_RANGE);
+        HANDLE_CASE(THERMAL_TARGET_BAD);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/thermocycler-refresh/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-refresh/src/plate_control.cpp
@@ -1,0 +1,85 @@
+/**
+ * @file plate_control.cpp
+ * @brief Defines the PlateControl class, which implements control logic for
+ * the thermal plate elements on the Thermocycler.
+ * @details This class exists to separate the actual feedback control system
+ * for the thermal plate from the logical control of it. The class provides
+ * functions to set the parameters of a thermal control step, and then it will
+ * handle all of the closed-loop control to get to the desired temperature
+ * in the way that the command wants.
+ */
+
+#include "thermocycler-refresh/plate_control.hpp"
+
+#include "thermocycler-refresh/thermal_general.hpp"
+
+using namespace plate_control;
+
+auto PlateControl::update_control() -> UpdateRet {
+    PlateControlVals values = {0.0F};
+    switch (_status) {
+        case PlateStatus::INITIAL_HEAT:
+        case PlateStatus::INITIAL_COOL:
+            if (temp_within_setpoint()) {
+                _status = PlateStatus::OVERSHOOT;
+            } else {
+                update_ramp(_left);
+                update_ramp(_right);
+                update_ramp(_center);
+            }
+            break;
+        case PlateStatus::OVERSHOOT:
+            // TODO overshoot control...  update target, track time
+            _status = PlateStatus::STEADY_STATE;
+            break;
+        case PlateStatus::STEADY_STATE:
+            if (plate_temp() > _setpoint) {
+                _status = PlateStatus::OVERSHOOT;
+            }
+            break;
+    }
+
+    values.left_power = update_pid(_left);
+    values.right_power = update_pid(_right);
+    values.center_power = update_pid(_center);
+    if (!_fan.manual_control) {
+        values.fan_power = update_pid(_fan);
+    }
+
+    return UpdateRet(values);
+}
+
+auto PlateControl::set_new_target(double setpoint, double ramp_rate,
+                                  double hold_time) -> bool {
+    _ramp_rate = ramp_rate;
+    _hold_time = hold_time;
+    _setpoint = setpoint;
+
+    if (ramp_rate == RAMP_INFINITE) {
+        _left.temp_target = _setpoint;
+        _right.temp_target = _setpoint;
+        _center.temp_target = _setpoint;
+    } else {
+        _left.temp_target = plate_temp();
+        _right.temp_target = plate_temp();
+        _center.temp_target = plate_temp();
+    }
+    // The fan always just targets the target temperature w/ an offset
+    _fan.temp_target = _setpoint + FAN_SETPOINT_OFFSET;
+
+    // For heating vs cooling, go based off of the average plate. Might
+    // have to reconsider this, see how it works for small changes.
+    _status = (setpoint > plate_temp()) ? PlateStatus::INITIAL_HEAT
+                                        : PlateStatus::INITIAL_COOL;
+    return true;
+}
+
+[[nodiscard]] auto PlateControl::plate_temp() const -> double {
+    return (_left.current_temp() + _right.current_temp() +
+            _center.current_temp()) /
+           PELTIER_COUNT;
+}
+
+[[nodiscard]] auto PlateControl::temp_within_setpoint() const -> bool {
+    return std::abs(_setpoint - plate_temp()) < SETPOINT_THRESHOLD;
+}

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_system_policy.cpp
     test_system_task.cpp
     test_thermal_plate_task.cpp
+    test_plate_control.cpp
     # GCode parse tests
     test_m14.cpp
     test_m104.cpp

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_m141d.cpp
     test_m104d.cpp
     test_m106.cpp
+    test_m107.cpp
     test_m108.cpp
     test_m140.cpp
     test_m140d.cpp

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -240,6 +240,83 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                 }
             }
         }
+        WHEN("sending a SetFanAutomatic message") {
+            std::string message_text = std::string("M107\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the thermal plate task "
+                "and not immediately ack") {
+                REQUIRE(tasks->get_thermal_plate_queue().backing_deque.size() !=
+                        0);
+                auto plate_message =
+                    tasks->get_thermal_plate_queue().backing_deque.front();
+                auto set_fan_auto_message =
+                    std::get<messages::SetFanAutomaticMessage>(plate_message);
+                tasks->get_system_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = set_fan_auto_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("M107 OK\n"));
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending a bad response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = set_fan_auto_message.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending an ack with error back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = set_fan_auto_message.id,
+                            .with_error =
+                                errors::ErrorCode::THERMAL_HEATSINK_FAN_ERROR});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should print the error rather than ack") {
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "ERR403:thermal:Could not "
+                                                 "control heatsink fan\n"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                    }
+                }
+            }
+        }
         WHEN("sending a SetLidTemperature message") {
             std::string message_text = std::string("M140 S101.0\n");
             auto message_obj =

--- a/stm32-modules/thermocycler-refresh/tests/test_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_lid_heater_task.cpp
@@ -289,12 +289,14 @@ SCENARIO("lid heater task message passing") {
         tasks->get_lid_heater_queue().backing_deque.push_back(
             messages::LidHeaterMessage(read_message));
         tasks->run_lid_heater_task();
+#if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
         CHECK(std::holds_alternative<messages::ErrorMessage>(
             tasks->get_host_comms_queue().backing_deque.front()));
         auto error_msg = std::get<messages::ErrorMessage>(
             tasks->get_host_comms_queue().backing_deque.front());
         CHECK(error_msg.code == errors::ErrorCode::THERMISTOR_LID_SHORT);
         tasks->get_host_comms_queue().backing_deque.pop_front();
+#endif
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
 
         WHEN("Sending a SetHeaterDebug message to enable the heater") {
@@ -401,12 +403,14 @@ SCENARIO("lid heater task message passing") {
         tasks->get_lid_heater_queue().backing_deque.push_back(
             messages::LidHeaterMessage(read_message));
         tasks->run_lid_heater_task();
+#if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
         CHECK(std::holds_alternative<messages::ErrorMessage>(
             tasks->get_host_comms_queue().backing_deque.front()));
         auto error_msg = std::get<messages::ErrorMessage>(
             tasks->get_host_comms_queue().backing_deque.front());
         CHECK(error_msg.code == errors::ErrorCode::THERMISTOR_LID_DISCONNECTED);
         tasks->get_host_comms_queue().backing_deque.pop_front();
+#endif
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
 
         WHEN("Sending a SetHeaterDebug message to enable the heater") {

--- a/stm32-modules/thermocycler-refresh/tests/test_m107.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m107.cpp
@@ -1,0 +1,58 @@
+#include "catch2/catch.hpp"
+
+// Push this diagnostic to avoid a compiler error about printing to too
+// small of a buffer... which we're doing on purpose!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-refresh/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("SetFanAutomatic (M107) parser works", "[gcode][parse][m107]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetFanAutomatic::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M107 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetFanAutomatic::write_response_into(
+                buffer.begin(), buffer.begin() + 5);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M107 ccccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a valid input") {
+        std::string buffer = "M107\n";
+        WHEN("parsing") {
+            auto res =
+                gcode::SetFanAutomatic::parse(buffer.begin(), buffer.end());
+            THEN("a valid gcode should be produced") {
+                REQUIRE(res.first.has_value());
+                REQUIRE(res.second != buffer.begin());
+            }
+        }
+    }
+    GIVEN("an invalid input") {
+        std::string buffer = "M 108\n";
+        WHEN("parsing") {
+            auto res =
+                gcode::SetFanAutomatic::parse(buffer.begin(), buffer.end());
+            THEN("an error should be produced") {
+                REQUIRE(!res.first.has_value());
+                REQUIRE(res.second == buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_plate_control.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_plate_control.cpp
@@ -1,0 +1,75 @@
+#include <vector>
+
+#include "catch2/catch.hpp"
+#include "thermocycler-refresh/plate_control.hpp"
+
+using namespace thermal_general;
+
+static constexpr double UPDATE_RATE_SEC = 0.005F;
+static constexpr double ROOM_TEMP = 23.0F;
+static constexpr double HOT_TEMP = 90.0F;
+static constexpr double COLD_TEMP = 4.0F;
+
+SCENARIO("Plate Control peltier testing") {
+    GIVEN("A PlateControl object with room temperature thermistors") {
+        std::vector<Thermistor> thermistors;
+        for (int i = 0; i < (PeltierID::PELTIER_NUMBER * 2) + 1; ++i) {
+            thermistors.push_back(Thermistor{
+                .temp_c = ROOM_TEMP,
+                .overtemp_limit_c = 105.0,
+                .disconnected_error =
+                    errors::ErrorCode::THERMISTOR_HEATSINK_DISCONNECTED,
+                .short_error = errors::ErrorCode::THERMISTOR_HEATSINK_SHORT,
+                .overtemp_error =
+                    errors::ErrorCode::THERMISTOR_HEATSINK_OVERTEMP,
+                .error_bit = (uint8_t)(1 << i)});
+        }
+        Peltier left{.id = PeltierID::PELTIER_LEFT,
+                     .thermistors = Peltier::ThermistorPair(
+                         thermistors.at(THERM_BACK_LEFT),
+                         thermistors.at(THERM_FRONT_LEFT)),
+                     .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
+        Peltier right{.id = PeltierID::PELTIER_RIGHT,
+                      .thermistors = Peltier::ThermistorPair(
+                          thermistors.at(THERM_BACK_RIGHT),
+                          thermistors.at(THERM_FRONT_RIGHT)),
+                      .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
+        Peltier center{.id = PeltierID::PELTIER_CENTER,
+                       .thermistors = Peltier::ThermistorPair(
+                           thermistors.at(THERM_BACK_CENTER),
+                           thermistors.at(THERM_FRONT_CENTER)),
+                       .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
+        HeatsinkFan fan{.thermistor = thermistors.at(THERM_HEATSINK),
+                        .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
+        auto plateControl = plate_control::PlateControl(left, right, center,
+                                                        fan, UPDATE_RATE_SEC);
+        THEN("The temperature reads correctly") {
+            REQUIRE(plateControl.plate_temp() == ROOM_TEMP);
+            REQUIRE(plateControl.setpoint() == 0.0F);
+        }
+        WHEN("Setting a hot target temperature") {
+            plateControl.set_new_target(HOT_TEMP);
+            REQUIRE(plateControl.setpoint() == HOT_TEMP);
+            THEN("Updating control should drive peltiers hot") {
+                auto ctrl = plateControl.update_control();
+                REQUIRE(ctrl.has_value());
+                auto controlValues = ctrl.value();
+                REQUIRE(controlValues.center_power > 0.0F);
+                REQUIRE(controlValues.right_power > 0.0F);
+                REQUIRE(controlValues.left_power > 0.0F);
+            }
+        }
+        WHEN("Setting a cold target temperature") {
+            plateControl.set_new_target(COLD_TEMP);
+            REQUIRE(plateControl.setpoint() == COLD_TEMP);
+            THEN("Updating control should drive peltiers cold") {
+                auto ctrl = plateControl.update_control();
+                REQUIRE(ctrl.has_value());
+                auto controlValues = ctrl.value();
+                REQUIRE(controlValues.center_power < 0.0F);
+                REQUIRE(controlValues.right_power < 0.0F);
+                REQUIRE(controlValues.left_power < 0.0F);
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_plate_control.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_plate_control.cpp
@@ -9,9 +9,11 @@ static constexpr double UPDATE_RATE_SEC = 0.005F;
 static constexpr double ROOM_TEMP = 23.0F;
 static constexpr double HOT_TEMP = 90.0F;
 static constexpr double COLD_TEMP = 4.0F;
+static constexpr double WARM_TEMP = 28.0F;
+static constexpr double THRESHOLD = 0.5F;
 
-SCENARIO("Plate Control peltier testing") {
-    GIVEN("A PlateControl object with room temperature thermistors") {
+SCENARIO("PlateControl peltier control works") {
+    GIVEN("a PlateControl object with room temperature thermistors") {
         std::vector<Thermistor> thermistors;
         for (int i = 0; i < (PeltierID::PELTIER_NUMBER * 2) + 1; ++i) {
             thermistors.push_back(Thermistor{
@@ -43,14 +45,16 @@ SCENARIO("Plate Control peltier testing") {
                         .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
         auto plateControl = plate_control::PlateControl(left, right, center,
                                                         fan, UPDATE_RATE_SEC);
-        THEN("The temperature reads correctly") {
+        THEN("the temperature reads correctly") {
             REQUIRE(plateControl.plate_temp() == ROOM_TEMP);
             REQUIRE(plateControl.setpoint() == 0.0F);
         }
-        WHEN("Setting a hot target temperature") {
+        WHEN("setting a hot target temperature") {
             plateControl.set_new_target(HOT_TEMP);
             REQUIRE(plateControl.setpoint() == HOT_TEMP);
-            THEN("Updating control should drive peltiers hot") {
+            REQUIRE(plateControl.status() ==
+                    plate_control::PlateStatus::INITIAL_HEAT);
+            THEN("updating control should drive peltiers hot") {
                 auto ctrl = plateControl.update_control();
                 REQUIRE(ctrl.has_value());
                 auto controlValues = ctrl.value();
@@ -58,17 +62,254 @@ SCENARIO("Plate Control peltier testing") {
                 REQUIRE(controlValues.right_power > 0.0F);
                 REQUIRE(controlValues.left_power > 0.0F);
             }
+            WHEN("simulating a ramp") {
+                auto temperature = plateControl.plate_temp();
+                while ((temperature += 1.0F) < (HOT_TEMP - THRESHOLD)) {
+                    for (auto &therm : thermistors) {
+                        therm.temp_c = temperature;
+                    }
+                    auto ctrl = plateControl.update_control();
+                    REQUIRE(ctrl.has_value());
+                    REQUIRE(plateControl.status() ==
+                            plate_control::PlateStatus::INITIAL_HEAT);
+                }
+                temperature = HOT_TEMP;
+                for (auto &therm : thermistors) {
+                    therm.temp_c = temperature;
+                }
+
+                auto ctrl = plateControl.update_control();
+                REQUIRE(ctrl.has_value());
+                REQUIRE(plateControl.status() !=
+                        plate_control::PlateStatus::INITIAL_HEAT);
+            }
         }
-        WHEN("Setting a cold target temperature") {
+        WHEN("setting a cold target temperature") {
             plateControl.set_new_target(COLD_TEMP);
             REQUIRE(plateControl.setpoint() == COLD_TEMP);
-            THEN("Updating control should drive peltiers cold") {
+            THEN("updating control should drive peltiers cold") {
                 auto ctrl = plateControl.update_control();
                 REQUIRE(ctrl.has_value());
                 auto controlValues = ctrl.value();
                 REQUIRE(controlValues.center_power < 0.0F);
                 REQUIRE(controlValues.right_power < 0.0F);
                 REQUIRE(controlValues.left_power < 0.0F);
+            }
+            WHEN("simulating a ramp") {
+                auto temperature = plateControl.plate_temp();
+                while ((temperature -= 1.0F) > (COLD_TEMP + THRESHOLD)) {
+                    for (auto &therm : thermistors) {
+                        therm.temp_c = temperature;
+                    }
+                    auto ctrl = plateControl.update_control();
+                    REQUIRE(ctrl.has_value());
+                    REQUIRE(plateControl.status() ==
+                            plate_control::PlateStatus::INITIAL_COOL);
+                }
+                temperature = COLD_TEMP;
+                for (auto &therm : thermistors) {
+                    therm.temp_c = temperature;
+                }
+
+                auto ctrl = plateControl.update_control();
+                REQUIRE(ctrl.has_value());
+                REQUIRE(plateControl.status() !=
+                        plate_control::PlateStatus::INITIAL_COOL);
+            }
+        }
+    }
+}
+
+SCENARIO("PlateControl idle fan control works") {
+    GIVEN("a PlateControl object with room temperature thermistors") {
+        std::vector<Thermistor> thermistors;
+        for (int i = 0; i < (PeltierID::PELTIER_NUMBER * 2) + 1; ++i) {
+            thermistors.push_back(Thermistor{
+                .temp_c = ROOM_TEMP,
+                .overtemp_limit_c = 105.0,
+                .disconnected_error =
+                    errors::ErrorCode::THERMISTOR_HEATSINK_DISCONNECTED,
+                .short_error = errors::ErrorCode::THERMISTOR_HEATSINK_SHORT,
+                .overtemp_error =
+                    errors::ErrorCode::THERMISTOR_HEATSINK_OVERTEMP,
+                .error_bit = (uint8_t)(1 << i)});
+        }
+        Peltier left{.id = PeltierID::PELTIER_LEFT,
+                     .thermistors = Peltier::ThermistorPair(
+                         thermistors.at(THERM_BACK_LEFT),
+                         thermistors.at(THERM_FRONT_LEFT)),
+                     .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
+        Peltier right{.id = PeltierID::PELTIER_RIGHT,
+                      .thermistors = Peltier::ThermistorPair(
+                          thermistors.at(THERM_BACK_RIGHT),
+                          thermistors.at(THERM_FRONT_RIGHT)),
+                      .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
+        Peltier center{.id = PeltierID::PELTIER_CENTER,
+                       .thermistors = Peltier::ThermistorPair(
+                           thermistors.at(THERM_BACK_CENTER),
+                           thermistors.at(THERM_FRONT_CENTER)),
+                       .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
+        HeatsinkFan fan{.thermistor = thermistors.at(THERM_HEATSINK),
+                        .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
+        auto plateControl = plate_control::PlateControl(left, right, center,
+                                                        fan, UPDATE_RATE_SEC);
+        WHEN("getting fan power for an idle system") {
+            WHEN("the heatsink is at room temperature") {
+                auto power = plateControl.fan_idle_power();
+                THEN("the fan should be turned off") { REQUIRE(power == 0.0F); }
+            }
+            WHEN("the heatsink is between 68 and 75 degrees") {
+                for (double temp = 68.0F; temp < 75.0F; temp += 1.0F) {
+                    fan.thermistor.temp_c = temp;
+                    auto power = plateControl.fan_idle_power();
+                    THEN("the fan power should be temp / 100") {
+                        REQUIRE_THAT(power, Catch::Matchers::WithinAbs(
+                                                temp / 100.0F, 0.01));
+                    }
+                }
+            }
+            WHEN("heatsink temperature is over 75 degrees") {
+                fan.thermistor.temp_c = 75.5F;
+                auto power = plateControl.fan_idle_power();
+                THEN("the fan power should be 0.8") {
+                    REQUIRE_THAT(power, Catch::Matchers::WithinAbs(0.8, 0.01));
+                }
+            }
+        }
+    }
+}
+
+SCENARIO("PlateControl active fan control works") {
+    GIVEN(
+        "a PlateControl object with room temperature thermistors and FAN pid "
+        "of (1,0,0)") {
+        std::vector<Thermistor> thermistors;
+        for (int i = 0; i < (PeltierID::PELTIER_NUMBER * 2) + 1; ++i) {
+            thermistors.push_back(Thermistor{
+                .temp_c = ROOM_TEMP,
+                .overtemp_limit_c = 105.0,
+                .disconnected_error =
+                    errors::ErrorCode::THERMISTOR_HEATSINK_DISCONNECTED,
+                .short_error = errors::ErrorCode::THERMISTOR_HEATSINK_SHORT,
+                .overtemp_error =
+                    errors::ErrorCode::THERMISTOR_HEATSINK_OVERTEMP,
+                .error_bit = (uint8_t)(1 << i)});
+        }
+        Peltier left{.id = PeltierID::PELTIER_LEFT,
+                     .thermistors = Peltier::ThermistorPair(
+                         thermistors.at(THERM_BACK_LEFT),
+                         thermistors.at(THERM_FRONT_LEFT)),
+                     .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
+        Peltier right{.id = PeltierID::PELTIER_RIGHT,
+                      .thermistors = Peltier::ThermistorPair(
+                          thermistors.at(THERM_BACK_RIGHT),
+                          thermistors.at(THERM_FRONT_RIGHT)),
+                      .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
+        Peltier center{.id = PeltierID::PELTIER_CENTER,
+                       .thermistors = Peltier::ThermistorPair(
+                           thermistors.at(THERM_BACK_CENTER),
+                           thermistors.at(THERM_FRONT_CENTER)),
+                       .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
+        HeatsinkFan fan{.thermistor = thermistors.at(THERM_HEATSINK),
+                        .pid = PID(1, 0, 0, UPDATE_RATE_SEC, 1.0, -1.0)};
+        auto plateControl = plate_control::PlateControl(left, right, center,
+                                                        fan, UPDATE_RATE_SEC);
+        GIVEN("a fan in manual mode") {
+            fan.manual_control = true;
+            WHEN("the setpoint is set to ramp the peltiers down") {
+                plateControl.set_new_target(COLD_TEMP);
+                AND_WHEN("the heatsink is at a reasonable temperature") {
+                    THEN("updating control should give fan power of 0") {
+                        auto ctrl = plateControl.update_control();
+                        REQUIRE(ctrl.has_value());
+                        REQUIRE(ctrl.value().fan_power == 0.0F);
+                        REQUIRE(fan.manual_control);
+                    }
+                }
+                AND_WHEN("the heatsink is dangerously warm") {
+                    fan.thermistor.temp_c = HOT_TEMP;
+                    THEN("updating control forces the fan out of manual mode") {
+                        auto ctrl = plateControl.update_control();
+                        REQUIRE(ctrl.has_value());
+                        REQUIRE(ctrl.value().fan_power > 0.0F);
+                        REQUIRE(!fan.manual_control);
+                    }
+                }
+            }
+        }
+        WHEN("the setpoint is set to ramp the peltiers down") {
+            plateControl.set_new_target(COLD_TEMP);
+            auto ctrl = plateControl.update_control();
+            REQUIRE(ctrl.has_value());
+            THEN("the fan should drive at exactly 0.7") {
+                REQUIRE(ctrl.value().fan_power == 0.7F);
+            }
+            AND_WHEN("the target temperature is reached with heatsink at 60") {
+                for (auto &therm : thermistors) {
+                    therm.temp_c = COLD_TEMP;
+                }
+                fan.thermistor.temp_c = 60.0F;
+                ctrl = plateControl.update_control();
+                REQUIRE(ctrl.has_value());
+                THEN("the fan is driven between 0.35 and 0.55") {
+                    REQUIRE(ctrl.value().fan_power >= 0.35);
+                    REQUIRE(ctrl.value().fan_power <= 0.55);
+                }
+            }
+        }
+        WHEN("the setpoint is set to ramp the peltiers up to a warm temp") {
+            plateControl.set_new_target(WARM_TEMP);
+            auto ctrl = plateControl.update_control();
+            REQUIRE(ctrl.has_value());
+            THEN("the fan should drive at exactly 0.15") {
+                REQUIRE(ctrl.value().fan_power == 0.15F);
+            }
+            AND_WHEN(
+                "the target temperature is reached with heatsink at target + "
+                "2") {
+                for (auto &therm : thermistors) {
+                    therm.temp_c = WARM_TEMP;
+                }
+                fan.thermistor.temp_c = WARM_TEMP + 2.0F;
+                ctrl = plateControl.update_control();
+                REQUIRE(ctrl.has_value());
+                THEN("the fan is driven between 0.35 and 0.55") {
+                    REQUIRE(ctrl.value().fan_power >= 0.35);
+                    REQUIRE(ctrl.value().fan_power <= 0.55);
+                }
+            }
+        }
+        WHEN("the setpoint is set to ramp the peltiers up to a hot temp") {
+            plateControl.set_new_target(HOT_TEMP);
+            auto ctrl = plateControl.update_control();
+            REQUIRE(ctrl.has_value());
+            THEN("the fan should drive at exactly 0.15") {
+                REQUIRE(ctrl.value().fan_power == 0.15F);
+            }
+            AND_WHEN("the target temperature is reached with heatsink at 73") {
+                for (auto &therm : thermistors) {
+                    therm.temp_c = HOT_TEMP;
+                }
+                fan.thermistor.temp_c = 73;
+                ctrl = plateControl.update_control();
+                REQUIRE(ctrl.has_value());
+                THEN("the fan is driven between 0.30 and 0.55") {
+                    REQUIRE(ctrl.value().fan_power >= 0.30);
+                    REQUIRE(ctrl.value().fan_power <= 0.55);
+                }
+            }
+            AND_WHEN(
+                "the target temperature is reached with heatsink at HOT_TEMP") {
+                for (auto &therm : thermistors) {
+                    therm.temp_c = HOT_TEMP;
+                }
+                fan.thermistor.temp_c = HOT_TEMP;
+                ctrl = plateControl.update_control();
+                REQUIRE(ctrl.has_value());
+                THEN("the fan is driven at 0.8") {
+                    REQUIRE_THAT(ctrl.value().fan_power,
+                                 Catch::Matchers::WithinAbs(0.8, 0.01));
+                }
             }
         }
     }

--- a/stm32-modules/thermocycler-refresh/tests/test_plate_control.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_plate_control.cpp
@@ -274,6 +274,11 @@ SCENARIO("PlateControl active fan control works") {
                 ctrl = plateControl.update_control();
                 REQUIRE(ctrl.has_value());
                 THEN("the fan is driven between 0.35 and 0.55") {
+                    REQUIRE_THAT(fan.temp_target,
+                                 Catch::Matchers::WithinAbs(
+                                     WARM_TEMP + plate_control::PlateControl::
+                                                     FAN_SETPOINT_OFFSET,
+                                     0.1));
                     REQUIRE(ctrl.value().fan_power >= 0.35);
                     REQUIRE(ctrl.value().fan_power <= 0.55);
                 }
@@ -294,6 +299,8 @@ SCENARIO("PlateControl active fan control works") {
                 ctrl = plateControl.update_control();
                 REQUIRE(ctrl.has_value());
                 THEN("the fan is driven between 0.30 and 0.55") {
+                    REQUIRE_THAT(fan.temp_target,
+                                 Catch::Matchers::WithinAbs(70.0F, 0.1));
                     REQUIRE(ctrl.value().fan_power >= 0.30);
                     REQUIRE(ctrl.value().fan_power <= 0.55);
                 }

--- a/stm32-modules/thermocycler-refresh/tests/test_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_thermal_plate_task.cpp
@@ -588,7 +588,7 @@ SCENARIO("thermal plate task message passing") {
                 }
             }
         }
-        WHEN("Sending a SetPlateTemperature message to enable the lid") {
+        WHEN("Sending a SetPlateTemperature message to enable the plate") {
             auto message = messages::SetPlateTemperatureMessage{
                 .id = 123, .setpoint = 68.0F, .hold_time = 111};
             tasks->get_thermal_plate_queue().backing_deque.push_back(


### PR DESCRIPTION
### Overview
Adds automatic fan control, per the control regimes outlined in the TC-R page on Confluence. Tested on a unit by ramping between a few different temperatures with the `test_plate_pid.py` script and changing the setpoints. 

### Changelog
- Moved logic for setting Peltier & Fan outputs to a PlateControl module to reduce the logic encapsulated in the Thermal Plate task
- Added a gcode M107 that resets the fan to automatic control if it has been set to manual mode
- Changed structuring of public structures in `thermal_general` such that the peltiers/fans maintain references to thermistor handles instead of just storing the current temperature
- Disabled asynchronous thermistor error messages, which were the only messages that would be sent asynchronously on the system... functionality is still there but it's commented out with a `#define` 

### Review Requests
- Right now, the structs in `thermal_general` are only used as basic shells for holding information, while the actual control of everything takes place in the thermal plate task _or_ the PlateControl class. Is that a bit of an antipattern? Should the actual setting of outputs move to PlateControl instead of being in the thermal plate task?