### PR TITLE
feat(thermocycler-refresh): Add TMC2130 SPI interface

### DIFF
--- a/stm32-modules/common/tests/CMakeLists.txt
+++ b/stm32-modules/common/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ include(AddBuildAndTestTarget)
 
 add_executable(${TARGET_MODULE_NAME}
     test_main.cpp
+    test_bit_utils.cpp
     test_ack_cache.cpp
     test_double_buffer.cpp
     test_gcode_parse.cpp 

--- a/stm32-modules/common/tests/test_bit_utils.cpp
+++ b/stm32-modules/common/tests/test_bit_utils.cpp
@@ -1,0 +1,130 @@
+#include <array>
+#include <span>
+
+#include "catch2/catch.hpp"
+#include "core/bit_utils.hpp"
+
+SCENARIO("bytes_to_int works") {
+    GIVEN("a 2 byte input") {
+        auto arr = std::array<uint8_t, 2>{1, 2};
+        WHEN("parsing 2 bytes from both bytes") {
+            uint16_t val = 0;
+            auto next = bit_utils::bytes_to_int(arr.cbegin(), arr.cend(), val);
+            THEN("it is converted to a uint16_t") { REQUIRE(val == 0x0102); }
+            THEN("the return iterator points to the end") {
+                REQUIRE(next == arr.cend());
+            }
+        }
+        WHEN("parsing 2 bytes from only 1 byte") {
+            uint16_t val = 0;
+            auto next =
+                bit_utils::bytes_to_int(arr.cbegin(), arr.cbegin() + 1, val);
+            THEN("only the first byte is read") { REQUIRE(val == 0x0100); }
+            THEN("the return points to the second byte") {
+                REQUIRE(next == (arr.cbegin() + 1));
+            }
+        }
+        WHEN("parsing 1 byte from 2 bytes") {
+            uint8_t val = 0;
+            auto next = bit_utils::bytes_to_int(arr.cbegin(), arr.cend(), val);
+            THEN("only the first byte is read") { REQUIRE(val == 0x01); }
+            THEN("the return points to the second byte") {
+                REQUIRE(next == (std::next(arr.cbegin())));
+            }
+        }
+        WHEN("parsing from a view") {
+            uint16_t val = 0;
+            auto next = bit_utils::bytes_to_int(std::views::all(arr), val);
+            THEN("The parse should provide the right number") {
+                REQUIRE(val == 0x0102);
+                REQUIRE(next == arr.cend());
+            }
+        }
+    }
+    GIVEN("a 4 byte input") {
+        auto arr = std::array<uint8_t, 4>{0xFF, 0xef, 0x3, 0x1};
+
+        WHEN("parsing 4 bytes") {
+            uint32_t val = 0;
+            auto next = bit_utils::bytes_to_int(arr.cbegin(), arr.cend(), val);
+            THEN("it is converted to a uint32_t") {
+                REQUIRE(val == 0xFFEF0301);
+            }
+            THEN("the return points to the end") {
+                REQUIRE(next == arr.cend());
+            }
+        }
+
+        WHEN("called with a 2 byte output request") {
+            uint16_t val = 0;
+            auto next = bit_utils::bytes_to_int(arr, val);
+            THEN("only the first two bytes are converted") {
+                REQUIRE(val == 0xFFEF);
+            }
+            THEN("the return points to 2 bytes in") {
+                REQUIRE(next == (arr.cbegin() + 2));
+            }
+        }
+
+        WHEN("called with an 8 byte output request") {
+            uint64_t val = 0;
+            auto next = bit_utils::bytes_to_int(arr, val);
+            THEN("only the first 4 bytes of the output are filled") {
+                REQUIRE(val == 0xffef030100000000);
+            }
+            THEN("the iterator points to the end") {
+                REQUIRE(next == arr.cend());
+            }
+        }
+    }
+    GIVEN("a 1 byte span") {
+        auto arr = std::array<uint8_t, 1>{0xdd};
+        WHEN("called with a one byte request") {
+            uint8_t val = 0;
+            auto next = bit_utils::bytes_to_int(arr.cbegin(), arr.cend(), val);
+            THEN("it is converted to a uint8_t") { REQUIRE(val == 0xDD); }
+            THEN("the iterator points to the end") {
+                REQUIRE(next == arr.cend());
+            }
+        }
+    }
+}
+
+SCENARIO("int_to_bytes works") {
+    GIVEN("some integers") {
+        auto arr = std::array<uint8_t, 7>{};
+        uint32_t i32 = 0x01234567;
+        uint16_t i16 = 0x89ab;
+        uint8_t i8 = 0xcd;
+        auto iter = arr.begin();
+
+        WHEN("called") {
+            iter = bit_utils::int_to_bytes(i32, iter, arr.end());
+            iter = bit_utils::int_to_bytes(i16, iter, arr.end());
+            iter = bit_utils::int_to_bytes(i8, iter, arr.end());
+            THEN("The values are written into the array") {
+                REQUIRE(arr[0] == 0x01);
+                REQUIRE(arr[1] == 0x23);
+                REQUIRE(arr[2] == 0x45);
+                REQUIRE(arr[3] == 0x67);
+                REQUIRE(arr[4] == 0x89);
+                REQUIRE(arr[5] == 0xab);
+                REQUIRE(arr[6] == 0xcd);
+            }
+            AND_WHEN("converting data back") {
+                iter = arr.begin();
+                uint32_t i32_out;
+                uint16_t i16_out;
+                uint8_t i8_out;
+                iter = bit_utils::bytes_to_int(iter, arr.end(), i32_out);
+                iter = bit_utils::bytes_to_int(iter, arr.end(), i16_out);
+                iter = bit_utils::bytes_to_int(iter, arr.end(), i8_out);
+                THEN("values are identical") {
+                    REQUIRE(i32 == i32_out);
+                    REQUIRE(i16 == i16_out);
+                    REQUIRE(i8 == i8_out);
+                }
+            }
+        }
+    }
+}

--- a/stm32-modules/include/common/core/bit_utils.hpp
+++ b/stm32-modules/include/common/core/bit_utils.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <iterator>
+#include <ranges>
+#include <span>
+#include <type_traits>
+
+namespace bit_utils {
+
+template <typename Iter>
+concept ByteIterator = requires {
+    {std::forward_iterator<Iter>};
+    {std::is_same_v<std::iter_value_t<Iter>, uint8_t>};
+};
+
+/**
+ * Convert a span of bytes into a single integer. The first index being the most
+ * significant byte. Big endian.
+ * @tparam InputIter The input iterator to read from, which must refer to a
+ * byte and satisfy InputIterator
+ * @tparam InputEnd The limit to the input, which must satisfy
+ * is_sentinel_for<InputIter>
+ * @tparam OutputIntType The type of the result. Must be an integer.
+ * @param input Input iterator to read from
+ * @param limit Input limit to read until
+ * @param output The output parameter.
+ * @returns Iterator to one-past where the last byte was read from.
+ *
+ * If the input iterator pair does not contain enough data to completely specify
+ * OutputType, then OutputType will remain incomplete in the less-significant
+ * parts, e.g. trying to parse a uint32_t from 0x112233 will result in output =
+ * 0x11223300.
+ */
+template <typename Input, typename Limit, typename OutputIntType>
+requires std::is_integral_v<OutputIntType> && ByteIterator<Input> &&
+    std::sentinel_for<Limit, Input>
+[[nodiscard]] auto bytes_to_int(Input input, Limit limit, OutputIntType& output)
+    -> Input {
+    output = 0;
+    for (ssize_t byte_index = sizeof(output) - 1;
+         input != limit && byte_index >= 0; input++, byte_index--) {
+        output |= (static_cast<OutputIntType>(*input) << (byte_index * 8));
+    }
+    return input;
+}
+
+/**
+ * overload of bytes_to_int to support direct range or view calls
+ * @tparam InputContainer A type satisfying forward_range containing uint8_t
+ * @tparam OutputIntType The type of the int to return; must satisfy
+ * is_integral_v
+ * @param input The input container to read from
+ * @param output The output int to write to
+ * @returns Iterator at one past the last byte that was read.
+ *
+ * For more details see the overload taking iterators.
+ */
+
+template <typename InputContainer, typename OutputIntType>
+requires std::is_integral_v<OutputIntType> &&
+    std::ranges::forward_range<InputContainer> &&
+    std::is_same_v<std::ranges::range_value_t<InputContainer>, uint8_t>
+auto bytes_to_int(const InputContainer& input, OutputIntType& output)
+    -> std::ranges::iterator_t<const InputContainer> {
+    return bytes_to_int(input.begin(), input.end(), output);
+}
+
+/**
+ * Write an integer into a container. Big Endian.
+ * @tparam Output Output iterator type satisfying output_iterator
+ * @tparam Limit Limit for writing. Must satisfy sentinel_for<Output>.
+ * @tparam InputIntType The type written into the iterator. Must be an integer.
+ * Must satisfy is_integral_v.
+ * @param output iterator to write to
+ * @param limit Limit to write to
+ * @param input integer
+ * @returns iterator one-past-end of written bytes
+ *
+ * Bytes will be written into the container until either the size of the integer
+ * or the size of the container is reached, meaning that output may be partial.
+ */
+template <typename InputIntType, typename Output, typename Limit>
+requires std::is_integral_v<InputIntType> &&
+    std::output_iterator<Output, uint8_t> && ByteIterator<Output> &&
+    std::sentinel_for<Limit, Output>
+[[nodiscard]] auto int_to_bytes(InputIntType input, Output output, Limit limit)
+    -> Output {
+    for (ssize_t x = sizeof(input) - 1; x >= 0 && output != limit;
+         x--, output++) {
+        *output = (input >> (x * 8));
+    }
+    return output;
+}
+
+}  // namespace bit_utils

--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_hardware.h
@@ -25,6 +25,13 @@ void motor_spi_initialize(void);
  */
 bool motor_spi_sendreceive(uint8_t *in, uint8_t *out, size_t len);
 
+/**
+ * @brief Sets the enable pin on the TMC2130
+ * @param[in] enable True to enable, false to disable the TMC
+ * @return True if the enable pin was set, false if it couldn't be set
+ */
+bool motor_spi_set_enable(bool enable);
+
 /** @brief This function handles SPI2 global interrupt. */
 void SPI2_IRQHandler(void);
 

--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_hardware.h
@@ -1,0 +1,34 @@
+/**
+ * @file motor_spi_hardware.h
+ * @brief SPI interface to communicate with the Trinamic TMC2130 motor driver
+ */
+
+#ifndef MOTOR_SPI_HARDWARE_H__
+#define MOTOR_SPI_HARDWARE_H__
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+/** @brief Initialize the SPI bus for the motor driver.*/
+void motor_spi_initialize(void);
+
+/**
+ * @brief Sends & receives data over the SPI bus
+ * 
+ * @param[in] in The buffer to write. Must contain \c len bytes.
+ * @param[out] out Returns the \c len bytes read from the TMC2130
+ * @return True on success, false on any error to write/read
+ */
+bool motor_spi_sendreceive(uint8_t *in, uint8_t *out, size_t len);
+
+/** @brief This function handles SPI2 global interrupt. */
+void SPI2_IRQHandler(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  /* MOTOR_SPI_HARDWARE_H__ */

--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_hardware.h
@@ -30,7 +30,7 @@ bool motor_spi_sendreceive(uint8_t *in, uint8_t *out, size_t len);
  * @param[in] enable True to enable, false to disable the TMC
  * @return True if the enable pin was set, false if it couldn't be set
  */
-bool motor_spi_set_enable(bool enable);
+bool motor_set_output_enable(bool enable);
 
 /** @brief This function handles SPI2 global interrupt. */
 void SPI2_IRQHandler(void);

--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_hardware.h
@@ -10,15 +10,15 @@ extern "C" {
 #endif  // __cplusplus
 
 #include <stdbool.h>
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 /** @brief Initialize the SPI bus for the motor driver.*/
 void motor_spi_initialize(void);
 
 /**
  * @brief Sends & receives data over the SPI bus
- * 
+ *
  * @param[in] in The buffer to write. Must contain \c len bytes.
  * @param[out] out Returns the \c len bytes read from the TMC2130
  * @return True on success, false on any error to write/read

--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_policy.hpp
@@ -5,14 +5,13 @@
 
 class MotorSpiPolicy {
   public:
-    using ReadRT = std::optional<tmc2130::RegisterSerializedType>;
+    using RxTxReturn = std::optional<tmc2130::MessageT>;
     auto transmit_receive(tmc2130::MessageT& data)
-        -> std::optional<tmc2130::MessageT> {
-        using RT = std::optional<tmc2130::MessageT>;
+        ->  RxTxReturn {
         tmc2130::MessageT retBuf = {0};
         if (motor_spi_sendreceive(data.data(), retBuf.data(), data.size())) {
-            return RT(retBuf);
+            return RxTxReturn(retBuf);
         }
-        return RT(0);
+        return RxTxReturn();
     }
 };

--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_policy.hpp
@@ -6,11 +6,11 @@
 class MotorSpiPolicy {
   public:
     using ReadRT = std::optional<tmc2130::RegisterSerializedType>;
-    auto transmit_receive(tmc2130::MessageT& data) 
+    auto transmit_receive(tmc2130::MessageT& data)
         -> std::optional<tmc2130::MessageT> {
         using RT = std::optional<tmc2130::MessageT>;
         tmc2130::MessageT retBuf = {0};
-        if(motor_spi_sendreceive(data.data(), retBuf.data(), data.size())) {
+        if (motor_spi_sendreceive(data.data(), retBuf.data(), data.size())) {
             return RT(retBuf);
         }
         return RT(0);

--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_policy.hpp
@@ -6,12 +6,16 @@
 class MotorSpiPolicy {
   public:
     using RxTxReturn = std::optional<tmc2130::MessageT>;
-    auto transmit_receive(tmc2130::MessageT& data)
-        ->  RxTxReturn {
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    auto transmit_receive(tmc2130::MessageT& data) -> RxTxReturn {
         tmc2130::MessageT retBuf = {0};
         if (motor_spi_sendreceive(data.data(), retBuf.data(), data.size())) {
             return RxTxReturn(retBuf);
         }
         return RxTxReturn();
+    }
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    auto set_enable(bool enable) -> bool {
+        return motor_set_output_enable(enable);
     }
 };

--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_spi_policy.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "firmware/motor_spi_hardware.h"
+#include "thermocycler-refresh/tmc2130.hpp"
+
+class MotorSpiPolicy {
+  public:
+    using ReadRT = std::optional<tmc2130::RegisterSerializedType>;
+    auto transmit_receive(tmc2130::MessageT& data) 
+        -> std::optional<tmc2130::MessageT> {
+        using RT = std::optional<tmc2130::MessageT>;
+        tmc2130::MessageT retBuf = {0};
+        if(motor_spi_sendreceive(data.data(), retBuf.data(), data.size())) {
+            return RT(retBuf);
+        }
+        return RT(0);
+    }
+};

--- a/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <map>
+
+#include "thermocycler-refresh/tmc2130.hpp"
+
+class TestTMC2130Policy {
+  public:
+
+    using ReadRT = std::optional<uint64_t>;
+
+    TestTMC2130Policy() : _registers() {
+        _registers[(uint8_t)tmc2130::Registers::general_config] = 0;
+        _registers[(uint8_t)tmc2130::Registers::general_status] = 0;
+        _registers[(uint8_t)tmc2130::Registers::io_input] = 0;
+        _registers[(uint8_t)tmc2130::Registers::ihold_irun] = 0;
+        _registers[(uint8_t)tmc2130::Registers::tpower_down] = 0;
+        _registers[(uint8_t)tmc2130::Registers::tstep] = 0;
+        _registers[(uint8_t)tmc2130::Registers::tpwmthrs] = 0;
+        _registers[(uint8_t)tmc2130::Registers::tcoolthrs] = 0;
+        _registers[(uint8_t)tmc2130::Registers::thigh] = 0;
+        _registers[(uint8_t)tmc2130::Registers::xdirect] = 0;
+        _registers[(uint8_t)tmc2130::Registers::vdcmin] = 0;
+    }
+
+    auto write_register(tmc2130::Registers addr, uint64_t value) -> bool {
+        if(_registers.count((uint8_t)addr) == 0) {
+            return false;
+        }
+        _registers[(uint8_t)addr] = value;
+        return true;
+    }
+
+    auto read_register(tmc2130::Registers addr) -> ReadRT {
+        if(_registers.count((uint8_t)addr) == 0) {
+            return ReadRT();
+        }
+        return ReadRT(_registers[(uint8_t)addr]);
+    }
+
+  private:
+    using RegMap = std::map<uint8_t, uint64_t>;
+    RegMap _registers;
+};

--- a/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
@@ -6,7 +6,7 @@
 
 class TestTMC2130Policy {
   public:
-    using ReadRT = std::optional<uint64_t>;
+    using ReadRT = std::optional<tmc2130::RegisterSerializedType>;
 
     TestTMC2130Policy() : _registers() {
         _registers[(uint8_t)tmc2130::Registers::GCONF] = 0;
@@ -42,7 +42,8 @@ class TestTMC2130Policy {
         _registers[(uint8_t)tmc2130::Registers::LOST_STEPS] = 0;
     }
 
-    auto write_register(tmc2130::Registers addr, uint64_t value) -> bool {
+    auto write_register(tmc2130::Registers addr,
+                        tmc2130::RegisterSerializedType value) -> bool {
         if (_registers.count((uint8_t)addr) == 0) {
             return false;
         }
@@ -58,6 +59,6 @@ class TestTMC2130Policy {
     }
 
   private:
-    using RegMap = std::map<uint8_t, uint64_t>;
+    using RegMap = std::map<uint8_t, tmc2130::RegisterSerializedType>;
     RegMap _registers;
 };

--- a/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
@@ -69,16 +69,25 @@ class TestTMC2130Policy {
         iter = bit_utils::int_to_bytes(get_status(), iter, ret.end());
         iter = bit_utils::int_to_bytes(_cache, iter, ret.end());
         _cache = _registers[addr];
+        if(addr == static_cast<uint8_t>(tmc2130::Registers::GSTAT)) {
+            // This register is cleared upon read, so clear it here
+            _registers[addr] = 0x00;
+        }
         return RT(ret);
     }
 
-    /** Primarily for test integration.*/
+    // Primarily for test integration.
     auto read_register(tmc2130::Registers reg) -> ReadRT {
         auto addr = static_cast<uint8_t>(reg);
         if (_registers.count(addr) == 0) {
             return ReadRT(0);
         }
         return ReadRT(_registers[addr]);
+    }
+    
+    // Testing function to be able to set a fake error flag
+    auto set_gstat_error() -> void {
+        _registers[static_cast<uint8_t>(tmc2130::Registers::GSTAT)] |= 0x2;
     }
 
   private:

--- a/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
@@ -69,11 +69,16 @@ class TestTMC2130Policy {
         iter = bit_utils::int_to_bytes(get_status(), iter, ret.end());
         iter = bit_utils::int_to_bytes(_cache, iter, ret.end());
         _cache = _registers[addr];
-        if(addr == static_cast<uint8_t>(tmc2130::Registers::GSTAT)) {
+        if (addr == static_cast<uint8_t>(tmc2130::Registers::GSTAT)) {
             // This register is cleared upon read, so clear it here
             _registers[addr] = 0x00;
         }
         return RT(ret);
+    }
+
+    auto set_enable(bool enable) -> bool {
+        _enable = enable;
+        return true;
     }
 
     // Primarily for test integration.
@@ -84,7 +89,7 @@ class TestTMC2130Policy {
         }
         return ReadRT(_registers[addr]);
     }
-    
+
     // Testing function to be able to set a fake error flag
     auto set_gstat_error() -> void {
         _registers[static_cast<uint8_t>(tmc2130::Registers::GSTAT)] |= 0x2;
@@ -96,4 +101,5 @@ class TestTMC2130Policy {
     using RegMap = std::map<uint8_t, tmc2130::RegisterSerializedType>;
     RegMap _registers;
     tmc2130::RegisterSerializedType _cache = 0;
+    bool _enable = false;
 };

--- a/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
@@ -9,17 +9,37 @@ class TestTMC2130Policy {
     using ReadRT = std::optional<uint64_t>;
 
     TestTMC2130Policy() : _registers() {
-        _registers[(uint8_t)tmc2130::Registers::general_config] = 0;
-        _registers[(uint8_t)tmc2130::Registers::general_status] = 0;
-        _registers[(uint8_t)tmc2130::Registers::io_input] = 0;
-        _registers[(uint8_t)tmc2130::Registers::ihold_irun] = 0;
-        _registers[(uint8_t)tmc2130::Registers::tpower_down] = 0;
-        _registers[(uint8_t)tmc2130::Registers::tstep] = 0;
-        _registers[(uint8_t)tmc2130::Registers::tpwmthrs] = 0;
-        _registers[(uint8_t)tmc2130::Registers::tcoolthrs] = 0;
-        _registers[(uint8_t)tmc2130::Registers::thigh] = 0;
-        _registers[(uint8_t)tmc2130::Registers::xdirect] = 0;
-        _registers[(uint8_t)tmc2130::Registers::vdcmin] = 0;
+        _registers[(uint8_t)tmc2130::Registers::GCONF] = 0;
+        _registers[(uint8_t)tmc2130::Registers::GSTAT] = 0;
+        _registers[(uint8_t)tmc2130::Registers::IOIN] = 0;
+        _registers[(uint8_t)tmc2130::Registers::IHOLD_IRUN] = 0;
+        _registers[(uint8_t)tmc2130::Registers::TPOWERDOWN] = 0;
+        _registers[(uint8_t)tmc2130::Registers::TSTEP] = 0;
+        _registers[(uint8_t)tmc2130::Registers::TPWMTHRS] = 0;
+        _registers[(uint8_t)tmc2130::Registers::TCOOLTHRS] = 0;
+        _registers[(uint8_t)tmc2130::Registers::THIGH] = 0;
+        _registers[(uint8_t)tmc2130::Registers::XDIRECT] = 0;
+        _registers[(uint8_t)tmc2130::Registers::VDCMIN] = 0;
+        _registers[(uint8_t)tmc2130::Registers::CHOPCONF] = 0;
+        _registers[(uint8_t)tmc2130::Registers::COOLCONF] = 0;
+        _registers[(uint8_t)tmc2130::Registers::DCCTRL] = 0;
+        _registers[(uint8_t)tmc2130::Registers::DRVSTATUS] = 0;
+        _registers[(uint8_t)tmc2130::Registers::PWMCONF] = 0;
+        _registers[(uint8_t)tmc2130::Registers::ENCM_CTRL] = 0;
+        _registers[(uint8_t)tmc2130::Registers::MSLUT_0] = 0;
+        _registers[(uint8_t)tmc2130::Registers::MSLUT_1] = 0;
+        _registers[(uint8_t)tmc2130::Registers::MSLUT_2] = 0;
+        _registers[(uint8_t)tmc2130::Registers::MSLUT_3] = 0;
+        _registers[(uint8_t)tmc2130::Registers::MSLUT_4] = 0;
+        _registers[(uint8_t)tmc2130::Registers::MSLUT_5] = 0;
+        _registers[(uint8_t)tmc2130::Registers::MSLUT_6] = 0;
+        _registers[(uint8_t)tmc2130::Registers::MSLUT_7] = 0;
+        _registers[(uint8_t)tmc2130::Registers::MSLUTSEL] = 0;
+        _registers[(uint8_t)tmc2130::Registers::MSLUTSTART] = 0;
+        _registers[(uint8_t)tmc2130::Registers::MSCNT] = 0;
+        _registers[(uint8_t)tmc2130::Registers::MSCURACT] = 0;
+        _registers[(uint8_t)tmc2130::Registers::PWM_SCALE] = 0;
+        _registers[(uint8_t)tmc2130::Registers::LOST_STEPS] = 0;
     }
 
     auto write_register(tmc2130::Registers addr, uint64_t value) -> bool {

--- a/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
@@ -6,7 +6,6 @@
 
 class TestTMC2130Policy {
   public:
-
     using ReadRT = std::optional<uint64_t>;
 
     TestTMC2130Policy() : _registers() {
@@ -24,7 +23,7 @@ class TestTMC2130Policy {
     }
 
     auto write_register(tmc2130::Registers addr, uint64_t value) -> bool {
-        if(_registers.count((uint8_t)addr) == 0) {
+        if (_registers.count((uint8_t)addr) == 0) {
             return false;
         }
         _registers[(uint8_t)addr] = value;
@@ -32,7 +31,7 @@ class TestTMC2130Policy {
     }
 
     auto read_register(tmc2130::Registers addr) -> ReadRT {
-        if(_registers.count((uint8_t)addr) == 0) {
+        if (_registers.count((uint8_t)addr) == 0) {
             return ReadRT();
         }
         return ReadRT(_registers[(uint8_t)addr]);

--- a/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_tmc2130_policy.hpp
@@ -53,9 +53,6 @@ class TestTMC2130Policy {
         iter = bit_utils::bytes_to_int(iter, data.end(), addr);
         iter = bit_utils::bytes_to_int(iter, data.end(), value);
 
-        std::cout << "Set address 0x" << std::hex << addr << " to val 0x"
-                  << value << std::endl;
-
         auto mode = addr & 0x80;
         addr &= ~0x80;
 
@@ -75,12 +72,13 @@ class TestTMC2130Policy {
         return RT(ret);
     }
 
-    auto read_register(tmc2130::Registers reg) -> std::optional<uint32_t> {
+    /** Primarily for test integration.*/
+    auto read_register(tmc2130::Registers reg) -> ReadRT {
         auto addr = static_cast<uint8_t>(reg);
         if (_registers.count(addr) == 0) {
-            return std::optional<uint32_t>(0);
+            return ReadRT(0);
         }
-        return std::optional<uint32_t>(_registers[addr]);
+        return ReadRT(_registers[addr]);
     }
 
   private:

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
@@ -42,9 +42,17 @@ class TMC2130 {
         return false;
     }
     /**
-     * @brief Get the current GCONF register status
+     * @brief Get the current GCONF register status. This register can
+     * be read, so this function gets it from the actual device.
      */
-    auto get_gconf() -> GConfig { return _registers.gconfig; }
+    template <TMC2130Policy Policy>
+    auto get_gconf(Policy& policy) -> GConfig { 
+        auto ret = read_register<GConfig>(policy);
+        if(ret.has_value()) {
+            _registers.gconfig = ret.value();
+        }
+        return _registers.gconfig;
+    }
 
     /**
      * @brief Update IHOLDIRUN register

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
@@ -4,370 +4,201 @@
  */
 #pragma once
 
-#include <bitset>
 #include <concepts>
 #include <cstdint>
 #include <optional>
 
 #include "systemwide.h"
+#include "thermocycler-refresh/tmc2130_registers.hpp"
 
 namespace tmc2130 {
 
-// Register mapping
-
-enum class Registers {
-    GCONF = 0x00,
-    GSTAT = 0x01,
-    IOIN = 0x04,
-    IHOLD_IRUN = 0x10,
-    TPOWERDOWN = 0x11,
-    TSTEP = 0x12,
-    TPWMTHRS = 0x13,
-    TCOOLTHRS = 0x14,
-    THIGH = 0x15,
-    XDIRECT = 0x2D,
-    VDCMIN = 0x33,
-    CHOPCONF = 0x6C,
-    COOLCONF = 0x6D,
-    DCCTRL = 0x6E,
-    DRVSTATUS = 0x6F,
-    PWMCONF = 0x70,
-    ENCM_CTRL = 0x72,
-    MSLUT_0 = 0x60,
-    MSLUT_1 = 0x61,
-    MSLUT_2 = 0x62,
-    MSLUT_3 = 0x63,
-    MSLUT_4 = 0x64,
-    MSLUT_5 = 0x65,
-    MSLUT_6 = 0x66,
-    MSLUT_7 = 0x67,
-    MSLUTSEL = 0x68,
-    MSLUTSTART = 0x69,
-    MSCNT = 0x6A,
-    MSCURACT = 0x6B,
-    PWM_SCALE = 0x71,
-    LOST_STEPS = 0x73,
-};
-
-struct GConfig {
-    static constexpr Registers address = Registers::GCONF;
-    static constexpr bool readable = true;
-    static constexpr bool writable = true;
-    static constexpr uint64_t bitlen = 17;
-
-    uint8_t i_scale_analog : 1 = 0;
-    uint8_t internal_rsense : 1 = 0;
-    uint8_t en_pwm_mode : 1 = 0;
-    uint8_t enc_commutation : 1 = 0;  // MUST be 0
-    uint8_t shaft : 1 = 0;
-    uint8_t diag0_error : 1 = 0;
-    uint8_t diag0_otpw : 1 = 0;
-    uint8_t diag0_stall : 1 = 0;
-    uint8_t diag1_stall : 1 = 0;
-    uint8_t diag1_index : 1 = 0;
-    uint8_t diag1_onstate : 1 = 0;
-    uint8_t diag1_steps_skipped : 1 = 0;
-    uint8_t diag0_int_pushpull : 1 = 0;
-    uint8_t diag1_pushpull : 1 = 0;
-    uint8_t small_hysteresis : 1 = 0;
-    uint8_t stop_enable : 1 = 0;
-    uint8_t direct_mode : 1 = 0;
-    uint8_t test_mode : 1 = 0;  // MUST be 0
-} __attribute__((packed));
-
-struct GStatus {
-    static constexpr Registers address = Registers::GSTAT;
-    static constexpr bool readable = true;
-    static constexpr bool writable = false;
-    static constexpr uint64_t bitlen = 3;
-
-    uint8_t reset : 1 = 0;
-    uint8_t driver_error : 1 = 0;
-    uint8_t undervoltage_error : 1 = 0;
-} __attribute__((packed));
-
-struct CurrentControl {
-    static constexpr Registers address = Registers::IHOLD_IRUN;
-    static constexpr bool readable = false;
-    static constexpr bool writable = true;
-    static constexpr uint64_t bitlen = 20;
-
-    uint8_t hold_current : 5 = 0;
-    uint8_t bit_padding_1 : 3 = 0;
-    uint8_t run_current : 5 = 0;
-    uint8_t bit_padding_2 : 3 = 0;
-    uint8_t hold_current_delay : 4 = 0;
-} __attribute__((packed));
-
-/**
- * This is the time to delay between
- */
-struct PowerDownDelay {
-    static constexpr Registers address = Registers::TPOWERDOWN;
-    static constexpr bool readable = false;
-    static constexpr bool writable = true;
-    static constexpr uint64_t bitlen = 8;
-
-    static constexpr double max_time = 4.0F;
-    static constexpr uint64_t max_val = 0xFF;
-
-    auto seconds() -> double {
-        return (static_cast<double>(time) / static_cast<double>(max_val)) *
-               max_time;
-    }
-    auto set_time(double seconds) -> bool {
-        if (seconds > max_time) {
-            return false;
-        }
-        time = static_cast<uint8_t>((seconds / max_time) *
-                                    static_cast<double>(max_val));
-        return true;
-    }
-
-    uint8_t time = 0;
-} __attribute__((packed));
-
-/**
- * This is the threshold velocity for switching on smart energy coolStep
- * and stallGuard.
- */
-struct TCoolThreshold {
-    static constexpr Registers address = Registers::TCOOLTHRS;
-    static constexpr bool readable = false;
-    static constexpr bool writable = true;
-    static constexpr uint64_t bitlen = 20;
-
-    uint32_t threshold : 20 = 0;
-} __attribute__((packed));
-
-/**
- * This is the velocity threshold at which the controller will automatically
- * move into a different chopper mode w/ fullstepping to maximize torque,
- * applied whenever TSTEP < THIGH
- */
-struct THigh {
-    static constexpr Registers address = Registers::THIGH;
-    static constexpr bool readable = false;
-    static constexpr bool writable = true;
-    static constexpr uint64_t bitlen = 20;
-
-    uint32_t threshold : 20 = 0;
-} __attribute__((packed));
-
-/**
- * The CHOPCONFIG register contains a number of configuration options for the
- * Chopper control.
- */
-struct ChopConfig {
-    static constexpr Registers address = Registers::CHOPCONF;
-    static constexpr bool readable = false;
-    static constexpr bool writable = true;
-    static constexpr uint64_t bitlen = 31;
-
-    /** 0 = Driver disable
-     *  1 = "use only with TBL >= 2"
-     *  2...15 sets duration of slow decay phase:
-     * Nclk = 12 + 32 * TOFF
-     */
-    uint8_t toff : 4 = 0;
-    /**
-     * CHM = 0: sets hysteresis start value added to HEND
-     *  - Add 1,2,...,8 to hysteresis low value HEND
-     *
-     * CHM = 1: sets fast decay time, TFD :
-     *  - Nclk = 32*HSTRT
-     */
-    uint8_t hstrt : 3 = 0;
-    /**
-     * CHM = 0: Hysteresis is -3, -2, -1, ... 12. This is the hysteresis
-     * value used for the hysteresis chopper
-     *
-     * CHM = 1: Sine wave offset. 1/512 of the val gets added to abs of each
-     * sine wave entry
-     */
-    uint8_t hend : 4 = 0;
-    /**
-     * CHM = 1: MSB of fast decay time setting TFD
-     */
-    uint8_t fd3 : 1 = 0;
-    /**
-     * CHM = 1: Fast decay mode. Set to 1 to disable current comparator
-     * usage for termination of fast decay cycle.
-     */
-    uint8_t disfdcc : 1 = 0;
-    /**
-     * 0 = chopper OFF time fixed as set by TOFF (aka hstrt and fd3)
-     *
-     * 1 = Random mode, TOFF is modulated by [-12,3] clocks
-     */
-    uint8_t rndtf : 1 = 0;
-    /**
-     * Chopper mode. 0 = standard mode, 1 = constant off-time with fast decay.
-     */
-    uint8_t chm : 1 = 0;
-    /**
-     * Blank Time Select. Sets comparator blank time to 16,24,36,54
-     */
-    uint8_t tbl : 2 = 2;
-    /**
-     * 0 = low sensitivity, high sense resistor voltage
-     *
-     * 1 = high sensitivity, low sense resistor voltage
-     */
-    uint8_t vsense : 1 = 0;
-    /**
-     * High velocity fullstep selection: Enables switching to fullstep when
-     * VHIGH is exceeded. Only switches at 45º position.
-     */
-    uint8_t vhighfs : 1 = 0;
-    /**
-     * High Velocity Chopper Mode: Enables switching to chm=1 and fd=0 when
-     * VHIGH is exceeded. If set, the TOFF setting automatically becomes
-     * doubled during high velocity operation.
-     */
-    uint8_t vhighchm : 1 = 0;
-    /**
-     * SYNC PWM synchronization clock: Allows synchroniation of the chopper
-     * for both phases of a two phase motor to avoid occurrence of a beat.
-     * Automatically switched off above VHIGH
-     *
-     * 0 = disabled
-     *
-     * 1...15 = synchronized with fsync = fclk/(sync*64)
-     */
-    uint8_t sync : 4 = 0;
-    /**
-     * Microstep resolution:
-     *
-     * 0 = native 256 microstep setting
-     *
-     * 0b1...0b1000 = 128,64,32,16,8,4,2,FULLSTEP
-     *
-     * Reduced microstep resolution for STEP/DIR operation. Resolution gives
-     * the number of microstep entries per sine quarter wave.
-     */
-    uint8_t mres : 4 = 0;
-    /**
-     * Interpolation to 256 microsteps: If set, the actual MRES becomes
-     * extrapolated to 256 usteps for smoothest motor operation
-     */
-    uint8_t intpol : 1 = 0;
-    /**
-     * Enable double edge step pulses: If set, enable step impulse at each
-     * step edge to reduce step frequency requirement
-     */
-    uint8_t dedge : 1 = 0;
-    /**
-     * Short to GND protectino disable:
-     *
-     * 0 = short to gnd protection on
-     *
-     * 1 = short to gnd protection disabled
-     */
-    uint8_t diss2g : 1 = 0;
-} __attribute__((packed));
-
-/**
- * COOLCONF contains information to configure the Coolstep and Smartguard (SG)
- * features in the TMC2130
- */
-struct CoolConf {
-    static constexpr Registers address = Registers::COOLCONF;
-    static constexpr bool readable = false;
-    static constexpr bool writable = true;
-    static constexpr uint64_t bitlen = 25;
-
-    /**
-     * Minimum SG value for smart current control & smart current enable.
-     *
-     * If SG result falls below SEMIN*32, motor current increases to
-     * reduce motor load angle.
-     *
-     * 0 = smart current control coolStep OFF
-     *
-     * 1..15 = set threshold value
-     */
-    uint8_t semin : 4 = 0;
-    uint8_t padding_1 : 1 = 0;
-    /**
-     * Current up step width: Current increment steps per measured SG value:
-     *
-     * 1,2,4,8
-     */
-    uint8_t seup : 2 = 0;
-    uint8_t padding_2 : 1 = 0;
-    /**
-     * If the SG result is >= (SEMIN+SEMAX+1)*32, motor current decreases
-     * to save energy.
-     */
-    uint8_t semax : 4 = 0;
-    uint8_t padding_3 : 1 = 0;
-    /**
-     * Current down step speed:
-     *
-     * 0: for each 32 SG values, decrease by one
-     *
-     * 1: for each 8 SG values, decrease by one
-     *
-     * 2: for each 2 SG values, decrease by one
-     *
-     * 3: for each SG value, decrease by one
-     */
-    uint8_t sedn : 2 = 0;
-    /**
-     * Minimum current for smart current control:
-     *
-     * 0 = 1/2 of current setting in IRUN
-     *
-     * 1 = 1/4 of current setting in IRUN
-     */
-    uint8_t seimin : 1 = 0;
-    /**
-     * SG Threshold Value: This signed value controlls SG level for stall
-     * output and sets optimum measurement range for readout. A lower val
-     * gives a higher sensitivity. Zero is starting value working with most
-     * motors.
-     *
-     * -64 to +63: Higher value makes SG less sensitive and requires more
-     * torque to indicate a stall
-     */
-    int8_t sgt : 7 = 0;
-    uint8_t padding_4 : 1 = 0;
-    /**
-     * SG filter enable:
-     *
-     * 0 = standard mode, high time res for SG
-     *
-     * 1 = filtered mode, SG signal updated for each 4 full steps
-     */
-    uint8_t sfilt : 1 = 0;
-} __attribute__((packed));
-
 /** Hardware abstraction policy for the TMC2130 communication.*/
 template <typename Policy>
-concept TMC2130Policy = requires(Policy& p, Registers addr, uint64_t value) {
+concept TMC2130Policy = requires(Policy& p, Registers addr,
+                                 RegisterSerializedType value) {
     // A function to write to a register
     { p.write_register(addr, value) } -> std::same_as<bool>;
     // A function to read from a register
-    { p.read_register(addr) } -> std::same_as<std::optional<uint64_t>>;
+    {
+        p.read_register(addr)
+        } -> std::same_as<std::optional<RegisterSerializedType>>;
     // TODO a function to commence a movement
 };
 
-/** Template concept to constrain what structures encapsulate registers.*/
-template <typename Reg>
-concept TMC2130Register = requires(Reg& r, uint64_t value) {
-    // Struct has a valid register address
-    std::same_as<decltype(Reg::address), Registers&>;
-    // Struct has a bool saying whether it can be read
-    std::same_as<decltype(Reg::readable), bool>;
-    // Struct has a bool saying whether it can be written
-    std::same_as<decltype(Reg::writable), bool>;
-    // Struct has an integer with the total number of bits in a register
-    std::integral<decltype(Reg::bitlen)>;
+#if 0
+/** Hardware abstraction policy for the TMC2130 communication.*/
+template <typename Policy>
+concept TMC2130Policy = requires(Policy& p, Registers addr, RegisterSerializedType value) {
+    // A function to read & write to a register. addr should include the
+    // read/write bit.
+    {
+        p.transmit_receive(addr, value)
+        } -> std::same_as<std::optional<tmc2130::RegisterSerializedType>>;
+    // TODO a function to commence a movement
 };
+#endif
 
 class TMC2130 {
   public:
+    enum class WriteFlag { READ = 0x00, WRITE = 0x80 };
+
+    // FUNCTIONS TO SET INDIVIDUAL REGISTERS
+
+    /**
+     * @brief Update GCONF register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    template <TMC2130Policy Policy>
+    auto set_gconf(GConfig reg, Policy& policy) -> bool {
+        // Assert that bits that MUST be 0 are actually 0
+        if ((reg.enc_commutation != 0) || (reg.test_mode != 0)) {
+            return false;
+        }
+        if (set_register(policy, reg)) {
+            _registers.gconfig = reg;
+            return true;
+        }
+        return false;
+    }
+    /**
+     * @brief Get the current GCONF register status
+     */
+    auto get_gconf() -> GConfig { return _registers.gconfig; }
+
+    /**
+     * @brief Update IHOLDIRUN register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    template <TMC2130Policy Policy>
+    auto set_current_control(CurrentControl reg, Policy& policy) -> bool {
+        // Assert that bits that MUST be 0 are actually 0
+        if ((reg.bit_padding_1 != 0) || (reg.bit_padding_2 != 0)) {
+            return false;
+        }
+        if (set_register(policy, reg)) {
+            _registers.ihold_irun = reg;
+            return true;
+        }
+        return false;
+    }
+    /**
+     * @brief Get the current IHOLDIRUN register status
+     */
+    auto get_current_control() -> CurrentControl {
+        return _registers.ihold_irun;
+    }
+
+    /**
+     * @brief Update TPOWERDOWN register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    template <TMC2130Policy Policy>
+    auto set_power_down_delay(double time, Policy& policy) -> bool {
+        PowerDownDelay temp_reg;
+        if (temp_reg.set_time(time)) {
+            if (set_register(policy, temp_reg)) {
+                _registers.tpowerdown = temp_reg;
+                return true;
+            }
+        }
+        return false;
+    }
+    /**
+     * @brief Get current power down delay in \b seconds
+     */
+    auto get_power_down_delay() -> double {
+        return _registers.tpowerdown.seconds();
+    }
+
+    /**
+     * @brief Update TCOOLTHRSH register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    template <TMC2130Policy Policy>
+    auto set_cool_threshold(TCoolThreshold reg, Policy& policy) -> bool {
+        if (set_register(policy, reg)) {
+            _registers.tcoolthrs = reg;
+            return true;
+        }
+        return false;
+    }
+    /**
+     * @brief Get the current TCOOLTHRSH register status
+     */
+    auto get_cool_threshold() -> TCoolThreshold { return _registers.tcoolthrs; }
+
+    /**
+     * @brief Update THIGH register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    template <TMC2130Policy Policy>
+    auto set_thigh(THigh reg, Policy& policy) -> bool {
+        if (set_register(policy, reg)) {
+            _registers.thigh = reg;
+            return true;
+        }
+        return false;
+    }
+    /**
+     * @brief Get the current THIGH register status
+     */
+    auto get_thigh() -> THigh { return _registers.thigh; }
+
+    /**
+     * @brief Update CHOPCONF register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    template <TMC2130Policy Policy>
+    auto set_chop_config(ChopConfig reg, Policy& policy) -> bool {
+        if (set_register(policy, reg)) {
+            _registers.chopconf = reg;
+            return true;
+        }
+        return false;
+    }
+    /**
+     * @brief Get the current CHOPCONF register status
+     */
+    auto get_chop_config() -> ChopConfig { return _registers.chopconf; }
+
+    /**
+     * @brief Update COOLCONF register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    template <TMC2130Policy Policy>
+    auto set_cool_config(CoolConfig reg, Policy& policy) -> bool {
+        // Assert that bits that MUST be 0 are actually 0
+        if ((reg.padding_1 != 0) || (reg.padding_2 != 0) ||
+            (reg.padding_3 != 0) || (reg.padding_4 != 0)) {
+            return false;
+        }
+        if (set_register(policy, reg)) {
+            _registers.coolconf = reg;
+            return true;
+        }
+        return false;
+    }
+    /**
+     * @brief Get the current COOLCONF register status
+     */
+    auto get_cool_config() -> CoolConfig { return _registers.coolconf; }
+
+  private:
     /**
      * @brief Set a register on the TMC2130
      *
@@ -382,8 +213,8 @@ class TMC2130 {
     template <TMC2130Register Reg, TMC2130Policy Policy>
     auto set_register(Policy& policy, Reg& reg) -> bool {
         static_assert(Reg::writable);
-        auto serialized = *reinterpret_cast<uint64_t*>(&reg);
-        serialized &= ((uint64_t)1 << Reg::bitlen) - 1;
+        auto serialized = *reinterpret_cast<RegisterSerializedType*>(&reg);
+        serialized &= ((RegisterSerializedType)1 << Reg::bitlen) - 1;
         return policy.write_register(reg.address, serialized);
     }
     /**
@@ -396,7 +227,7 @@ class TMC2130 {
      * can't be read.
      */
     template <TMC2130Register Reg, TMC2130Policy Policy>
-    auto get_register(Policy& policy) -> std::optional<Reg> {
+    auto read_register(Policy& policy) -> std::optional<Reg> {
         using RT = std::optional<Reg>;
         static_assert(Reg::readable);
         auto ret = policy.read_register(Reg::address);
@@ -405,5 +236,7 @@ class TMC2130 {
         }
         return RT(*reinterpret_cast<Reg*>(&ret.value()));
     }
+
+    TMC2130RegisterMap _registers = {};
 };
 }  // namespace tmc2130

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
@@ -13,7 +13,7 @@
 
 namespace tmc2130 {
 
-// Register mapping 
+// Register mapping
 
 enum class Registers {
     general_config = 0x00,
@@ -32,12 +32,12 @@ enum class Registers {
 /**
  * @brief This function removes the \c Len lowest bits from a 64 bit integer
  * and automatically shifts it by \c Len bits rightwards
- * 
+ *
  * @tparam Len The number of bits to remove
  * @tparam Ret The return type, uint8_t by default
  */
 template <size_t Len, typename Ret = uint8_t>
-auto pop_bits(uint64_t &val) -> Ret {
+auto pop_bits(uint64_t& val) -> Ret {
     // Masks Len number of bits (e.g. ((1 << 4) - 1) is 0b1111)
     static constexpr Ret bitmask = (1 << Len) - 1;
     auto ret = Ret(val & bitmask);
@@ -49,21 +49,23 @@ auto pop_bits(uint64_t &val) -> Ret {
  * @brief This function pushes the \c Len lowest bits of \c bits
  * into the variable \c val and then shifts \c val by \c Len bits
  * leftwards
- * 
+ *
  * @tparam Len The number of bits to push into \c val
  * @param[inout] val The value to modify
  * @param[in] bits The bits to add to \c val
  */
 template <size_t Len>
-auto push_bits(uint64_t &val, uint64_t bits) -> void {
+auto push_bits(uint64_t& val, uint64_t bits) -> void {
     // Masks Len number of bits (1 << 4 is 0b00001)
     static constexpr uint64_t bitmask = (1 << Len) - 1;
     val = val << Len;
     val |= (bits & bitmask);
 };
 
-struct GConf {
+struct GConfig {
     static constexpr Registers address = Registers::general_config;
+    static constexpr bool readable = true;
+    static constexpr bool writable = true;
     auto serialize() -> uint64_t {
         uint64_t ret = 0;
         push_bits<1>(ret, direct_mode);
@@ -87,49 +89,128 @@ struct GConf {
         return ret;
     }
 
-    static auto create(uint64_t reg) -> GConf {
-        GConf gconf;
-        gconf.i_scale_analog = pop_bits<1>(reg);
-        gconf.internal_rsense = pop_bits<1>(reg);
-        gconf.en_pwm_mode = pop_bits<1>(reg);
+    static auto create(uint64_t reg) -> GConfig {
+        GConfig ret;
+        ret.i_scale_analog = pop_bits<1>(reg);
+        ret.internal_rsense = pop_bits<1>(reg);
+        ret.en_pwm_mode = pop_bits<1>(reg);
         static_cast<void>(pop_bits<1>(reg));
-        gconf.shaft = pop_bits<1>(reg);
-        gconf.diag0_error = pop_bits<1>(reg);
-        gconf.diag0_otpw = pop_bits<1>(reg);
-        gconf.diag0_stall = pop_bits<1>(reg);
-        gconf.diag1_stall = pop_bits<1>(reg);
-        gconf.diag1_index = pop_bits<1>(reg);
-        gconf.diag1_onstate = pop_bits<1>(reg);
-        gconf.diag1_steps_skipped = pop_bits<1>(reg);
-        gconf.diag0_int_pushpull = pop_bits<1>(reg);
-        gconf.diag1_pushpull = pop_bits<1>(reg);
-        gconf.small_hysteresis = pop_bits<1>(reg);
-        gconf.stop_enable = pop_bits<1>(reg);
-        gconf.direct_mode = pop_bits<1>(reg);
+        ret.shaft = pop_bits<1>(reg);
+        ret.diag0_error = pop_bits<1>(reg);
+        ret.diag0_otpw = pop_bits<1>(reg);
+        ret.diag0_stall = pop_bits<1>(reg);
+        ret.diag1_stall = pop_bits<1>(reg);
+        ret.diag1_index = pop_bits<1>(reg);
+        ret.diag1_onstate = pop_bits<1>(reg);
+        ret.diag1_steps_skipped = pop_bits<1>(reg);
+        ret.diag0_int_pushpull = pop_bits<1>(reg);
+        ret.diag1_pushpull = pop_bits<1>(reg);
+        ret.small_hysteresis = pop_bits<1>(reg);
+        ret.stop_enable = pop_bits<1>(reg);
+        ret.direct_mode = pop_bits<1>(reg);
 
-        return gconf;
+        return ret;
     }
 
     uint8_t i_scale_analog : 1 = 0;
-    uint8_t internal_rsense : 1  = 0;
-    uint8_t en_pwm_mode : 1  = 0;
-    //uint8_t enc_commutation : 1  = 0; // Disabled, must be 0
-    uint8_t shaft : 1  = 0;
-    uint8_t diag0_error : 1  = 0;
-    uint8_t diag0_otpw : 1  = 0;
-    uint8_t diag0_stall : 1  = 0;
-    uint8_t diag1_stall : 1  = 0;
-    uint8_t diag1_index : 1  = 0;
-    uint8_t diag1_onstate : 1  = 0;
-    uint8_t diag1_steps_skipped : 1  = 0;
-    uint8_t diag0_int_pushpull : 1  = 0;
-    uint8_t diag1_pushpull : 1  = 0;
-    uint8_t small_hysteresis : 1  = 0;
-    uint8_t stop_enable : 1  = 0;
-    uint8_t direct_mode : 1  = 0;
-    //uint8_t test_mode : 1 = 0; // Disabled, must be 0
+    uint8_t internal_rsense : 1 = 0;
+    uint8_t en_pwm_mode : 1 = 0;
+    // uint8_t enc_commutation : 1  = 0; // Disabled, must be 0
+    uint8_t shaft : 1 = 0;
+    uint8_t diag0_error : 1 = 0;
+    uint8_t diag0_otpw : 1 = 0;
+    uint8_t diag0_stall : 1 = 0;
+    uint8_t diag1_stall : 1 = 0;
+    uint8_t diag1_index : 1 = 0;
+    uint8_t diag1_onstate : 1 = 0;
+    uint8_t diag1_steps_skipped : 1 = 0;
+    uint8_t diag0_int_pushpull : 1 = 0;
+    uint8_t diag1_pushpull : 1 = 0;
+    uint8_t small_hysteresis : 1 = 0;
+    uint8_t stop_enable : 1 = 0;
+    uint8_t direct_mode : 1 = 0;
+    // uint8_t test_mode : 1 = 0; // Disabled, must be 0
 };
 
+struct GStatus {
+    static constexpr Registers address = Registers::general_status;
+    static constexpr bool readable = true;
+    static constexpr bool writable = false;
+
+    auto serialize() -> uint64_t {
+        uint64_t ret = 0;
+        push_bits<1>(ret, undervoltage_error);
+        push_bits<1>(ret, driver_error);
+        push_bits<1>(ret, reset);
+
+        return ret;
+    }
+
+    static auto create(uint64_t reg) -> GStatus {
+        GStatus ret;
+        ret.reset = pop_bits<1>(reg);
+        ret.driver_error = pop_bits<1>(reg);
+        ret.undervoltage_error = pop_bits<1>(reg);
+
+        return ret;
+    }
+
+    uint8_t reset : 1 = 0;
+    uint8_t driver_error : 1 = 0;
+    uint8_t undervoltage_error : 1 = 0;
+};
+
+struct CurrentControl {
+    static constexpr Registers address = Registers::ihold_irun;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+
+    auto serialize() -> uint64_t {
+        uint64_t ret = 0;
+        push_bits<4>(ret, hold_current_delay);
+        push_bits<3>(ret, 0);
+        push_bits<5>(ret, run_current);
+        push_bits<3>(ret, 0);
+        push_bits<5>(ret, hold_current);
+
+        return ret;
+    }
+
+    static auto create(uint64_t reg) -> CurrentControl {
+        CurrentControl ret;
+        ret.hold_current = pop_bits<5>(reg);
+        static_cast<void>(pop_bits<3>(reg));  // 3 bits of padding until IRUN
+        ret.run_current = pop_bits<5>(reg);
+        static_cast<void>(
+            pop_bits<3>(reg));  // 3 bits of padding until IHOLDDELAY
+        ret.hold_current_delay = pop_bits<4>(reg);
+
+        return ret;
+    }
+
+    uint8_t hold_current : 5 = 0;
+    uint8_t run_current : 5 = 0;
+    uint8_t hold_current_delay : 4 = 0;
+};
+
+struct PowerDownDelay {
+    static constexpr Registers address = Registers::tpower_down;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+
+    static constexpr double max_time = 4.0F;
+    static constexpr uint64_t max_val = 0xFF;
+
+    auto serialize() -> uint64_t {
+        return (uint64_t)((double)max_val * (time / max_time));
+    }
+    static auto create(uint64_t reg) -> PowerDownDelay {
+        return PowerDownDelay{.time =
+                                  ((double)reg / (double)max_val) * max_time};
+    }
+
+    double time = 0.0F;
+};
 /** Hardware abstraction policy for the TMC2130 communication.*/
 template <typename Policy>
 concept TMC2130Policy = requires(Policy& p, Registers addr, uint64_t value) {
@@ -142,9 +223,13 @@ concept TMC2130Policy = requires(Policy& p, Registers addr, uint64_t value) {
 
 /** Template concept to constrain what structures encapsulate registers.*/
 template <typename Reg>
-concept TMC2130Register = requires (Reg& r, uint64_t value) {
+concept TMC2130Register = requires(Reg& r, uint64_t value) {
     // Struct has a valid register address
     std::same_as<decltype(r.address), Registers&>;
+    // Struct has a bool saying whether it can be read
+    std::same_as<decltype(r.readable), bool>;
+    // Struct has a bool saying whether it can be written
+    std::same_as<decltype(r.writable), bool>;
     // Struct has a serialize() function
     { r.serialize() } -> std::same_as<uint64_t>;
     // Struct has a constructor from a serialized value
@@ -153,20 +238,40 @@ concept TMC2130Register = requires (Reg& r, uint64_t value) {
 
 class TMC2130 {
   public:
-
+    /**
+     * @brief Set a register on the TMC2130
+     *
+     * @tparam Reg The type of register to set
+     * @tparam Policy Abstraction class for actual writing
+     * @param[in] policy Instance of the abstraction policy to use
+     * @param[in] reg The register to write
+     * @return True if the register could be written, false otherwise.
+     * Attempts to write to an unwirteable register will throw a static
+     * assertion.
+     */
     template <TMC2130Register Reg, TMC2130Policy Policy>
     auto set_register(Policy& policy, Reg& reg) -> bool {
+        static_assert(Reg::writable);
         return policy.write_register(reg.address, reg.serialize());
     }
-
+    /**
+     * @brief Read a register on the TMC2130
+     *
+     * @tparam Reg The type of register to read
+     * @tparam Policy Abstraction class for actual writing
+     * @param[in] policy Instance of the abstraction policy to use
+     * @return The contents of the register, or nothing if the register
+     * can't be read.
+     */
     template <TMC2130Register Reg, TMC2130Policy Policy>
     auto get_register(Policy& policy) -> std::optional<Reg> {
         using RT = std::optional<Reg>;
+        static_assert(Reg::readable);
         auto ret = policy.read_register(Reg::address);
-        if(!ret.has_value()) {
+        if (!ret.has_value()) {
             return RT();
         }
         return RT(Reg::create(ret.value()));
     }
 };
-}
+}  // namespace tmc2130

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
@@ -87,24 +87,27 @@ struct GConf {
         return ret;
     }
 
-    auto set(uint64_t reg) -> void {
-        i_scale_analog = pop_bits<1>(reg);
-        internal_rsense = pop_bits<1>(reg);
-        en_pwm_mode = pop_bits<1>(reg);
+    static auto create(uint64_t reg) -> GConf {
+        GConf gconf;
+        gconf.i_scale_analog = pop_bits<1>(reg);
+        gconf.internal_rsense = pop_bits<1>(reg);
+        gconf.en_pwm_mode = pop_bits<1>(reg);
         static_cast<void>(pop_bits<1>(reg));
-        shaft = pop_bits<1>(reg);
-        diag0_error = pop_bits<1>(reg);
-        diag0_otpw = pop_bits<1>(reg);
-        diag0_stall = pop_bits<1>(reg);
-        diag1_stall = pop_bits<1>(reg);
-        diag1_index = pop_bits<1>(reg);
-        diag1_onstate = pop_bits<1>(reg);
-        diag1_steps_skipped = pop_bits<1>(reg);
-        diag0_int_pushpull = pop_bits<1>(reg);
-        diag1_pushpull = pop_bits<1>(reg);
-        small_hysteresis = pop_bits<1>(reg);
-        stop_enable = pop_bits<1>(reg);
-        direct_mode = pop_bits<1>(reg);
+        gconf.shaft = pop_bits<1>(reg);
+        gconf.diag0_error = pop_bits<1>(reg);
+        gconf.diag0_otpw = pop_bits<1>(reg);
+        gconf.diag0_stall = pop_bits<1>(reg);
+        gconf.diag1_stall = pop_bits<1>(reg);
+        gconf.diag1_index = pop_bits<1>(reg);
+        gconf.diag1_onstate = pop_bits<1>(reg);
+        gconf.diag1_steps_skipped = pop_bits<1>(reg);
+        gconf.diag0_int_pushpull = pop_bits<1>(reg);
+        gconf.diag1_pushpull = pop_bits<1>(reg);
+        gconf.small_hysteresis = pop_bits<1>(reg);
+        gconf.stop_enable = pop_bits<1>(reg);
+        gconf.direct_mode = pop_bits<1>(reg);
+
+        return gconf;
     }
 
     uint8_t i_scale_analog : 1 = 0;
@@ -145,25 +148,25 @@ concept TMC2130Register = requires (Reg& r, uint64_t value) {
     // Struct has a serialize() function
     { r.serialize() } -> std::same_as<uint64_t>;
     // Struct has a constructor from a serialized value
-    { r.set(value) } -> std::same_as<void>;
+    { Reg::create(value) } -> std::same_as<Reg>;
 };
 
 class TMC2130 {
   public:
 
-    template <TMC2130Policy Policy, TMC2130Register Reg>
+    template <TMC2130Register Reg, TMC2130Policy Policy>
     auto set_register(Policy& policy, Reg& reg) -> bool {
         return policy.write_register(reg.address, reg.serialize());
     }
 
-    template <TMC2130Policy Policy, TMC2130Register Reg>
-    auto get_register(Policy& policy, Reg& reg) -> std::optional<Reg> {
+    template <TMC2130Register Reg, TMC2130Policy Policy>
+    auto get_register(Policy& policy) -> std::optional<Reg> {
         using RT = std::optional<Reg>;
-        auto ret = policy.read_register(reg.address);
+        auto ret = policy.read_register(Reg::address);
         if(!ret.has_value()) {
             return RT();
         }
-        return RT(reg.set(ret.value()));
+        return RT(Reg::create(ret.value()));
     }
 };
 }

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
@@ -16,106 +16,49 @@ namespace tmc2130 {
 // Register mapping
 
 enum class Registers {
-    general_config = 0x00,
-    general_status = 0x01,
-    io_input = 0x04,
-    ihold_irun = 0x10,
-    tpower_down = 0x11,
-    tstep = 0x12,
-    tpwmthrs = 0x13,
-    tcoolthrs = 0x14,
-    thigh = 0x15,
-    xdirect = 0x2D,
-    vdcmin = 0x33,
-};
-
-/**
- * @brief This function removes the \c Len lowest bits from a 64 bit integer
- * and automatically shifts it by \c Len bits rightwards
- *
- * @tparam Len The number of bits to remove
- * @tparam Ret The return type, uint8_t by default
- */
-template <size_t Len, typename Ret = uint8_t>
-auto pop_bits(uint64_t& val) -> Ret {
-    // Masks Len number of bits (e.g. ((1 << 4) - 1) is 0b1111)
-    static constexpr Ret bitmask = (1 << Len) - 1;
-    auto ret = Ret(val & bitmask);
-    val = val >> Len;
-    return (Ret)ret;
-};
-
-/**
- * @brief This function pushes the \c Len lowest bits of \c bits
- * into the variable \c val and then shifts \c val by \c Len bits
- * leftwards
- *
- * @tparam Len The number of bits to push into \c val
- * @param[inout] val The value to modify
- * @param[in] bits The bits to add to \c val
- */
-template <size_t Len>
-auto push_bits(uint64_t& val, uint64_t bits) -> void {
-    // Masks Len number of bits (1 << 4 is 0b00001)
-    static constexpr uint64_t bitmask = (1 << Len) - 1;
-    val = val << Len;
-    val |= (bits & bitmask);
+    GCONF = 0x00,
+    GSTAT = 0x01,
+    IOIN = 0x04,
+    IHOLD_IRUN = 0x10,
+    TPOWERDOWN = 0x11,
+    TSTEP = 0x12,
+    TPWMTHRS = 0x13,
+    TCOOLTHRS = 0x14,
+    THIGH = 0x15,
+    XDIRECT = 0x2D,
+    VDCMIN = 0x33,
+    CHOPCONF = 0x6C,
+    COOLCONF = 0x6D,
+    DCCTRL = 0x6E,
+    DRVSTATUS = 0x6F,
+    PWMCONF = 0x70,
+    ENCM_CTRL = 0x72,
+    MSLUT_0 = 0x60,
+    MSLUT_1 = 0x61,
+    MSLUT_2 = 0x62,
+    MSLUT_3 = 0x63,
+    MSLUT_4 = 0x64,
+    MSLUT_5 = 0x65,
+    MSLUT_6 = 0x66,
+    MSLUT_7 = 0x67,
+    MSLUTSEL = 0x68,
+    MSLUTSTART = 0x69,
+    MSCNT = 0x6A,
+    MSCURACT = 0x6B,
+    PWM_SCALE = 0x71,
+    LOST_STEPS = 0x73,
 };
 
 struct GConfig {
-    static constexpr Registers address = Registers::general_config;
+    static constexpr Registers address = Registers::GCONF;
     static constexpr bool readable = true;
     static constexpr bool writable = true;
-    auto serialize() -> uint64_t {
-        uint64_t ret = 0;
-        push_bits<1>(ret, direct_mode);
-        push_bits<1>(ret, stop_enable);
-        push_bits<1>(ret, small_hysteresis);
-        push_bits<1>(ret, diag1_pushpull);
-        push_bits<1>(ret, diag0_int_pushpull);
-        push_bits<1>(ret, diag1_steps_skipped);
-        push_bits<1>(ret, diag1_onstate);
-        push_bits<1>(ret, diag1_index);
-        push_bits<1>(ret, diag1_stall);
-        push_bits<1>(ret, diag0_stall);
-        push_bits<1>(ret, diag0_otpw);
-        push_bits<1>(ret, diag0_error);
-        push_bits<1>(ret, shaft);
-        push_bits<1>(ret, 0);
-        push_bits<1>(ret, en_pwm_mode);
-        push_bits<1>(ret, internal_rsense);
-        push_bits<1>(ret, i_scale_analog);
-
-        return ret;
-    }
-
-    static auto create(uint64_t reg) -> GConfig {
-        GConfig ret;
-        ret.i_scale_analog = pop_bits<1>(reg);
-        ret.internal_rsense = pop_bits<1>(reg);
-        ret.en_pwm_mode = pop_bits<1>(reg);
-        static_cast<void>(pop_bits<1>(reg));
-        ret.shaft = pop_bits<1>(reg);
-        ret.diag0_error = pop_bits<1>(reg);
-        ret.diag0_otpw = pop_bits<1>(reg);
-        ret.diag0_stall = pop_bits<1>(reg);
-        ret.diag1_stall = pop_bits<1>(reg);
-        ret.diag1_index = pop_bits<1>(reg);
-        ret.diag1_onstate = pop_bits<1>(reg);
-        ret.diag1_steps_skipped = pop_bits<1>(reg);
-        ret.diag0_int_pushpull = pop_bits<1>(reg);
-        ret.diag1_pushpull = pop_bits<1>(reg);
-        ret.small_hysteresis = pop_bits<1>(reg);
-        ret.stop_enable = pop_bits<1>(reg);
-        ret.direct_mode = pop_bits<1>(reg);
-
-        return ret;
-    }
+    static constexpr uint64_t bitlen = 17;
 
     uint8_t i_scale_analog : 1 = 0;
     uint8_t internal_rsense : 1 = 0;
     uint8_t en_pwm_mode : 1 = 0;
-    // uint8_t enc_commutation : 1  = 0; // Disabled, must be 0
+    uint8_t enc_commutation : 1 = 0;  // MUST be 0
     uint8_t shaft : 1 = 0;
     uint8_t diag0_error : 1 = 0;
     uint8_t diag0_otpw : 1 = 0;
@@ -129,88 +72,277 @@ struct GConfig {
     uint8_t small_hysteresis : 1 = 0;
     uint8_t stop_enable : 1 = 0;
     uint8_t direct_mode : 1 = 0;
-    // uint8_t test_mode : 1 = 0; // Disabled, must be 0
-};
+    uint8_t test_mode : 1 = 0;  // MUST be 0
+} __attribute__((packed));
 
 struct GStatus {
-    static constexpr Registers address = Registers::general_status;
+    static constexpr Registers address = Registers::GSTAT;
     static constexpr bool readable = true;
     static constexpr bool writable = false;
-
-    auto serialize() -> uint64_t {
-        uint64_t ret = 0;
-        push_bits<1>(ret, undervoltage_error);
-        push_bits<1>(ret, driver_error);
-        push_bits<1>(ret, reset);
-
-        return ret;
-    }
-
-    static auto create(uint64_t reg) -> GStatus {
-        GStatus ret;
-        ret.reset = pop_bits<1>(reg);
-        ret.driver_error = pop_bits<1>(reg);
-        ret.undervoltage_error = pop_bits<1>(reg);
-
-        return ret;
-    }
+    static constexpr uint64_t bitlen = 3;
 
     uint8_t reset : 1 = 0;
     uint8_t driver_error : 1 = 0;
     uint8_t undervoltage_error : 1 = 0;
-};
+} __attribute__((packed));
 
 struct CurrentControl {
-    static constexpr Registers address = Registers::ihold_irun;
+    static constexpr Registers address = Registers::IHOLD_IRUN;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
-
-    auto serialize() -> uint64_t {
-        uint64_t ret = 0;
-        push_bits<4>(ret, hold_current_delay);
-        push_bits<3>(ret, 0);
-        push_bits<5>(ret, run_current);
-        push_bits<3>(ret, 0);
-        push_bits<5>(ret, hold_current);
-
-        return ret;
-    }
-
-    static auto create(uint64_t reg) -> CurrentControl {
-        CurrentControl ret;
-        ret.hold_current = pop_bits<5>(reg);
-        static_cast<void>(pop_bits<3>(reg));  // 3 bits of padding until IRUN
-        ret.run_current = pop_bits<5>(reg);
-        static_cast<void>(
-            pop_bits<3>(reg));  // 3 bits of padding until IHOLDDELAY
-        ret.hold_current_delay = pop_bits<4>(reg);
-
-        return ret;
-    }
+    static constexpr uint64_t bitlen = 20;
 
     uint8_t hold_current : 5 = 0;
+    uint8_t bit_padding_1 : 3 = 0;
     uint8_t run_current : 5 = 0;
+    uint8_t bit_padding_2 : 3 = 0;
     uint8_t hold_current_delay : 4 = 0;
-};
+} __attribute__((packed));
 
+/**
+ * This is the time to delay between
+ */
 struct PowerDownDelay {
-    static constexpr Registers address = Registers::tpower_down;
+    static constexpr Registers address = Registers::TPOWERDOWN;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
+    static constexpr uint64_t bitlen = 8;
 
     static constexpr double max_time = 4.0F;
     static constexpr uint64_t max_val = 0xFF;
 
-    auto serialize() -> uint64_t {
-        return (uint64_t)((double)max_val * (time / max_time));
+    auto seconds() -> double {
+        return (static_cast<double>(time) / static_cast<double>(max_val)) *
+               max_time;
     }
-    static auto create(uint64_t reg) -> PowerDownDelay {
-        return PowerDownDelay{.time =
-                                  ((double)reg / (double)max_val) * max_time};
+    auto set_time(double seconds) -> bool {
+        if (seconds > max_time) {
+            return false;
+        }
+        time = static_cast<uint8_t>((seconds / max_time) *
+                                    static_cast<double>(max_val));
+        return true;
     }
 
-    double time = 0.0F;
-};
+    uint8_t time = 0;
+} __attribute__((packed));
+
+/**
+ * This is the threshold velocity for switching on smart energy coolStep
+ * and stallGuard.
+ */
+struct TCoolThreshold {
+    static constexpr Registers address = Registers::TCOOLTHRS;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint64_t bitlen = 20;
+
+    uint32_t threshold : 20 = 0;
+} __attribute__((packed));
+
+/**
+ * This is the velocity threshold at which the controller will automatically
+ * move into a different chopper mode w/ fullstepping to maximize torque,
+ * applied whenever TSTEP < THIGH
+ */
+struct THigh {
+    static constexpr Registers address = Registers::THIGH;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint64_t bitlen = 20;
+
+    uint32_t threshold : 20 = 0;
+} __attribute__((packed));
+
+/**
+ * The CHOPCONFIG register contains a number of configuration options for the
+ * Chopper control.
+ */
+struct ChopConfig {
+    static constexpr Registers address = Registers::CHOPCONF;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint64_t bitlen = 31;
+
+    /** 0 = Driver disable
+     *  1 = "use only with TBL >= 2"
+     *  2...15 sets duration of slow decay phase:
+     * Nclk = 12 + 32 * TOFF
+     */
+    uint8_t toff : 4 = 0;
+    /**
+     * CHM = 0: sets hysteresis start value added to HEND
+     *  - Add 1,2,...,8 to hysteresis low value HEND
+     *
+     * CHM = 1: sets fast decay time, TFD :
+     *  - Nclk = 32*HSTRT
+     */
+    uint8_t hstrt : 3 = 0;
+    /**
+     * CHM = 0: Hysteresis is -3, -2, -1, ... 12. This is the hysteresis
+     * value used for the hysteresis chopper
+     *
+     * CHM = 1: Sine wave offset. 1/512 of the val gets added to abs of each
+     * sine wave entry
+     */
+    uint8_t hend : 4 = 0;
+    /**
+     * CHM = 1: MSB of fast decay time setting TFD
+     */
+    uint8_t fd3 : 1 = 0;
+    /**
+     * CHM = 1: Fast decay mode. Set to 1 to disable current comparator
+     * usage for termination of fast decay cycle.
+     */
+    uint8_t disfdcc : 1 = 0;
+    /**
+     * 0 = chopper OFF time fixed as set by TOFF (aka hstrt and fd3)
+     *
+     * 1 = Random mode, TOFF is modulated by [-12,3] clocks
+     */
+    uint8_t rndtf : 1 = 0;
+    /**
+     * Chopper mode. 0 = standard mode, 1 = constant off-time with fast decay.
+     */
+    uint8_t chm : 1 = 0;
+    /**
+     * Blank Time Select. Sets comparator blank time to 16,24,36,54
+     */
+    uint8_t tbl : 2 = 2;
+    /**
+     * 0 = low sensitivity, high sense resistor voltage
+     *
+     * 1 = high sensitivity, low sense resistor voltage
+     */
+    uint8_t vsense : 1 = 0;
+    /**
+     * High velocity fullstep selection: Enables switching to fullstep when
+     * VHIGH is exceeded. Only switches at 45º position.
+     */
+    uint8_t vhighfs : 1 = 0;
+    /**
+     * High Velocity Chopper Mode: Enables switching to chm=1 and fd=0 when
+     * VHIGH is exceeded. If set, the TOFF setting automatically becomes
+     * doubled during high velocity operation.
+     */
+    uint8_t vhighchm : 1 = 0;
+    /**
+     * SYNC PWM synchronization clock: Allows synchroniation of the chopper
+     * for both phases of a two phase motor to avoid occurrence of a beat.
+     * Automatically switched off above VHIGH
+     *
+     * 0 = disabled
+     *
+     * 1...15 = synchronized with fsync = fclk/(sync*64)
+     */
+    uint8_t sync : 4 = 0;
+    /**
+     * Microstep resolution:
+     *
+     * 0 = native 256 microstep setting
+     *
+     * 0b1...0b1000 = 128,64,32,16,8,4,2,FULLSTEP
+     *
+     * Reduced microstep resolution for STEP/DIR operation. Resolution gives
+     * the number of microstep entries per sine quarter wave.
+     */
+    uint8_t mres : 4 = 0;
+    /**
+     * Interpolation to 256 microsteps: If set, the actual MRES becomes
+     * extrapolated to 256 usteps for smoothest motor operation
+     */
+    uint8_t intpol : 1 = 0;
+    /**
+     * Enable double edge step pulses: If set, enable step impulse at each
+     * step edge to reduce step frequency requirement
+     */
+    uint8_t dedge : 1 = 0;
+    /**
+     * Short to GND protectino disable:
+     *
+     * 0 = short to gnd protection on
+     *
+     * 1 = short to gnd protection disabled
+     */
+    uint8_t diss2g : 1 = 0;
+} __attribute__((packed));
+
+/**
+ * COOLCONF contains information to configure the Coolstep and Smartguard (SG)
+ * features in the TMC2130
+ */
+struct CoolConf {
+    static constexpr Registers address = Registers::COOLCONF;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint64_t bitlen = 25;
+
+    /**
+     * Minimum SG value for smart current control & smart current enable.
+     *
+     * If SG result falls below SEMIN*32, motor current increases to
+     * reduce motor load angle.
+     *
+     * 0 = smart current control coolStep OFF
+     *
+     * 1..15 = set threshold value
+     */
+    uint8_t semin : 4 = 0;
+    uint8_t padding_1 : 1 = 0;
+    /**
+     * Current up step width: Current increment steps per measured SG value:
+     *
+     * 1,2,4,8
+     */
+    uint8_t seup : 2 = 0;
+    uint8_t padding_2 : 1 = 0;
+    /**
+     * If the SG result is >= (SEMIN+SEMAX+1)*32, motor current decreases
+     * to save energy.
+     */
+    uint8_t semax : 4 = 0;
+    uint8_t padding_3 : 1 = 0;
+    /**
+     * Current down step speed:
+     *
+     * 0: for each 32 SG values, decrease by one
+     *
+     * 1: for each 8 SG values, decrease by one
+     *
+     * 2: for each 2 SG values, decrease by one
+     *
+     * 3: for each SG value, decrease by one
+     */
+    uint8_t sedn : 2 = 0;
+    /**
+     * Minimum current for smart current control:
+     *
+     * 0 = 1/2 of current setting in IRUN
+     *
+     * 1 = 1/4 of current setting in IRUN
+     */
+    uint8_t seimin : 1 = 0;
+    /**
+     * SG Threshold Value: This signed value controlls SG level for stall
+     * output and sets optimum measurement range for readout. A lower val
+     * gives a higher sensitivity. Zero is starting value working with most
+     * motors.
+     *
+     * -64 to +63: Higher value makes SG less sensitive and requires more
+     * torque to indicate a stall
+     */
+    int8_t sgt : 7 = 0;
+    uint8_t padding_4 : 1 = 0;
+    /**
+     * SG filter enable:
+     *
+     * 0 = standard mode, high time res for SG
+     *
+     * 1 = filtered mode, SG signal updated for each 4 full steps
+     */
+    uint8_t sfilt : 1 = 0;
+} __attribute__((packed));
+
 /** Hardware abstraction policy for the TMC2130 communication.*/
 template <typename Policy>
 concept TMC2130Policy = requires(Policy& p, Registers addr, uint64_t value) {
@@ -225,15 +357,13 @@ concept TMC2130Policy = requires(Policy& p, Registers addr, uint64_t value) {
 template <typename Reg>
 concept TMC2130Register = requires(Reg& r, uint64_t value) {
     // Struct has a valid register address
-    std::same_as<decltype(r.address), Registers&>;
+    std::same_as<decltype(Reg::address), Registers&>;
     // Struct has a bool saying whether it can be read
-    std::same_as<decltype(r.readable), bool>;
+    std::same_as<decltype(Reg::readable), bool>;
     // Struct has a bool saying whether it can be written
-    std::same_as<decltype(r.writable), bool>;
-    // Struct has a serialize() function
-    { r.serialize() } -> std::same_as<uint64_t>;
-    // Struct has a constructor from a serialized value
-    { Reg::create(value) } -> std::same_as<Reg>;
+    std::same_as<decltype(Reg::writable), bool>;
+    // Struct has an integer with the total number of bits in a register
+    std::integral<decltype(Reg::bitlen)>;
 };
 
 class TMC2130 {
@@ -252,7 +382,9 @@ class TMC2130 {
     template <TMC2130Register Reg, TMC2130Policy Policy>
     auto set_register(Policy& policy, Reg& reg) -> bool {
         static_assert(Reg::writable);
-        return policy.write_register(reg.address, reg.serialize());
+        auto serialized = *reinterpret_cast<uint64_t*>(&reg);
+        serialized &= ((uint64_t)1 << Reg::bitlen) - 1;
+        return policy.write_register(reg.address, serialized);
     }
     /**
      * @brief Read a register on the TMC2130
@@ -271,7 +403,7 @@ class TMC2130 {
         if (!ret.has_value()) {
             return RT();
         }
-        return RT(Reg::create(ret.value()));
+        return RT(*reinterpret_cast<Reg*>(&ret.value()));
     }
 };
 }  // namespace tmc2130

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
@@ -1,0 +1,169 @@
+/**
+ * @file tmc2130.hpp
+ * @brief Interface to control a TMC2130 IC
+ */
+#pragma once
+
+#include <bitset>
+#include <concepts>
+#include <cstdint>
+#include <optional>
+
+#include "systemwide.h"
+
+namespace tmc2130 {
+
+// Register mapping 
+
+enum class Registers {
+    general_config = 0x00,
+    general_status = 0x01,
+    io_input = 0x04,
+    ihold_irun = 0x10,
+    tpower_down = 0x11,
+    tstep = 0x12,
+    tpwmthrs = 0x13,
+    tcoolthrs = 0x14,
+    thigh = 0x15,
+    xdirect = 0x2D,
+    vdcmin = 0x33,
+};
+
+/**
+ * @brief This function removes the \c Len lowest bits from a 64 bit integer
+ * and automatically shifts it by \c Len bits rightwards
+ * 
+ * @tparam Len The number of bits to remove
+ * @tparam Ret The return type, uint8_t by default
+ */
+template <size_t Len, typename Ret = uint8_t>
+auto pop_bits(uint64_t &val) -> Ret {
+    // Masks Len number of bits (e.g. ((1 << 4) - 1) is 0b1111)
+    static constexpr Ret bitmask = (1 << Len) - 1;
+    auto ret = Ret(val & bitmask);
+    val = val >> Len;
+    return (Ret)ret;
+};
+
+/**
+ * @brief This function pushes the \c Len lowest bits of \c bits
+ * into the variable \c val and then shifts \c val by \c Len bits
+ * leftwards
+ * 
+ * @tparam Len The number of bits to push into \c val
+ * @param[inout] val The value to modify
+ * @param[in] bits The bits to add to \c val
+ */
+template <size_t Len>
+auto push_bits(uint64_t &val, uint64_t bits) -> void {
+    // Masks Len number of bits (1 << 4 is 0b00001)
+    static constexpr uint64_t bitmask = (1 << Len) - 1;
+    val = val << Len;
+    val |= (bits & bitmask);
+};
+
+struct GConf {
+    static constexpr Registers address = Registers::general_config;
+    auto serialize() -> uint64_t {
+        uint64_t ret = 0;
+        push_bits<1>(ret, direct_mode);
+        push_bits<1>(ret, stop_enable);
+        push_bits<1>(ret, small_hysteresis);
+        push_bits<1>(ret, diag1_pushpull);
+        push_bits<1>(ret, diag0_int_pushpull);
+        push_bits<1>(ret, diag1_steps_skipped);
+        push_bits<1>(ret, diag1_onstate);
+        push_bits<1>(ret, diag1_index);
+        push_bits<1>(ret, diag1_stall);
+        push_bits<1>(ret, diag0_stall);
+        push_bits<1>(ret, diag0_otpw);
+        push_bits<1>(ret, diag0_error);
+        push_bits<1>(ret, shaft);
+        push_bits<1>(ret, 0);
+        push_bits<1>(ret, en_pwm_mode);
+        push_bits<1>(ret, internal_rsense);
+        push_bits<1>(ret, i_scale_analog);
+
+        return ret;
+    }
+
+    auto set(uint64_t reg) -> void {
+        i_scale_analog = pop_bits<1>(reg);
+        internal_rsense = pop_bits<1>(reg);
+        en_pwm_mode = pop_bits<1>(reg);
+        static_cast<void>(pop_bits<1>(reg));
+        shaft = pop_bits<1>(reg);
+        diag0_error = pop_bits<1>(reg);
+        diag0_otpw = pop_bits<1>(reg);
+        diag0_stall = pop_bits<1>(reg);
+        diag1_stall = pop_bits<1>(reg);
+        diag1_index = pop_bits<1>(reg);
+        diag1_onstate = pop_bits<1>(reg);
+        diag1_steps_skipped = pop_bits<1>(reg);
+        diag0_int_pushpull = pop_bits<1>(reg);
+        diag1_pushpull = pop_bits<1>(reg);
+        small_hysteresis = pop_bits<1>(reg);
+        stop_enable = pop_bits<1>(reg);
+        direct_mode = pop_bits<1>(reg);
+    }
+
+    uint8_t i_scale_analog : 1 = 0;
+    uint8_t internal_rsense : 1  = 0;
+    uint8_t en_pwm_mode : 1  = 0;
+    //uint8_t enc_commutation : 1  = 0; // Disabled, must be 0
+    uint8_t shaft : 1  = 0;
+    uint8_t diag0_error : 1  = 0;
+    uint8_t diag0_otpw : 1  = 0;
+    uint8_t diag0_stall : 1  = 0;
+    uint8_t diag1_stall : 1  = 0;
+    uint8_t diag1_index : 1  = 0;
+    uint8_t diag1_onstate : 1  = 0;
+    uint8_t diag1_steps_skipped : 1  = 0;
+    uint8_t diag0_int_pushpull : 1  = 0;
+    uint8_t diag1_pushpull : 1  = 0;
+    uint8_t small_hysteresis : 1  = 0;
+    uint8_t stop_enable : 1  = 0;
+    uint8_t direct_mode : 1  = 0;
+    //uint8_t test_mode : 1 = 0; // Disabled, must be 0
+};
+
+/** Hardware abstraction policy for the TMC2130 communication.*/
+template <typename Policy>
+concept TMC2130Policy = requires(Policy& p, Registers addr, uint64_t value) {
+    // A function to write to a register
+    { p.write_register(addr, value) } -> std::same_as<bool>;
+    // A function to read from a register
+    { p.read_register(addr) } -> std::same_as<std::optional<uint64_t>>;
+    // TODO a function to commence a movement
+};
+
+/** Template concept to constrain what structures encapsulate registers.*/
+template <typename Reg>
+concept TMC2130Register = requires (Reg& r, uint64_t value) {
+    // Struct has a valid register address
+    std::same_as<decltype(r.address), Registers&>;
+    // Struct has a serialize() function
+    { r.serialize() } -> std::same_as<uint64_t>;
+    // Struct has a constructor from a serialized value
+    { r.set(value) } -> std::same_as<void>;
+};
+
+class TMC2130 {
+  public:
+
+    template <TMC2130Policy Policy, TMC2130Register Reg>
+    auto set_register(Policy& policy, Reg& reg) -> bool {
+        return policy.write_register(reg.address, reg.serialize());
+    }
+
+    template <TMC2130Policy Policy, TMC2130Register Reg>
+    auto get_register(Policy& policy, Reg& reg) -> std::optional<Reg> {
+        using RT = std::optional<Reg>;
+        auto ret = policy.read_register(reg.address);
+        if(!ret.has_value()) {
+            return RT();
+        }
+        return RT(reg.set(ret.value()));
+    }
+};
+}

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
@@ -55,6 +55,18 @@ class TMC2130 {
     }
 
     /**
+     * @brief Get the general status register
+     */
+    template <TMC2130Policy Policy>
+    [[nodiscard]] auto get_gstatus(Policy& policy) -> GStatus { 
+        auto ret = read_register<GStatus>(policy);
+        if(ret.has_value()) {
+            return ret.value();
+        }
+        return GStatus { .driver_error = 1 };
+    }
+
+    /**
      * @brief Update IHOLDIRUN register
      * @param reg New configuration register to set
      * @param policy Instance of abstraction policy to use

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130.hpp
@@ -282,8 +282,8 @@ class TMC2130 {
         // Ignore the typical linter warning because we're only using
         // this on __packed structures that mimic hardware registers
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        auto value = *reinterpret_cast<RegisterSerializedType*>(&reg);
-        value &= ((RegisterSerializedType)1 << Reg::bitlen) - 1;
+        auto value = *reinterpret_cast<RegisterSerializedTypeA*>(&reg);
+        value &= (static_cast<RegisterSerializedType>(1) << Reg::bitlen) - 1;
         return _spi.write(Reg::address, value, policy);
     }
     /**
@@ -298,6 +298,7 @@ class TMC2130 {
     template <TMC2130Register Reg, TMC2130Policy Policy>
     auto read_register(Policy& policy) -> std::optional<Reg> {
         using RT = std::optional<Reg>;
+        // using RegA = __attribute__((__may_alias__)) Reg;
         static_assert(Reg::readable);
         auto ret = _spi.read(Reg::address, policy);
         if (!ret.has_value()) {

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_interface.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_interface.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <optional>
+
+#include "thermocycler-refresh/tmc2130_registers.hpp"
+
+namespace tmc2130 {
+
+// The type of a single TMC2130 message.
+using MessageT = std::array<uint8_t, 5>;
+
+// Flag for whether this is a read or write
+enum class WriteFlag { READ = 0x00, WRITE = 0x80 };
+
+// Hardware abstraction policy for the TMC2130 communication.
+template <typename Policy>
+concept TMC2130InterfacePolicy = requires(Policy& p, MessageT& data) {
+    // A function to read & write to a register. addr should include the
+    // read/write bit.
+    { p.transmit_receive(data) } -> std::same_as<std::optional<MessageT>>;
+    // TODO a function to commence a movement
+};
+
+/**
+ * @brief Provides SPI access to the TMC2130
+ */
+class TMC2130Interface {
+  public:
+    /**
+     * @brief Build a message to send over SPI
+     * @param[in] addr The address to write to
+     * @param[in] mode The mode to use, either WRITE or READ
+     * @param[in] val The contents to write to the address (0 if this is a read)
+     * @return An array with the contents of the message, or nothing if
+     * there was an error
+     */
+    auto build_message(Registers addr, WriteFlag mode,
+                       RegisterSerializedType val) -> std::optional<MessageT> {
+        using RT = std::optional<MessageT>;
+        MessageT buffer = {0};
+        auto iter = buffer.begin();
+        auto addr_byte = static_cast<uint8_t>(addr);
+        addr_byte |= static_cast<uint8_t>(mode);
+        iter = bit_utils::int_to_bytes(addr_byte, iter, buffer.end());
+        iter = bit_utils::int_to_bytes(val, iter, buffer.end());
+        if (iter != buffer.end()) {
+            return RT();
+        }
+        return RT(buffer);
+    }
+
+    /**
+     * @brief Write to a register
+     *
+     * @tparam Policy Type used for bus-level SPI comms
+     * @param[in] addr The address to write to
+     * @param[in] val The value to write
+     * @param[in] policy Instance of \c Policy
+     * @return True on success, false on error to write
+     */
+    template <TMC2130InterfacePolicy Policy>
+    auto write(Registers addr, RegisterSerializedType value, Policy& policy)
+        -> bool {
+        auto buffer = build_message(addr, WriteFlag::WRITE, value);
+        if (!buffer.has_value()) {
+            return false;
+        }
+        return policy.transmit_receive(buffer.value()).has_value();
+    }
+
+    /**
+     * @brief Read from a register. This actually performs two SPI
+     * transactions, as the first one will not return the correct data.
+     *
+     * @tparam Policy Type used for bus-level SPI comms
+     * @param addr The address to read from
+     * @param[in] policy Instance of \c Policy
+     * @return Nothing on error, read value on success
+     */
+    template <TMC2130InterfacePolicy Policy>
+    auto read(Registers addr, Policy& policy)
+        -> std::optional<RegisterSerializedType> {
+        using RT = std::optional<RegisterSerializedType>;
+        auto buffer = build_message(addr, WriteFlag::READ, 0);
+        if (!buffer.has_value()) {
+            return RT();
+        }
+        auto ret = policy.transmit_receive(buffer.value());
+        if (!ret.has_value()) {
+            return RT();
+        }
+        ret = policy.transmit_receive(buffer.value());
+        if (!ret.has_value()) {
+            return RT();
+        }
+        auto iter = ret.value().begin();
+        std::advance(iter, 1);
+
+        RegisterSerializedType retval;
+        iter = bit_utils::bytes_to_int(iter, ret.value().end(), retval);
+        return RT(retval);
+    }
+};
+
+}  // namespace tmc2130

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_interface.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_interface.hpp
@@ -1,7 +1,7 @@
 /**
  * @file tmc2130_interface.hpp
  * @brief Provides a templatized SPI interface to talk to the TMC2130
- * 
+ *
  */
 #pragma once
 
@@ -11,8 +11,10 @@
 
 namespace tmc2130 {
 
+static constexpr size_t MESSAGE_LEN = 5;
+
 // The type of a single TMC2130 message.
-using MessageT = std::array<uint8_t, 5>;
+using MessageT = std::array<uint8_t, MESSAGE_LEN>;
 
 // Flag for whether this is a read or write
 enum class WriteFlag { READ = 0x00, WRITE = 0x80 };
@@ -39,11 +41,12 @@ class TMC2130Interface {
      * @return An array with the contents of the message, or nothing if
      * there was an error
      */
-    auto build_message(Registers addr, WriteFlag mode,
-                       RegisterSerializedType val) -> std::optional<MessageT> {
+    static auto build_message(Registers addr, WriteFlag mode,
+                              RegisterSerializedType val)
+        -> std::optional<MessageT> {
         using RT = std::optional<MessageT>;
         MessageT buffer = {0};
-        auto iter = buffer.begin();
+        auto* iter = buffer.begin();
         auto addr_byte = static_cast<uint8_t>(addr);
         addr_byte |= static_cast<uint8_t>(mode);
         iter = bit_utils::int_to_bytes(addr_byte, iter, buffer.end());
@@ -98,10 +101,10 @@ class TMC2130Interface {
         if (!ret.has_value()) {
             return RT();
         }
-        auto iter = ret.value().begin();
+        auto* iter = ret.value().begin();
         std::advance(iter, 1);
 
-        RegisterSerializedType retval;
+        RegisterSerializedType retval = 0;
         iter = bit_utils::bytes_to_int(iter, ret.value().end(), retval);
         return RT(retval);
     }

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_interface.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_interface.hpp
@@ -1,3 +1,8 @@
+/**
+ * @file tmc2130_interface.hpp
+ * @brief Provides a templatized SPI interface to talk to the TMC2130
+ * 
+ */
 #pragma once
 
 #include <optional>

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
@@ -61,7 +61,7 @@ concept TMC2130Register = requires(Reg& r, uint64_t value) {
     std::integral<decltype(Reg::bitlen)>;
 };
 
-struct GConfig {
+struct __attribute__((packed, __may_alias__)) GConfig {
     static constexpr Registers address = Registers::GCONF;
     static constexpr bool readable = true;
     static constexpr bool writable = true;
@@ -85,9 +85,9 @@ struct GConfig {
     uint8_t stop_enable : 1 = 0;
     uint8_t direct_mode : 1 = 0;
     uint8_t test_mode : 1 = 0;  // MUST be 0
-} __attribute__((packed)) __attribute__((__may_alias__));
+};
 
-struct GStatus {
+struct __attribute__((packed, __may_alias__)) GStatus {
     static constexpr Registers address = Registers::GSTAT;
     static constexpr bool readable = true;
     static constexpr bool writable = false;
@@ -96,12 +96,12 @@ struct GStatus {
     uint8_t undervoltage_error : 1 = 0;
     uint8_t driver_error : 1 = 0;
     uint8_t reset : 1 = 0;
-} __attribute__((packed)) __attribute__((__may_alias__));
+};
 
 /**
  * This register sets the control current for holding and running.
  */
-struct CurrentControl {
+struct __attribute__((packed, __may_alias__)) CurrentControl {
     static constexpr Registers address = Registers::IHOLD_IRUN;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
@@ -115,13 +115,13 @@ struct CurrentControl {
     uint8_t bit_padding_2 : 3 = 0;
     // Motor powers down after (hold_current_delay * (2^18)) clock cycles
     uint8_t hold_current_delay : 4 = 0;
-} __attribute__((packed)) __attribute__((__may_alias__));
+};
 
 /**
  * This is the time to delay between ending a movement and moving to power-down
  * current. Scale goes up to "about 4 seconds"
  */
-struct PowerDownDelay {
+struct __attribute__((packed, __may_alias__)) PowerDownDelay {
     static constexpr Registers address = Registers::TPOWERDOWN;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
@@ -143,41 +143,40 @@ struct PowerDownDelay {
     }
 
     uint8_t time = 0;
-
-} __attribute__((packed)) __attribute__((__may_alias__));
+};
 
 /**
  * This is the threshold velocity for switching on smart energy coolStep
  * and stallGuard.
  */
-struct TCoolThreshold {
+struct __attribute__((packed, __may_alias__)) TCoolThreshold {
     static constexpr Registers address = Registers::TCOOLTHRS;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
     static constexpr uint64_t bitlen = 20;
 
     uint32_t threshold : 20 = 0;
-} __attribute__((packed)) __attribute__((__may_alias__));
+};
 
 /**
  * This is the velocity threshold at which the controller will automatically
  * move into a different chopper mode w/ fullstepping to maximize torque,
  * applied whenever TSTEP < THIGH
  */
-struct THigh {
+struct __attribute__((packed, __may_alias__)) THigh {
     static constexpr Registers address = Registers::THIGH;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
     static constexpr uint64_t bitlen = 20;
 
     uint32_t threshold : 20 = 0;
-} __attribute__((packed)) __attribute__((__may_alias__));
+};
 
 /**
  * The CHOPCONFIG register contains a number of configuration options for the
  * Chopper control.
  */
-struct ChopConfig {
+struct __attribute__((packed, __may_alias__)) ChopConfig {
     static constexpr Registers address = Registers::CHOPCONF;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
@@ -284,13 +283,13 @@ struct ChopConfig {
      * 1 = short to gnd protection disabled
      */
     uint8_t diss2g : 1 = 0;
-} __attribute__((packed)) __attribute__((__may_alias__));
+};
 
 /**
  * COOLCONF contains information to configure the Coolstep and Smartguard (SG)
  * features in the TMC2130
  */
-struct CoolConfig {
+struct __attribute__((packed, __may_alias__)) CoolConfig {
     static constexpr Registers address = Registers::COOLCONF;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
@@ -360,7 +359,7 @@ struct CoolConfig {
      * 1 = filtered mode, SG signal updated for each 4 full steps
      */
     uint8_t sfilt : 1 = 0;
-} __attribute__((packed)) __attribute__((__may_alias__));
+};
 
 // Encapsulates all of the registers that should be configured by software
 struct TMC2130RegisterMap {
@@ -375,5 +374,7 @@ struct TMC2130RegisterMap {
 
 // Registers are all 32 bits
 using RegisterSerializedType = uint32_t;
+// Type definition to allow type aliasing for pointer dereferencing
+using RegisterSerializedTypeA = __attribute__((__may_alias__)) uint32_t;
 
 }  // namespace tmc2130

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
@@ -13,7 +13,7 @@ namespace tmc2130 {
 
 // Register mapping
 
-enum class Registers {
+enum class Registers: uint8_t {
     GCONF = 0x00,
     GSTAT = 0x01,
     IOIN = 0x04,

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
@@ -1,0 +1,381 @@
+/**
+ * @file tmc2130_registers.hpp
+ * @brief Contains register mapping information for the TMC2130 motor
+ * driver IC.
+ * 
+ */
+#pragma once
+
+#include <concepts>
+#include <cstdint>
+
+namespace tmc2130 {
+
+// Register mapping
+
+enum class Registers {
+    GCONF = 0x00,
+    GSTAT = 0x01,
+    IOIN = 0x04,
+    IHOLD_IRUN = 0x10,
+    TPOWERDOWN = 0x11,
+    TSTEP = 0x12,
+    TPWMTHRS = 0x13,
+    TCOOLTHRS = 0x14,
+    THIGH = 0x15,
+    XDIRECT = 0x2D,
+    VDCMIN = 0x33,
+    CHOPCONF = 0x6C,
+    COOLCONF = 0x6D,
+    DCCTRL = 0x6E,
+    DRVSTATUS = 0x6F,
+    PWMCONF = 0x70,
+    ENCM_CTRL = 0x72,
+    MSLUT_0 = 0x60,
+    MSLUT_1 = 0x61,
+    MSLUT_2 = 0x62,
+    MSLUT_3 = 0x63,
+    MSLUT_4 = 0x64,
+    MSLUT_5 = 0x65,
+    MSLUT_6 = 0x66,
+    MSLUT_7 = 0x67,
+    MSLUTSEL = 0x68,
+    MSLUTSTART = 0x69,
+    MSCNT = 0x6A,
+    MSCURACT = 0x6B,
+    PWM_SCALE = 0x71,
+    LOST_STEPS = 0x73,
+};
+
+
+/** Template concept to constrain what structures encapsulate registers.*/
+template <typename Reg>
+concept TMC2130Register = requires(Reg& r, uint64_t value) {
+    // Struct has a valid register address
+    std::same_as<decltype(Reg::address), Registers&>;
+    // Struct has a bool saying whether it can be read
+    std::same_as<decltype(Reg::readable), bool>;
+    // Struct has a bool saying whether it can be written
+    std::same_as<decltype(Reg::writable), bool>;
+    // Struct has an integer with the total number of bits in a register.
+    // This is used to mask the 64-bit value before writing to the IC.
+    std::integral<decltype(Reg::bitlen)>;
+};
+
+struct GConfig {
+    static constexpr Registers address = Registers::GCONF;
+    static constexpr bool readable = true;
+    static constexpr bool writable = true;
+    static constexpr uint64_t bitlen = 17;
+
+    uint8_t i_scale_analog : 1 = 0;
+    uint8_t internal_rsense : 1 = 0;
+    uint8_t en_pwm_mode : 1 = 0;
+    uint8_t enc_commutation : 1 = 0;  // MUST be 0
+    uint8_t shaft : 1 = 0;
+    uint8_t diag0_error : 1 = 0;
+    uint8_t diag0_otpw : 1 = 0;
+    uint8_t diag0_stall : 1 = 0;
+    uint8_t diag1_stall : 1 = 0;
+    uint8_t diag1_index : 1 = 0;
+    uint8_t diag1_onstate : 1 = 0;
+    uint8_t diag1_steps_skipped : 1 = 0;
+    uint8_t diag0_int_pushpull : 1 = 0;
+    uint8_t diag1_pushpull : 1 = 0;
+    uint8_t small_hysteresis : 1 = 0;
+    uint8_t stop_enable : 1 = 0;
+    uint8_t direct_mode : 1 = 0;
+    uint8_t test_mode : 1 = 0;  // MUST be 0
+} __attribute__((packed));
+
+struct GStatus {
+    static constexpr Registers address = Registers::GSTAT;
+    static constexpr bool readable = true;
+    static constexpr bool writable = false;
+    static constexpr uint64_t bitlen = 3;
+
+    uint8_t reset : 1 = 0;
+    uint8_t driver_error : 1 = 0;
+    uint8_t undervoltage_error : 1 = 0;
+} __attribute__((packed));
+
+/**
+ * This register sets the control current for holding and running.
+ */
+struct CurrentControl {
+    static constexpr Registers address = Registers::IHOLD_IRUN;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint64_t bitlen = 20;
+
+    // Arbitrary scale from 0-31
+    uint8_t hold_current : 5 = 0;
+    uint8_t bit_padding_1 : 3 = 0;
+    // Arbitrary scale from 0-31
+    uint8_t run_current : 5 = 0;
+    uint8_t bit_padding_2 : 3 = 0;
+    // Motor powers down after (hold_current_delay * (2^18)) clock cycles
+    uint8_t hold_current_delay : 4 = 0;
+} __attribute__((packed));
+
+/**
+ * This is the time to delay between ending a movement and moving to power-down
+ * current. Scale goes up to "about 4 seconds"
+ */
+struct PowerDownDelay {
+    static constexpr Registers address = Registers::TPOWERDOWN;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint64_t bitlen = 8;
+
+    static constexpr double max_time = 4.0F;
+    static constexpr uint64_t max_val = 0xFF;
+
+    auto seconds() -> double {
+        return (static_cast<double>(time) / static_cast<double>(max_val)) *
+               max_time;
+    }
+    auto set_time(double seconds) -> bool {
+        if (seconds > max_time) {
+            return false;
+        }
+        time = static_cast<uint8_t>((seconds / max_time) *
+                                    static_cast<double>(max_val));
+        return true;
+    }
+
+    uint8_t time = 0;
+
+} __attribute__((packed));
+
+/**
+ * This is the threshold velocity for switching on smart energy coolStep
+ * and stallGuard.
+ */
+struct TCoolThreshold {
+    static constexpr Registers address = Registers::TCOOLTHRS;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint64_t bitlen = 20;
+
+    uint32_t threshold : 20 = 0;
+} __attribute__((packed));
+
+/**
+ * This is the velocity threshold at which the controller will automatically
+ * move into a different chopper mode w/ fullstepping to maximize torque,
+ * applied whenever TSTEP < THIGH
+ */
+struct THigh {
+    static constexpr Registers address = Registers::THIGH;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint64_t bitlen = 20;
+
+    uint32_t threshold : 20 = 0;
+} __attribute__((packed));
+
+/**
+ * The CHOPCONFIG register contains a number of configuration options for the
+ * Chopper control.
+ */
+struct ChopConfig {
+    static constexpr Registers address = Registers::CHOPCONF;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint64_t bitlen = 31;
+
+    /** 0 = Driver disable
+     *  1 = "use only with TBL >= 2"
+     *  2...15 sets duration of slow decay phase:
+     * Nclk = 12 + 32 * TOFF
+     */
+    uint8_t toff : 4 = 0;
+    /**
+     * CHM = 0: sets hysteresis start value added to HEND
+     *  - Add 1,2,...,8 to hysteresis low value HEND
+     *
+     * CHM = 1: sets fast decay time, TFD :
+     *  - Nclk = 32*HSTRT
+     */
+    uint8_t hstrt : 3 = 0;
+    /**
+     * CHM = 0: Hysteresis is -3, -2, -1, ... 12. This is the hysteresis
+     * value used for the hysteresis chopper
+     *
+     * CHM = 1: Sine wave offset. 1/512 of the val gets added to abs of each
+     * sine wave entry
+     */
+    uint8_t hend : 4 = 0;
+    /**
+     * CHM = 1: MSB of fast decay time setting TFD
+     */
+    uint8_t fd3 : 1 = 0;
+    /**
+     * CHM = 1: Fast decay mode. Set to 1 to disable current comparator
+     * usage for termination of fast decay cycle.
+     */
+    uint8_t disfdcc : 1 = 0;
+    /**
+     * 0 = chopper OFF time fixed as set by TOFF (aka hstrt and fd3)
+     *
+     * 1 = Random mode, TOFF is modulated by [-12,3] clocks
+     */
+    uint8_t rndtf : 1 = 0;
+    /**
+     * Chopper mode. 0 = standard mode, 1 = constant off-time with fast decay.
+     */
+    uint8_t chm : 1 = 0;
+    /**
+     * Blank Time Select. Sets comparator blank time to 16,24,36,54
+     */
+    uint8_t tbl : 2 = 2;
+    /**
+     * 0 = low sensitivity, high sense resistor voltage
+     *
+     * 1 = high sensitivity, low sense resistor voltage
+     */
+    uint8_t vsense : 1 = 0;
+    /**
+     * High velocity fullstep selection: Enables switching to fullstep when
+     * VHIGH is exceeded. Only switches at 45º position.
+     */
+    uint8_t vhighfs : 1 = 0;
+    /**
+     * High Velocity Chopper Mode: Enables switching to chm=1 and fd=0 when
+     * VHIGH is exceeded. If set, the TOFF setting automatically becomes
+     * doubled during high velocity operation.
+     */
+    uint8_t vhighchm : 1 = 0;
+    /**
+     * SYNC PWM synchronization clock: Allows synchroniation of the chopper
+     * for both phases of a two phase motor to avoid occurrence of a beat.
+     * Automatically switched off above VHIGH
+     *
+     * 0 = disabled
+     *
+     * 1...15 = synchronized with fsync = fclk/(sync*64)
+     */
+    uint8_t sync : 4 = 0;
+    /**
+     * Microstep resolution:
+     *
+     * 0 = native 256 microstep setting
+     *
+     * 0b1...0b1000 = 128,64,32,16,8,4,2,FULLSTEP
+     *
+     * Reduced microstep resolution for STEP/DIR operation. Resolution gives
+     * the number of microstep entries per sine quarter wave.
+     */
+    uint8_t mres : 4 = 0;
+    /**
+     * Interpolation to 256 microsteps: If set, the actual MRES becomes
+     * extrapolated to 256 usteps for smoothest motor operation
+     */
+    uint8_t intpol : 1 = 0;
+    /**
+     * Enable double edge step pulses: If set, enable step impulse at each
+     * step edge to reduce step frequency requirement
+     */
+    uint8_t dedge : 1 = 0;
+    /**
+     * Short to GND protectino disable:
+     *
+     * 0 = short to gnd protection on
+     *
+     * 1 = short to gnd protection disabled
+     */
+    uint8_t diss2g : 1 = 0;
+} __attribute__((packed));
+
+/**
+ * COOLCONF contains information to configure the Coolstep and Smartguard (SG)
+ * features in the TMC2130
+ */
+struct CoolConfig {
+    static constexpr Registers address = Registers::COOLCONF;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint64_t bitlen = 25;
+
+    /**
+     * Minimum SG value for smart current control & smart current enable.
+     *
+     * If SG result falls below SEMIN*32, motor current increases to
+     * reduce motor load angle.
+     *
+     * 0 = smart current control coolStep OFF
+     *
+     * 1..15 = set threshold value
+     */
+    uint8_t semin : 4 = 0;
+    uint8_t padding_1 : 1 = 0;
+    /**
+     * Current up step width: Current increment steps per measured SG value:
+     *
+     * 1,2,4,8
+     */
+    uint8_t seup : 2 = 0;
+    uint8_t padding_2 : 1 = 0;
+    /**
+     * If the SG result is >= (SEMIN+SEMAX+1)*32, motor current decreases
+     * to save energy.
+     */
+    uint8_t semax : 4 = 0;
+    uint8_t padding_3 : 1 = 0;
+    /**
+     * Current down step speed:
+     *
+     * 0: for each 32 SG values, decrease by one
+     *
+     * 1: for each 8 SG values, decrease by one
+     *
+     * 2: for each 2 SG values, decrease by one
+     *
+     * 3: for each SG value, decrease by one
+     */
+    uint8_t sedn : 2 = 0;
+    /**
+     * Minimum current for smart current control:
+     *
+     * 0 = 1/2 of current setting in IRUN
+     *
+     * 1 = 1/4 of current setting in IRUN
+     */
+    uint8_t seimin : 1 = 0;
+    /**
+     * SG Threshold Value: This signed value controlls SG level for stall
+     * output and sets optimum measurement range for readout. A lower val
+     * gives a higher sensitivity. Zero is starting value working with most
+     * motors.
+     *
+     * -64 to +63: Higher value makes SG less sensitive and requires more
+     * torque to indicate a stall
+     */
+    int8_t sgt : 7 = 0;
+    uint8_t padding_4 : 1 = 0;
+    /**
+     * SG filter enable:
+     *
+     * 0 = standard mode, high time res for SG
+     *
+     * 1 = filtered mode, SG signal updated for each 4 full steps
+     */
+    uint8_t sfilt : 1 = 0;
+} __attribute__((packed));
+
+// Encapsulates all of the registers that should be configured by software
+struct TMC2130RegisterMap {
+    GConfig gconfig = {};
+    CurrentControl ihold_irun = {};
+    PowerDownDelay tpowerdown = {};
+    TCoolThreshold tcoolthrs = {};
+    THigh thigh = {};
+    ChopConfig chopconf = {};
+    CoolConfig coolconf = {};
+};
+
+// Registers are all 32 bits
+using RegisterSerializedType = uint32_t;
+
+}

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
@@ -130,17 +130,16 @@ struct PowerDownDelay {
     static constexpr double max_time = 4.0F;
     static constexpr uint64_t max_val = 0xFF;
 
-    auto seconds() -> double {
-        return (static_cast<double>(time) / static_cast<double>(max_val)) *
+    [[nodiscard]] static auto reg_to_seconds(uint8_t reg) -> double {
+        return (static_cast<double>(reg) / static_cast<double>(max_val)) *
                max_time;
     }
-    auto set_time(double seconds) -> bool {
+    static auto seconds_to_reg(double seconds) -> uint8_t {
         if (seconds > max_time) {
-            return false;
+            return max_val;
         }
-        time = static_cast<uint8_t>((seconds / max_time) *
+        return static_cast<uint8_t>((seconds / max_time) *
                                     static_cast<double>(max_val));
-        return true;
     }
 
     uint8_t time = 0;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
@@ -85,7 +85,7 @@ struct GConfig {
     uint8_t stop_enable : 1 = 0;
     uint8_t direct_mode : 1 = 0;
     uint8_t test_mode : 1 = 0;  // MUST be 0
-} __attribute__((packed));
+} __attribute__((packed)) __attribute__((__may_alias__));
 
 struct GStatus {
     static constexpr Registers address = Registers::GSTAT;
@@ -96,7 +96,7 @@ struct GStatus {
     uint8_t undervoltage_error : 1 = 0;
     uint8_t driver_error : 1 = 0;
     uint8_t reset : 1 = 0;
-} __attribute__((packed));
+} __attribute__((packed)) __attribute__((__may_alias__));
 
 /**
  * This register sets the control current for holding and running.
@@ -115,7 +115,7 @@ struct CurrentControl {
     uint8_t bit_padding_2 : 3 = 0;
     // Motor powers down after (hold_current_delay * (2^18)) clock cycles
     uint8_t hold_current_delay : 4 = 0;
-} __attribute__((packed));
+} __attribute__((packed)) __attribute__((__may_alias__));
 
 /**
  * This is the time to delay between ending a movement and moving to power-down
@@ -144,7 +144,7 @@ struct PowerDownDelay {
 
     uint8_t time = 0;
 
-} __attribute__((packed));
+} __attribute__((packed)) __attribute__((__may_alias__));
 
 /**
  * This is the threshold velocity for switching on smart energy coolStep
@@ -157,7 +157,7 @@ struct TCoolThreshold {
     static constexpr uint64_t bitlen = 20;
 
     uint32_t threshold : 20 = 0;
-} __attribute__((packed));
+} __attribute__((packed)) __attribute__((__may_alias__));
 
 /**
  * This is the velocity threshold at which the controller will automatically
@@ -171,7 +171,7 @@ struct THigh {
     static constexpr uint64_t bitlen = 20;
 
     uint32_t threshold : 20 = 0;
-} __attribute__((packed));
+} __attribute__((packed)) __attribute__((__may_alias__));
 
 /**
  * The CHOPCONFIG register contains a number of configuration options for the
@@ -284,7 +284,7 @@ struct ChopConfig {
      * 1 = short to gnd protection disabled
      */
     uint8_t diss2g : 1 = 0;
-} __attribute__((packed));
+} __attribute__((packed)) __attribute__((__may_alias__));
 
 /**
  * COOLCONF contains information to configure the Coolstep and Smartguard (SG)
@@ -360,7 +360,7 @@ struct CoolConfig {
      * 1 = filtered mode, SG signal updated for each 4 full steps
      */
     uint8_t sfilt : 1 = 0;
-} __attribute__((packed));
+} __attribute__((packed)) __attribute__((__may_alias__));
 
 // Encapsulates all of the registers that should be configured by software
 struct TMC2130RegisterMap {

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
@@ -2,7 +2,7 @@
  * @file tmc2130_registers.hpp
  * @brief Contains register mapping information for the TMC2130 motor
  * driver IC.
- * 
+ *
  */
 #pragma once
 
@@ -46,7 +46,6 @@ enum class Registers {
     PWM_SCALE = 0x71,
     LOST_STEPS = 0x73,
 };
-
 
 /** Template concept to constrain what structures encapsulate registers.*/
 template <typename Reg>
@@ -378,4 +377,4 @@ struct TMC2130RegisterMap {
 // Registers are all 32 bits
 using RegisterSerializedType = uint32_t;
 
-}
+}  // namespace tmc2130

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/tmc2130_registers.hpp
@@ -93,9 +93,9 @@ struct GStatus {
     static constexpr bool writable = false;
     static constexpr uint64_t bitlen = 3;
 
-    uint8_t reset : 1 = 0;
-    uint8_t driver_error : 1 = 0;
     uint8_t undervoltage_error : 1 = 0;
+    uint8_t driver_error : 1 = 0;
+    uint8_t reset : 1 = 0;
 } __attribute__((packed));
 
 /**

--- a/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
@@ -25,6 +25,7 @@ set(${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS
   ${THERMAL_DIR}/thermal_plate_policy.cpp
   ${THERMAL_DIR}/freertos_lid_heater_task.cpp
   ${THERMAL_DIR}/lid_heater_policy.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/motor_task/motor_spi_hardware.c
   )
 
 # Add source files that should NOT be checked by clang-tidy here

--- a/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/firmware/CMakeLists.txt
@@ -25,7 +25,6 @@ set(${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS
   ${THERMAL_DIR}/thermal_plate_policy.cpp
   ${THERMAL_DIR}/freertos_lid_heater_task.cpp
   ${THERMAL_DIR}/lid_heater_policy.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/motor_task/motor_spi_hardware.c
   )
 
 # Add source files that should NOT be checked by clang-tidy here
@@ -43,6 +42,7 @@ set(${TARGET_MODULE_NAME}_FW_NONLINTABLE_SRCS
   ${THERMAL_DIR}/thermal_peltier_hardware.c
   ${THERMAL_DIR}/thermal_fan_hardware.c
   ${THERMAL_DIR}/thermal_heater_hardware.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/motor_task/motor_spi_hardware.c
   )
 
 add_executable(${TARGET_MODULE_NAME}

--- a/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_spi_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_spi_hardware.c
@@ -1,0 +1,138 @@
+/**
+ * @file motor_spi_hardware.c
+ * @brief SPI interface to communicate with the Trinamic TMC2130 motor driver
+ */
+
+#include "firmware/motor_spi_hardware.h"
+// HAL includes
+#include "stm32g4xx_hal_dma.h" // Required to link to hal_spi
+#include "stm32g4xx_hal_spi.h"
+// FreeRTOS includes
+#include "FreeRTOS.h"
+#include "semphr.h"
+#include "task.h"
+
+// LOCAL DEFINES
+
+/** Flag to mark a SPI Write to the chip.*/
+#define FLAG_WRITE  (0x80)
+/** Flag to mark a SPI Read to the chip.*/
+#define FLAG_READ   (0x00)
+/** Empty byte to write when reading.*/
+#define EMPTY_WRITE (0x00)
+/** Length of an entire message is 5 bytes: status byte + 4 register bytes.*/
+#define TMC_MESSAGE_SIZE (1 + 4)
+/** Default register to read from if we don't care about return.*/
+#define READ_REG_DEFAULT (0x00 | FLAG_READ)
+
+/** Get a single byte out of a 64 bit value. Higher values are
+ *  more significant (0 = LSB, 3 = MSB)*/
+#define GET_BYTE(val, byte) ((uint8_t)((val >> (byte * 8)) & 0xFF))
+/** Move a single byte to fit into a 64 bit value. Higher \c byte
+ * values are more significant (0 = LSB, 3 = MSB).*/
+#define SET_BYTE(val, byte) (((uint64_t)val) << (byte * 8))
+
+struct motor_spi_hardware {
+    SPI_HandleTypeDef handle;
+    TaskHandle_t task_to_notify;
+    bool initialized;
+};
+
+// STATIC VARIABLES
+static struct motor_spi_hardware _spi = {
+    .handle = {0},
+    .task_to_notify =  NULL,
+    .initialized = false
+};
+
+// STATIC FUNCTION DEFINITIONS
+static void spi_interrupt_service(void);
+
+// PUBLIC FUNCTION IMPLEMENTATION
+
+void motor_spi_initialize(void) {
+    if(!_spi.initialized) {
+        HAL_StatusTypeDef ret;
+        _spi.handle.Instance = SPI2;
+        _spi.handle.Init.Mode = SPI_MODE_MASTER;
+        _spi.handle.Init.Direction = SPI_DIRECTION_2LINES;
+        _spi.handle.Init.DataSize = SPI_DATASIZE_8BIT;
+        _spi.handle.Init.CLKPolarity = SPI_POLARITY_HIGH;
+        _spi.handle.Init.CLKPhase = SPI_PHASE_2EDGE;
+        _spi.handle.Init.NSS = SPI_NSS_HARD_OUTPUT;
+        _spi.handle.Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16;
+        _spi.handle.Init.FirstBit = SPI_FIRSTBIT_MSB;
+        _spi.handle.Init.TIMode = SPI_TIMODE_DISABLE;
+        _spi.handle.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
+        _spi.handle.Init.CRCPolynomial = 7;
+        _spi.handle.Init.CRCLength = SPI_CRC_LENGTH_DATASIZE;
+        _spi.handle.Init.NSSPMode = SPI_NSS_PULSE_DISABLE;
+        ret = HAL_SPI_Init(&_spi.handle);
+        configASSERT(ret == HAL_OK);
+        _spi.initialized = true;
+    }
+}
+
+bool motor_spi_sendreceive(uint8_t *in, uint8_t *out, size_t len) {
+    const TickType_t max_block_time = pdMS_TO_TICKS(100);
+    HAL_StatusTypeDef ret;
+    uint32_t notification_val = 0;
+
+    if(!_spi.initialized || (_spi.task_to_notify != NULL)) { 
+        return false;
+    }
+
+    _spi.task_to_notify = xTaskGetCurrentTaskHandle();
+    ret = HAL_SPI_TransmitReceive_IT(&_spi.handle, in, out, len);
+    if(ret != HAL_OK) {
+        _spi.task_to_notify = NULL;
+        return false;
+    }
+    notification_val = ulTaskNotifyTake(pdTRUE, max_block_time);
+    if(notification_val != 1) {
+        _spi.task_to_notify = NULL;
+        return false;
+    }
+    return true;
+}
+
+void SPI2_IRQHandler(void)
+{
+  /* USER CODE BEGIN SPI2_IRQn 0 */
+
+  /* USER CODE END SPI2_IRQn 0 */
+  HAL_SPI_IRQHandler(&_spi.handle);
+  /* USER CODE BEGIN SPI2_IRQn 1 */
+
+  /* USER CODE END SPI2_IRQn 1 */
+}
+
+// STATIC FUNCTION IMPLEMENTATION
+
+static void spi_interrupt_service(void) {
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    if( _spi.task_to_notify == NULL ) {
+        return;
+    }
+    vTaskNotifyGiveFromISR( _spi.task_to_notify, &xHigherPriorityTaskWoken );
+    _spi.task_to_notify = NULL;
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+}
+
+/**
+ * @brief Overwritten HAL function for SPI TxRx Complete Callback.
+ * @details If a task is blocked waiting for the SPI transaction to finish,
+ * this function unblocks that task.
+ */
+void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi) {
+    spi_interrupt_service();
+}
+
+/**
+ * @brief Overwritten HAL function for SPI Error Callback.
+ * @details If a task is blocked waiting for the SPI transaction to finish,
+ * this function unblocks that task.
+ */
+void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi) {
+    spi_interrupt_service();
+}

--- a/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_spi_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_spi_hardware.c
@@ -26,8 +26,6 @@
 #define EMPTY_WRITE (0x00)
 /** Length of an entire message is 5 bytes: status byte + 4 register bytes.*/
 #define TMC_MESSAGE_SIZE (1 + 4)
-/** Default register to read from if we don't care about return.*/
-#define READ_REG_DEFAULT (0x00 | FLAG_READ)
 
 /** Port for the enable pin.*/
 #define MOTOR_SPI_ENABLE_PORT (GPIOE)
@@ -149,13 +147,7 @@ bool motor_set_output_enable(bool enable) {
 
 void SPI2_IRQHandler(void)
 {
-  /* USER CODE BEGIN SPI2_IRQn 0 */
-
-  /* USER CODE END SPI2_IRQn 0 */
   HAL_SPI_IRQHandler(&_spi.handle);
-  /* USER CODE BEGIN SPI2_IRQn 1 */
-
-  /* USER CODE END SPI2_IRQn 1 */
 }
 
 // STATIC FUNCTION IMPLEMENTATION

--- a/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_spi_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_spi_hardware.c
@@ -139,7 +139,7 @@ bool motor_spi_sendreceive(uint8_t *in, uint8_t *out, size_t len) {
     return true;
 }
 
-bool motor_spi_set_enable(bool enable) {
+bool motor_set_output_enable(bool enable) {
     if(!_spi.initialized) { return false; }
     _spi.enabled = enable;
     HAL_GPIO_WritePin(MOTOR_SPI_ENABLE_PORT, MOTOR_SPI_ENABLE_PIN, 

--- a/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_spi_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_spi_hardware.c
@@ -108,7 +108,7 @@ void motor_spi_initialize(void) {
         HAL_GPIO_Init(MOTOR_SPI_NSS_PORT, &gpio);
         spi_set_nss(false);
 
-        motor_spi_set_enable(false);
+        motor_set_output_enable(false);
     }
 }
 

--- a/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_spi_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_spi_hardware.c
@@ -7,6 +7,8 @@
 // HAL includes
 #include "stm32g4xx_hal_dma.h" // Required to link to hal_spi
 #include "stm32g4xx_hal_spi.h"
+#include "stm32g4xx_hal_gpio.h"
+#include "stm32g4xx_hal_rcc.h"
 // FreeRTOS includes
 #include "FreeRTOS.h"
 #include "semphr.h"
@@ -25,6 +27,11 @@
 /** Default register to read from if we don't care about return.*/
 #define READ_REG_DEFAULT (0x00 | FLAG_READ)
 
+/** Port for the enable pin.*/
+#define MOTOR_SPI_ENABLE_PORT (GPIOE)
+/** Pin for enable pin.*/
+#define MOTOR_SPI_ENABLE_PIN (GPIO_PIN_15)
+
 /** Get a single byte out of a 64 bit value. Higher values are
  *  more significant (0 = LSB, 3 = MSB)*/
 #define GET_BYTE(val, byte) ((uint8_t)((val >> (byte * 8)) & 0xFF))
@@ -35,6 +42,7 @@
 struct motor_spi_hardware {
     SPI_HandleTypeDef handle;
     TaskHandle_t task_to_notify;
+    bool enabled;
     bool initialized;
 };
 
@@ -42,6 +50,7 @@ struct motor_spi_hardware {
 static struct motor_spi_hardware _spi = {
     .handle = {0},
     .task_to_notify =  NULL,
+    .enabled = false,
     .initialized = false
 };
 
@@ -60,7 +69,7 @@ void motor_spi_initialize(void) {
         _spi.handle.Init.CLKPolarity = SPI_POLARITY_HIGH;
         _spi.handle.Init.CLKPhase = SPI_PHASE_2EDGE;
         _spi.handle.Init.NSS = SPI_NSS_HARD_OUTPUT;
-        _spi.handle.Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16;
+        _spi.handle.Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_128;
         _spi.handle.Init.FirstBit = SPI_FIRSTBIT_MSB;
         _spi.handle.Init.TIMode = SPI_TIMODE_DISABLE;
         _spi.handle.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
@@ -69,7 +78,18 @@ void motor_spi_initialize(void) {
         _spi.handle.Init.NSSPMode = SPI_NSS_PULSE_DISABLE;
         ret = HAL_SPI_Init(&_spi.handle);
         configASSERT(ret == HAL_OK);
+
+        // Initialize the GPIO
+        __HAL_RCC_GPIOE_CLK_ENABLE();
+        GPIO_InitTypeDef gpio = {0};
+        gpio.Pin = MOTOR_SPI_ENABLE_PIN;
+        gpio.Mode = GPIO_MODE_OUTPUT_PP;
+        gpio.Pull = GPIO_NOPULL;
+        gpio.Speed = GPIO_SPEED_LOW;
+        HAL_GPIO_Init(MOTOR_SPI_ENABLE_PORT, &gpio);
         _spi.initialized = true;
+
+        motor_spi_set_enable(false);
     }
 }
 
@@ -93,6 +113,14 @@ bool motor_spi_sendreceive(uint8_t *in, uint8_t *out, size_t len) {
         _spi.task_to_notify = NULL;
         return false;
     }
+    return true;
+}
+
+bool motor_spi_set_enable(bool enable) {
+    if(!_spi.initialized) { return false; }
+    _spi.enabled = enable;
+    HAL_GPIO_WritePin(MOTOR_SPI_ENABLE_PORT, MOTOR_SPI_ENABLE_PIN, 
+        (enable) ? GPIO_PIN_RESET : GPIO_PIN_SET);
     return true;
 }
 

--- a/stm32-modules/thermocycler-refresh/firmware/system/stm32g4xx_hal_msp.c
+++ b/stm32-modules/thermocycler-refresh/firmware/system/stm32g4xx_hal_msp.c
@@ -255,6 +255,91 @@ void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* htim_base)
 
 }
 
+/**
+* @brief SPI MSP Initialization
+* This function configures the hardware resources used in this example
+* @param hspi: SPI handle pointer
+* @retval None
+*/
+void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi)
+{
+  GPIO_InitTypeDef GPIO_InitStruct = {0};
+  if(hspi->Instance==SPI2)
+  {
+  /* USER CODE BEGIN SPI2_MspInit 0 */
+
+  /* USER CODE END SPI2_MspInit 0 */
+    /* Peripheral clock enable */
+    __HAL_RCC_SPI2_CLK_ENABLE();
+
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOD_CLK_ENABLE();
+    /**SPI2 GPIO Configuration
+    PB13     ------> SPI2_SCK
+    PB14     ------> SPI2_MISO
+    PB15     ------> SPI2_MOSI
+    PD15     ------> SPI2_NSS
+    */
+    GPIO_InitStruct.Pin = GPIO_PIN_13|GPIO_PIN_14|GPIO_PIN_15;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
+    HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+    GPIO_InitStruct.Pin = GPIO_PIN_15;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Alternate = GPIO_AF6_SPI2;
+    HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
+
+    /* SPI2 interrupt Init */
+    HAL_NVIC_SetPriority(SPI2_IRQn, 5, 0);
+    HAL_NVIC_EnableIRQ(SPI2_IRQn);
+  /* USER CODE BEGIN SPI2_MspInit 1 */
+
+  /* USER CODE END SPI2_MspInit 1 */
+  }
+
+}
+
+/**
+* @brief SPI MSP De-Initialization
+* This function freeze the hardware resources used in this example
+* @param hspi: SPI handle pointer
+* @retval None
+*/
+void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi)
+{
+  if(hspi->Instance==SPI2)
+  {
+  /* USER CODE BEGIN SPI2_MspDeInit 0 */
+
+  /* USER CODE END SPI2_MspDeInit 0 */
+    /* Peripheral clock disable */
+    __HAL_RCC_SPI2_CLK_DISABLE();
+
+    /**SPI2 GPIO Configuration
+    PB13     ------> SPI2_SCK
+    PB14     ------> SPI2_MISO
+    PB15     ------> SPI2_MOSI
+    PD15     ------> SPI2_NSS
+    */
+    HAL_GPIO_DeInit(GPIOB, GPIO_PIN_13|GPIO_PIN_14|GPIO_PIN_15);
+
+    HAL_GPIO_DeInit(GPIOD, GPIO_PIN_15);
+
+    /* SPI2 interrupt DeInit */
+    HAL_NVIC_DisableIRQ(SPI2_IRQn);
+  /* USER CODE BEGIN SPI2_MspDeInit 1 */
+
+  /* USER CODE END SPI2_MspDeInit 1 */
+  }
+
+}
+
+
 /* USER CODE BEGIN 1 */
 
 /* USER CODE END 1 */

--- a/stm32-modules/thermocycler-refresh/firmware/system/stm32g4xx_hal_msp.c
+++ b/stm32-modules/thermocycler-refresh/firmware/system/stm32g4xx_hal_msp.c
@@ -287,12 +287,13 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi)
     GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin = GPIO_PIN_15;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-    GPIO_InitStruct.Alternate = GPIO_AF6_SPI2;
-    HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
+    // Uncomment to intialize PD15 as a hardware NSS signal
+    //GPIO_InitStruct.Pin = GPIO_PIN_15;
+    //GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    //GPIO_InitStruct.Pull = GPIO_NOPULL;
+    //GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    //GPIO_InitStruct.Alternate = GPIO_AF6_SPI2;
+    //HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
     /* SPI2 interrupt Init */
     HAL_NVIC_SetPriority(SPI2_IRQn, 5, 0);

--- a/stm32-modules/thermocycler-refresh/firmware/system/stm32g4xx_hal_msp.c
+++ b/stm32-modules/thermocycler-refresh/firmware/system/stm32g4xx_hal_msp.c
@@ -287,14 +287,6 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi)
     GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
-    // Uncomment to intialize PD15 as a hardware NSS signal
-    //GPIO_InitStruct.Pin = GPIO_PIN_15;
-    //GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    //GPIO_InitStruct.Pull = GPIO_NOPULL;
-    //GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-    //GPIO_InitStruct.Alternate = GPIO_AF6_SPI2;
-    //HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
-
     /* SPI2 interrupt Init */
     HAL_NVIC_SetPriority(SPI2_IRQn, 5, 0);
     HAL_NVIC_EnableIRQ(SPI2_IRQn);

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_system_policy.cpp
     test_system_task.cpp
     test_thermal_plate_task.cpp
+    test_tmc2130.cpp
     # GCode parse tests
     test_m14.cpp
     test_m104.cpp

--- a/stm32-modules/thermocycler-refresh/tests/test_tmc2130.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_tmc2130.cpp
@@ -1,0 +1,39 @@
+#include <array>
+
+#include "catch2/catch.hpp"
+#include "systemwide.h"
+#include "thermocycler-refresh/tmc2130.hpp"
+#include "test/test_tmc2130_policy.hpp"
+
+// Full register map to make iterating less painful
+static constexpr std::array<tmc2130::Registers, 11> _registers = {
+    tmc2130::Registers::general_config,
+    tmc2130::Registers::general_status,
+    tmc2130::Registers::io_input,
+    tmc2130::Registers::ihold_irun,
+    tmc2130::Registers::tpower_down,
+    tmc2130::Registers::tstep,
+    tmc2130::Registers::tpwmthrs,
+    tmc2130::Registers::tcoolthrs,
+    tmc2130::Registers::thigh,
+    tmc2130::Registers::xdirect,
+    tmc2130::Registers::vdcmin,
+};
+
+SCENARIO("tmc2130 register logic works") {
+    GIVEN("a tmc2130 and a blank register map") {
+        tmc2130::TMC2130 tmc;
+        TestTMC2130Policy policy;
+
+        WHEN("setting gconfig register to all 0") {
+            tmc2130::GConf gconf;
+            auto ret = tmc.set_register(policy, gconf);
+            REQUIRE(ret);
+            THEN("the register reads all 0's") {
+                auto reg_val = policy.read_register(tmc2130::Registers::general_config);
+                REQUIRE(reg_val.has_value());
+                REQUIRE(reg_val.value() == 0);
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_tmc2130.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_tmc2130.cpp
@@ -5,17 +5,7 @@
 #include "test/test_tmc2130_policy.hpp"
 #include "thermocycler-refresh/tmc2130.hpp"
 
-// Full register map to make iterating less painful
-static constexpr std::array<tmc2130::Registers, 11> _registers = {
-    tmc2130::Registers::general_config, tmc2130::Registers::general_status,
-    tmc2130::Registers::io_input,       tmc2130::Registers::ihold_irun,
-    tmc2130::Registers::tpower_down,    tmc2130::Registers::tstep,
-    tmc2130::Registers::tpwmthrs,       tmc2130::Registers::tcoolthrs,
-    tmc2130::Registers::thigh,          tmc2130::Registers::xdirect,
-    tmc2130::Registers::vdcmin,
-};
-
-SCENARIO("tmc2130 register logic works") {
+SCENARIO("tmc2130 register structures work") {
     GIVEN("a tmc2130 and a blank register map") {
         tmc2130::TMC2130 tmc;
         TestTMC2130Policy policy;
@@ -25,8 +15,7 @@ SCENARIO("tmc2130 register logic works") {
             auto ret = tmc.set_register(policy, gconf);
             REQUIRE(ret);
             THEN("the register reads all 0's") {
-                auto reg_val =
-                    policy.read_register(tmc2130::Registers::general_config);
+                auto reg_val = policy.read_register(tmc2130::Registers::GCONF);
                 REQUIRE(reg_val.has_value());
                 REQUIRE(reg_val.value() == 0);
             }
@@ -37,8 +26,7 @@ SCENARIO("tmc2130 register logic works") {
             auto ret = tmc.set_register(policy, gconf);
             REQUIRE(ret);
             THEN("the register reads correctly") {
-                auto reg_val =
-                    policy.read_register(tmc2130::Registers::general_config);
+                auto reg_val = policy.read_register(tmc2130::Registers::GCONF);
                 REQUIRE(reg_val.has_value());
                 static constexpr uint64_t expected = 0x10021;
                 REQUIRE(reg_val.value() == expected);
@@ -63,33 +51,81 @@ SCENARIO("tmc2130 register logic works") {
             REQUIRE(ret);
             THEN("the register should be set correctly") {
                 auto reg_val =
-                    policy.read_register(tmc2130::Registers::ihold_irun);
+                    policy.read_register(tmc2130::Registers::IHOLD_IRUN);
                 REQUIRE(reg_val.has_value());
                 REQUIRE(reg_val.value() == expected);
             }
         }
-        WHEN("setting PowerDownDelay to max time") {
-            tmc2130::PowerDownDelay reg{.time =
-                                            tmc2130::PowerDownDelay::max_time};
-            static constexpr uint64_t expected = 0xFF;
-            auto ret = tmc.set_register(policy, reg);
-            REQUIRE(ret);
-            THEN("the register should be set correctly") {
-                auto reg_val =
-                    policy.read_register(tmc2130::Registers::tpower_down);
-                REQUIRE(reg_val.has_value());
-                REQUIRE(reg_val.value() == expected);
-            }
-        }
-        WHEN("setting PowerDownDelay to max time") {
+        WHEN("setting PowerDownDelay to max time / 2") {
             tmc2130::PowerDownDelay reg{
-                .time = tmc2130::PowerDownDelay::max_time / 2};
-            static constexpr uint64_t expected = 0xFF / 2;
+                .time = tmc2130::PowerDownDelay::max_val / 2};
+            static constexpr double expected_time =
+                tmc2130::PowerDownDelay::max_time / 2;
+            REQUIRE_THAT(reg.seconds(),
+                         Catch::Matchers::WithinAbs(expected_time, 0.1));
             auto ret = tmc.set_register(policy, reg);
             REQUIRE(ret);
             THEN("the register should be set correctly") {
                 auto reg_val =
-                    policy.read_register(tmc2130::Registers::tpower_down);
+                    policy.read_register(tmc2130::Registers::TPOWERDOWN);
+                REQUIRE(reg_val.has_value());
+                REQUIRE(reg_val.value() ==
+                        tmc2130::PowerDownDelay::max_val / 2);
+            }
+            THEN("setting the struct's time to 1 second") {
+                REQUIRE(reg.set_time(1.0F));
+                THEN("the time should be updated correctly") {
+                    REQUIRE_THAT(reg.seconds(),
+                                 Catch::Matchers::WithinAbs(1.0F, 0.1));
+                }
+            }
+        }
+        WHEN("setting TCoolThreshold") {
+            tmc2130::TCoolThreshold reg{.threshold = 0xABCDE};
+            static constexpr uint64_t expected = 0xABCDE;
+            auto ret = tmc.set_register(policy, reg);
+            REQUIRE(ret);
+            THEN("the register should be set correctly") {
+                auto reg_val =
+                    policy.read_register(tmc2130::Registers::TCOOLTHRS);
+                REQUIRE(reg_val.has_value());
+                REQUIRE(reg_val.value() == expected);
+            }
+        }
+        WHEN("setting THigh") {
+            tmc2130::THigh reg{.threshold = 0xABCDE};
+            static constexpr uint64_t expected = 0xABCDE;
+            auto ret = tmc.set_register(policy, reg);
+            REQUIRE(ret);
+            THEN("the register should be set correctly") {
+                auto reg_val = policy.read_register(tmc2130::Registers::THIGH);
+                REQUIRE(reg_val.has_value());
+                REQUIRE(reg_val.value() == expected);
+            }
+        }
+        WHEN("setting ChopConfig") {
+            tmc2130::ChopConfig chop{.toff = 0xA,
+                                     .hstrt = 4,
+                                     .hend = 0,
+                                     .fd3 = 1,
+                                     .disfdcc = 0,
+                                     .rndtf = 1,
+                                     .chm = 1,
+                                     .tbl = 1,
+                                     .vsense = 0,
+                                     .vhighfs = 1,
+                                     .vhighchm = 0,
+                                     .sync = 0xA,
+                                     .mres = 0xA,
+                                     .intpol = 0,
+                                     .dedge = 1,
+                                     .diss2g = 0};
+            static constexpr uint64_t expected = 0x2AA4E84A;
+            auto ret = tmc.set_register(policy, chop);
+            REQUIRE(ret);
+            THEN("the register should be set correctly") {
+                auto reg_val =
+                    policy.read_register(tmc2130::Registers::CHOPCONF);
                 REQUIRE(reg_val.has_value());
                 REQUIRE(reg_val.value() == expected);
             }

--- a/stm32-modules/thermocycler-refresh/tests/test_tmc2130.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_tmc2130.cpp
@@ -35,5 +35,30 @@ SCENARIO("tmc2130 register logic works") {
                 REQUIRE(reg_val.value() == 0);
             }
         }
+        WHEN("setting gconfig register to have some nonzero elements") {
+            tmc2130::GConf gconf {
+                .i_scale_analog = 1,
+                .diag0_error = 1,
+                .direct_mode = 1
+            };
+            auto ret = tmc.set_register(policy, gconf);
+            REQUIRE(ret);
+            THEN("the register reads correctly") {
+                auto reg_val = policy.read_register(tmc2130::Registers::general_config);
+                REQUIRE(reg_val.has_value());
+                static constexpr uint64_t expected = 0x10021;
+                REQUIRE(reg_val.value() == expected);
+            }
+            AND_WHEN("reading back the register") {
+                auto readback = tmc.get_register<tmc2130::GConf>(policy);
+                REQUIRE(readback.has_value());
+                auto readback_val = readback.value();
+                REQUIRE(readback_val.i_scale_analog == 1);
+                REQUIRE(readback_val.diag0_error == 1);
+                REQUIRE(readback_val.direct_mode == 1);
+                REQUIRE(readback_val.stop_enable == 0);
+                REQUIRE(readback_val.shaft == 0);
+            }
+        }
     }
 }

--- a/stm32-modules/thermocycler-refresh/tests/test_tmc2130.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_tmc2130.cpp
@@ -5,6 +5,17 @@
 #include "test/test_tmc2130_policy.hpp"
 #include "thermocycler-refresh/tmc2130.hpp"
 
+SCENARIO("tmc2130 register structures are defined correctly") {
+    REQUIRE(sizeof(tmc2130::GConfig) <= sizeof(uint32_t));
+    REQUIRE(sizeof(tmc2130::GStatus) <= sizeof(uint32_t));
+    REQUIRE(sizeof(tmc2130::CurrentControl) <= sizeof(uint32_t));
+    REQUIRE(sizeof(tmc2130::PowerDownDelay) <= sizeof(uint32_t));
+    REQUIRE(sizeof(tmc2130::TCoolThreshold) <= sizeof(uint32_t));
+    REQUIRE(sizeof(tmc2130::THigh) <= sizeof(uint32_t));
+    REQUIRE(sizeof(tmc2130::ChopConfig) <= sizeof(uint32_t));
+    REQUIRE(sizeof(tmc2130::CoolConfig) <= sizeof(uint32_t));
+}
+
 SCENARIO("tmc2130 interface class API works") {
     GIVEN("a tmc2130 interface and a blank register map") {
         tmc2130::TMC2130Interface spi;
@@ -81,7 +92,7 @@ SCENARIO("tmc2130 register API works") {
                 REQUIRE(reg_val.value() == expected);
             }
             AND_WHEN("reading back the register") {
-                auto readback = tmc.get_gconf();
+                auto readback = tmc.get_gconf(policy);
                 REQUIRE(readback.i_scale_analog == 1);
                 REQUIRE(readback.diag0_error == 1);
                 REQUIRE(readback.direct_mode == 1);
@@ -91,7 +102,7 @@ SCENARIO("tmc2130 register API works") {
                     readback.en_pwm_mode = 1;
                     REQUIRE(tmc.set_gconf(readback, policy));
                     THEN("the updated value should be reflected") {
-                        gconf = tmc.get_gconf();
+                        gconf = tmc.get_gconf(policy);
                         REQUIRE(gconf.en_pwm_mode == 1);
                         REQUIRE(readback.i_scale_analog == 1);
                         REQUIRE(readback.diag0_error == 1);

--- a/stm32-modules/thermocycler-refresh/tests/test_tmc2130.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_tmc2130.cpp
@@ -5,14 +5,14 @@
 #include "test/test_tmc2130_policy.hpp"
 #include "thermocycler-refresh/tmc2130.hpp"
 
-SCENARIO("tmc2130 register structures work") {
-    GIVEN("a tmc2130 and a blank register map") {
+SCENARIO("tmc2130 register API works") {
+    GIVEN("a tmc2130 and a blank TMC2130 register map") {
         tmc2130::TMC2130 tmc;
         TestTMC2130Policy policy;
 
         WHEN("setting gconfig register to all 0") {
             tmc2130::GConfig gconf;
-            auto ret = tmc.set_register(policy, gconf);
+            auto ret = tmc.set_gconf(gconf, policy);
             REQUIRE(ret);
             THEN("the register reads all 0's") {
                 auto reg_val = policy.read_register(tmc2130::Registers::GCONF);
@@ -23,31 +23,42 @@ SCENARIO("tmc2130 register structures work") {
         WHEN("setting gconfig register to have some nonzero elements") {
             tmc2130::GConfig gconf{
                 .i_scale_analog = 1, .diag0_error = 1, .direct_mode = 1};
-            auto ret = tmc.set_register(policy, gconf);
+            auto ret = tmc.set_gconf(gconf, policy);
             REQUIRE(ret);
             THEN("the register reads correctly") {
                 auto reg_val = policy.read_register(tmc2130::Registers::GCONF);
                 REQUIRE(reg_val.has_value());
-                static constexpr uint64_t expected = 0x10021;
+                static constexpr uint32_t expected = 0x10021;
                 REQUIRE(reg_val.value() == expected);
             }
             AND_WHEN("reading back the register") {
-                auto readback = tmc.get_register<tmc2130::GConfig>(policy);
-                REQUIRE(readback.has_value());
-                auto readback_val = readback.value();
-                REQUIRE(readback_val.i_scale_analog == 1);
-                REQUIRE(readback_val.diag0_error == 1);
-                REQUIRE(readback_val.direct_mode == 1);
-                REQUIRE(readback_val.stop_enable == 0);
-                REQUIRE(readback_val.shaft == 0);
+                auto readback = tmc.get_gconf();
+                REQUIRE(readback.i_scale_analog == 1);
+                REQUIRE(readback.diag0_error == 1);
+                REQUIRE(readback.direct_mode == 1);
+                REQUIRE(readback.stop_enable == 0);
+                REQUIRE(readback.shaft == 0);
+                AND_WHEN("changing a value in the register") {
+                    readback.en_pwm_mode = 1;
+                    REQUIRE(tmc.set_gconf(readback, policy));
+                    THEN("the updated value should be reflected") {
+                        gconf = tmc.get_gconf();
+                        REQUIRE(gconf.en_pwm_mode == 1);
+                        REQUIRE(readback.i_scale_analog == 1);
+                        REQUIRE(readback.diag0_error == 1);
+                        REQUIRE(readback.direct_mode == 1);
+                        REQUIRE(readback.stop_enable == 0);
+                        REQUIRE(readback.shaft == 0);
+                    }
+                }
             }
         }
         WHEN("setting CurrentControl") {
             tmc2130::CurrentControl reg{.hold_current = 0xE,
                                         .run_current = 0x1E,
                                         .hold_current_delay = 0xF};
-            static constexpr uint64_t expected = 0xF1E0E;
-            auto ret = tmc.set_register(policy, reg);
+            static constexpr uint32_t expected = 0xF1E0E;
+            auto ret = tmc.set_current_control(reg, policy);
             REQUIRE(ret);
             THEN("the register should be set correctly") {
                 auto reg_val =
@@ -55,35 +66,47 @@ SCENARIO("tmc2130 register structures work") {
                 REQUIRE(reg_val.has_value());
                 REQUIRE(reg_val.value() == expected);
             }
+            AND_WHEN("reading back the register") {
+                auto readback = tmc.get_current_control();
+                THEN("the register should be the same") {
+                    REQUIRE(readback.hold_current == reg.hold_current);
+                    REQUIRE(readback.run_current == reg.run_current);
+                    REQUIRE(readback.hold_current_delay ==
+                            reg.hold_current_delay);
+                }
+            }
+        }
+        WHEN("setting CurrentControl with invalid parameters") {
+            tmc2130::CurrentControl reg{.hold_current = 0xE,
+                                        .bit_padding_1 = 1,
+                                        .run_current = 0x1E,
+                                        .hold_current_delay = 0xF};
+            auto ret = tmc.set_current_control(reg, policy);
+            THEN("an error is returned") { REQUIRE(!ret); }
         }
         WHEN("setting PowerDownDelay to max time / 2") {
-            tmc2130::PowerDownDelay reg{
-                .time = tmc2130::PowerDownDelay::max_val / 2};
-            static constexpr double expected_time =
-                tmc2130::PowerDownDelay::max_time / 2;
-            REQUIRE_THAT(reg.seconds(),
-                         Catch::Matchers::WithinAbs(expected_time, 0.1));
-            auto ret = tmc.set_register(policy, reg);
-            REQUIRE(ret);
+            auto settime = tmc2130::PowerDownDelay::max_time / 2.0F;
+            auto expected_reg = tmc2130::PowerDownDelay::max_val / 2;
+            REQUIRE(tmc.set_power_down_delay(settime, policy));
             THEN("the register should be set correctly") {
                 auto reg_val =
                     policy.read_register(tmc2130::Registers::TPOWERDOWN);
                 REQUIRE(reg_val.has_value());
-                REQUIRE(reg_val.value() ==
-                        tmc2130::PowerDownDelay::max_val / 2);
+                REQUIRE(reg_val.value() == expected_reg);
             }
-            THEN("setting the struct's time to 1 second") {
-                REQUIRE(reg.set_time(1.0F));
-                THEN("the time should be updated correctly") {
-                    REQUIRE_THAT(reg.seconds(),
-                                 Catch::Matchers::WithinAbs(1.0F, 0.1));
-                }
+        }
+        WHEN("setting a PowerDownDelay structure time") {
+            tmc2130::PowerDownDelay reg;
+            REQUIRE(reg.set_time(1.0F));
+            THEN("the time should be updated correctly") {
+                REQUIRE_THAT(reg.seconds(),
+                             Catch::Matchers::WithinAbs(1.0F, 0.1));
             }
         }
         WHEN("setting TCoolThreshold") {
             tmc2130::TCoolThreshold reg{.threshold = 0xABCDE};
-            static constexpr uint64_t expected = 0xABCDE;
-            auto ret = tmc.set_register(policy, reg);
+            static constexpr uint32_t expected = 0xABCDE;
+            auto ret = tmc.set_cool_threshold(reg, policy);
             REQUIRE(ret);
             THEN("the register should be set correctly") {
                 auto reg_val =
@@ -91,16 +114,28 @@ SCENARIO("tmc2130 register structures work") {
                 REQUIRE(reg_val.has_value());
                 REQUIRE(reg_val.value() == expected);
             }
+            AND_WHEN("reading back the register") {
+                auto readback = tmc.get_cool_threshold();
+                THEN("the register should be updated") {
+                    REQUIRE(readback.threshold == 0xABCDE);
+                }
+            }
         }
         WHEN("setting THigh") {
             tmc2130::THigh reg{.threshold = 0xABCDE};
-            static constexpr uint64_t expected = 0xABCDE;
-            auto ret = tmc.set_register(policy, reg);
+            static constexpr uint32_t expected = 0xABCDE;
+            auto ret = tmc.set_thigh(reg, policy);
             REQUIRE(ret);
             THEN("the register should be set correctly") {
                 auto reg_val = policy.read_register(tmc2130::Registers::THIGH);
                 REQUIRE(reg_val.has_value());
                 REQUIRE(reg_val.value() == expected);
+            }
+            AND_WHEN("reading back the register") {
+                auto readback = tmc.get_thigh();
+                THEN("the register should be updated") {
+                    REQUIRE(readback.threshold == 0xABCDE);
+                }
             }
         }
         WHEN("setting ChopConfig") {
@@ -120,14 +155,63 @@ SCENARIO("tmc2130 register structures work") {
                                      .intpol = 0,
                                      .dedge = 1,
                                      .diss2g = 0};
-            static constexpr uint64_t expected = 0x2AA4E84A;
-            auto ret = tmc.set_register(policy, chop);
+            static constexpr uint32_t expected = 0x2AA4E84A;
+            auto ret = tmc.set_chop_config(chop, policy);
             REQUIRE(ret);
             THEN("the register should be set correctly") {
                 auto reg_val =
                     policy.read_register(tmc2130::Registers::CHOPCONF);
                 REQUIRE(reg_val.has_value());
                 REQUIRE(reg_val.value() == expected);
+            }
+            AND_WHEN("reading back the register") {
+                auto readback = tmc.get_chop_config();
+                THEN("the register should be updated") {
+                    REQUIRE(readback.toff == chop.toff);
+                    REQUIRE(readback.hstrt == chop.hstrt);
+                    REQUIRE(readback.fd3 == chop.fd3);
+                    REQUIRE(readback.disfdcc == chop.disfdcc);
+                    REQUIRE(readback.chm == chop.chm);
+                    REQUIRE(readback.sync == chop.sync);
+                }
+            }
+        }
+        WHEN("setting CoolConfig") {
+            tmc2130::CoolConfig cool{.semin = 0,
+                                     .seup = 1,
+                                     .semax = 3,
+                                     .sedn = 1,
+                                     .seimin = 0,
+                                     .sgt = 64,
+                                     .sfilt = 0};
+            static constexpr uint32_t expected = 0x402320;
+            auto ret = tmc.set_cool_config(cool, policy);
+            REQUIRE(ret);
+            THEN("the register should be set correctly") {
+                auto reg_val =
+                    policy.read_register(tmc2130::Registers::COOLCONF);
+                REQUIRE(reg_val.has_value());
+                REQUIRE(reg_val.value() == expected);
+            }
+            AND_WHEN("reading back the register") {
+                auto readback = tmc.get_cool_config();
+                THEN("the register should be updated") {
+                    REQUIRE(readback.semin == cool.semin);
+                    REQUIRE(readback.seup == cool.seup);
+                    REQUIRE(readback.semax == cool.semax);
+                    REQUIRE(readback.sedn == cool.sedn);
+                    REQUIRE(readback.seimin == cool.seimin);
+                    REQUIRE(readback.sgt == cool.sgt);
+                    REQUIRE(readback.sfilt == cool.sfilt);
+                }
+            }
+            AND_WHEN("trying to set invalid register") {
+                cool.padding_1 = 1;
+                ret = tmc.set_cool_config(cool, policy);
+                THEN("the writing fails and the register is left alone") {
+                    REQUIRE(!ret);
+                    REQUIRE(tmc.get_cool_config().padding_1 == 0);
+                }
             }
         }
     }

--- a/stm32-modules/thermocycler-refresh/tests/test_tmc2130.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_tmc2130.cpp
@@ -2,21 +2,16 @@
 
 #include "catch2/catch.hpp"
 #include "systemwide.h"
-#include "thermocycler-refresh/tmc2130.hpp"
 #include "test/test_tmc2130_policy.hpp"
+#include "thermocycler-refresh/tmc2130.hpp"
 
 // Full register map to make iterating less painful
 static constexpr std::array<tmc2130::Registers, 11> _registers = {
-    tmc2130::Registers::general_config,
-    tmc2130::Registers::general_status,
-    tmc2130::Registers::io_input,
-    tmc2130::Registers::ihold_irun,
-    tmc2130::Registers::tpower_down,
-    tmc2130::Registers::tstep,
-    tmc2130::Registers::tpwmthrs,
-    tmc2130::Registers::tcoolthrs,
-    tmc2130::Registers::thigh,
-    tmc2130::Registers::xdirect,
+    tmc2130::Registers::general_config, tmc2130::Registers::general_status,
+    tmc2130::Registers::io_input,       tmc2130::Registers::ihold_irun,
+    tmc2130::Registers::tpower_down,    tmc2130::Registers::tstep,
+    tmc2130::Registers::tpwmthrs,       tmc2130::Registers::tcoolthrs,
+    tmc2130::Registers::thigh,          tmc2130::Registers::xdirect,
     tmc2130::Registers::vdcmin,
 };
 
@@ -26,31 +21,30 @@ SCENARIO("tmc2130 register logic works") {
         TestTMC2130Policy policy;
 
         WHEN("setting gconfig register to all 0") {
-            tmc2130::GConf gconf;
+            tmc2130::GConfig gconf;
             auto ret = tmc.set_register(policy, gconf);
             REQUIRE(ret);
             THEN("the register reads all 0's") {
-                auto reg_val = policy.read_register(tmc2130::Registers::general_config);
+                auto reg_val =
+                    policy.read_register(tmc2130::Registers::general_config);
                 REQUIRE(reg_val.has_value());
                 REQUIRE(reg_val.value() == 0);
             }
         }
         WHEN("setting gconfig register to have some nonzero elements") {
-            tmc2130::GConf gconf {
-                .i_scale_analog = 1,
-                .diag0_error = 1,
-                .direct_mode = 1
-            };
+            tmc2130::GConfig gconf{
+                .i_scale_analog = 1, .diag0_error = 1, .direct_mode = 1};
             auto ret = tmc.set_register(policy, gconf);
             REQUIRE(ret);
             THEN("the register reads correctly") {
-                auto reg_val = policy.read_register(tmc2130::Registers::general_config);
+                auto reg_val =
+                    policy.read_register(tmc2130::Registers::general_config);
                 REQUIRE(reg_val.has_value());
                 static constexpr uint64_t expected = 0x10021;
                 REQUIRE(reg_val.value() == expected);
             }
             AND_WHEN("reading back the register") {
-                auto readback = tmc.get_register<tmc2130::GConf>(policy);
+                auto readback = tmc.get_register<tmc2130::GConfig>(policy);
                 REQUIRE(readback.has_value());
                 auto readback_val = readback.value();
                 REQUIRE(readback_val.i_scale_analog == 1);
@@ -58,6 +52,46 @@ SCENARIO("tmc2130 register logic works") {
                 REQUIRE(readback_val.direct_mode == 1);
                 REQUIRE(readback_val.stop_enable == 0);
                 REQUIRE(readback_val.shaft == 0);
+            }
+        }
+        WHEN("setting CurrentControl") {
+            tmc2130::CurrentControl reg{.hold_current = 0xE,
+                                        .run_current = 0x1E,
+                                        .hold_current_delay = 0xF};
+            static constexpr uint64_t expected = 0xF1E0E;
+            auto ret = tmc.set_register(policy, reg);
+            REQUIRE(ret);
+            THEN("the register should be set correctly") {
+                auto reg_val =
+                    policy.read_register(tmc2130::Registers::ihold_irun);
+                REQUIRE(reg_val.has_value());
+                REQUIRE(reg_val.value() == expected);
+            }
+        }
+        WHEN("setting PowerDownDelay to max time") {
+            tmc2130::PowerDownDelay reg{.time =
+                                            tmc2130::PowerDownDelay::max_time};
+            static constexpr uint64_t expected = 0xFF;
+            auto ret = tmc.set_register(policy, reg);
+            REQUIRE(ret);
+            THEN("the register should be set correctly") {
+                auto reg_val =
+                    policy.read_register(tmc2130::Registers::tpower_down);
+                REQUIRE(reg_val.has_value());
+                REQUIRE(reg_val.value() == expected);
+            }
+        }
+        WHEN("setting PowerDownDelay to max time") {
+            tmc2130::PowerDownDelay reg{
+                .time = tmc2130::PowerDownDelay::max_time / 2};
+            static constexpr uint64_t expected = 0xFF / 2;
+            auto ret = tmc.set_register(policy, reg);
+            REQUIRE(ret);
+            THEN("the register should be set correctly") {
+                auto reg_val =
+                    policy.read_register(tmc2130::Registers::tpower_down);
+                REQUIRE(reg_val.has_value());
+                REQUIRE(reg_val.value() == expected);
             }
         }
     }


### PR DESCRIPTION
### Summary

Adds in a class to control the TMC2130 motor IC. Primary interface to the class is through bit-packed structures. Right now this _just_ adds the SPI register control, there isn't any support for moving the motors.

- Added the bit_utils header from OT3 as a nice utility
- Tested on a board by butchering the `freertos_system_task` and pinging registers. Confirmed that it can set the gconfig register and readback from the gstat register as expected.
- Unit tests cover setting/getting all of the registers that we are expecting to use
- Should be fine to merge without the other motor setup code, really shouldn't conflict with any of that work. 

### Review Requests

Sanity check that the system for serializing/deserializing the bitpacked structures won't have any issues... the data seemed fine in a debugger but it's on the riskier side with the pointer reinterpret casts and such