### PR TITLE
feat(thermocycler-refresh): LED actions support

### DIFF
--- a/stm32-modules/common/src/CMakeLists.txt
+++ b/stm32-modules/common/src/CMakeLists.txt
@@ -24,6 +24,7 @@ add_custom_command(
 # Configure lintable/nonlintable sources here
 set(CORE_LINTABLE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/pid.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/xt1511.cpp
   )
 set(CORE_NONLINTABLE_SOURCES 
   ${CMAKE_CURRENT_BINARY_DIR}/thermistor_lookups.cpp

--- a/stm32-modules/common/src/xt1511.cpp
+++ b/stm32-modules/common/src/xt1511.cpp
@@ -1,0 +1,11 @@
+/**
+ * @file xt1511.cpp
+ * @brief Implementation of xt1511 functions
+ *
+ */
+#include "core/xt1511.hpp"
+
+auto xt1511::operator==(const xt1511::XT1511& l, const xt1511::XT1511& r)
+    -> bool {
+    return ((l.g == r.g) && (l.r == r.r) && (l.b == r.b) && (l.w == r.w));
+}

--- a/stm32-modules/common/tests/CMakeLists.txt
+++ b/stm32-modules/common/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_ack_cache.cpp
     test_double_buffer.cpp
     test_gcode_parse.cpp 
+    test_generic_timer.cpp
     test_pid.cpp
     test_thermistor_conversions.cpp
     test_xt1511.cpp

--- a/stm32-modules/common/tests/test_generic_timer.cpp
+++ b/stm32-modules/common/tests/test_generic_timer.cpp
@@ -1,0 +1,152 @@
+
+#include "catch2/catch.hpp"
+#include "core/timer.hpp"
+#include "test/test_timer_handle.hpp"
+
+using namespace test_timer_handle;
+using namespace timer;
+
+SCENARIO("TestTimerHandle works") {
+    GIVEN("a TestTimerHandle with period 100ms and autoreload") {
+        constexpr uint32_t PERIOD = 100;
+        InterruptCounter itr;
+        TestTimerHandle timer("Test1", PERIOD, true, itr.provide_callback());
+        REQUIRE(itr._count == 0);
+        WHEN("starting the timer") {
+            timer.start();
+            AND_WHEN("incremementing by 100ms") {
+                timer.tick(PERIOD);
+                THEN("the interrupt is fired") {
+                    REQUIRE(itr._count == 1);
+                    REQUIRE(timer.active());
+                    REQUIRE(timer.remaining_time() == PERIOD);
+                }
+                AND_WHEN("incremementing by another 100ms") {
+                    timer.tick(PERIOD);
+                    THEN("the interrupt is fired") {
+                        REQUIRE(itr._count == 2);
+                        REQUIRE(timer.active());
+                        REQUIRE(timer.remaining_time() == PERIOD);
+                    }
+                }
+            }
+            AND_WHEN("incremementing by 99ms") {
+                timer.tick(PERIOD - 1);
+                THEN("the interrupt is not fired") {
+                    REQUIRE(itr._count == 0);
+                    REQUIRE(timer.active());
+                    REQUIRE(timer.remaining_time() == 1);
+                }
+            }
+            AND_WHEN("incremementing by 1ms") {
+                timer.tick(1);
+                THEN("the interrupt is not fired") {
+                    REQUIRE(itr._count == 0);
+                    REQUIRE(timer.active());
+                    REQUIRE(timer.remaining_time() == PERIOD - 1);
+                }
+            }
+            AND_WHEN("incremementing by 200ms") {
+                timer.tick(PERIOD * 2);
+                THEN("the interrupt is fired twice") {
+                    REQUIRE(itr._count == 2);
+                    REQUIRE(timer.active());
+                    REQUIRE(timer.remaining_time() == PERIOD);
+                }
+            }
+            AND_WHEN("incremementing by 250ms") {
+                timer.tick(static_cast<uint32_t>(PERIOD * 2.5));
+                THEN("the interrupt is fired twice") {
+                    REQUIRE(itr._count == 2);
+                    REQUIRE(timer.active());
+                    REQUIRE(timer.remaining_time() == PERIOD / 2);
+                }
+                AND_WHEN("turning the timer off") {
+                    timer.stop();
+                    THEN("the timer is off") {
+                        REQUIRE(!timer.active());
+                        REQUIRE(timer.remaining_time() == 0);
+                    }
+                }
+            }
+        }
+    }
+    GIVEN("a TestTimerHandle with a period 100ms and no autoreload") {
+        constexpr uint32_t PERIOD = 100;
+        InterruptCounter itr;
+        TestTimerHandle timer("Test1", PERIOD, false, itr.provide_callback());
+        REQUIRE(itr._count == 0);
+        WHEN("starting the timer") {
+            timer.start();
+            AND_WHEN("incremementing by 100ms") {
+                timer.tick(PERIOD);
+                THEN("the interrupt is fired and the timer is off") {
+                    REQUIRE(itr._count == 1);
+                    REQUIRE(!timer.active());
+                    REQUIRE(timer.remaining_time() == 0);
+                }
+                AND_WHEN("incremementing by another 100ms") {
+                    timer.tick(PERIOD);
+                    THEN("the interrupt is not fired") {
+                        REQUIRE(itr._count == 1);
+                        REQUIRE(!timer.active());
+                        REQUIRE(timer.remaining_time() == 0);
+                    }
+                }
+            }
+            AND_WHEN("incremementing by 200ms") {
+                timer.tick(PERIOD * 2);
+                THEN("the interrupt is fired and the timer is off") {
+                    REQUIRE(itr._count == 1);
+                    REQUIRE(!timer.active());
+                    REQUIRE(timer.remaining_time() == 0);
+                }
+            }
+        }
+    }
+}
+
+SCENARIO("GenericTimer class works") {
+    GIVEN("a GenericTimer with a period of 100ms and autoreload enabled") {
+        constexpr uint32_t PERIOD = 100;
+        InterruptCounter itr;
+        auto timer = GenericTimer<TestTimerHandle>("Test2", PERIOD, true,
+                                                   itr.provide_callback());
+
+        REQUIRE(itr._count == 0);
+        WHEN("manually invoking the callback") {
+            timer.callback();
+            THEN("the count is incremented") { REQUIRE(itr._count == 1); }
+        }
+        WHEN("starting the timer") {
+            REQUIRE(timer.start());
+            AND_WHEN("incrementing by 100ms") {
+                timer.get_handle().tick(PERIOD);
+                THEN("the interrupt is triggered and timer is active") {
+                    REQUIRE(itr._count == 1);
+                    REQUIRE(timer.active());
+                    REQUIRE(timer.get_handle().remaining_time() == PERIOD);
+                }
+            }
+        }
+    }
+    GIVEN("a GenericTimer with a period of 100ms and autoreload disabled") {
+        constexpr uint32_t PERIOD = 100;
+        InterruptCounter itr;
+        auto timer = GenericTimer<TestTimerHandle>("Test2", PERIOD, false,
+                                                   itr.provide_callback());
+
+        REQUIRE(itr._count == 0);
+        WHEN("starting the timer") {
+            REQUIRE(timer.start());
+            AND_WHEN("incrementing by 100ms") {
+                timer.get_handle().tick(PERIOD);
+                THEN("the interrupt is triggered and timer is inactive") {
+                    REQUIRE(itr._count == 1);
+                    REQUIRE(!timer.active());
+                    REQUIRE(timer.get_handle().remaining_time() == 0);
+                }
+            }
+        }
+    }
+}

--- a/stm32-modules/common/tests/test_xt1511.cpp
+++ b/stm32-modules/common/tests/test_xt1511.cpp
@@ -31,6 +31,18 @@ SCENARIO("XT1511 structure works") {
     }
 }
 
+SCENARIO("XT1511 equals operator works") {
+    GIVEN("two unequal XT1511 structs") {
+        XT1511 left{.w = 10};
+        XT1511 right{.w = 100};
+        THEN("they should evaluate not equal") { REQUIRE(left != right); }
+    }
+    GIVEN("two equal XT1511 structs") {
+        XT1511 left{}, right{};
+        THEN("they should evaluate equal") { REQUIRE(left == right); }
+    }
+}
+
 SCENARIO("XT1511String driver works") {
     GIVEN("an XT1511String with 1 pixels, half-speed, 16-bit PWM values") {
         constexpr size_t led_count = 1;

--- a/stm32-modules/common/tests/test_xt1511.cpp
+++ b/stm32-modules/common/tests/test_xt1511.cpp
@@ -7,15 +7,51 @@
 
 using namespace xt1511;
 
-SCENARIO("xt1511 driver works") {
-    GIVEN("an XT1511String with 16 pixels and 16-bit PWM values") {
+SCENARIO("XT1511 structure works") {
+    GIVEN("a default XT1511 structure") {
+        XT1511 led{};
+        THEN("all of the color values are 0") {
+            REQUIRE(led.w == 0);
+            REQUIRE(led.r == 0);
+            REQUIRE(led.g == 0);
+            REQUIRE(led.b == 0);
+        }
+        WHEN("setting values to 10") {
+            led.r = led.b = led.g = led.w = 10;
+            AND_WHEN("setting the scale to 2x") {
+                led.set_scale(2);
+                THEN("the values are doubled to 20") {
+                    REQUIRE(led.w == 20);
+                    REQUIRE(led.r == 20);
+                    REQUIRE(led.g == 20);
+                    REQUIRE(led.b == 20);
+                }
+            }
+        }
+    }
+}
+
+SCENARIO("XT1511String driver works") {
+    GIVEN("an XT1511String with 1 pixels, half-speed, 16-bit PWM values") {
+        constexpr size_t led_count = 1;
+        auto leds = XT1511String<uint16_t, led_count>(Speed::HALF);
+        THEN("the pwm values match the half-speed spec") {
+            REQUIRE(leds.pwm_off_percentage() == leds.PWM_OFF_HALF_SPEED);
+            REQUIRE(leds.pwm_on_percentage() == leds.PWM_ON_HALF_SPEED);
+        }
+    }
+    GIVEN("an XT1511String with 16 pixels, full-speed, and 16-bit PWM values") {
         constexpr size_t led_count = 16;
         constexpr uint16_t max_pwm = 1000;
-        XT1511String<uint16_t, led_count> leds;
-        constexpr uint16_t off_value = leds.PWM_OFF_PERCENTAGE * max_pwm;
-        constexpr uint16_t on_value = leds.PWM_ON_PERCENTAGE * max_pwm;
+        auto leds = XT1511String<uint16_t, led_count>(Speed::FULL);
+        uint16_t off_value = leds.pwm_off_percentage() * max_pwm;
+        uint16_t on_value = leds.pwm_on_percentage() * max_pwm;
         constexpr size_t pwm_count = 32 * 16;  // Does not include stop bit
         auto policy = TestXT1511Policy<led_count>(max_pwm);
+        THEN("the pwm values match the full-speed spec") {
+            REQUIRE(leds.pwm_off_percentage() == leds.PWM_OFF_FULL_SPEED);
+            REQUIRE(leds.pwm_on_percentage() == leds.PWM_ON_FULL_SPEED);
+        }
         WHEN("writing the default pixels") {
             REQUIRE(leds.write(policy));
             THEN("the output is 32*16 0's and then stop bits") {

--- a/stm32-modules/include/common/core/timer.hpp
+++ b/stm32-modules/include/common/core/timer.hpp
@@ -43,7 +43,7 @@ class GenericTimer {
 
     auto start() -> bool { return _handle.start(); }
     auto stop() -> bool { return _handle.stop(); }
-    [[nodiscard]] auto const active() -> bool { return _handle.active(); }
+    [[nodiscard]] auto active() const -> bool { return _handle.active(); }
 
     auto callback() -> void { _callback(); }
 

--- a/stm32-modules/include/common/core/timer.hpp
+++ b/stm32-modules/include/common/core/timer.hpp
@@ -36,10 +36,9 @@ class GenericTimer {
   public:
     using Callback = std::function<void()>;
     GenericTimer(const char* name, uint32_t period_ms, bool autoreload,
-                 Callback callback)
-        : _callback(std::move(callback)),
-          _handle(name, period_ms, autoreload,
-                  std::bind(&GenericTimer<Handle>::callback, this)) {}
+                 Callback callback_in)
+        : _callback(std::move(callback_in)),
+          _handle(name, period_ms, autoreload, [this] { callback(); }) {}
 
     auto start() -> bool { return _handle.start(); }
     auto stop() -> bool { return _handle.stop(); }

--- a/stm32-modules/include/common/core/timer.hpp
+++ b/stm32-modules/include/common/core/timer.hpp
@@ -1,0 +1,57 @@
+/**
+ * @file timer.hpp
+ * @brief Provides a generic class for one-shot or periodic timer callback
+ * functionality.
+ */
+
+#pragma once
+
+#include <concepts>
+#include <functional>
+
+namespace timer {
+
+/**
+ * @brief Defines constraints for a class that implements the low-level
+ * aspects of a timer.
+ *
+ * @tparam Handle The type of the timer handle.
+ */
+template <typename Handle>
+concept TimerHandle = requires(Handle& h, const char* name, uint32_t time_ms,
+                               bool autoreload,
+                               std::function<void()> callback) {
+    // Initializer function
+    {Handle(name, time_ms, autoreload, callback)};
+    // Start a timer
+    { h.start() } -> std::same_as<bool>;
+    // Stop a timer
+    { h.stop() } -> std::same_as<bool>;
+    // Check if a timer is active
+    { h.active() } -> std::same_as<bool>;
+};
+
+template <TimerHandle Handle>
+class GenericTimer {
+  public:
+    using Callback = std::function<void()>;
+    GenericTimer(const char* name, uint32_t period_ms, bool autoreload,
+                 Callback callback)
+        : _callback(std::move(callback)),
+          _handle(name, period_ms, autoreload,
+                  std::bind(&GenericTimer<Handle>::callback, this)) {}
+
+    auto start() -> bool { return _handle.start(); }
+    auto stop() -> bool { return _handle.stop(); }
+    [[nodiscard]] auto const active() -> bool { return _handle.active(); }
+
+    auto callback() -> void { _callback(); }
+
+    [[nodiscard]] auto get_handle() -> Handle& { return _handle; }
+
+  private:
+    Callback _callback;
+    Handle _handle;
+};
+
+}  // namespace timer

--- a/stm32-modules/include/common/core/xt1511.hpp
+++ b/stm32-modules/include/common/core/xt1511.hpp
@@ -68,6 +68,8 @@ struct XT1511 {
     }
 };
 
+auto operator==(const XT1511& l, const XT1511& r) -> bool;
+
 enum class Speed {
     FULL, /**< 800kHz.*/
     HALF, /**< 400kHz.*/

--- a/stm32-modules/include/common/core/xt1511.hpp
+++ b/stm32-modules/include/common/core/xt1511.hpp
@@ -59,12 +59,13 @@ concept XT1511Policy = requires(Policy& p, BufferT& b) {
 // This class represents a single XT1511
 struct XT1511 {
     // Data is sent in the order G, R, B, W
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     uint8_t g = 0, r = 0, b = 0, w = 0;
     auto set_scale(double scale) {
-        g *= scale;
-        r *= scale;
-        b *= scale;
-        w *= scale;
+        g = static_cast<uint8_t>(static_cast<double>(g) * scale);
+        r = static_cast<uint8_t>(static_cast<double>(r) * scale);
+        b = static_cast<uint8_t>(static_cast<double>(b) * scale);
+        w = static_cast<uint8_t>(static_cast<double>(w) * scale);
     }
 };
 

--- a/stm32-modules/include/common/firmware/freertos_timer.hpp
+++ b/stm32-modules/include/common/firmware/freertos_timer.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <functional>
+
+#include "FreeRTOS.h"
+#include "timers.h"
+
+namespace freertos_timer {
+
+// pdMS_TO_TICKS converts milliseconds to ticks. This can only be used for
+// FreeRTOS tick rates less than 1000 Hz.
+template <TickType_t timer_period = pdMS_TO_TICKS(1)>
+class FreeRTOSTimer {
+  public:
+    /*
+     * A software timer class. The priority of software timers in FreeRTOS is
+     * currently set to 6. Any tasks utilizing this timer should have either the
+     * same priority or higher priority than 6 for execution.
+     */
+    using Callback = std::function<void()>;
+    FreeRTOSTimer(const char* name, Callback callback)
+        : callback{std::move(callback)} {
+        timer = xTimerCreateStatic(name, timer_period, auto_reload, this,
+                                   timer_callback, &timer_buffer);
+    }
+    auto operator=(FreeRTOSTimer&) -> FreeRTOSTimer& = delete;
+    auto operator=(FreeRTOSTimer&&) -> FreeRTOSTimer&& = delete;
+    FreeRTOSTimer(FreeRTOSTimer&) = delete;
+    FreeRTOSTimer(FreeRTOSTimer&&) = delete;
+    ~FreeRTOSTimer() { xTimerDelete(timer, 0); }
+
+    void start() { xTimerStart(timer, 0); }
+
+    void stop() { xTimerStop(timer, 0); }
+
+  private:
+    TimerHandle_t timer{};
+    Callback callback;
+    StaticTimer_t timer_buffer{};
+    UBaseType_t auto_reload = pdTRUE;
+
+    static void timer_callback(TimerHandle_t xTimer) {
+        auto* timer_id = pvTimerGetTimerID(xTimer);
+        auto instance = static_cast<FreeRTOSTimer<timer_period>*>(timer_id);
+        instance->callback();
+    }
+};
+
+}  // namespace freertos_timer

--- a/stm32-modules/include/common/firmware/freertos_timer.hpp
+++ b/stm32-modules/include/common/firmware/freertos_timer.hpp
@@ -48,7 +48,7 @@ class FreeRTOSTimer {
 
     static void timer_callback(TimerHandle_t xTimer) {
         auto* timer_id = pvTimerGetTimerID(xTimer);
-        auto instance = static_cast<FreeRTOSTimer*>(timer_id);
+        auto* instance = static_cast<FreeRTOSTimer*>(timer_id);
         instance->_callback();
     }
 };

--- a/stm32-modules/include/common/test/test_timer_handle.hpp
+++ b/stm32-modules/include/common/test/test_timer_handle.hpp
@@ -1,0 +1,104 @@
+/**
+ * @file test_timer_handle.hpp
+ * @brief Implements a mock timer handle for testing the GenericTimer class
+ *
+ */
+#pragma once
+
+#include <functional>
+
+namespace test_timer_handle {
+
+class TestTimerHandle {
+  public:
+    using Callback = std::function<void()>;
+    TestTimerHandle(const char* name, uint32_t time_ms, bool autoreload,
+                    Callback callback)
+        : _name(name),
+          _time_ms(time_ms),
+          _autoreload(autoreload),
+          _callback(std::move(callback)),
+          _active(false),
+          _remaining_time(0) {}
+    TestTimerHandle(TestTimerHandle&) = delete;
+    auto operator=(TestTimerHandle&) -> TestTimerHandle& = delete;
+
+    auto start() -> bool {
+        if (_active) {
+            return false;
+        }
+        _active = true;
+        _remaining_time = _time_ms;
+        return true;
+    }
+
+    auto stop() -> bool {
+        if (!_active) {
+            return false;
+        }
+        _active = false;
+        _remaining_time = 0;
+        return true;
+    }
+
+    auto tick(uint32_t delta) -> void {
+        if (!_active) {
+            return;
+        }
+
+        if (delta == 0) {
+            delta = _remaining_time;
+        }
+
+        if (delta < _remaining_time) {
+            _remaining_time -= delta;
+            return;
+        }
+        // Timer ends on this tick
+        _callback();
+        if (_autoreload) {
+            _remaining_time = _time_ms;
+            delta -= _remaining_time;
+            if (delta > 0) {
+                // Recurse!
+                tick(delta);
+            }
+        } else {
+            // No autoreload means the remaining delta doesn't matter
+            _remaining_time = 0;
+            _active = false;
+        }
+    }
+
+    auto const active() -> bool { return _active; }
+
+    auto remaining_time() -> uint32_t { return _remaining_time; }
+
+  private:
+    const char* _name;
+    uint32_t _time_ms;
+    bool _autoreload;
+    Callback _callback;
+
+    bool _active;
+    uint32_t _remaining_time;
+};
+
+/**
+ * @brief Mock class to count how many times a function is triggered.
+ * Useful for testing Timer classes.
+ *
+ */
+struct InterruptCounter {
+    auto increment() -> void { ++_count; }
+
+    auto reset() -> void { _count = 0; }
+
+    [[nodiscard]] auto provide_callback() -> std::function<void()> {
+        return std::bind(&InterruptCounter::increment, this);
+    }
+
+    uint32_t _count = 0;
+};
+
+}  // namespace test_timer_handle

--- a/stm32-modules/include/common/test/test_timer_handle.hpp
+++ b/stm32-modules/include/common/test/test_timer_handle.hpp
@@ -70,7 +70,7 @@ class TestTimerHandle {
         }
     }
 
-    auto const active() -> bool { return _active; }
+    auto active() const -> bool { return _active; }
 
     auto remaining_time() -> uint32_t { return _remaining_time; }
 

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/colors.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/colors.hpp
@@ -1,0 +1,34 @@
+/**
+ * @file colors.hpp
+ * @brief Provide enumeration of colors on the system
+ */
+
+#pragma once
+
+#include "core/xt1511.hpp"
+
+namespace colors {
+
+// Enumerated colors to simplify controlling the system UI
+enum class Colors { SOFT_WHITE, WHITE, RED, GREEN, BLUE, ORANGE, NONE };
+
+// Enumerated actions for the system UI
+enum class Mode {
+    SOLID,    /**< Standard mode - just hold color steady.*/
+    PULSING,  /**< Pulse the selected color from 0 to 100% brightness.*/
+    BLINKING, /**< Blink the light on and off.*/
+    WIPE,     /**< Wipe across the UI left to right.*/
+};
+
+/**
+ * @brief Convert an enumerated color code to an XT1511 structure
+ * @param color The color code to convert
+ * @param brightness The brightness value to set for this color. The
+ * value for each LED will be linearly scaled by this amount, on a
+ * scale of 0 to 1.0
+ * @return xt1511::XT1511  containing the corresponding color mapped to
+ * the correct brightness
+ */
+auto get_color(Colors color, double brightness = 1.0F) -> xt1511::XT1511;
+
+}  // namespace colors

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -5,6 +5,7 @@
 #include <variant>
 
 #include "systemwide.h"
+#include "thermocycler-refresh/colors.hpp"
 #include "thermocycler-refresh/errors.hpp"
 
 namespace messages {
@@ -196,9 +197,19 @@ struct SetPIDConstantsMessage {
     double d;
 };
 
+struct UpdateUIMessage {
+    // Empty struct
+};
+
+struct SetLedMode {
+    colors::Colors color;
+    colors::Mode mode;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
-                   SetSerialNumberMessage, GetSystemInfoMessage>;
+                   SetSerialNumberMessage, GetSystemInfoMessage,
+                   UpdateUIMessage, SetLedMode>;
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, AcknowledgePrevious,
                    ErrorMessage, ForceUSBDisconnectMessage,

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/system_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/system_task.hpp
@@ -266,6 +266,9 @@ class SystemTask {
             get_message_queue().try_send(messages::UpdateUIMessage()));
     }
 
+    // To be used for tests
+    [[nodiscard]] auto get_led_state() -> LedState& { return _led_state; }
+
   private:
     Queue& _message_queue;
     tasks::Tasks<QueueImpl>* _task_registry;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/system_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/system_task.hpp
@@ -38,12 +38,12 @@ concept SystemExecutionPolicy = requires(Policy& p, const Policy& cp) {
 
 struct LedState {
     // Configured color of the LED, assuming
-    xt1511::XT1511 color;
-    colors::Mode mode;
+    xt1511::XT1511 color = colors::get_color(colors::Colors::SOFT_WHITE);
+    colors::Mode mode = colors::Mode::SOLID;
     // Utility counter for updating state in non-solid modes
-    uint32_t counter;
+    uint32_t counter = 0;
     // Period for movement in MS
-    uint32_t period;
+    uint32_t period = 0;
 };
 
 using Message = messages::SystemMessage;
@@ -184,6 +184,7 @@ class SystemTask {
     auto visit_message(const messages::UpdateUIMessage& message, Policy& policy)
         -> void {
         static_cast<void>(message);
+        static constexpr double TWO = 2.0F;
         _led_state.counter += LED_UPDATE_PERIOD_MS;
         if (_led_state.counter > _led_state.period) {
             _led_state.counter = 0;
@@ -198,14 +199,14 @@ class SystemTask {
                 // Set color as a triangle wave
                 double brightness = 0.0F;
                 if (_led_state.counter < (_led_state.period / 2)) {
-                    brightness = static_cast<float>(_led_state.counter) /
-                                 static_cast<float>(_led_state.period / 2);
+                    brightness = static_cast<double>(_led_state.counter) /
+                                 (static_cast<double>(_led_state.period) / TWO);
                 } else {
                     auto inverse_count =
                         std::abs(static_cast<int>(_led_state.period) -
                                  static_cast<int>(_led_state.counter));
                     brightness = static_cast<double>(inverse_count) /
-                                 static_cast<double>(_led_state.period / 2);
+                                 (static_cast<double>(_led_state.period) / TWO);
                 }
                 auto color = _led_state.color;
                 color.set_scale(brightness);

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/system_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/system_task.hpp
@@ -11,6 +11,7 @@
 #include "core/xt1511.hpp"
 #include "hal/message_queue.hpp"
 #include "systemwide.h"
+#include "thermocycler-refresh/colors.hpp"
 #include "thermocycler-refresh/messages.hpp"
 #include "thermocycler-refresh/tasks.hpp"
 
@@ -35,6 +36,16 @@ concept SystemExecutionPolicy = requires(Policy& p, const Policy& cp) {
         } -> std::same_as<std::array<char, SYSTEM_WIDE_SERIAL_NUMBER_LENGTH>>;
 };
 
+struct LedState {
+    // Configured color of the LED, assuming
+    xt1511::XT1511 color;
+    colors::Mode mode;
+    // Utility counter for updating state in non-solid modes
+    uint32_t counter;
+    // Period for movement in MS
+    uint32_t period;
+};
+
 using Message = messages::SystemMessage;
 
 // By using a template template parameter here, we allow the code instantiating
@@ -48,13 +59,23 @@ class SystemTask {
 
   public:
     using Queue = QueueImpl<Message>;
+    // Time between each write to the LED strip
+    static constexpr uint32_t LED_UPDATE_PERIOD_MS = 13;
+    // Time that each full "pulse" action should take (sine wave)
+    static constexpr uint32_t LED_PULSE_PERIOD_MS = 1000;
+    // Max brightness to set for automatic LED actions
+    static constexpr uint8_t LED_MAX_BRIGHTNESS = 0x20;
     explicit SystemTask(Queue& q)
         : _message_queue(q),
           _task_registry(nullptr),
           // NOLINTNEXTLINE(readability-redundant-member-init)
           _prep_cache(),
           // NOLINTNEXTLINE(readability-redundant-member-init)
-          _leds() {}
+          _leds(xt1511::Speed::HALF),
+          _led_state{.color = colors::get_color(colors::Colors::SOFT_WHITE),
+                     .mode = colors::Mode::SOLID,
+                     .counter = 0,
+                     .period = LED_PULSE_PERIOD_MS} {}
     SystemTask(const SystemTask& other) = delete;
     auto operator=(const SystemTask& other) -> SystemTask& = delete;
     SystemTask(SystemTask&& other) noexcept = delete;
@@ -68,11 +89,7 @@ class SystemTask {
     template <typename Policy>
     requires SystemExecutionPolicy<Policy>
     auto run_once(Policy& policy) -> void {
-        constexpr uint8_t default_white = 0x8;
         auto message = Message(std::monostate());
-
-        _leds.set_all(xt1511::XT1511{.w = default_white});
-        _leds.write(policy);
         _message_queue.recv(&message);
 
         auto visit_helper = [this, &policy](auto& message) -> void {
@@ -164,9 +181,89 @@ class SystemTask {
 
     template <typename Policy>
     requires SystemExecutionPolicy<Policy>
+    auto visit_message(const messages::UpdateUIMessage& message, Policy& policy)
+        -> void {
+        static_cast<void>(message);
+        _led_state.counter += LED_UPDATE_PERIOD_MS;
+        if (_led_state.counter > _led_state.period) {
+            _led_state.counter = 0;
+        }
+
+        switch (_led_state.mode) {
+            case colors::Mode::SOLID:
+                // Don't bother with timer
+                _leds.set_all(_led_state.color);
+                break;
+            case colors::Mode::PULSING: {
+                // Set color as a triangle wave
+                double brightness = 0.0F;
+                if (_led_state.counter < (_led_state.period / 2)) {
+                    brightness = static_cast<float>(_led_state.counter) /
+                                 static_cast<float>(_led_state.period / 2);
+                } else {
+                    auto inverse_count =
+                        std::abs(static_cast<int>(_led_state.period) -
+                                 static_cast<int>(_led_state.counter));
+                    brightness = static_cast<double>(inverse_count) /
+                                 static_cast<double>(_led_state.period / 2);
+                }
+                auto color = _led_state.color;
+                color.set_scale(brightness);
+                _leds.set_all(color);
+                break;
+            }
+            case colors::Mode::BLINKING:
+                // Turn on color for half of the duty cycle, off for the other
+                // half
+                if (_led_state.counter < (_led_state.period / 2)) {
+                    _leds.set_all(_led_state.color);
+                } else {
+                    _leds.set_all(xt1511::XT1511{});
+                }
+                break;
+            case colors::Mode::WIPE: {
+                static constexpr size_t trail_length = SYSTEM_LED_COUNT;
+                static constexpr size_t head_max = (SYSTEM_LED_COUNT * 2);
+                auto percent_done = static_cast<double>(_led_state.counter) /
+                                    static_cast<double>(_led_state.period);
+                auto head_position = static_cast<size_t>(
+                    static_cast<double>(head_max) * percent_done);
+                for (size_t i = 0; i < SYSTEM_LED_COUNT; ++i) {
+                    if ((i < head_position -
+                                 std::min(trail_length, head_position)) ||
+                        (i > head_position)) {
+                        _leds.pixel(i) = xt1511::XT1511{};
+                    } else {
+                        _leds.pixel(i) = _led_state.color;
+                    }
+                }
+                break;
+            }
+        }
+        static_cast<void>(_leds.write(policy));
+    }
+
+    template <SystemExecutionPolicy Policy>
+    auto visit_message(const messages::SetLedMode& message, Policy& policy)
+        -> void {
+        static_cast<void>(policy);
+        _led_state.color = colors::get_color(message.color);
+        _led_state.mode = message.mode;
+        _led_state.counter = 0;
+    }
+
+    template <typename Policy>
+    requires SystemExecutionPolicy<Policy>
     auto visit_message(const std::monostate& message, Policy& policy) -> void {
         static_cast<void>(message);
         static_cast<void>(policy);
+    }
+
+    // Should be provided to LED Timer to send LED Update messages. Ensure that
+    // the timer implementation does NOT execute in an interrupt context.
+    auto led_timer_callback() -> void {
+        static_cast<void>(
+            get_message_queue().try_send(messages::UpdateUIMessage()));
     }
 
   private:
@@ -174,6 +271,7 @@ class SystemTask {
     tasks::Tasks<QueueImpl>* _task_registry;
     BootloaderPrepAckCache _prep_cache;
     xt1511::XT1511String<PWM_T, SYSTEM_LED_COUNT> _leds;
+    LedState _led_state;
 };
 
 };  // namespace system_task

--- a/stm32-modules/thermocycler-refresh/firmware/system/FreeRTOSConfig.h
+++ b/stm32-modules/thermocycler-refresh/firmware/system/FreeRTOSConfig.h
@@ -84,7 +84,7 @@ extern uint32_t SystemCoreClock;
 #define configMAX_CO_ROUTINE_PRIORITIES (2)
 
 /* Software timer definitions. */
-#define configUSE_TIMERS 0
+#define configUSE_TIMERS 1
 #define configTIMER_TASK_PRIORITY (2)
 #define configTIMER_QUEUE_LENGTH 10
 #define configTIMER_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 2)

--- a/stm32-modules/thermocycler-refresh/firmware/system/freertos_idle_timer_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/freertos_idle_timer_task.cpp
@@ -13,8 +13,14 @@
 StaticTask_t
     idle_task_tcb;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+StaticTask_t
+    idle_timer_tcb;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 std::array<StackType_t, configMINIMAL_STACK_SIZE>
     idle_task_stack;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+std::array<StackType_t, configMINIMAL_STACK_SIZE>
+    idle_timer_stack;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 // This is a callback defined in a C file so it has to be linked as such
 extern "C" void vApplicationGetIdleTaskMemory(
@@ -24,4 +30,12 @@ extern "C" void vApplicationGetIdleTaskMemory(
     *ppxIdleTaskTCBBuffer = &idle_task_tcb;
     *ppxIdleTaskStackBuffer = idle_task_stack.data();
     *pulIdleTaskStackSize = idle_task_stack.size();
+}
+
+extern "C" void vApplicationGetTimerTaskMemory(
+    StaticTask_t **ppxTimerTaskTCBBuffer, StackType_t **ppxTimerTaskStackBuffer,
+    uint32_t *pulTimerTaskStackSize) {
+    *ppxTimerTaskTCBBuffer = &idle_timer_tcb;
+    *ppxTimerTaskStackBuffer = idle_timer_stack.data();
+    *pulTimerTaskStackSize = idle_timer_stack.size();
 }

--- a/stm32-modules/thermocycler-refresh/firmware/system/freertos_system_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/freertos_system_task.cpp
@@ -40,9 +40,10 @@ static StaticTask_t
     data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 // Periodic timer for UI updates
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static timer::GenericTimer<freertos_timer::FreeRTOSTimer> _led_timer(
-    "led timer", _task.LED_UPDATE_PERIOD_MS, true,
-    std::bind(&decltype(_task)::led_timer_callback, &_task));
+    "led timer", decltype(_task)::LED_UPDATE_PERIOD_MS, true,
+    [ObjectPtr = &_task] { ObjectPtr->led_timer_callback(); });
 
 // Actual function that runs inside the task, unused param because we don't get
 // to pick the function type

--- a/stm32-modules/thermocycler-refresh/firmware/system/freertos_system_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/freertos_system_task.cpp
@@ -6,7 +6,9 @@
 #include <array>
 
 #include "FreeRTOS.h"
+#include "core/timer.hpp"
 #include "firmware/freertos_message_queue.hpp"
+#include "firmware/freertos_timer.hpp"
 #include "firmware/system_hardware.h"
 #include "firmware/system_led_hardware.h"
 #include "firmware/system_policy.hpp"
@@ -37,18 +39,22 @@ static std::array<StackType_t, stack_size> stack;
 static StaticTask_t
     data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+// Periodic timer for UI updates
+static timer::GenericTimer<freertos_timer::FreeRTOSTimer> _led_timer(
+    "led timer", _task.LED_UPDATE_PERIOD_MS, true,
+    std::bind(&decltype(_task)::led_timer_callback, &_task));
+
 // Actual function that runs inside the task, unused param because we don't get
 // to pick the function type
 static void run(void *param) {
     system_hardware_setup();
     system_led_iniitalize();
-    static constexpr uint32_t delay_ticks = 100;
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto *task = reinterpret_cast<decltype(_task) *>(param);
     auto policy = SystemPolicy();
+    _led_timer.start();
     while (true) {
         task->run_once(policy);
-        vTaskDelay(delay_ticks);
     }
 }
 
@@ -56,7 +62,7 @@ static void run(void *param) {
 auto start() -> tasks::Task<TaskHandle_t,
                             system_task::SystemTask<FreeRTOSMessageQueue>> {
     auto *handle = xTaskCreateStatic(run, "SystemControl", stack.size(), &_task,
-                                     1, stack.data(), &data);
+                                     3, stack.data(), &data);
     _system_queue.provide_handle(handle);
     return tasks::Task<TaskHandle_t, decltype(_task)>{.handle = handle,
                                                       .task = &_task};

--- a/stm32-modules/thermocycler-refresh/firmware/system/system_led_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/system/system_led_hardware.c
@@ -26,7 +26,7 @@
 #define TIMER_CLOCK_FREQ (170000000)
 // These two together give a 400kHz total period
 #define TIM17_PRESCALER (0)
-#define TIM17_RELOAD (213)
+#define TIM17_RELOAD (424)
 // PWM should be scaled from 0 to MAX_PWM, inclusive
 #define MAX_PWM (TIM17_RELOAD + 1)
 
@@ -87,7 +87,7 @@ void system_led_iniitalize(void) {
     sConfigOC.Pulse = 0;
     sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
     sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
-    sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
+    sConfigOC.OCFastMode = TIM_OCFAST_ENABLE;
     sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
     sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
     hal_ret = HAL_TIM_PWM_ConfigChannel(&_leds.tim, &sConfigOC, _leds.tim_channel);
@@ -112,7 +112,7 @@ void system_led_iniitalize(void) {
     GPIO_InitStruct.Pin = GPIO_PIN_9;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
     GPIO_InitStruct.Alternate = GPIO_AF1_TIM17;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
@@ -208,6 +208,5 @@ void system_led_pulse_callback(void) {
         return;
     }
     vTaskNotifyGiveFromISR( _leds.task_to_notify, &xHigherPriorityTaskWoken );
-    _leds.task_to_notify = NULL;
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }

--- a/stm32-modules/thermocycler-refresh/src/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/src/CMakeLists.txt
@@ -58,6 +58,7 @@ set(CORE_LINTABLE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/errors.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/plate_control.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/board_revision.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/colors.cpp
   )
 set(CORE_NONLINTABLE_SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/thermistor_lookups.cpp

--- a/stm32-modules/thermocycler-refresh/src/colors.cpp
+++ b/stm32-modules/thermocycler-refresh/src/colors.cpp
@@ -1,0 +1,47 @@
+/**
+ * @file colors.cpp
+ * @brief Implements fetching color structures from codes
+ */
+
+#include "thermocycler-refresh/colors.hpp"
+
+using namespace colors;
+
+static constexpr uint8_t FULL = 0xFF;
+static constexpr uint8_t HIGH = 0xEE;
+static constexpr uint8_t MED = 0x50;
+
+// Public function implementation
+auto colors::get_color(Colors color, double brightness) -> xt1511::XT1511 {
+    if (brightness > 1.0F) {
+        brightness = 1.0F;
+    }
+    xt1511::XT1511 led{};
+    switch (color) {
+        case Colors::SOFT_WHITE:
+            led.w = HIGH;
+            break;
+        case Colors::WHITE:
+            led.g = HIGH;
+            led.r = HIGH;
+            led.b = HIGH;
+            break;
+        case Colors::RED:
+            led.r = MED;
+            break;
+        case Colors::GREEN:
+            led.g = HIGH;
+            break;
+        case Colors::BLUE:
+            led.b = FULL;
+            break;
+        case Colors::ORANGE:
+            led.g = MED;
+            led.r = FULL;
+            break;
+        case Colors::NONE:
+            break;
+    }
+    led.set_scale(brightness);
+    return led;
+}

--- a/stm32-modules/thermocycler-refresh/src/colors.cpp
+++ b/stm32-modules/thermocycler-refresh/src/colors.cpp
@@ -7,9 +7,17 @@
 
 using namespace colors;
 
-static constexpr uint8_t FULL = 0xFF;
-static constexpr uint8_t HIGH = 0xEE;
-static constexpr uint8_t MED = 0x50;
+namespace color_values {
+
+static constexpr auto SOFT_WHITE = xt1511::XT1511{.w = 0xEE};
+static constexpr auto WHITE = xt1511::XT1511{.g = 0xEE, .r = 0xEE, .b = 0xEE};
+static constexpr auto RED = xt1511::XT1511{.r = 0x50};
+static constexpr auto GREEN = xt1511::XT1511{.g = 0xEE};
+static constexpr auto BLUE = xt1511::XT1511{.b = 0xFF};
+static constexpr auto ORANGE = xt1511::XT1511{.g = 0x53, .r = 0xFF};
+static constexpr auto NONE = xt1511::XT1511{};
+
+}  // namespace color_values
 
 // Public function implementation
 auto colors::get_color(Colors color, double brightness) -> xt1511::XT1511 {
@@ -19,27 +27,25 @@ auto colors::get_color(Colors color, double brightness) -> xt1511::XT1511 {
     xt1511::XT1511 led{};
     switch (color) {
         case Colors::SOFT_WHITE:
-            led.w = HIGH;
+            led = color_values::SOFT_WHITE;
             break;
         case Colors::WHITE:
-            led.g = HIGH;
-            led.r = HIGH;
-            led.b = HIGH;
+            led = color_values::WHITE;
             break;
         case Colors::RED:
-            led.r = MED;
+            led = color_values::RED;
             break;
         case Colors::GREEN:
-            led.g = HIGH;
+            led = color_values::GREEN;
             break;
         case Colors::BLUE:
-            led.b = FULL;
+            led = color_values::BLUE;
             break;
         case Colors::ORANGE:
-            led.g = MED;
-            led.r = FULL;
+            led = color_values::ORANGE;
             break;
         case Colors::NONE:
+            led = color_values::NONE;
             break;
     }
     led.set_scale(brightness);

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_tmc2130.cpp
     test_board_revision_hardware.cpp
     test_board_revision.cpp
+    test_colors.cpp
     # GCode parse tests
     test_m14.cpp
     test_m104.cpp

--- a/stm32-modules/thermocycler-refresh/tests/test_colors.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_colors.cpp
@@ -1,0 +1,47 @@
+#include "catch2/catch.hpp"
+#include "thermocycler-refresh/colors.hpp"
+
+using namespace colors;
+
+SCENARIO("color converter works") {
+    GIVEN("some colors and full brightness") {
+        auto white = get_color(Colors::SOFT_WHITE);
+        auto blue = get_color(Colors::BLUE);
+        auto red = get_color(Colors::RED);
+        THEN("the result is as expected") {
+            REQUIRE(white == xt1511::XT1511{.w = 0xEE});
+            REQUIRE(blue == xt1511::XT1511{.b = 0xFF});
+            REQUIRE(red == xt1511::XT1511{.r = 0x50});
+        }
+        AND_GIVEN("some colors set to 150% brightness") {
+            auto white2 = get_color(Colors::SOFT_WHITE, 1.5);
+            auto blue2 = get_color(Colors::BLUE, 1.5);
+            auto red2 = get_color(Colors::RED, 1.5);
+            THEN("the colors are not scaled above 100%") {
+                REQUIRE(white == white2);
+                REQUIRE(blue == blue2);
+                REQUIRE(red == red2);
+            }
+        }
+    }
+    GIVEN("some colors and half brightness") {
+        auto white = get_color(Colors::SOFT_WHITE, 0.5);
+        auto blue = get_color(Colors::BLUE, 0.5);
+        auto red = get_color(Colors::RED, 0.5);
+        THEN("the result is as expected") {
+            REQUIRE(white == xt1511::XT1511{.w = 0xEE / 2});
+            REQUIRE(blue == xt1511::XT1511{.b = 0xFF / 2});
+            REQUIRE(red == xt1511::XT1511{.r = 0x50 / 2});
+        }
+    }
+    GIVEN("some colors and zero brightness") {
+        auto white = get_color(Colors::SOFT_WHITE, 0);
+        auto blue = get_color(Colors::BLUE, 0);
+        auto red = get_color(Colors::RED, 0);
+        THEN("the result is as expected") {
+            REQUIRE(white == xt1511::XT1511{});
+            REQUIRE(blue == xt1511::XT1511{});
+            REQUIRE(red == xt1511::XT1511{});
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_system_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_system_task.cpp
@@ -115,5 +115,40 @@ SCENARIO("system task message passing") {
                 }
             }
         }
+
+        WHEN("sending a set-led message") {
+            auto message = messages::SetLedMode{.color = colors::Colors::BLUE,
+                                                .mode = colors::Mode::SOLID};
+            tasks->get_system_queue().backing_deque.push_back(
+                messages::SystemMessage(message));
+            tasks->get_system_task().run_once(tasks->get_system_policy());
+            THEN("the task should get the message") {
+                REQUIRE(tasks->get_system_queue().backing_deque.empty());
+                AND_THEN("the task's LED status should be updated") {
+                    auto &led = tasks->get_system_task().get_led_state();
+                    REQUIRE(led.mode == message.mode);
+                    REQUIRE(led.color == colors::get_color(message.color));
+                    REQUIRE(led.counter == 0);
+                }
+            }
+            AND_THEN("sending an LED update message") {
+                tasks->get_system_queue().backing_deque.push_back(
+                    messages::SystemMessage(messages::UpdateUIMessage()));
+                tasks->get_system_task().run_once(tasks->get_system_policy());
+                THEN("the task should set the LED outputs appropriately") {
+                    auto &buf = tasks->get_system_policy().buffer();
+                    auto test_string =
+                        xt1511::XT1511String<uint16_t, 16>(xt1511::Speed::HALF);
+                    auto test_buf = TestXT1511Policy<16>(
+                        tasks->get_system_policy().get_max_pwm());
+                    test_string.set_all(
+                        colors::get_color(colors::Colors::BLUE));
+                    test_string.write(test_buf);
+                    for (size_t i = 0; i < buf.size(); ++i) {
+                        REQUIRE(buf[i] == test_buf.buffer()[i]);
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### Summary

Adds in UI action support to the system task.

- The periodic updating of the LED's is driven by a FreeRTOS periodic timer, lifted and somewhat modified from OT3
- XT1511 driver is modified to support the half-baud protocol options; this uses 400kHz instead of 800kHz and has slightly different control values. The code is switched to use this protocol because the peripheral clocks are at 170MHz and the math to get a timer going at 800kHz simply doesn't work out - the LEDs work fine most of the time, but repeated writes show some small glitches. Fortunately, 400kHz works fine without having to redo the clock muxing.
- Added a color mapping driver to standardize color values (lifted from TC 1.0)

Tested on hardware by changing System Task initialization code to each of the different actions + confirming they show the correct actions. The pulsing/blinking/wiping behavior is written to emulate the original thermocycler as close as possible.

Does not have automatic UI state setting. This will be added in the future to be controlled by the Thermal Plate Task.