### PR TITLE
feat(heater-shaker, thermocycler-refresh): Get simulator serial number from environment variable

### DIFF
--- a/stm32-modules/heater-shaker/simulator/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/simulator/CMakeLists.txt
@@ -19,7 +19,8 @@ target_link_libraries(
 )
 target_include_directories(
         heater-shaker-simulator 
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/heater-shaker)
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/heater-shaker
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/common)
 
 
 set_target_properties(heater-shaker-simulator

--- a/stm32-modules/heater-shaker/simulator/system_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/system_thread.cpp
@@ -11,6 +11,7 @@
 
 #include "heater-shaker/errors.hpp"
 #include "heater-shaker/tasks.hpp"
+#include "simulator/simulator_utils.hpp"
 #include "systemwide.h"
 
 using namespace system_thread;
@@ -67,25 +68,15 @@ struct system_thread::TaskControlBlock {
     SimSystemTask task;
 };
 
-template <size_t N>
-static auto get_serial_number() -> std::optional<std::array<char, N>> {
-    using RT = std::optional<std::array<char, N>>;
-    constexpr const char serial_number_varname[] = "SERIAL_NUMBER";
-    auto *env_p = std::getenv(serial_number_varname);
-    if (!env_p || (strlen(env_p) == 0)) {
-        return RT();
-    }
-    std::array<char, N> ret;
-    memcpy(ret.data(), env_p, std::min(strlen(env_p), N));
-    return RT(ret);
-}
-
 auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb) -> void {
     using namespace std::literals::chrono_literals;
     auto policy = SimSystemPolicy();
 
     // Populate the serial number on startup, if provided
-    auto ret = get_serial_number<SYSTEM_WIDE_SERIAL_NUMBER_LENGTH>();
+    constexpr const char serial_var_name[] = "SERIAL_NUMBER";
+    auto ret =
+        simulator_utils::get_serial_number<SYSTEM_WIDE_SERIAL_NUMBER_LENGTH>(
+            serial_var_name);
     if (ret.has_value()) {
         static_cast<void>(policy.set_serial_number(ret.value()));
     }

--- a/stm32-modules/heater-shaker/simulator/system_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/system_thread.cpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <iterator>
 #include <memory>
 #include <stop_token>
@@ -66,10 +67,31 @@ struct system_thread::TaskControlBlock {
     SimSystemTask task;
 };
 
+template <size_t N>
+static auto get_serial_number() -> std::optional<std::array<char, N>> {
+    using RT = std::optional<std::array<char, N>>;
+    constexpr const char serial_number_varname[] = "SERIAL_NUMBER";
+    auto *env_p = std::getenv(serial_number_varname);
+    if(!env_p || (strlen(env_p) == 0)) {
+        return RT();
+    }
+    std::array<char, N> ret;
+    memcpy(ret.data(), env_p, std::min(strlen(env_p), N));
+    return RT(ret);
+}
+
 auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb) -> void {
     using namespace std::literals::chrono_literals;
     auto policy = SimSystemPolicy();
+
+    // Populate the serial number on startup, if provided
+    auto ret = get_serial_number<SYSTEM_WIDE_SERIAL_NUMBER_LENGTH>();
+    if(ret.has_value()) {
+        static_cast<void>(policy.set_serial_number(ret.value()));
+    }
+
     tcb->queue.set_stop_token(st);
+
     while (!st.stop_requested()) {
         try {
             tcb->task.run_once(policy);

--- a/stm32-modules/heater-shaker/simulator/system_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/system_thread.cpp
@@ -72,7 +72,7 @@ static auto get_serial_number() -> std::optional<std::array<char, N>> {
     using RT = std::optional<std::array<char, N>>;
     constexpr const char serial_number_varname[] = "SERIAL_NUMBER";
     auto *env_p = std::getenv(serial_number_varname);
-    if(!env_p || (strlen(env_p) == 0)) {
+    if (!env_p || (strlen(env_p) == 0)) {
         return RT();
     }
     std::array<char, N> ret;
@@ -86,7 +86,7 @@ auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb) -> void {
 
     // Populate the serial number on startup, if provided
     auto ret = get_serial_number<SYSTEM_WIDE_SERIAL_NUMBER_LENGTH>();
-    if(ret.has_value()) {
+    if (ret.has_value()) {
         static_cast<void>(policy.set_serial_number(ret.value()));
     }
 

--- a/stm32-modules/include/common/simulator/simulator_utils.hpp
+++ b/stm32-modules/include/common/simulator/simulator_utils.hpp
@@ -33,7 +33,7 @@ static auto get_serial_number(const char *var_name)
     }
 
     std::array<char, N> ret;
-    memcpy(ret.data(), env_p, std::min(strlen(env_p), N));
+    strncpy(ret.data(), env_p, N);
     return RT(ret);
 }
 

--- a/stm32-modules/include/common/simulator/simulator_utils.hpp
+++ b/stm32-modules/include/common/simulator/simulator_utils.hpp
@@ -13,16 +13,17 @@ namespace simulator_utils {
 
 /**
  * @brief Get the serial number from an environment variable
- * 
+ *
  * @tparam N Number of character bytes in thhe serial number array
  * @param[in] var_name The name of the environment variable to read
  * @return The serial number \e if one is defined in the environment variable
  * \c var_name
  */
 template <size_t N>
-static auto get_serial_number(const char *var_name) -> std::optional<std::array<char, N>> {
+static auto get_serial_number(const char *var_name)
+    -> std::optional<std::array<char, N>> {
     using RT = std::optional<std::array<char, N>>;
-    if(var_name == NULL) {
+    if (var_name == NULL) {
         return RT();
     }
 
@@ -36,4 +37,4 @@ static auto get_serial_number(const char *var_name) -> std::optional<std::array<
     return RT(ret);
 }
 
-}
+}  // namespace simulator_utils

--- a/stm32-modules/include/common/simulator/simulator_utils.hpp
+++ b/stm32-modules/include/common/simulator/simulator_utils.hpp
@@ -1,0 +1,39 @@
+/**
+ * @file simulator_utils.hpp
+ * @brief common utilities for simulator applications
+ */
+
+#pragma once
+
+#include <array>
+#include <cstdlib>
+#include <optional>
+
+namespace simulator_utils {
+
+/**
+ * @brief Get the serial number from an environment variable
+ * 
+ * @tparam N Number of character bytes in thhe serial number array
+ * @param[in] var_name The name of the environment variable to read
+ * @return The serial number \e if one is defined in the environment variable
+ * \c var_name
+ */
+template <size_t N>
+static auto get_serial_number(const char *var_name) -> std::optional<std::array<char, N>> {
+    using RT = std::optional<std::array<char, N>>;
+    if(var_name == NULL) {
+        return RT();
+    }
+
+    auto *env_p = std::getenv(var_name);
+    if (!env_p || (strlen(env_p) == 0)) {
+        return RT();
+    }
+
+    std::array<char, N> ret;
+    memcpy(ret.data(), env_p, std::min(strlen(env_p), N));
+    return RT(ret);
+}
+
+}

--- a/stm32-modules/thermocycler-refresh/simulator/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/simulator/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(
 target_include_directories(
   ${TARGET_MODULE_NAME}-simulator 
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/${TARGET_MODULE_NAME}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/common
   )
 
 

--- a/stm32-modules/thermocycler-refresh/simulator/system_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/system_thread.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 
 #include "core/xt1511.hpp"
+#include "simulator/simulator_utils.hpp"
 #include "systemwide.h"
 #include "thermocycler-refresh/errors.hpp"
 #include "thermocycler-refresh/tasks.hpp"
@@ -86,25 +87,15 @@ struct system_thread::TaskControlBlock {
     SimSystemTask task;
 };
 
-template <size_t N>
-static auto get_serial_number() -> std::optional<std::array<char, N>> {
-    using RT = std::optional<std::array<char, N>>;
-    constexpr const char serial_number_varname[] = "SERIAL_NUMBER";
-    auto* env_p = std::getenv(serial_number_varname);
-    if (!env_p || (strlen(env_p) == 0)) {
-        return RT();
-    }
-    std::array<char, N> ret;
-    memcpy(ret.data(), env_p, std::min(strlen(env_p), N));
-    return RT(ret);
-}
-
 auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb) -> void {
     using namespace std::literals::chrono_literals;
     auto policy = SimSystemPolicy();
 
     // Populate the serial number on startup, if provided
-    auto ret = get_serial_number<SYSTEM_WIDE_SERIAL_NUMBER_LENGTH>();
+    constexpr const char serial_var_name[] = "SERIAL_NUMBER";
+    auto ret =
+        simulator_utils::get_serial_number<SYSTEM_WIDE_SERIAL_NUMBER_LENGTH>(
+            serial_var_name);
     if (ret.has_value()) {
         static_cast<void>(policy.set_serial_number(ret.value()));
     }


### PR DESCRIPTION
The `system_task` for each module now checks on startup for an environment variable `SERIAL_NUMBER` and sets the serial number for the system appropriately if it is defined. Tested on my local terminal by using gcode `M115`