### PR TITLE
feat(thermocycler-refresh): Seal motor configuration command

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -22,6 +22,7 @@
 #include "core/utility.hpp"
 #include "systemwide.h"
 #include "thermocycler-refresh/errors.hpp"
+#include "thermocycler-refresh/motor_utils.hpp"
 #include "thermocycler-refresh/tmc2130_registers.hpp"
 
 namespace gcode {
@@ -780,6 +781,86 @@ struct GetSealDriveStatus {
             return buf;
         }
         return buf + res;
+    }
+};
+
+struct SetSealParameter {
+    /**
+     * @brief SetSealParameter uses M243.D. Lets users set parameters for the
+     * seal stepper movement. Intended for internal testing use to find
+     * optimal settings for StallGuard repeatability.
+     *
+     * Syntax: M243.D <parameter> <value>\n
+     * Returns: M243.D OK\n
+     *
+     */
+    using ParseResult = std::optional<SetSealParameter>;
+
+    /** Enumeration of supported parameters.*/
+    using SealParameter = motor_util::SealStepper::Parameter;
+
+    static constexpr auto prefix =
+        std::array{'M', '2', '4', '3', '.', 'D', ' '};
+    static constexpr const char* response = "M243.D OK\n";
+
+    /** Array of parameters to allow easy searching for legal parameters.*/
+    static constexpr std::array<char, 6> _parameters = {
+        static_cast<char>(SealParameter::Velocity),
+        static_cast<char>(SealParameter::Acceleration),
+        static_cast<char>(SealParameter::StallguardThreshold),
+        static_cast<char>(SealParameter::StallguardMinVelocity),
+        static_cast<char>(SealParameter::RunCurrent),
+        static_cast<char>(SealParameter::HoldCurrent)};
+
+    /** The parameter to set.*/
+    SealParameter parameter;
+    /** The value to set \c parameter to.*/
+    uint32_t value;
+
+    template <typename Input>
+    static auto inline is_legal_parameter(const Input parameter_char) -> bool {
+        return std::find(_parameters.begin(), _parameters.end(),
+                         parameter_char) != _parameters.end();
+    }
+
+    template <typename InputIt, typename Limit>
+    requires std::contiguous_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        // Next character should be one of the seal parameters
+        auto parameter_char = *working;
+        std::advance(working, 1);
+        if (!is_legal_parameter(parameter_char)) {
+            // Not a valid parameter
+            return std::make_pair(ParseResult(), input);
+        }
+        working = gobble_whitespace(working, limit);
+        if (working == limit) {
+            // No value was defined
+            return std::make_pair(ParseResult(), input);
+        }
+
+        auto value_res = parse_value<uint32_t>(working, limit);
+        if (!value_res.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(
+            ParseResult(SetSealParameter{
+                .parameter = static_cast<SealParameter>(parameter_char),
+                .value = value_res.first.value()}),
+            value_res.second);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    static auto write_response_into(InputIt buf, InputLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
     }
 };
 

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -815,7 +815,7 @@ struct SetSealParameter {
     /** The parameter to set.*/
     SealParameter parameter;
     /** The value to set \c parameter to.*/
-    uint32_t value;
+    int32_t value;
 
     template <typename Input>
     static auto inline is_legal_parameter(const Input parameter_char) -> bool {
@@ -845,7 +845,7 @@ struct SetSealParameter {
             return std::make_pair(ParseResult(), input);
         }
 
-        auto value_res = parse_value<uint32_t>(working, limit);
+        auto value_res = parse_value<int32_t>(working, limit);
         if (!value_res.first.has_value()) {
             return std::make_pair(ParseResult(), input);
         }

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
@@ -46,7 +46,7 @@ class HostCommsTask {
         gcode::DeactivateLidHeating, gcode::SetPIDConstants,
         gcode::SetPlateTemperature, gcode::DeactivatePlate,
         gcode::SetFanAutomatic, gcode::ActuateSealStepperDebug,
-        gcode::GetSealDriveStatus>;
+        gcode::GetSealDriveStatus, gcode::SetSealParameter>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::ActuateSolenoid, gcode::ActuateLidStepperDebug,
@@ -54,7 +54,8 @@ class HostCommsTask {
                  gcode::SetHeaterDebug, gcode::SetLidTemperature,
                  gcode::DeactivateLidHeating, gcode::SetPIDConstants,
                  gcode::SetPlateTemperature, gcode::DeactivatePlate,
-                 gcode::SetFanAutomatic, gcode::ActuateSealStepperDebug>;
+                 gcode::SetFanAutomatic, gcode::ActuateSealStepperDebug,
+                 gcode::SetSealParameter>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetLidTempDebugCache = AckCache<8, gcode::GetLidTemperatureDebug>;
     using GetPlateTempDebugCache = AckCache<8, gcode::GetPlateTemperatureDebug>;
@@ -908,6 +909,29 @@ class HostCommsTask {
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
         auto message = messages::GetSealDriveStatusMessage{.id = id};
+        if (!task_registry->motor->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::SetSealParameter& seal_gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(seal_gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::SetSealParameterMessage{
+            .id = id, .param = seal_gcode.parameter, .value = seal_gcode.value};
         if (!task_registry->motor->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -34,7 +34,7 @@ concept Response = requires(ResponseType rt) {
 
 /*
 ** Message structs initiate actions. These may be changes in physical state, or
-** a request to send back some data. Each carries an ID, which should be copied4
+** a request to send back some data. Each carries an ID, which should be copied
 *V into
 ** the response.
 */

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -7,6 +7,7 @@
 #include "systemwide.h"
 #include "thermocycler-refresh/colors.hpp"
 #include "thermocycler-refresh/errors.hpp"
+#include "thermocycler-refresh/motor_utils.hpp"
 #include "thermocycler-refresh/tmc2130_registers.hpp"
 
 namespace messages {
@@ -33,8 +34,8 @@ concept Response = requires(ResponseType rt) {
 
 /*
 ** Message structs initiate actions. These may be changes in physical state, or
-** a request to send back some data. Each carries an ID, which should be copied
-*into
+** a request to send back some data. Each carries an ID, which should be copied4
+*V into
 ** the response.
 */
 // The from_system elements are a bit of a hack because we don't have full
@@ -175,6 +176,12 @@ struct GetSealDriveStatusResponse {
     tmc2130::DriveStatus status;
 };
 
+struct SetSealParameterMessage {
+    uint32_t id;
+    motor_util::SealStepper::Parameter param;
+    uint32_t value;
+};
+
 struct GetPlateTempMessage {
     uint32_t id;
 };
@@ -268,5 +275,5 @@ using MotorMessage =
     ::std::variant<std::monostate, ActuateSolenoidMessage,
                    LidStepperDebugMessage, LidStepperComplete,
                    SealStepperDebugMessage, SealStepperComplete,
-                   GetSealDriveStatusMessage>;
+                   GetSealDriveStatusMessage, SetSealParameterMessage>;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -35,7 +35,7 @@ concept Response = requires(ResponseType rt) {
 /*
 ** Message structs initiate actions. These may be changes in physical state, or
 ** a request to send back some data. Each carries an ID, which should be copied
-*V into
+*into
 ** the response.
 */
 // The from_system elements are a bit of a hack because we don't have full

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -179,7 +179,7 @@ struct GetSealDriveStatusResponse {
 struct SetSealParameterMessage {
     uint32_t id;
     motor_util::SealStepper::Parameter param;
-    uint32_t value;
+    int32_t value;
 };
 
 struct GetPlateTempMessage {

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
@@ -320,8 +320,8 @@ class MotorTask {
             case Parameter::StallguardMinVelocity: {
                 auto value =
                     motor_util::SealStepper::velocity_to_tstep(msg.value);
-                static constexpr const uint32_t min_tstep = -64;
-                static constexpr const uint32_t max_tstep = 63;
+                static constexpr const uint32_t min_tstep = 0;
+                static constexpr const uint32_t max_tstep = (1 << 20) - 1;
                 value = std::clamp(static_cast<uint32_t>(value), min_tstep,
                                    max_tstep);
                 _tmc2130.get_register_map().tcoolthrs.threshold = value;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
@@ -302,14 +302,16 @@ class MotorTask {
         auto with_error = errors::ErrorCode::NO_ERROR;
         switch (msg.param) {
             case Parameter::Velocity:
-                _seal_velocity = msg.value;
+                _seal_velocity = static_cast<uint32_t>(
+                    std::max(msg.value, static_cast<int32_t>(1)));
                 break;
             case Parameter::Acceleration:
-                _seal_acceleration = msg.value;
+                _seal_acceleration = static_cast<uint32_t>(
+                    std::max(msg.value, static_cast<int32_t>(1)));
                 break;
             case Parameter::StallguardThreshold: {
-                static constexpr const uint32_t min_sgt = -64;
-                static constexpr const uint32_t max_sgt = 63;
+                static constexpr const int32_t min_sgt = -64;
+                static constexpr const int32_t max_sgt = 63;
                 auto value = std::clamp(msg.value, min_sgt, max_sgt);
                 _tmc2130.get_register_map().coolconf.sgt = value;
                 ret = _tmc2130.write_config(policy);
@@ -320,7 +322,8 @@ class MotorTask {
                     motor_util::SealStepper::velocity_to_tstep(msg.value);
                 static constexpr const uint32_t min_tstep = -64;
                 static constexpr const uint32_t max_tstep = 63;
-                value = std::clamp(value, min_tstep, max_tstep);
+                value = std::clamp(static_cast<uint32_t>(value), min_tstep,
+                                   max_tstep);
                 _tmc2130.get_register_map().tcoolthrs.threshold = value;
                 ret = _tmc2130.write_config(policy);
                 break;
@@ -328,7 +331,8 @@ class MotorTask {
             case Parameter::RunCurrent: {
                 static constexpr const uint32_t min_current = 0;
                 static constexpr const uint32_t max_current = 0x1F;
-                auto value = std::clamp(msg.value, min_current, max_current);
+                auto value = std::clamp(static_cast<uint32_t>(msg.value),
+                                        min_current, max_current);
                 _tmc2130.get_register_map().ihold_irun.run_current = value;
                 ret = _tmc2130.write_config(policy);
                 break;
@@ -336,7 +340,8 @@ class MotorTask {
             case Parameter::HoldCurrent: {
                 static constexpr const uint32_t min_current = 0;
                 static constexpr const uint32_t max_current = 0x1F;
-                auto value = std::clamp(msg.value, min_current, max_current);
+                auto value = std::clamp(static_cast<uint32_t>(msg.value),
+                                        min_current, max_current);
                 _tmc2130.get_register_map().ihold_irun.hold_current = value;
                 ret = _tmc2130.write_config(policy);
                 break;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
@@ -307,7 +307,7 @@ class MotorTask {
                 break;
             case Parameter::Acceleration:
                 _seal_acceleration = static_cast<uint32_t>(
-                    std::max(msg.value, static_cast<int32_t>(1)));
+                    std::max(msg.value, static_cast<int32_t>(0)));
                 break;
             case Parameter::StallguardThreshold: {
                 static constexpr const int32_t min_sgt = -64;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_utils.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_utils.hpp
@@ -68,6 +68,52 @@ class LidStepper {
     }
 };
 
+class SealStepper {
+  public:
+    /** Enumeration of supported parameters.*/
+    enum class Parameter : char {
+        Velocity = 'V',
+        Acceleration = 'A',
+        StallguardThreshold = 'T',
+        StallguardMinVelocity = 'M',
+        RunCurrent = 'R',
+        HoldCurrent = 'H'
+    };
+
+    // 16MHz external oscillator
+    static constexpr const double tmc_external_clock = 16000000;
+
+    /**
+     * @brief Convert a velocity into a period value
+     *
+     * @param velocity The velocity in steps/second
+     * @param clock Clock rate of the TMC2130. Default to \ref
+     * tmc_external_clock
+     * @return uint32_t containing the number of \c clock ticks per each motor
+     * step
+     */
+    [[nodiscard]] static auto inline velocity_to_tstep(
+        double velocity, double clock = tmc_external_clock) -> uint32_t {
+        return static_cast<uint32_t>(clock / velocity);
+    }
+
+    /**
+     * @brief Convert a period of TMC2130 clock ticks into a velocity in
+     * steps/sec
+     *
+     * @param tstep The period to convert, in \c clock ticks per each motor step
+     * @param clock Clock rate of the TMC2130. Default to \ref
+     * tmc_external_clock
+     * @return double containing the velocity in steps/second
+     */
+    [[nodiscard]] static auto inline tstep_to_velocity(
+        uint32_t tstep, double clock = tmc_external_clock) -> double {
+        // Avoid divide-by-zero issues, bound tstep to at least 1
+        tstep = std::max(tstep, static_cast<uint32_t>(1));
+        return clock / static_cast<double>(tstep);
+    }
+};
+
 /** The end condition for this movement.*/
 enum class MovementType {
     FixedDistance,  // This movement goes for a fixed number of steps.

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -9,6 +9,7 @@ import re
 import serial
 import datetime
 import time
+from enum import Enum
 
 from serial.tools.list_ports import grep
 from typing import Any, Callable, Dict, Tuple, List, Optional
@@ -184,4 +185,27 @@ def set_solenoid(engaged: bool, ser: serial.Serial):
     ser.write(f'G28.D {value}\n'.encode())
     res = ser.readline()
     guard_error(res, b'G28.D OK')
+    print(res)
+
+def move_seal_steps(steps: int, ser: serial.Serial):
+    print(f'Moving seal by {steps} steps')
+    ser.write(f'M241.D {steps}\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M241.D OK')
+    print(res)
+
+class SealParam(Enum):
+    VELOCITY = 'V'
+    ACCELERATION = 'A'
+    STALLGUARD_THRESHOLD = 'T'
+    STALLGUARD_MIN_VELOCITY = 'M'
+    RUN_CURRENT = 'R'
+    HOLD_CURRENT = 'H'
+
+# Debug command to set a seal parameter
+def set_seal_param(param: SealParam, value: int, ser: serial.Serial):
+    print(f'Setting {param} ({param.value}) to {value}')
+    ser.write(f'M243.D {param.value} {value}\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M243.D OK')
     print(res)

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_m240d.cpp
     test_m241d.cpp
     test_m242d.cpp
+    test_m243d.cpp
 )
 
 target_include_directories(${TARGET_MODULE_NAME} 

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -1569,6 +1569,64 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                 }
             }
         }
+        WHEN("sending a SetSealParameter command") {
+            auto message_text = std::string("M243.D V 10000\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN("the task should pass the message and not immediately ack") {
+                REQUIRE(tasks->get_motor_queue().has_message());
+                auto motor_msg = tasks->get_motor_queue().backing_deque.front();
+                REQUIRE(
+                    std::holds_alternative<messages::SetSealParameterMessage>(
+                        motor_msg));
+                auto seal_stepper_msg =
+                    std::get<messages::SetSealParameterMessage>(motor_msg);
+                tasks->get_motor_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(!tasks->get_host_comms_queue().has_message());
+                AND_WHEN("sending good response back to comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{.responding_to_id =
+                                                          seal_stepper_msg.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        const char response[] = "M243.D OK\n";
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith(response));
+                        REQUIRE(written_secondpass ==
+                                tx_buf.begin() + strlen(response));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending invalid ID back to comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = seal_stepper_msg.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/stm32-modules/thermocycler-refresh/tests/test_m243d.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m243d.cpp
@@ -1,0 +1,81 @@
+#include "catch2/catch.hpp"
+#include "thermocycler-refresh/gcodes.hpp"
+
+SCENARIO("gcode m243.d parameter utility function works") {
+    GIVEN("invalid parameter") {
+        std::array<char, 4> inputs = {'a', 'B', 'r', 'w'};
+        WHEN("checking for validity") {
+            for (auto c : inputs) {
+                THEN("no match occurs") {
+                    REQUIRE(!gcode::SetSealParameter::is_legal_parameter(c));
+                }
+            }
+        }
+    }
+    GIVEN("valid parameter") {
+        std::array<char, 6> inputs = {'V', 'A', 'T', 'M', 'R', 'H'};
+        WHEN("checking for validity") {
+            for (auto c : inputs) {
+                THEN("match occurs") {
+                    REQUIRE(gcode::SetSealParameter::is_legal_parameter(c));
+                }
+            }
+        }
+    }
+}
+
+SCENARIO("gcode m243.d works", "[gcode][parse][m243d]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(64, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetSealParameter::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::StartsWith("M243.D OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetSealParameter::write_response_into(
+                buffer.begin(), buffer.begin() + 8);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M243.D Occcccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("command to set velocity") {
+        std::string buffer = "M243.D V 10000\n";
+        WHEN("parsing the command") {
+            auto parsed =
+                gcode::SetSealParameter::parse(buffer.begin(), buffer.end());
+            THEN("the result should be correct") {
+                REQUIRE(parsed.second != buffer.begin());
+                REQUIRE(parsed.first.has_value());
+                REQUIRE(parsed.first.value().parameter ==
+                        gcode::SetSealParameter::SealParameter::Velocity);
+                REQUIRE(parsed.first.value().value == 10000);
+            }
+        }
+    }
+    GIVEN("command to set acceleration") {
+        std::string buffer = "M243.D A 40\n";
+        WHEN("parsing the command") {
+            auto parsed =
+                gcode::SetSealParameter::parse(buffer.begin(), buffer.end());
+            THEN("the result should be correct") {
+                REQUIRE(parsed.second != buffer.begin());
+                REQUIRE(parsed.first.has_value());
+                REQUIRE(parsed.first.value().parameter ==
+                        gcode::SetSealParameter::SealParameter::Acceleration);
+                REQUIRE(parsed.first.value().value == 40);
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_motor_utils.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_motor_utils.cpp
@@ -163,6 +163,29 @@ SCENARIO("MovementProfile functionality with flat acceleration") {
     }
 }
 
+SCENARIO("seal stepper utilities work") {
+    using namespace motor_util;
+    GIVEN("tmc2130 clock speed of 1000Hz") {
+        double clock = 1000;
+        GIVEN("velocity of 25 steps/sec") {
+            double velocity = 25;
+            WHEN("converting velocity to period") {
+                auto period = SealStepper::velocity_to_tstep(velocity, clock);
+                THEN("period is 40 clock ticks") { REQUIRE(period == 40); }
+            }
+        }
+        GIVEN("period of 40 clock ticks") {
+            uint32_t period = 40;
+            WHEN("converting period to velocity") {
+                auto velocity = SealStepper::tstep_to_velocity(period, clock);
+                THEN("velocity is 25 steps/sec") {
+                    REQUIRE_THAT(velocity, Catch::Matchers::WithinAbs(25, 0.1));
+                }
+            }
+        }
+    }
+}
+
 SCENARIO("MovementProfile acceleration testing") {
     GIVEN("a movement profile with a 1Hz frequency") {
         constexpr int frequency = 1;


### PR DESCRIPTION
Adds a debug gcode (M243.D) intended for internal development testing with the seal motor driver subsystem

* M243.D allows configuration of velocity, acceleration, stallguard threshold, stallguard minimum velocity, and hold & drive current
* Tested by running commands for each config option through python utilities. As a bonus, was able to confirm that overheat detection works (if you crank the drive current up to max you get a fault during movement).

