### PR TITLE
feat(thermocycler): Lid limit switches

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_hardware.h
@@ -80,6 +80,20 @@ bool motor_hardware_lid_stepper_check_fault(void);
 bool motor_hardware_lid_stepper_reset(void);
 
 /**
+ * @brief Read the Lid Closed switch
+ *
+ * @return true if the lid is closed, false otherwise
+ */
+bool motor_hardware_lid_read_closed(void);
+
+/**
+ * @brief Read the Lid Open switch
+ *
+ * @return true if the lid is fully open, false otherwise
+ */
+bool motor_hardware_lid_read_open(void);
+
+/**
  * @brief Sets the enable pin on the TMC2130
  * @param[in] enable True to enable, false to disable the TMC
  * @return True if the enable pin was set, false if it couldn't be set

--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_policy.hpp
@@ -62,6 +62,20 @@ class MotorPolicy {
     auto lid_solenoid_engage() -> void;
 
     /**
+     * @brief Read whether the Closed Switch is active
+     *
+     * @return true if the lid is closed, false otherwise
+     */
+    auto lid_read_closed_switch() -> bool;
+
+    /**
+     * @brief Read whether the Open Switch is active
+     *
+     * @return true if the lid is fully open, false otherwise
+     */
+    auto lid_read_open_switch() -> bool;
+
+    /**
      * @brief Start a new seal stepper movement
      *
      * @param callback Function to call on every tick

--- a/stm32-modules/include/thermocycler-refresh/test/test_motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_motor_policy.hpp
@@ -37,6 +37,10 @@ class TestMotorPolicy : public TestTMC2130Policy {
     auto lid_solenoid_disengage() -> void { _solenoid_engaged = false; }
     auto lid_solenoid_engage() -> void { _solenoid_engaged = true; }
 
+    auto lid_read_closed_switch() -> bool { return _lid_closed_switch; }
+
+    auto lid_read_open_switch() -> bool { return _lid_open_switch; }
+
     auto seal_stepper_start(Callback cb) -> bool {
         if (_seal_moving) {
             return false;
@@ -63,6 +67,10 @@ class TestMotorPolicy : public TestTMC2130Policy {
     auto get_angle() -> double { return _actual_angle; }
     auto seal_moving() -> bool { return _seal_moving; }
 
+    auto set_lid_open_switch(bool val) -> void { _lid_open_switch = val; }
+
+    auto set_lid_closed_switch(bool val) -> void { _lid_closed_switch = val; }
+
   private:
     // Solenoid is engaged when unpowered
     bool _solenoid_engaged = true;
@@ -71,5 +79,7 @@ class TestMotorPolicy : public TestTMC2130Policy {
     bool _lid_moving = false;
     bool _lid_fault = false;
     bool _seal_moving = false;
+    bool _lid_open_switch = false;
+    bool _lid_closed_switch = false;
     Callback _callback;
 };

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -250,6 +250,16 @@ struct SetLedMode {
     colors::Mode mode;
 };
 
+struct GetLidStatusMessage {
+    uint32_t id;
+};
+
+struct GetLidStatusResponse {
+    uint32_t responding_to_id;
+    motor_util::LidStepper::Status lid;
+    motor_util::SealStepper::Status seal;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage,
@@ -259,7 +269,8 @@ using HostCommsMessage =
                    ErrorMessage, ForceUSBDisconnectMessage,
                    GetSystemInfoResponse, GetLidTemperatureDebugResponse,
                    GetPlateTemperatureDebugResponse, GetPlateTempResponse,
-                   GetLidTempResponse, GetSealDriveStatusResponse>;
+                   GetLidTempResponse, GetSealDriveStatusResponse,
+                   GetLidStatusResponse>;
 using ThermalPlateMessage =
     ::std::variant<std::monostate, ThermalPlateTempReadComplete,
                    GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,
@@ -271,9 +282,8 @@ using LidHeaterMessage =
                    GetLidTemperatureDebugMessage, SetHeaterDebugMessage,
                    GetLidTempMessage, SetLidTemperatureMessage,
                    DeactivateLidHeatingMessage, SetPIDConstantsMessage>;
-using MotorMessage =
-    ::std::variant<std::monostate, ActuateSolenoidMessage,
-                   LidStepperDebugMessage, LidStepperComplete,
-                   SealStepperDebugMessage, SealStepperComplete,
-                   GetSealDriveStatusMessage, SetSealParameterMessage>;
+using MotorMessage = ::std::variant<
+    std::monostate, ActuateSolenoidMessage, LidStepperDebugMessage,
+    LidStepperComplete, SealStepperDebugMessage, SealStepperComplete,
+    GetSealDriveStatusMessage, SetSealParameterMessage, GetLidStatusMessage>;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
@@ -358,6 +358,18 @@ class MotorTask {
             messages::HostCommsMessage(response)));
     }
 
+    template <MotorExecutionPolicy Policy>
+    auto visit_message(const messages::GetLidStatusMessage& msg, Policy& policy)
+        -> void {
+        static_cast<void>(policy);
+        auto response = messages::GetLidStatusResponse{
+            .responding_to_id = msg.id,
+            .lid = motor_util::LidStepper::Status::UNKNOWN,
+            .seal = motor_util::SealStepper::Status::UNKNOWN};
+        static_cast<void>(_task_registry->comms->get_message_queue().try_send(
+            messages::HostCommsMessage(response)));
+    }
+
     // Callback for each tick() during a seal stepper movement
     template <MotorExecutionPolicy Policy>
     auto seal_step_callback(Policy& policy) -> void {

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_utils.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_utils.hpp
@@ -36,6 +36,27 @@ class LidStepper {
     constexpr static double ROTATION_TO_STEPS = DEGREES_TO_MICROSTEPS * 360;
 
   public:
+    /** Possible states of the lid stepper.*/
+    enum class Status { BETWEEN, CLOSED, OPEN, UNKNOWN };
+
+    [[nodiscard]] static auto status_to_string(Status status) -> const char* {
+        switch (status) {
+            case Status::BETWEEN:
+                return "in_between";
+                break;
+            case Status::CLOSED:
+                return "closed";
+                break;
+            case Status::OPEN:
+                return "open";
+                break;
+            case Status::UNKNOWN:
+                return "unknown";
+                break;
+        }
+        return "unknown";
+    }
+
     /**
      * @brief Convert a current value in milliamperes to a DAC value.
      *
@@ -80,8 +101,29 @@ class SealStepper {
         HoldCurrent = 'H'
     };
 
+    /** Possible status of the seal stepper.*/
+    enum class Status { BETWEEN, ENGAGED, RETRACTED, UNKNOWN };
+
     // 16MHz external oscillator
     static constexpr const double tmc_external_clock = 16000000;
+
+    [[nodiscard]] static auto status_to_string(Status status) -> const char* {
+        switch (status) {
+            case Status::BETWEEN:
+                return "in_between";
+                break;
+            case Status::ENGAGED:
+                return "engaged";
+                break;
+            case Status::RETRACTED:
+                return "retracted";
+                break;
+            case Status::UNKNOWN:
+                return "unknown";
+                break;
+        }
+        return "unknown";
+    }
 
     /**
      * @brief Convert a velocity into a period value

--- a/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_hardware.c
@@ -35,6 +35,21 @@ extern "C" {
 #define LID_STEPPER_VREF_CHANNEL DAC_CHANNEL_1
 #define LID_STEPPER_STEP_Channel TIM_CHANNEL_1
 
+/** Port for the lid closed optical switch.*/
+#define LID_CLOSED_SWITCH_PORT (GPIOD)
+/** Pin for the lid closed optical switch.*/
+#define LID_CLOSED_SWITCH_PIN (GPIO_PIN_9)
+
+/** Port for the lid open optical switch.*/
+#define LID_OPEN_SWITCH_PORT (GPIOB)
+/** Pin for the lid open optical switch.*/
+#define LID_OPEN_SWITCH_PIN (GPIO_PIN_7)
+
+/** Port for the Photointerrupt Enable line.*/
+#define PHOTOINTERRUPT_ENABLE_PORT (GPIOE)
+/** Pin for the photointerrupt enable line.*/
+#define PHOTOINTERRUPT_ENABLE_PIN (GPIO_PIN_0)
+
 /** Port for the step pulse pin.*/
 #define SEAL_STEPPER_STEP_PORT (GPIOB)
 /** Pin for the step pulse pin.*/
@@ -212,6 +227,14 @@ bool motor_hardware_lid_stepper_reset(void) {
     return (motor_hardware_lid_stepper_check_fault() == true) ? false : true;
 }
 
+bool motor_hardware_lid_read_closed(void) {
+    return (HAL_GPIO_ReadPin(LID_CLOSED_SWITCH_PORT, LID_CLOSED_SWITCH_PIN) == GPIO_PIN_RESET) ? true : false;
+}
+
+bool motor_hardware_lid_read_open(void) {
+    return (HAL_GPIO_ReadPin(LID_OPEN_SWITCH_PORT, LID_OPEN_SWITCH_PIN) == GPIO_PIN_SET) ? true : false;
+}
+
 
 bool motor_hardware_set_seal_enable(bool enable) {
     // Active low
@@ -309,6 +332,29 @@ static void init_motor_gpio(void)
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
     GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
     HAL_GPIO_Init(LID_STEPPER_CONTROL_Port, &GPIO_InitStruct);
+
+    GPIO_InitStruct.Pin = LID_CLOSED_SWITCH_PIN;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FAST;
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Alternate = 0;
+    HAL_GPIO_Init(LID_CLOSED_SWITCH_PORT, &GPIO_InitStruct);
+    
+    GPIO_InitStruct.Pin = LID_OPEN_SWITCH_PIN;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FAST;
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Alternate = 0;
+    HAL_GPIO_Init(LID_OPEN_SWITCH_PORT, &GPIO_InitStruct);
+
+    // Initialize photointerrupt to 3.3v to enable
+    GPIO_InitStruct.Pin = PHOTOINTERRUPT_ENABLE_PIN;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_LOW;
+	GPIO_InitStruct.Alternate = 0;
+    HAL_GPIO_Init(PHOTOINTERRUPT_ENABLE_PORT, &GPIO_InitStruct);
+    HAL_GPIO_WritePin(PHOTOINTERRUPT_ENABLE_PORT, PHOTOINTERRUPT_ENABLE_PIN, GPIO_PIN_SET);
 
     GPIO_InitStruct.Pin = SEAL_STEPPER_ENABLE_PIN;
     GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;

--- a/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_hardware.c
@@ -460,7 +460,7 @@ static void init_tim2(TIM_HandleTypeDef* htim) {
     htim->Init.Prescaler = uwPrescalerValue;
     htim->Init.CounterMode = TIM_COUNTERMODE_UP;
     htim->Init.Period = uwPeriodValue;
-    htim->Init.ClockDivision = 0;
+    htim->Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
     htim->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
     hal_ret = HAL_TIM_OC_Init(htim);

--- a/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_policy.cpp
@@ -47,6 +47,16 @@ auto MotorPolicy::lid_solenoid_engage() -> void {
     motor_hardware_solenoid_engage();
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto MotorPolicy::lid_read_closed_switch() -> bool {
+    return motor_hardware_lid_read_closed();
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto MotorPolicy::lid_read_open_switch() -> bool {
+    return motor_hardware_lid_read_open();
+}
+
 auto MotorPolicy::seal_stepper_start(std::function<void()> callback) -> bool {
     _seal_callback = std::move(callback);
     return motor_hardware_start_seal_movement();

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -209,3 +209,11 @@ def set_seal_param(param: SealParam, value: int, ser: serial.Serial):
     res = ser.readline()
     guard_error(res, b'M243.D OK')
     print(res)
+
+# Debug command to get lid status
+def get_lid_status(ser: serial.Serial):
+    print('Getting lid status')
+    ser.write(f'M119\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M119 Lid:')
+    print(res)

--- a/stm32-modules/thermocycler-refresh/simulator/motor_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/motor_thread.cpp
@@ -41,6 +41,10 @@ class SimMotorPolicy : public SimTMC2130Policy {
     auto lid_solenoid_disengage() -> void { _solenoid_engaged = false; }
     auto lid_solenoid_engage() -> void { _solenoid_engaged = true; }
 
+    auto lid_read_closed_switch() -> bool { return _lid_closed_switch; }
+
+    auto lid_read_open_switch() -> bool { return _lid_open_switch; }
+
     auto seal_stepper_start(Callback cb) -> bool {
         if (_seal_moving) {
             return false;
@@ -67,6 +71,8 @@ class SimMotorPolicy : public SimTMC2130Policy {
     int32_t _actual_angle = 0;
     bool _moving = false;
     bool _lid_fault = false;
+    bool _lid_open_switch = false;
+    bool _lid_closed_switch = false;
     bool _seal_moving = false;
     Callback _callback;
 };

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_m106.cpp
     test_m107.cpp
     test_m108.cpp
+    test_m119.cpp
     test_m140.cpp
     test_m140d.cpp
     test_m141.cpp

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -1657,7 +1657,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should ack the previous message") {
-                        const char response[] = "M119 Lid:unknown Seal:unknown OK\n";
+                        const char response[] =
+                            "M119 Lid:unknown Seal:unknown OK\n";
                         REQUIRE_THAT(tx_buf,
                                      Catch::Matchers::StartsWith(response));
                         REQUIRE(written_secondpass ==

--- a/stm32-modules/thermocycler-refresh/tests/test_m119.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m119.cpp
@@ -1,0 +1,47 @@
+#include "catch2/catch.hpp"
+
+// Push this diagnostic to avoid a compiler error about printing to too
+// small of a buffer... which we're doing on purpose!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-refresh/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+#include "thermocycler-refresh/motor_utils.hpp"
+
+SCENARIO("GetLidStatus (M119) parser works", "[gcode][parse][m119]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto lid = motor_util::LidStepper::Status::UNKNOWN;
+            auto seal = motor_util::SealStepper::Status::UNKNOWN;
+            auto written = gcode::GetLidStatus::write_response_into(
+                buffer.begin(), buffer.end(), lid, seal);
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "M119 Lid:unknown Seal:unknown OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("a valid input") {
+        std::string buffer = "M119\n";
+        WHEN("parsing") {
+            auto res = gcode::GetLidStatus::parse(buffer.begin(), buffer.end());
+            THEN("a valid gcode should be produced") {
+                REQUIRE(res.first.has_value());
+                REQUIRE(res.second != buffer.begin());
+            }
+        }
+    }
+    GIVEN("an invalid input") {
+        std::string buffer = "M 119\n";
+        WHEN("parsing") {
+            auto res = gcode::GetLidStatus::parse(buffer.begin(), buffer.end());
+            THEN("an error should be produced") {
+                REQUIRE(!res.first.has_value());
+                REQUIRE(res.second == buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_motor_utils.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_motor_utils.cpp
@@ -77,6 +77,40 @@ SCENARIO("Lid stepper microstep conversion works") {
     }
 }
 
+SCENARIO("lid status stringification works") {
+    using Status = motor_util::LidStepper::Status;
+    std::array<Status, 4> inputs = {Status::BETWEEN, Status::CLOSED,
+                                    Status::OPEN, Status::UNKNOWN};
+    std::array<std::string, 4> outputs = {"in_between", "closed", "open",
+                                          "unknown"};
+    WHEN("converting lid status enums to strings ") {
+        for (size_t i = 0; i < inputs.size(); ++i) {
+            auto result =
+                motor_util::LidStepper::status_to_string(inputs.at(i));
+            DYNAMIC_SECTION("the string is as expected" << i) {
+                REQUIRE_THAT(result, Catch::Matchers::Equals(outputs.at(i)));
+            }
+        }
+    }
+}
+
+SCENARIO("seal status stringification works") {
+    using Status = motor_util::SealStepper::Status;
+    std::array<Status, 4> inputs = {Status::BETWEEN, Status::ENGAGED,
+                                    Status::RETRACTED, Status::UNKNOWN};
+    std::array<std::string, 4> outputs = {"in_between", "engaged", "retracted",
+                                          "unknown"};
+    WHEN("converting lid status enums to strings") {
+        for (size_t i = 0; i < inputs.size(); ++i) {
+            auto result =
+                motor_util::SealStepper::status_to_string(inputs.at(i));
+            DYNAMIC_SECTION("the string is as expected " << i) {
+                REQUIRE_THAT(result, Catch::Matchers::Equals(outputs.at(i)));
+            }
+        }
+    }
+}
+
 SCENARIO("MovementProfile functionality with flat acceleration") {
     GIVEN("a movement profile with a 1Hz interrupt") {
         constexpr int frequency = 1;


### PR DESCRIPTION
### Summary

Adds code to read the open/close limit switches, and polls them during lid movements to stop the motor when they are triggered.

The switches are _not_ set as interrupts because one of them conflicts with one of the ADC Ready interrupts on line 9. The ADC read timing is more important to the system as a whole, so the limit switches get read on a polling basis.

* Adds M119 GetLidStatus, which mirrors the version from the original Thermocycler but adds in a return variable including the status of the seal stepper.
* Tested by sending move commands to open/close the lid and making sure that 1) triggering the correct switch stops movement 2) the irrelevant switch is ignored completely.

Might end up having to add overdrive handling for close commands to make sure the lid is fully closed, that is TBD.