### PR TITLE
docs(modules): update readme for cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Magnetic Module (Magdeck) and Thermocycler.
 
 This repo uses [CMake](https://cmake.org) as a configuration and build management tool. It requires
 CMake 3.20 since it uses [presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
-to manage cross-compilation and project configuration options. If you want to interact with the STM32 hardware, you should also install [st-link](https://github.com/stlink-org/stlink). 
+to manage cross-compilation and project configuration options. 
+- Before you can configure any of the cmake presets, you may need to manually install a C compiler and a C++ compiler (e.g. `sudo apt install gcc g++` on Ubuntu)
+- If you want to interact with the STM32 hardware, you should also install [st-link](https://github.com/stlink-org/stlink). 
 
 First, clone the repository and change into the directory:
 


### PR DESCRIPTION
Added a note in the readme that configuring the cmake presets will require a C and C++ compiler after noticing that `cmake --preset arduino` fails if there's no g++ on a Linux machine.