### PR TITLE
feat(thermocycler-refresh): thermal debug command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ arduino_ide
 build-stm32-cross/
 stm32-tools/
 build-stm32-host/
+build-arduino/
 
 # Custom CMake Config
 /CMakeUserPresets.json

--- a/stm32-modules/include/thermocycler-refresh/firmware/thermal_fan_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/thermal_fan_hardware.h
@@ -22,6 +22,12 @@ void thermal_fan_initialize(void);
  */
 bool thermal_fan_set_power(double power);
 
+/**
+ * @brief Retreives the current power setting of the fans
+ * @return double containing current fan power
+ */
+double thermal_fan_get_power(void);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/stm32-modules/include/thermocycler-refresh/firmware/thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/thermal_plate_policy.hpp
@@ -19,4 +19,6 @@ class ThermalPlatePolicy {
     auto get_peltier(PeltierID peltier) -> std::pair<PeltierDirection, double>;
 
     auto set_fan(double power) -> bool;
+
+    auto get_fan() -> double;
 };

--- a/stm32-modules/include/thermocycler-refresh/test/test_thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_thermal_plate_policy.hpp
@@ -54,6 +54,8 @@ class TestThermalPlatePolicy {
         return true;
     }
 
+    auto get_fan() -> double { return _fan_power; }
+
     bool _enabled = false;
     TestPeltier _left = TestPeltier();
     TestPeltier _center = TestPeltier();

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
@@ -46,8 +46,8 @@ class HostCommsTask {
         gcode::DeactivateLidHeating, gcode::SetPIDConstants,
         gcode::SetPlateTemperature, gcode::DeactivatePlate,
         gcode::SetFanAutomatic, gcode::ActuateSealStepperDebug,
-        gcode::GetSealDriveStatus, gcode::SetSealParameter,
-        gcode::GetLidStatus>;
+        gcode::GetSealDriveStatus, gcode::SetSealParameter, gcode::GetLidStatus,
+        gcode::GetThermalPowerDebug>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::ActuateSolenoid, gcode::ActuateLidStepperDebug,
@@ -64,6 +64,10 @@ class HostCommsTask {
     using GetLidTempCache = AckCache<8, gcode::GetLidTemp>;
     using GetSealDriveStatusCache = AckCache<8, gcode::GetSealDriveStatus>;
     using GetLidStatusCache = AckCache<8, gcode::GetLidStatus>;
+    // This is a two-stage message since both the Plate and Lid tasks have
+    // to respond.
+    using GetThermalPowerCache = AckCache<8, gcode::GetThermalPowerDebug,
+                                          messages::GetPlatePowerResponse>;
 
   public:
     static constexpr size_t TICKS_TO_WAIT_ON_SEND = 10;
@@ -86,7 +90,9 @@ class HostCommsTask {
           // NOLINTNEXTLINE(readability-redundant-member-init)
           get_seal_drive_status_cache(),
           // NOLINTNEXTLINE(readability-redundant-member-init)
-          get_lid_status_cache() {}
+          get_lid_status_cache(),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
+          get_thermal_power_cache() {}
     HostCommsTask(const HostCommsTask& other) = delete;
     auto operator=(const HostCommsTask& other) -> HostCommsTask& = delete;
     HostCommsTask(HostCommsTask&& other) noexcept = delete;
@@ -425,6 +431,69 @@ class HostCommsTask {
                 } else {
                     return cache_element.write_response_into(
                         tx_into, tx_limit, response.lid, response.seal);
+                }
+            },
+            cache_entry);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(const messages::GetPlatePowerResponse& response,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        // Follow up by sending a message to the lid
+        auto cache_entry = get_thermal_power_cache.remove_if_present(
+            response.responding_to_id);
+        return std::visit(
+            [tx_into, tx_limit, response, this](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (!std::is_same_v<gcode::GetThermalPowerDebug, T>) {
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                } else {
+                    auto id = get_thermal_power_cache.add(response);
+                    if (id == 0) {
+                        return errors::write_into(
+                            tx_into, tx_limit,
+                            errors::ErrorCode::GCODE_CACHE_FULL);
+                    }
+                    auto message = messages::GetThermalPowerMessage{.id = id};
+                    if (!task_registry->lid_heater->get_message_queue()
+                             .try_send(message, TICKS_TO_WAIT_ON_SEND)) {
+                        get_thermal_power_cache.remove_if_present(id);
+                        return errors::write_into(
+                            tx_into, tx_limit,
+                            errors::ErrorCode::INTERNAL_QUEUE_FULL);
+                    }
+                    // Nothing gets written for this command
+                    return tx_into;
+                }
+            },
+            cache_entry);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(const messages::GetLidPowerResponse& response,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        // Now we can send complete response to host computer
+        auto cache_entry = get_thermal_power_cache.remove_if_present(
+            response.responding_to_id);
+        return std::visit(
+            [tx_into, tx_limit, response](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (!std::is_same_v<messages::GetPlatePowerResponse,
+                                              T>) {
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                } else {
+                    return gcode::GetThermalPowerDebug::write_response_into(
+                        tx_into, tx_limit, cache_element.left,
+                        cache_element.center, cache_element.right,
+                        response.heater, cache_element.fans);
                 }
             },
             cache_entry);
@@ -990,6 +1059,28 @@ class HostCommsTask {
         return std::make_pair(true, tx_into);
     }
 
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::GetThermalPowerDebug& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = get_thermal_power_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::GetThermalPowerMessage{.id = id};
+        if (!task_registry->thermal_plate->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
     // Our error handler just writes an error and bails
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
@@ -1012,6 +1103,7 @@ class HostCommsTask {
     GetLidTempCache get_lid_temp_cache;
     GetSealDriveStatusCache get_seal_drive_status_cache;
     GetLidStatusCache get_lid_status_cache;
+    GetThermalPowerCache get_thermal_power_cache;
     bool may_connect_latch = true;
 };
 

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -329,10 +329,8 @@ class LidHeaterTask {
     template <LidHeaterExecutionPolicy Policy>
     auto visit_message(const messages::GetThermalPowerMessage& msg,
                        Policy& policy) -> void {
-        static_cast<void>(policy);
-
         auto response = messages::GetLidPowerResponse{
-            .responding_to_id = msg.id, .heater = 0.0F};
+            .responding_to_id = msg.id, .heater = policy.get_heater_power()};
 
         static_cast<void>(
             _task_registry->comms->get_message_queue().try_send(response));

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -326,6 +326,18 @@ class LidHeaterTask {
             _task_registry->comms->get_message_queue().try_send(response));
     }
 
+    template <LidHeaterExecutionPolicy Policy>
+    auto visit_message(const messages::GetThermalPowerMessage& msg,
+                       Policy& policy) -> void {
+        static_cast<void>(policy);
+
+        auto response = messages::GetLidPowerResponse{
+            .responding_to_id = msg.id, .heater = 0.0F};
+
+        static_cast<void>(
+            _task_registry->comms->get_message_queue().try_send(response));
+    }
+
     auto handle_temperature_conversion(uint16_t conversion_result,
                                        Thermistor& thermistor) -> void {
         auto visitor = [this, &thermistor](const auto value) -> void {

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -200,6 +200,25 @@ struct SetPeltierDebugMessage {
     PeltierSelection selection;
 };
 
+// Can be sent to both plate task and lid task
+struct GetThermalPowerMessage {
+    uint32_t id;
+};
+
+// Plate Task response to GetThermalPowerMessage
+struct GetPlatePowerResponse {
+    uint32_t responding_to_id;
+
+    double left, center, right, fans;
+};
+
+// Lid Task response to GetThermalPowerMessage
+struct GetLidPowerResponse {
+    uint32_t responding_to_id;
+
+    double heater;
+};
+
 struct SetFanManualMessage {
     uint32_t id;
     double power;
@@ -264,24 +283,25 @@ using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage,
                    UpdateUIMessage, SetLedMode>;
-using HostCommsMessage =
-    ::std::variant<std::monostate, IncomingMessageFromHost, AcknowledgePrevious,
-                   ErrorMessage, ForceUSBDisconnectMessage,
-                   GetSystemInfoResponse, GetLidTemperatureDebugResponse,
-                   GetPlateTemperatureDebugResponse, GetPlateTempResponse,
-                   GetLidTempResponse, GetSealDriveStatusResponse,
-                   GetLidStatusResponse>;
+using HostCommsMessage = ::std::variant<
+    std::monostate, IncomingMessageFromHost, AcknowledgePrevious, ErrorMessage,
+    ForceUSBDisconnectMessage, GetSystemInfoResponse,
+    GetLidTemperatureDebugResponse, GetPlateTemperatureDebugResponse,
+    GetPlateTempResponse, GetLidTempResponse, GetSealDriveStatusResponse,
+    GetLidStatusResponse, GetPlatePowerResponse, GetLidPowerResponse>;
 using ThermalPlateMessage =
     ::std::variant<std::monostate, ThermalPlateTempReadComplete,
                    GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,
                    SetFanManualMessage, GetPlateTempMessage,
                    SetPlateTemperatureMessage, DeactivatePlateMessage,
-                   SetPIDConstantsMessage, SetFanAutomaticMessage>;
+                   SetPIDConstantsMessage, SetFanAutomaticMessage,
+                   GetThermalPowerMessage>;
 using LidHeaterMessage =
     ::std::variant<std::monostate, LidTempReadComplete,
                    GetLidTemperatureDebugMessage, SetHeaterDebugMessage,
                    GetLidTempMessage, SetLidTemperatureMessage,
-                   DeactivateLidHeatingMessage, SetPIDConstantsMessage>;
+                   DeactivateLidHeatingMessage, SetPIDConstantsMessage,
+                   GetThermalPowerMessage>;
 using MotorMessage = ::std::variant<
     std::monostate, ActuateSolenoidMessage, LidStepperDebugMessage,
     LidStepperComplete, SealStepperDebugMessage, SealStepperComplete,

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -539,6 +539,22 @@ class ThermalPlateTask {
             _task_registry->comms->get_message_queue().try_send(response));
     }
 
+    template <ThermalPlateExecutionPolicy Policy>
+    auto visit_message(const messages::GetThermalPowerMessage& msg,
+                       Policy& policy) -> void {
+        static_cast<void>(policy);
+
+        auto response =
+            messages::GetPlatePowerResponse{.responding_to_id = msg.id,
+                                            .left = 0.0F,
+                                            .center = 0.0F,
+                                            .right = 0.0F,
+                                            .fans = 0.0F};
+
+        static_cast<void>(
+            _task_registry->comms->get_message_queue().try_send(response));
+    }
+
     auto handle_temperature_conversion(uint16_t conversion_result,
                                        Thermistor& thermistor) -> void {
         auto visitor = [this, &thermistor](const auto value) -> void {

--- a/stm32-modules/thermocycler-refresh/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/host_comms_task/freertos_comms_task.cpp
@@ -50,7 +50,7 @@ static auto _top_task = host_comms_task::HostCommsTask(_comms_queue);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _tasks = std::make_pair(&_top_task, &_local_task);
 
-static constexpr uint32_t stack_size = 500;
+static constexpr uint32_t stack_size = 2000;
 // Stack as a std::array because why not
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static std::array<StackType_t, stack_size> stack;

--- a/stm32-modules/thermocycler-refresh/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/host_comms_task/freertos_comms_task.cpp
@@ -50,7 +50,7 @@ static auto _top_task = host_comms_task::HostCommsTask(_comms_queue);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _tasks = std::make_pair(&_top_task, &_local_task);
 
-static constexpr uint32_t stack_size = 2000;
+static constexpr uint32_t stack_size = 2048;
 // Stack as a std::array because why not
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static std::array<StackType_t, stack_size> stack;

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_fan_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_fan_hardware.c
@@ -156,6 +156,10 @@ bool thermal_fan_set_power(double power) {
     return true;
 }
 
+double thermal_fan_get_power(void) {
+    return _fans.power;
+}
+
 // Local function implementations
 
 static bool thermal_fan_set_enable(bool enabled) {

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
@@ -41,3 +41,6 @@ auto ThermalPlatePolicy::set_fan(double power) -> bool {
     power = std::clamp(power, (double)0.0F, (double)1.0F);
     return thermal_fan_set_power(power);
 }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto ThermalPlatePolicy::get_fan() -> double { return thermal_fan_get_power(); }

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -65,6 +65,23 @@ def get_plate_temperatures(ser: serial.Serial) -> Tuple[float, float, float, flo
     temp_hs = float(match.group('HST'))
     return temp_hs, temp_r, temp_l, temp_c
 
+_THERMAL_POWER_RE = re.compile(
+    '^M103.D L:(?P<L>.+) C:(?P<C>.+) R:(?P<R>.+) H:(?P<H>.+) F:(?P<F>.+) OK\n'
+)
+def get_thermal_power(ser: serial.Serial) -> Tuple[float, float, float, float, float]:
+    ser.write(b'M103.D\n')
+    res = ser.readline()
+    guard_error(res, b'M103.D ')
+    res_s = res.decode()
+    match = re.match(_THERMAL_POWER_RE, res_s)
+    left = float(match.group('L'))
+    center = float(match.group('C'))
+    right = float(match.group('R'))
+    heater = float(match.group('H'))
+    fans = float(match.group('F'))
+    print(res)
+    return left, center, right, heater, fans
+
 _PLATE_TEMP_RE = re.compile('^M105 T:(?P<target>.+) C:(?P<temp>.+) OK\n')
 # JUST gets the base temperature of the plate
 def get_plate_temperature(ser: serial.Serial) -> float:

--- a/stm32-modules/thermocycler-refresh/simulator/thermal_plate_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/thermal_plate_thread.cpp
@@ -81,6 +81,8 @@ struct SimThermalPlatePolicy {
         _fan_power = power;
         return true;
     }
+
+    auto get_fan() -> double { return _fan_power; }
 };
 
 struct thermal_plate_thread::TaskControlBlock {

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_motor_utils.cpp
     # GCode parse tests
     test_m14.cpp
+    test_m103d.cpp
     test_m104.cpp
     test_m105.cpp
     test_m105d.cpp

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -1689,6 +1689,120 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                 }
             }
         }
+        WHEN("sending a GetThermalPowerDebug command") {
+            auto message_text = std::string("M103.D\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the plate task and not "
+                "immediately ack") {
+                REQUIRE(tasks->get_thermal_plate_queue().backing_deque.size() !=
+                        0);
+                auto plate_message =
+                    tasks->get_thermal_plate_queue().backing_deque.front();
+                REQUIRE(
+                    std::holds_alternative<messages::GetThermalPowerMessage>(
+                        plate_message));
+                auto get_plate_message =
+                    std::get<messages::GetThermalPowerMessage>(plate_message);
+                AND_WHEN("sending a good response to host comms") {
+                    auto response = messages::HostCommsMessage(
+                        messages::GetPlatePowerResponse{
+                            .responding_to_id = get_plate_message.id,
+                            .left = 0.0,
+                            .center = 0.1,
+                            .right = 0.2,
+                            .fans = 0.5});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should not ack the message yet") {
+                        REQUIRE(written_secondpass == written_firstpass);
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                    THEN("the task passes the message to the lid task") {
+                        REQUIRE(tasks->get_lid_heater_queue().has_message());
+                        auto lid_message =
+                            tasks->get_lid_heater_queue().backing_deque.front();
+                        REQUIRE(std::holds_alternative<
+                                messages::GetThermalPowerMessage>(lid_message));
+                        auto get_lid_message =
+                            std::get<messages::GetThermalPowerMessage>(
+                                lid_message);
+                        AND_WHEN("sending good response to comms") {
+                            auto response = messages::HostCommsMessage(
+                                messages::GetLidPowerResponse{
+                                    .responding_to_id = get_lid_message.id,
+                                    .heater = 0.3});
+                            tasks->get_host_comms_queue()
+                                .backing_deque.push_back(response);
+                            auto written_thirdpass =
+                                tasks->get_host_comms_task().run_once(
+                                    tx_buf.begin(), tx_buf.end());
+                            THEN("the task should ack the previous message") {
+                                const char response_msg[] =
+                                    "M103.D L:0.00 C:0.10 R:0.20 H:0.30 F:0.50 "
+                                    "OK\n";
+                                REQUIRE_THAT(
+                                    tx_buf,
+                                    Catch::Matchers::StartsWith(response_msg));
+                                REQUIRE(written_thirdpass ==
+                                        tx_buf.begin() + strlen(response_msg));
+                                REQUIRE(!tasks->get_host_comms_queue()
+                                             .has_message());
+                            }
+                        }
+                        AND_WHEN("sending a bad response to host comms") {
+                            auto response = messages::HostCommsMessage(
+                                messages::GetLidPowerResponse{
+                                    .responding_to_id = get_lid_message.id + 1,
+                                    .heater = 1.0});
+                            tasks->get_host_comms_queue()
+                                .backing_deque.push_back(response);
+                            auto written_thirdpass =
+                                tasks->get_host_comms_task().run_once(
+                                    tx_buf.begin(), tx_buf.end());
+                            THEN("an error is written") {
+                                REQUIRE(!tasks->get_host_comms_queue()
+                                             .has_message());
+                                REQUIRE_THAT(
+                                    tx_buf,
+                                    Catch::Matchers::StartsWith("ERR005"));
+                                REQUIRE(written_thirdpass > written_secondpass);
+                            }
+                        }
+                    }
+                }
+                AND_WHEN("sending a bad response to host comms") {
+                    auto response = messages::HostCommsMessage(
+                        messages::GetPlatePowerResponse{
+                            .responding_to_id = get_plate_message.id + 1,
+                            .left = 0.0,
+                            .center = 0.1,
+                            .right = 0.2,
+                            .fans = 0.5});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("an error is written") {
+                        REQUIRE(!tasks->get_host_comms_queue().has_message());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(!tasks->get_lid_heater_queue().has_message());
+                        REQUIRE(written_secondpass > written_firstpass);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/stm32-modules/thermocycler-refresh/tests/test_m103d.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m103d.cpp
@@ -1,0 +1,58 @@
+#include "catch2/catch.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-refresh/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("GetThermalPowerDebug (M103.D) parser works",
+         "[gocde][parse][m103.d]") {
+    GIVEN("a response buffer large enough for formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("writing response") {
+            auto written = gcode::GetThermalPowerDebug::write_response_into(
+                buffer.begin(), buffer.end(), 0.0, 0.1, 0.2, 0.3, 0.4);
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(
+                    buffer,
+                    Catch::Matchers::StartsWith(
+                        "M103.D L:0.00 C:0.10 R:0.20 H:0.30 F:0.40 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetThermalPowerDebug::write_response_into(
+                buffer.begin(), buffer.begin() + 7, 0.0, 0.1, 0.2, 0.3, 0.4);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M103.Dcccccccccc";
+                response.at(6) = '\0';
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("correct input") {
+        std::string input("M103.D\n");
+        WHEN("parsing the command") {
+            auto parsed =
+                gcode::GetThermalPowerDebug::parse(input.begin(), input.end());
+            THEN("the command should be correct") {
+                REQUIRE(parsed.second != input.begin());
+                REQUIRE(parsed.first.has_value());
+            }
+        }
+    }
+    GIVEN("incorrect input") {
+        std::string input("M103.E \n");
+        WHEN("parsing the command") {
+            auto parsed =
+                gcode::GetThermalPowerDebug::parse(input.begin(), input.end());
+            THEN("the command should be incrorrect") {
+                REQUIRE(parsed.second == input.begin());
+                REQUIRE(!parsed.first.has_value());
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary
Adds a command M103.D to get the current power output level for the peltiers, heater, and fans. This has been requested for initial thermal profiling data gathering.

- Also includes a much larger stack for the host comms task. There were crashes happening and the debugger showed the stack pointer way too high for what was allocated. I want to try to set up stack height monitoring when I've got a chance, for now just bumping up the stack size as a mitigation...
- New command depends on multiple tasks (plate and lid tasks), and thus uses the Ack Cache a little differently than other commands - it caches the original gcode while querying the first task, and then caches the response of the first task while querying the second task.
- Tested by setting some peltier/fan/heater levels on a PCBand reading them back with the command.