### PR TITLE
feat(thermocycler-refresh): Lid stepper overdrive movements

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_hardware.h
@@ -49,7 +49,7 @@ void motor_hardware_setup(const motor_hardware_callbacks* callbacks);
  * @brief Start a lid stepper movement
  * @param[in] steps Number of steps to move the stepper
  */
-void motor_hardware_lid_stepper_start(int32_t steps);
+void motor_hardware_lid_stepper_start(int32_t steps, bool overdrive);
 /**
  * @brief Stop a lid stepper movement
  *

--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_policy.hpp
@@ -34,7 +34,7 @@ class MotorPolicy {
      * @param steps Number of steps to move. Can be positive or negative
      * to indicate direction.
      */
-    auto lid_stepper_start(int32_t steps) -> void;
+    auto lid_stepper_start(int32_t steps, bool overdrive) -> void;
     /**
      * @brief Stop any movement on the lid stepper.
      *

--- a/stm32-modules/include/thermocycler-refresh/test/test_motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_motor_policy.hpp
@@ -15,7 +15,8 @@ class TestMotorPolicy : public TestTMC2130Policy {
     static constexpr uint32_t MotorTickFrequency = 1000000;
 
     auto lid_stepper_set_dac(uint8_t dac_val) -> void { _dac_val = dac_val; }
-    auto lid_stepper_start(int32_t steps) -> void {
+    auto lid_stepper_start(int32_t steps, bool overdrive) -> void {
+        _lid_overdrive = overdrive;
         // Simulate jumping right to the end
         if (_lid_fault) {
             return;
@@ -71,6 +72,8 @@ class TestMotorPolicy : public TestTMC2130Policy {
 
     auto set_lid_closed_switch(bool val) -> void { _lid_closed_switch = val; }
 
+    auto get_lid_overdrive() -> bool { return _lid_overdrive; }
+
   private:
     // Solenoid is engaged when unpowered
     bool _solenoid_engaged = true;
@@ -81,5 +84,6 @@ class TestMotorPolicy : public TestTMC2130Policy {
     bool _seal_moving = false;
     bool _lid_open_switch = false;
     bool _lid_closed_switch = false;
+    bool _lid_overdrive = false;
     Callback _callback;
 };

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
@@ -911,7 +911,7 @@ class HostCommsTask {
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
         auto message = messages::LidStepperDebugMessage{
-            .id = id, .angle = lid_stepper_gcode.angle};
+            .id = id, .angle = lid_stepper_gcode.angle, .overdrive = lid_stepper_gcode.overdrive};
         if (!task_registry->motor->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
@@ -911,7 +911,9 @@ class HostCommsTask {
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
         auto message = messages::LidStepperDebugMessage{
-            .id = id, .angle = lid_stepper_gcode.angle, .overdrive = lid_stepper_gcode.overdrive};
+            .id = id,
+            .angle = lid_stepper_gcode.angle,
+            .overdrive = lid_stepper_gcode.overdrive};
         if (!task_registry->motor->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -148,6 +148,7 @@ struct ActuateSolenoidMessage {
 struct LidStepperDebugMessage {
     uint32_t id;
     double angle;
+    bool overdrive;
 };
 
 struct LidStepperComplete {};

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
@@ -48,9 +48,10 @@ concept MotorExecutionPolicy = requires(Policy& p,
     // A function to set the stepper DAC as a register value
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     {p.lid_stepper_set_dac(1)};
-    // A function to start a stepper movement
+    // A function to start a stepper movement. Accepts a number of steps,
+    // and a boolean argument for whether this is an overdrive movement.
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    {p.lid_stepper_start(1)};
+    {p.lid_stepper_start(1, true)};
     // A function to stop a stepper movement
     {p.lid_stepper_stop()};
     // A function to check for a fault in the stepper movement
@@ -182,7 +183,8 @@ class MotorTask {
             policy.lid_stepper_set_dac(motor_util::LidStepper::current_to_dac(
                 LID_STEPPER_DEFAULT_VOLTAGE));
             policy.lid_stepper_start(
-                motor_util::LidStepper::angle_to_microsteps(msg.angle));
+                motor_util::LidStepper::angle_to_microsteps(msg.angle),
+                msg.overdrive);
             _lid_stepper_state.status = StepperState::MOVING;
             _lid_stepper_state.response_id = msg.id;
         } else {

--- a/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/motor_task/motor_policy.cpp
@@ -18,8 +18,8 @@ auto MotorPolicy::lid_stepper_set_dac(uint8_t dac_val) -> void {
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-auto MotorPolicy::lid_stepper_start(int32_t steps) -> void {
-    motor_hardware_lid_stepper_start(steps);
+auto MotorPolicy::lid_stepper_start(int32_t steps, bool overdrive) -> void {
+    motor_hardware_lid_stepper_start(steps, overdrive);
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -169,9 +169,12 @@ def set_peltier_pid(p: float, i: float, d: float, ser: serial.Serial):
     print(res)
 
 # Debug command to move the hinge motor
-def move_lid_angle(angle: float, ser: serial.Serial):
-    print(f'Moving lid by {angle}º')
-    ser.write(f'M240.D {angle}\n'.encode())
+def move_lid_angle(angle: float, overdrive: bool, ser: serial.Serial):
+    print(f'Moving lid by {angle}º overdrive = {overdrive}')
+    if(overdrive):
+        ser.write(f'M240.D {angle} O\n'.encode())
+    else:
+        ser.write(f'M240.D {angle}\n'.encode())
     res = ser.readline()
     guard_error(res, b'M240.D OK')
     print(res)

--- a/stm32-modules/thermocycler-refresh/simulator/motor_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/motor_thread.cpp
@@ -19,7 +19,8 @@ class SimMotorPolicy : public SimTMC2130Policy {
     // Functionality to fulfill concept
 
     auto lid_stepper_set_dac(uint8_t dac_val) -> void { _dac_val = dac_val; }
-    auto lid_stepper_start(int32_t steps) -> void {
+    auto lid_stepper_start(int32_t steps, bool overdrive) -> void {
+        _lid_overdrive = overdrive;
         // Simulate jumping right to the end
         if (_lid_fault) {
             return;
@@ -74,6 +75,7 @@ class SimMotorPolicy : public SimTMC2130Policy {
     bool _lid_open_switch = false;
     bool _lid_closed_switch = false;
     bool _seal_moving = false;
+    bool _lid_overdrive = false;
     Callback _callback;
 };
 

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -1415,6 +1415,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                 REQUIRE(written_firstpass == tx_buf.begin());
                 REQUIRE(!tasks->get_host_comms_queue().has_message());
                 REQUIRE(lid_stepper_msg.angle == 10.0F);
+                REQUIRE(!lid_stepper_msg.overdrive);
                 AND_WHEN("sending good response back to comms task") {
                     auto response = messages::HostCommsMessage(
                         messages::AcknowledgePrevious{.responding_to_id =

--- a/stm32-modules/thermocycler-refresh/tests/test_m240d.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m240d.cpp
@@ -37,12 +37,13 @@ SCENARIO("gcode m240.d works", "[gcode][parse][m240d]") {
                 REQUIRE(parsed.first.has_value());
                 REQUIRE_THAT(parsed.first.value().angle,
                              Catch::Matchers::WithinAbs(20, 0.1));
+                REQUIRE(!parsed.first.value().overdrive);
             }
         }
     }
 
-    GIVEN("command to move motor -20.5 degrees") {
-        std::string buffer = "M240.D -20.5\n";
+    GIVEN("command to move motor -20.5 degrees with overdrive") {
+        std::string buffer = "M240.D -20.5 O\n";
         WHEN("parsing the command") {
             auto parsed = gcode::ActuateLidStepperDebug::parse(buffer.begin(),
                                                                buffer.end());
@@ -51,6 +52,7 @@ SCENARIO("gcode m240.d works", "[gcode][parse][m240d]") {
                 REQUIRE(parsed.first.has_value());
                 REQUIRE_THAT(parsed.first.value().angle,
                              Catch::Matchers::WithinAbs(-20.5, 0.1));
+                REQUIRE(parsed.first.value().overdrive);
             }
         }
     }

--- a/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
@@ -49,10 +49,11 @@ SCENARIO("motor task message passing") {
         WHEN("sending a LidStepperDebugMessage") {
             static constexpr double ANGLE = 10.0F;
             auto message =
-                messages::LidStepperDebugMessage{.id = 123, .angle = ANGLE};
+                messages::LidStepperDebugMessage{.id = 123, .angle = ANGLE, .overdrive = true};
             motor_queue.backing_deque.push_back(message);
             tasks->run_motor_task();
             THEN("the message is received but no response is sent yet") {
+                REQUIRE(motor_policy.get_lid_overdrive());
                 REQUIRE(motor_policy.get_vref() > 0);
                 REQUIRE(motor_policy.get_angle() ==
                         motor_util::LidStepper::angle_to_microsteps(ANGLE));

--- a/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
@@ -48,8 +48,8 @@ SCENARIO("motor task message passing") {
         }
         WHEN("sending a LidStepperDebugMessage") {
             static constexpr double ANGLE = 10.0F;
-            auto message =
-                messages::LidStepperDebugMessage{.id = 123, .angle = ANGLE, .overdrive = true};
+            auto message = messages::LidStepperDebugMessage{
+                .id = 123, .angle = ANGLE, .overdrive = true};
             motor_queue.backing_deque.push_back(message);
             tasks->run_motor_task();
             THEN("the message is received but no response is sent yet") {


### PR DESCRIPTION
Adds support for "overdrive" movements, during which the stop flags are ignored. This will mostly be used for the automated lid open/close state machines to move to precise angles based on limit switch positions, which will _not_ be at the literal end of travel.

The overdrive option can be set by setting a flag on the Lid Stepper debug movement command. Tested by sending the command to drive into the limit switches, works as intended on hardware.