### PR TITLE
fix(thermocycler-refresh): DFU bootloader fix

### DIFF
--- a/stm32-modules/thermocycler-refresh/firmware/system/system_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/system/system_hardware.c
@@ -44,37 +44,46 @@ void system_debug_led(int set)
 
 void system_hardware_enter_bootloader(void) {
 
-  // We have to uninitialize as many of the peripherals as possible, because the bootloader
-  // expects to start as the system comes up
+    // We have to uninitialize as many of the peripherals as possible, because the bootloader
+    // expects to start as the system comes up
 
-  // The HAL has ways to turn off all the core clocking and the clock security system
-  HAL_RCC_DisableLSECSS();
-  HAL_RCC_DeInit();
+    // The HAL has ways to turn off all the core clocking and the clock security system
+    HAL_RCC_DisableLSECSS();
+    HAL_RCC_DeInit();
+    HAL_DeInit();
 
-  // systick should be off at boot
-  SysTick->CTRL = 0;
-  SysTick->LOAD = 0;
-  SysTick->VAL = 0;
+    // systick should be off at boot
+    SysTick->CTRL = 0;
+    SysTick->LOAD = 0;
+    SysTick->VAL = 0;
 
-  // We have to make sure that the processor is mapping the system memory region to address 0,
-  // which the bootloader expects
-  __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH();
-  // and now we're ready to set the system up to start executing system flash.
-  // arm cortex initialization means that
 
-  // address 0 in the bootable region is the address where the processor should start its stack
-  // which we have to do as late as possible because as soon as we do this the c and c++ runtime
-  // environment is no longer valid
-  __set_MSP(*((uint32_t*)SYSMEM_START));
+    /* Clear Interrupt Enable Register & Interrupt Pending Register */
+    for (int i=0;i<8;i++)
+    {
+        NVIC->ICER[i]=0xFFFFFFFF;
+        NVIC->ICPR[i]=0xFFFFFFFF;
+    }
 
-  // finally, jump to the bootloader. we do this in inline asm because we need
-  // this to be a naked call (no caller-side prep like stacking return addresses)
-  // and to have a naked function you need to define it as a function, not a
-  // function pointer, and we don't statically know the address here since it is
-  // whatever's contained in that second word of the bsystem memory region.
-asm volatile (
-  "bx %0"
-  : // no outputs
-  : "r" (*sysmem_boot_loc)
-  : "memory"  );
+    // We have to make sure that the processor is mapping the system memory region to address 0,
+    // which the bootloader expects
+    __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH();
+    // and now we're ready to set the system up to start executing system flash.
+    // arm cortex initialization means that
+
+    // address 0 in the bootable region is the address where the processor should start its stack
+    // which we have to do as late as possible because as soon as we do this the c and c++ runtime
+    // environment is no longer valid
+    __set_MSP(*((uint32_t*)SYSMEM_START));
+
+    // finally, jump to the bootloader. we do this in inline asm because we need
+    // this to be a naked call (no caller-side prep like stacking return addresses)
+    // and to have a naked function you need to define it as a function, not a
+    // function pointer, and we don't statically know the address here since it is
+    // whatever's contained in that second word of the bsystem memory region.
+    asm volatile (
+        "bx %0"
+        : // no outputs
+        : "r" (*sysmem_boot_loc)
+        : "memory"  );
 }

--- a/stm32-modules/thermocycler-refresh/firmware/system/system_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/system/system_hardware.c
@@ -50,7 +50,6 @@ void system_hardware_enter_bootloader(void) {
     // The HAL has ways to turn off all the core clocking and the clock security system
     HAL_RCC_DisableLSECSS();
     HAL_RCC_DeInit();
-    HAL_DeInit();
 
     // systick should be off at boot
     SysTick->CTRL = 0;


### PR DESCRIPTION
### Summary 

For some reason, after #225 was merged the DFU bootloader stopped working on the Thermocycler-Refresh MCU, and this wasn't noticed because the bootloader wasn't being used during development. The issue doesn't seem to be directly related to that PR, but instead relates to the NVIC not being fully cleared when the system goes into reset. This PR manually clears out the relevant registers and, in testing on both Rev 1 and Rev 2 boards, lets the bootloader successfully enumerate over USB as a DFU device.