### PR TITLE
feat(thermocycler-refresh): automated LED strip behavior

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -273,14 +273,10 @@ struct SetLedMode {
 // This message is sent to the System Task by each
 // subsystem task to update what the current error state is.
 struct UpdateTaskErrorState {
-    // Each subsystem can signal its own errors so the 
+    // Each subsystem can signal its own errors so the
     // system task can independently track whether there is
     // a reason to trigger the error light condition
-    enum class Tasks : uint8_t {
-        THERMAL_PLATE,
-        THERMAL_LID,
-        MOTOR
-    };
+    enum class Tasks : uint8_t { THERMAL_PLATE, THERMAL_LID, MOTOR };
 
     Tasks task;
     errors::ErrorCode current_error = errors::ErrorCode::NO_ERROR;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -270,6 +270,38 @@ struct SetLedMode {
     colors::Mode mode;
 };
 
+// This message is sent to the System Task by each
+// subsystem task to update what the current error state is.
+struct UpdateTaskErrorState {
+    // Each subsystem can signal its own errors so the 
+    // system task can independently track whether there is
+    // a reason to trigger the error light condition
+    enum class Tasks : uint8_t {
+        THERMAL_PLATE,
+        THERMAL_LID,
+        MOTOR
+    };
+
+    Tasks task;
+    errors::ErrorCode current_error = errors::ErrorCode::NO_ERROR;
+};
+
+// This message is sent to the System Task by just the Thermal
+// Plate Task to update what the current state of the thermal
+// subsystem is. This dictates how the UI LED's are controlled
+// if there is no active error flag.
+struct UpdatePlateState {
+    enum class PlateState : uint8_t {
+        IDLE,
+        HEATING,
+        AT_HOT_TEMP,
+        COOLING,
+        AT_COLD_TEMP
+    };
+
+    PlateState state;
+};
+
 struct GetLidStatusMessage {
     uint32_t id;
 };
@@ -283,7 +315,8 @@ struct GetLidStatusResponse {
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage,
-                   UpdateUIMessage, SetLedMode>;
+                   UpdateUIMessage, SetLedMode, UpdateTaskErrorState,
+                   UpdatePlateState>;
 using HostCommsMessage = ::std::variant<
     std::monostate, IncomingMessageFromHost, AcknowledgePrevious, ErrorMessage,
     ForceUSBDisconnectMessage, GetSystemInfoResponse,

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/system_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/system_task.hpp
@@ -261,11 +261,11 @@ class SystemTask {
     }
 
     template <SystemExecutionPolicy Policy>
-    auto visit_message(const messages::UpdateTaskErrorState& message, Policy& policy)
-        -> void  {
+    auto visit_message(const messages::UpdateTaskErrorState& message,
+                       Policy& policy) -> void {
         static_cast<void>(policy);
         using Tasks = messages::UpdateTaskErrorState::Tasks;
-        switch(message.task) {
+        switch (message.task) {
             case Tasks::THERMAL_PLATE:
                 _plate_error = message.current_error;
                 break;
@@ -279,8 +279,8 @@ class SystemTask {
     }
 
     template <SystemExecutionPolicy Policy>
-    auto visit_message(const messages::UpdatePlateState& message, Policy& policy)
-        -> void  {
+    auto visit_message(const messages::UpdatePlateState& message,
+                       Policy& policy) -> void {
         static_cast<void>(policy);
         _plate_state = message.state;
     }
@@ -303,18 +303,16 @@ class SystemTask {
     [[nodiscard]] auto get_led_state() -> LedState& { return _led_state; }
 
   private:
-
     // Update current state of the UI based on task errors and plate action
     auto update_led_mode_from_system() -> void {
         using namespace colors;
-        if(_plate_error != errors::ErrorCode::NO_ERROR ||
-           _lid_error != errors::ErrorCode::NO_ERROR ||
-           _motor_error != errors::ErrorCode::NO_ERROR ) {
-
+        if (_plate_error != errors::ErrorCode::NO_ERROR ||
+            _lid_error != errors::ErrorCode::NO_ERROR ||
+            _motor_error != errors::ErrorCode::NO_ERROR) {
             _led_state.color = get_color(Colors::ORANGE);
             _led_state.mode = Mode::BLINKING;
         } else {
-            switch(_plate_state) {
+            switch (_plate_state) {
                 case PlateState::IDLE:
                     _led_state.color = get_color(Colors::SOFT_WHITE);
                     _led_state.mode = Mode::SOLID;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/system_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/system_task.hpp
@@ -250,7 +250,6 @@ class SystemTask {
         static_cast<void>(policy);
         _led_state.color = colors::get_color(message.color);
         _led_state.mode = message.mode;
-        _led_state.counter = 0;
     }
 
     template <typename Policy>

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -265,11 +265,14 @@ class ThermalPlateTask {
                 // We went from an error state to no error state... so go idle
                 _state.system_status = State::IDLE;
             }
+            send_current_error();
         }
 
         if (_state.system_status == State::CONTROLLING) {
             update_control(policy);
+            send_current_state();
         } else if (_state.system_status == State::IDLE) {
+            send_current_state();
             auto fan_power = _plate_control.fan_idle_power();
             if (!_fans.manual_control) {
                 if (!policy.set_fan(fan_power)) {
@@ -717,6 +720,48 @@ class ThermalPlateTask {
         return policy.set_peltier(peltier.id,
                                   std::clamp(power, (double)0.0F, (double)1.0F),
                                   direction);
+    }
+
+    /**
+     * @brief Send a message to the System Task with our current 
+     * most_relevant_error
+     * 
+     */
+    auto send_current_error() -> void {
+        auto error_msg = messages::UpdateTaskErrorState{
+            .task = messages::UpdateTaskErrorState::Tasks::THERMAL_PLATE,
+            .current_error = most_relevant_error()
+        };
+        static_cast<void>(_task_registry->system->get_message_queue().try_send(error_msg));
+    }
+
+    /**
+     * @brief Send a message to the System Task with the current state of 
+     * the plate task. This is used to update the LED control for the UI
+     */
+    auto send_current_state() -> void {
+        using PlateState = messages::UpdatePlateState::PlateState;
+        auto state = PlateState::IDLE;
+        // State only matters if there's no error
+        if(_state.system_status == State::CONTROLLING) {
+            bool ramping = true;
+            auto plate_control_status = _plate_control.status();
+            if(plate_control_status == plate_control::PlateStatus::OVERSHOOT ||
+               plate_control_status == plate_control::PlateStatus::STEADY_STATE) {
+                ramping = false;
+            }
+            // We consider whether the plate is going to a hot or cold temp, 
+            // and whether it is ramping or already at the target
+            if(_plate_control.setpoint() > 
+                static_cast<double>(plate_control::TemperatureZone::COLD)) {
+                state = (ramping) ? PlateState::HEATING : PlateState::AT_HOT_TEMP;
+            } else {
+                state = (ramping) ? PlateState::COOLING : PlateState::AT_COLD_TEMP;
+            }
+        }
+
+        auto message = messages::UpdatePlateState{.state = state};
+        static_cast<void>(_task_registry->system->get_message_queue().try_send(message));
     }
 
     Queue& _message_queue;

--- a/stm32-modules/thermocycler-refresh/firmware/system/freertos_system_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/freertos_system_task.cpp
@@ -90,7 +90,7 @@ static void run(void *param) {
 auto start() -> tasks::Task<TaskHandle_t,
                             system_task::SystemTask<FreeRTOSMessageQueue>> {
     auto *handle = xTaskCreateStatic(run, "SystemControl", stack.size(), &_task,
-                                     3, stack.data(), &data);
+                                     1, stack.data(), &data);
     _system_queue.provide_handle(handle);
     return tasks::Task<TaskHandle_t, decltype(_task)>{.handle = handle,
                                                       .task = &_task};


### PR DESCRIPTION
### Summary 

Sets up LED control matching the original thermocycler, where the state of the LED strip is based on the current Plate Control status:
- Errors cause the Orange Light Of Death (OLOD), and if the error condition goes away the light will cease
- When idle, the LED's are solid white
- Hot targets (>23C) are red, cold targets are blue
- The LED's pulse while ramping and are solid at target

Tested on a thermocycler by setting temperature targets and/or unplugging the thermistors, all of the states work as expected. There is some infrastructure for errors to come from the Lid and Motor tasks but right now that isn't utilized.