### PR TITLE
fix(thermocycler-refresh, heater-shaker): remove iostream dependency

### DIFF
--- a/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/socket_sim_driver.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <boost/asio.hpp>
+#include <iostream>
 #include <iterator>
 #include <memory>
 #include <regex>

--- a/stm32-modules/heater-shaker/simulator/stdin_sim_driver.cpp
+++ b/stm32-modules/heater-shaker/simulator/stdin_sim_driver.cpp
@@ -1,6 +1,7 @@
 #include "simulator/stdin_sim_driver.hpp"
 
 #include <boost/asio.hpp>
+#include <iostream>
 #include <regex>
 
 #include "simulator/simulator_queue.hpp"

--- a/stm32-modules/include/heater-shaker/heater-shaker/gcodes.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/gcodes.hpp
@@ -13,7 +13,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 #include <iterator>
 #include <optional>
 #include <utility>

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -13,7 +13,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 #include <iterator>
 #include <optional>
 #include <utility>

--- a/stm32-modules/thermocycler-refresh/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/socket_sim_driver.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <boost/asio.hpp>
+#include <iostream>
 #include <iterator>
 #include <memory>
 #include <regex>

--- a/stm32-modules/thermocycler-refresh/simulator/stdin_sim_driver.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/stdin_sim_driver.cpp
@@ -1,6 +1,7 @@
 #include "simulator/stdin_sim_driver.hpp"
 
 #include <boost/asio.hpp>
+#include <iostream>
 #include <regex>
 
 #include "simulator/simulator_queue.hpp"


### PR DESCRIPTION
Taking out this `#include` decreased the flash usage from ~50% to ~25%... and took out one of the `malloc` calls on system initialization.