### PR TITLE
feat(thermocycler-refresh): add EEPROM driver

### DIFF
--- a/stm32-modules/common/tests/CMakeLists.txt
+++ b/stm32-modules/common/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ include(AddBuildAndTestTarget)
 
 add_executable(${TARGET_MODULE_NAME}
     test_main.cpp
+    test_at24c0xc.cpp
     test_bit_utils.cpp
     test_ack_cache.cpp
     test_double_buffer.cpp

--- a/stm32-modules/common/tests/test_at24c0xc.cpp
+++ b/stm32-modules/common/tests/test_at24c0xc.cpp
@@ -2,12 +2,14 @@
 #include "core/at24c0xc.hpp"
 #include "test/test_at24c0xc_policy.hpp"
 
+using namespace at24c0xc_test_policy;
+
 TEST_CASE("TestAT24C0XCPolicy functionality") {
     GIVEN("a test policy of 32 pages") {
         auto policy = TestAT24C0XCPolicy<32>();
         WHEN("writing a full page") {
             std::array<uint8_t, 9> buffer = {0, 0, 1, 2, 3, 4, 5, 6, 7};
-            REQUIRE(policy.i2c_write(0, buffer));
+            REQUIRE(policy.i2c_write(0, buffer.begin(), buffer.size()));
             THEN("the internal buffer does not match what was written") {
                 for (int i = 0; i < 8; ++i) {
                     DYNAMIC_SECTION(std::string("Buffer index ") << i) {
@@ -17,7 +19,7 @@ TEST_CASE("TestAT24C0XCPolicy functionality") {
             }
             AND_WHEN("reading a full page") {
                 std::array<uint8_t, 8> readback = {0};
-                policy.i2c_read(0, readback);
+                policy.i2c_read(0, readback.begin(), readback.size());
                 THEN("the returned buffer does not match what was written") {
                     for (int i = 0; i < 8; ++i) {
                         DYNAMIC_SECTION(std::string("Buffer index ") << i) {
@@ -31,7 +33,7 @@ TEST_CASE("TestAT24C0XCPolicy functionality") {
             policy.set_write_protect(false);
             WHEN("writing a full page") {
                 std::array<uint8_t, 9> buffer = {0, 0, 1, 2, 3, 4, 5, 6, 7};
-                REQUIRE(policy.i2c_write(0, buffer));
+                REQUIRE(policy.i2c_write(0, buffer.begin(), buffer.size()));
                 THEN("the internal buffer matches what was written") {
                     for (int i = 0; i < 8; ++i) {
                         DYNAMIC_SECTION(std::string("Buffer index ") << i) {
@@ -41,7 +43,7 @@ TEST_CASE("TestAT24C0XCPolicy functionality") {
                 }
                 AND_WHEN("reading a full page") {
                     std::array<uint8_t, 8> readback = {0};
-                    policy.i2c_read(0, readback);
+                    policy.i2c_read(0, readback.begin(), readback.size());
                     THEN("the returned buffer matches what was written") {
                         for (int i = 0; i < 8; ++i) {
                             DYNAMIC_SECTION(std::string("Buffer index ") << i) {

--- a/stm32-modules/common/tests/test_at24c0xc.cpp
+++ b/stm32-modules/common/tests/test_at24c0xc.cpp
@@ -1,5 +1,4 @@
 #include "catch2/catch.hpp"
-
 #include "core/at24c0xc.hpp"
 #include "test/test_at24c0xc_policy.hpp"
 
@@ -7,16 +6,100 @@ TEST_CASE("TestAT24C0XCPolicy functionality") {
     GIVEN("a test policy of 32 pages") {
         auto policy = TestAT24C0XCPolicy<32>();
         WHEN("writing a full page") {
-            std::array<uint8_t, 9> buffer = {
-                0, 0, 1, 2, 3, 4, 5, 6, 7 };
+            std::array<uint8_t, 9> buffer = {0, 0, 1, 2, 3, 4, 5, 6, 7};
             REQUIRE(policy.i2c_write(0, buffer));
-            THEN("the internal buffer matches what was written") {
-                for(int i = 0; i < 8; ++i) {
+            THEN("the internal buffer does not match what was written") {
+                for (int i = 0; i < 8; ++i) {
                     DYNAMIC_SECTION(std::string("Buffer index ") << i) {
-                        REQUIRE(policy._buffer[i] == buffer[i+1]);
+                        REQUIRE(policy._buffer[i] == 0);
                     }
                 }
             }
+            AND_WHEN("reading a full page") {
+                std::array<uint8_t, 8> readback = {0};
+                policy.i2c_read(0, readback);
+                THEN("the returned buffer does not match what was written") {
+                    for (int i = 0; i < 8; ++i) {
+                        DYNAMIC_SECTION(std::string("Buffer index ") << i) {
+                            REQUIRE(readback[i] == 0);
+                        }
+                    }
+                }
+            }
+        }
+        GIVEN("write protect disabled") {
+            policy.set_write_protect(false);
+            WHEN("writing a full page") {
+                std::array<uint8_t, 9> buffer = {0, 0, 1, 2, 3, 4, 5, 6, 7};
+                REQUIRE(policy.i2c_write(0, buffer));
+                THEN("the internal buffer matches what was written") {
+                    for (int i = 0; i < 8; ++i) {
+                        DYNAMIC_SECTION(std::string("Buffer index ") << i) {
+                            REQUIRE(policy._buffer[i] == buffer[i + 1]);
+                        }
+                    }
+                }
+                AND_WHEN("reading a full page") {
+                    std::array<uint8_t, 8> readback = {0};
+                    policy.i2c_read(0, readback);
+                    THEN("the returned buffer matches what was written") {
+                        for (int i = 0; i < 8; ++i) {
+                            DYNAMIC_SECTION(std::string("Buffer index ") << i) {
+                                REQUIRE(readback[i] == buffer[i + 1]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct TwoFloats {
+    float a, b;
+};
+
+TEST_CASE("AT24C0XC class functionality") {
+    using namespace at24c0xc;
+    constexpr const size_t pages = 32;
+    constexpr const uint8_t address = 0b1010100;
+    GIVEN("a 32-page AT24C0xC") {
+        auto policy = TestAT24C0XCPolicy<pages>();
+        auto eeprom = AT24C0xC<pages, address>();
+        THEN("size is 32 * 8 bytes") { REQUIRE(eeprom.size() == pages * 8); }
+        WHEN("writing a float to page 0") {
+            float value = 10.0;
+            eeprom.write_value(0, value, policy);
+            AND_WHEN("reading back the stored value") {
+                auto readback = eeprom.read_value<float>(0, policy);
+                THEN("the same number is returned") {
+                    REQUIRE(readback.has_value());
+                    REQUIRE(readback.value() == value);
+                }
+            }
+            AND_WHEN("reading back the stored value as a double") {
+                auto readback = eeprom.read_value<double>(0, policy);
+                THEN("the returned number is wrong") {
+                    REQUIRE(readback.has_value());
+                    REQUIRE(readback.value() != value);
+                }
+            }
+        }
+        WHEN("writing a struct to page 4") {
+            TwoFloats value = {.a = 1.0, .b = 2.0};
+            eeprom.write_value(4, value, policy);
+            AND_WHEN("reading back the stored value") {
+                auto readback = eeprom.read_value<TwoFloats>(4, policy);
+                THEN("the same number is returned") {
+                    REQUIRE(readback.has_value());
+                    REQUIRE(readback.value().a == value.a);
+                    REQUIRE(readback.value().b == value.b);
+                }
+            }
+        }
+        WHEN("reading from page 35") {
+            auto ret = eeprom.read_value<double>(35, policy);
+            THEN("nothing is read") { REQUIRE(!ret.has_value()); }
         }
     }
 }

--- a/stm32-modules/common/tests/test_at24c0xc.cpp
+++ b/stm32-modules/common/tests/test_at24c0xc.cpp
@@ -1,0 +1,22 @@
+#include "catch2/catch.hpp"
+
+#include "core/at24c0xc.hpp"
+#include "test/test_at24c0xc_policy.hpp"
+
+TEST_CASE("TestAT24C0XCPolicy functionality") {
+    GIVEN("a test policy of 32 pages") {
+        auto policy = TestAT24C0XCPolicy<32>();
+        WHEN("writing a full page") {
+            std::array<uint8_t, 9> buffer = {
+                0, 0, 1, 2, 3, 4, 5, 6, 7 };
+            REQUIRE(policy.i2c_write(0, buffer));
+            THEN("the internal buffer matches what was written") {
+                for(int i = 0; i < 8; ++i) {
+                    DYNAMIC_SECTION(std::string("Buffer index ") << i) {
+                        REQUIRE(policy._buffer[i] == buffer[i+1]);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/stm32-modules/include/common/core/at24c0xc.hpp
+++ b/stm32-modules/include/common/core/at24c0xc.hpp
@@ -59,7 +59,7 @@ class AT24C0xC {
     // Either a 1024 or 2048 bit device
     static_assert((PAGES == 16) || (PAGES == 32),
                   "EEPROM size must be 1024 or 2048 bits");
-        
+
     // Address is lower 7 bits
     static_assert(ADDRESS < MAX_ADDR, "Address must be a 7-bit value");
 
@@ -91,8 +91,8 @@ class AT24C0xC {
         // Actual address is based on the byte.
         BufferT buffer;
         buffer.at(0) = page * PAGE_LENGTH;
-        auto *itr = bit_utils::int_to_bytes(value_int,
-                                           buffer.begin() + 1, buffer.end());
+        auto *itr = bit_utils::int_to_bytes(value_int, buffer.begin() + 1,
+                                            buffer.end());
         if (itr != buffer.end()) {
             // Error converting data
             return false;
@@ -116,7 +116,8 @@ class AT24C0xC {
      */
     template <typename T, AT24C0xC_Policy Policy>
     requires std::is_trivially_copyable_v<T>
-    [[nodiscard]] auto read_value(uint8_t page, Policy &policy) -> std::optional<T> {
+    [[nodiscard]] auto read_value(uint8_t page, Policy &policy)
+        -> std::optional<T> {
         using RT = std::optional<T>;
         using BufferT = std::array<uint8_t, PAGE_LENGTH>;
         // Check memory bounds

--- a/stm32-modules/include/common/core/at24c0xc.hpp
+++ b/stm32-modules/include/common/core/at24c0xc.hpp
@@ -87,7 +87,7 @@ class AT24C0xC {
         }
         // Because T must be trivially copyable, this is not a dangerous copy
         uint64_t value_int = 0;
-        std::memcpy(&value_int, &value, sizeof(T));
+        std::memcpy(&value_int, &value, sizeof(value));
         // Actual address is based on the byte.
         BufferT buffer;
         buffer.at(0) = page * PAGE_LENGTH;

--- a/stm32-modules/include/common/core/at24c0xc.hpp
+++ b/stm32-modules/include/common/core/at24c0xc.hpp
@@ -33,6 +33,25 @@ concept AT24C0xC_Policy = requires(Policy &policy, uint8_t addr,
     { policy.set_write_protect(true) } -> std::same_as<void>;
 };
 
+/**
+ * @brief Class encapsulating the AT24C01C and AT24C02C
+ * EEPROM chips.
+ *
+ * The EEPROM consists of 16 or 32 pages of 8 bytes each.
+ * One page can be written at a time, and an unlimited
+ * number of bytes can be read in a single transaction.
+ *
+ * This driver groups all writes & reads into entire-page
+ * actions. Any arbitrary Plain-Old-Data type may be written
+ * to the EEPROM, so long as it is serializable into 8 or less
+ * bytes.
+ *
+ * @tparam PAGES Number of data pages. Must be 16 or 32.
+ * @tparam ADDRESS The I2C address for this device. Pass
+ * in the <b>7-bit value</b> specified in the datasheet,
+ * this driver will automatically shift it left by 1 bit
+ * to create an 8-bit address.
+ */
 template <size_t PAGES, uint8_t ADDRESS>
 class AT24C0xC {
   public:
@@ -124,9 +143,11 @@ class AT24C0xC {
     [[nodiscard]] auto const size() -> size_t { return _size; }
 
   private:
-    // Total size of the EEPROm
+    // Total size of the EEPROM
     static constexpr const size_t _size = PAGES * PAGE_LENGTH;
-    static constexpr const uint8_t _address = ADDRESS;
+    // I2C address of the EEPROM, shifted 1 bit left from the
+    // datasheet.
+    static constexpr const uint8_t _address = ADDRESS << 1;
 };
 
 }  // namespace at24c0xc

--- a/stm32-modules/include/common/core/at24c0xc.hpp
+++ b/stm32-modules/include/common/core/at24c0xc.hpp
@@ -89,7 +89,7 @@ class AT24C0xC {
         // Actual address is based on the byte.
         BufferT buffer;
         buffer.at(0) = page * PAGE_LENGTH;
-        auto itr = bit_utils::int_to_bytes(static_cast<uint64_t>(value_int),
+        auto itr = bit_utils::int_to_bytes(value_int,
                                            buffer.begin() + 1, buffer.end());
         if (itr != buffer.end()) {
             // Error converting data
@@ -114,11 +114,11 @@ class AT24C0xC {
      */
     template <typename T, AT24C0xC_Policy Policy>
     requires std::is_trivially_copyable_v<T>
-    auto read_value(uint8_t page, Policy &policy) -> std::optional<T> {
+    [[nodiscard]] auto read_value(uint8_t page, Policy &policy) -> std::optional<T> {
         using RT = std::optional<T>;
         using BufferT = std::array<uint8_t, PAGE_LENGTH>;
         // Check memory bounds
-        if (page > PAGES) {
+        if (page >= PAGES) {
             return std::nullopt;
         }
         // Must write the address before reading everything else

--- a/stm32-modules/include/common/core/at24c0xc.hpp
+++ b/stm32-modules/include/common/core/at24c0xc.hpp
@@ -139,7 +139,7 @@ class AT24C0xC {
             return std::nullopt;
         }
         T value;
-        memcpy(&value, &value_int, sizeof(T));
+        memcpy(&value, &value_int, sizeof(value));
         return RT(value);
     }
 

--- a/stm32-modules/include/common/core/at24c0xc.hpp
+++ b/stm32-modules/include/common/core/at24c0xc.hpp
@@ -21,7 +21,7 @@ concept AT24C0xC_Policy = requires(Policy &policy, uint8_t addr,
                                    std::array<uint8_t, PAGE_LENGTH> receive) {
     // Function to write a page (8 bytes)
     { policy.i2c_write(addr, send) } -> std::same_as<bool>;
-    // Function to write a singlye byte
+    // Function to write a single byte
     { policy.i2c_write(addr, send[0]) } -> std::same_as<bool>;
     // Function to read a page (8 bytes).
     // First parameter is the device address, second

--- a/stm32-modules/include/common/core/at24c0xc.hpp
+++ b/stm32-modules/include/common/core/at24c0xc.hpp
@@ -55,11 +55,13 @@ concept AT24C0xC_Policy = requires(Policy &policy, uint8_t addr,
 template <size_t PAGES, uint8_t ADDRESS>
 class AT24C0xC {
   public:
+    static const constexpr uint8_t MAX_ADDR = 0x80;
     // Either a 1024 or 2048 bit device
     static_assert((PAGES == 16) || (PAGES == 32),
                   "EEPROM size must be 1024 or 2048 bits");
+        
     // Address is lower 7 bits
-    static_assert(ADDRESS < 0x80, "Address must be a 7-bit value");
+    static_assert(ADDRESS < MAX_ADDR, "Address must be a 7-bit value");
 
     /**
      * @brief Serialize and write a value of type T to the EEPROM
@@ -89,7 +91,7 @@ class AT24C0xC {
         // Actual address is based on the byte.
         BufferT buffer;
         buffer.at(0) = page * PAGE_LENGTH;
-        auto itr = bit_utils::int_to_bytes(value_int,
+        auto *itr = bit_utils::int_to_bytes(value_int,
                                            buffer.begin() + 1, buffer.end());
         if (itr != buffer.end()) {
             // Error converting data
@@ -131,7 +133,7 @@ class AT24C0xC {
             return std::nullopt;
         }
         uint64_t value_int = 0;
-        auto itr = bit_utils::bytes_to_int(buffer, value_int);
+        const auto *itr = bit_utils::bytes_to_int(buffer, value_int);
         if (itr != buffer.end()) {
             return std::nullopt;
         }
@@ -140,7 +142,7 @@ class AT24C0xC {
         return RT(value);
     }
 
-    [[nodiscard]] auto const size() -> size_t { return _size; }
+    [[nodiscard]] auto size() const -> size_t { return _size; }
 
   private:
     // Total size of the EEPROM

--- a/stm32-modules/include/common/core/at24c0xc.hpp
+++ b/stm32-modules/include/common/core/at24c0xc.hpp
@@ -1,0 +1,131 @@
+/**
+ * @file at24c0xc.hpp
+ * @brief Implements a generic driver for the AT24C0xC EEPROM IC's.
+ */
+
+#pragma once 
+
+#include <array>
+#include <cstring> // For memcpy
+
+#include "core/bit_utils.hpp"
+
+// Namespace for AT24C01C / AT24C02C driver
+namespace at24c0xc {
+
+static constexpr const size_t PAGE_LENGTH = 8;
+
+template <typename Policy>
+concept AT24C0xC_Policy = requires(Policy& policy, uint8_t addr, 
+        std::array<uint8_t, PAGE_LENGTH + 1> send,
+        std::array<uint8_t, PAGE_LENGTH> receive) {
+    // Function to write a page (8 bytes)
+    { policy.i2c_write(addr, send) } -> std::same_as<bool>;
+    // Function to write a singlye byte
+    { policy.i2c_write(addr, send[0]) } -> std::same_as<bool>;
+    // Function to read a page (8 bytes).
+    // First parameter is the device address, second
+    // is the array to return data. Length of transaction
+    // is deduced from the array type.
+    { policy.i2c_read(addr, receive) } -> std::same_as<bool>;
+    // Function to enable or disable protection.
+    // True turns on protection, false disables it.
+    { policy.set_write_protect(true) } -> std::same_as<void>;
+};
+
+template <size_t PAGES, uint8_t ADDRESS>
+class AT24C0xC {
+  public:
+    // Either a 1024 or 2048 bit device
+    static_assert((PAGES == 16) ||( PAGES == 32), 
+                  "EEPROM size must be 1024 or 2048 bits");
+    // Address is lower 7 bits
+    static_assert(ADDRESS < 0x80,
+                  "Address must be a 7-bit value");
+
+    /**
+     * @brief Serialize and write a value of type T to the EEPROM
+     * 
+     * @tparam Policy Instance of policy for sending/receiving over I2C 
+     * @tparam T The type to write. Must be serializable to an 8 byte
+     * or less value.
+     * @param page The page number to write to.
+     * @param value The value to write to \c page
+     * @param policy Instance of \c T
+     * @return true on success, false otherwise
+     */
+    template <AT24C0xC_Policy Policy, typename T>
+    requires std::is_trivially_copyable_v<T>
+    auto write_value(uint8_t page, T value, Policy &policy) -> bool {
+        // The type to be written must be serializable to a single page
+        static_assert(sizeof(T) <= PAGE_LENGTH,
+                      "Type T must be 8 bytes max to serialize");
+        using BufferT = std::array<uint8_t, PAGE_LENGTH + 1>;
+        // Check memory bounds
+        if(page > PAGES) {
+            return false;
+        }
+        // Because T must be trivially copyable, this is not a dangerous copy
+        uint64_t value_int = 0;
+        std::memcpy(&value_int, &value, sizeof(T));
+        // Actual address is based on the byte.
+        BufferT buffer;
+        buffer.at(0) = page * PAGE_LENGTH;
+        auto itr = bit_utils::int_to_bytes(static_cast<uint64_t>(value_int), buffer.begin() + 1, buffer.end());
+        if(itr != buffer.end()) {
+            // Error converting data
+            return false;
+        }
+
+        return policy.i2c_write(_address, buffer);
+    }
+
+    /**
+     * @brief Read and deserialize a value of type T from EEPROM
+     * 
+     * @tparam Policy 
+     * @tparam T 
+     * @param page 
+     * @param policy 
+     * @return std::optional<T> 
+     */
+    template <AT24C0xC_Policy Policy, typename T>
+    requires std::is_trivially_copyable_v<T>
+    auto read_value(uint8_t page, Policy &policy) -> std::optional<T> {
+        using RT = std::optional<T>;
+        using BufferT = std::array<uint8_t, PAGE_LENGTH>;
+        // Check memory bounds
+        if(page > PAGES) {
+            return RT();
+        }
+        // Must write the address before reading everything else
+        if( !policy.i2c_write(_address, page * PAGE_LENGTH) ) {
+            return RT();
+        }
+
+        BufferT buffer = {0};
+        if( !policy.i2c_read(_address, buffer) ) {
+            return RT();
+        }
+        uint64_t value_int = 0;
+        auto itr = bit_utils::bytes_to_int(buffer, value_int);
+        if(itr != buffer.end()) {
+            return RT();
+        }
+        T value;
+        memcpy(&value, &value_int, sizeof(T));
+        return RT(value);
+    }
+
+    [[nodiscard]] auto const size() -> size_t {
+        return _size;
+    }
+
+  private:  
+    // Total size of the EEPROm
+    static constexpr const size_t _size = PAGES * PAGE_LENGTH;
+    static constexpr const uint8_t _address = ADDRESS;
+    
+};
+
+}

--- a/stm32-modules/include/common/simulator/sim_at24c0xc_policy.hpp
+++ b/stm32-modules/include/common/simulator/sim_at24c0xc_policy.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <array>
+
+#include "core/at24c0xc.hpp"
+
+template <size_t PAGES>
+class SimAT24C0XCPolicy {
+  public:
+    static constexpr const size_t PAGE_LENGTH = at24c0xc::PAGE_LENGTH;
+    using Buffer = std::array<uint8_t, PAGES * PAGE_LENGTH>;
+
+    SimAT24C0XCPolicy()
+        : _buffer({0}), _data_pointer(0), _write_protect(true) {}
+
+    // --- Policy fulfillment -----------
+
+    template <size_t Length>
+    auto i2c_write(uint8_t addr, std::array<uint8_t, Length> &data) -> bool {
+        // Ignore address for test purposes
+        static_cast<void>(addr);
+        if (data.size() > 0) {
+            if (data.at(0) >= _buffer.size()) {
+                // Out of bounds write attempt
+                return false;
+            }
+            _data_pointer = data.at(0);
+            for (auto itr = data.begin() + 1; itr != data.end(); itr++) {
+                if (!_write_protect) {
+                    _buffer[_data_pointer++] = *itr;
+                }
+                // If data pointer is at a page boundary, wraparound
+                if ((_data_pointer % PAGE_LENGTH) == 0) {
+                    _data_pointer -= PAGE_LENGTH;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    // When only writing 1 byte, this policy can just
+    // update the internal data pointer
+    auto i2c_write(uint8_t addr, uint8_t data_addr) {
+        // Ignore address for test purposes
+        static_cast<void>(addr);
+        if (data_addr < _buffer.size()) {
+            _data_pointer = data_addr;
+            return true;
+        }
+        return false;
+    }
+
+    template <size_t Length>
+    auto i2c_read(uint8_t addr, std::array<uint8_t, Length> &data) -> bool {
+        // Ignore address for test purposes
+        static_cast<void>(addr);
+        // Data pointer is held over from the last transaction
+        for (auto &itr : data) {
+            itr = _buffer[_data_pointer++];
+            // Wraparound is at memory limit instead of page boundary
+            if (_data_pointer == _buffer.size()) {
+                _data_pointer = 0;
+            }
+        }
+        return true;
+    }
+
+    auto set_write_protect(bool write_protect) -> void {
+        _write_protect = write_protect;
+    }
+
+    Buffer _buffer;
+    size_t _data_pointer;
+    bool _write_protect;
+};

--- a/stm32-modules/include/common/simulator/sim_at24c0xc_policy.hpp
+++ b/stm32-modules/include/common/simulator/sim_at24c0xc_policy.hpp
@@ -85,4 +85,4 @@ class SimAT24C0XCPolicy {
     bool _write_protect;
 };
 
-}
+}  // namespace at24c0xc_sim_policy

--- a/stm32-modules/include/common/simulator/sim_at24c0xc_policy.hpp
+++ b/stm32-modules/include/common/simulator/sim_at24c0xc_policy.hpp
@@ -1,8 +1,17 @@
 #pragma once
 
 #include <array>
+#include <iterator>
 
 #include "core/at24c0xc.hpp"
+
+namespace at24c0xc_sim_policy {
+
+template <typename Iter>
+concept ByteIterator = requires {
+    {std::forward_iterator<Iter>};
+    {std::is_same_v<std::iter_value_t<Iter>, uint8_t>};
+};
 
 template <size_t PAGES>
 class SimAT24C0XCPolicy {
@@ -15,19 +24,20 @@ class SimAT24C0XCPolicy {
 
     // --- Policy fulfillment -----------
 
-    template <size_t Length>
-    auto i2c_write(uint8_t addr, std::array<uint8_t, Length> &data) -> bool {
+    template <ByteIterator Input>
+    auto i2c_write(uint8_t addr, Input data, size_t len) -> bool {
         // Ignore address for test purposes
         static_cast<void>(addr);
-        if (data.size() > 0) {
-            if (data.at(0) >= _buffer.size()) {
+        if (len > 0) {
+            if (*data >= _buffer.size()) {
                 // Out of bounds write attempt
                 return false;
             }
-            _data_pointer = data.at(0);
-            for (auto itr = data.begin() + 1; itr != data.end(); itr++) {
+            _data_pointer = *data;
+            ++data;
+            for (size_t i = 1; i < len; ++i, ++data) {
                 if (!_write_protect) {
-                    _buffer[_data_pointer++] = *itr;
+                    _buffer[_data_pointer++] = *data;
                 }
                 // If data pointer is at a page boundary, wraparound
                 if ((_data_pointer % PAGE_LENGTH) == 0) {
@@ -51,13 +61,13 @@ class SimAT24C0XCPolicy {
         return false;
     }
 
-    template <size_t Length>
-    auto i2c_read(uint8_t addr, std::array<uint8_t, Length> &data) -> bool {
+    template <ByteIterator Input>
+    auto i2c_read(uint8_t addr, Input data, size_t len) -> bool {
         // Ignore address for test purposes
         static_cast<void>(addr);
         // Data pointer is held over from the last transaction
-        for (auto &itr : data) {
-            itr = _buffer[_data_pointer++];
+        for (size_t i = 0; i < len; ++i, ++data) {
+            *data = _buffer[_data_pointer++];
             // Wraparound is at memory limit instead of page boundary
             if (_data_pointer == _buffer.size()) {
                 _data_pointer = 0;
@@ -74,3 +84,5 @@ class SimAT24C0XCPolicy {
     size_t _data_pointer;
     bool _write_protect;
 };
+
+}

--- a/stm32-modules/include/common/test/test_at24c0xc_policy.hpp
+++ b/stm32-modules/include/common/test/test_at24c0xc_policy.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <array>
+
+#include "core/at24c0xc.hpp"
+
+template <size_t PAGES>
+class TestAT24C0XCPolicy {
+  public:
+    static constexpr const size_t PAGE_LENGTH = at24c0xc::PAGE_LENGTH;
+    using Buffer = std::array<uint8_t, PAGES * PAGE_LENGTH>;
+
+    TestAT24C0XCPolicy() :
+        _buffer({0}),
+        _data_pointer(0) {}
+
+    // --- Policy fulfillment -----------
+
+    template <size_t Length>
+    auto i2c_write(uint8_t addr, std::array<uint8_t, Length> &data)
+        -> bool {
+        // Ignore address for test purposes
+        static_cast<void>(addr);
+        if(data.size() > 0) {
+            if(data.at(0) >= _buffer.size()) {
+                // Out of bounds write attempt
+                return false;
+            }
+            _data_pointer = data.at(0);
+            for(auto itr = data.begin() + 1; itr != data.end(); itr++) {
+                _buffer[_data_pointer++] = *itr;
+                // If data pointer is at a page boundary, wraparound
+                if((_data_pointer % PAGE_LENGTH) == 0) {
+                    _data_pointer -= PAGE_LENGTH;
+                }
+            }
+        }
+        
+        return true;
+    }
+
+    // When only writing 1 byte, this policy can just
+    // update the internal data pointer
+    auto i2c_write(uint8_t addr, uint8_t data_addr) {
+        // Ignore address for test purposes
+        static_cast<void>(addr);
+        if(data_addr < _buffer.size()) {
+            _data_pointer = data_addr;
+            return true;
+        }
+        return false;
+    }
+
+    template <size_t Length>
+    auto i2c_read(uint8_t addr, std::array<uint8_t, Length> &data) -> bool {
+        // Ignore address for test purposes
+        static_cast<void>(addr);
+        // Data pointer is held over from the last transaction
+        for(auto &itr : data) {
+            *itr = _buffer[_data_pointer++];
+            // Wraparound is at memory limit instead of page boundary
+            if(_data_pointer == _buffer.size()) {
+                _data_pointer = 0;
+            }
+        }
+        return true;
+    }
+
+    Buffer _buffer;
+    size_t _data_pointer;
+};

--- a/stm32-modules/include/common/test/test_at24c0xc_policy.hpp
+++ b/stm32-modules/include/common/test/test_at24c0xc_policy.hpp
@@ -10,32 +10,32 @@ class TestAT24C0XCPolicy {
     static constexpr const size_t PAGE_LENGTH = at24c0xc::PAGE_LENGTH;
     using Buffer = std::array<uint8_t, PAGES * PAGE_LENGTH>;
 
-    TestAT24C0XCPolicy() :
-        _buffer({0}),
-        _data_pointer(0) {}
+    TestAT24C0XCPolicy()
+        : _buffer({0}), _data_pointer(0), _write_protect(true) {}
 
     // --- Policy fulfillment -----------
 
     template <size_t Length>
-    auto i2c_write(uint8_t addr, std::array<uint8_t, Length> &data)
-        -> bool {
+    auto i2c_write(uint8_t addr, std::array<uint8_t, Length> &data) -> bool {
         // Ignore address for test purposes
         static_cast<void>(addr);
-        if(data.size() > 0) {
-            if(data.at(0) >= _buffer.size()) {
+        if (data.size() > 0) {
+            if (data.at(0) >= _buffer.size()) {
                 // Out of bounds write attempt
                 return false;
             }
             _data_pointer = data.at(0);
-            for(auto itr = data.begin() + 1; itr != data.end(); itr++) {
-                _buffer[_data_pointer++] = *itr;
+            for (auto itr = data.begin() + 1; itr != data.end(); itr++) {
+                if (!_write_protect) {
+                    _buffer[_data_pointer++] = *itr;
+                }
                 // If data pointer is at a page boundary, wraparound
-                if((_data_pointer % PAGE_LENGTH) == 0) {
+                if ((_data_pointer % PAGE_LENGTH) == 0) {
                     _data_pointer -= PAGE_LENGTH;
                 }
             }
         }
-        
+
         return true;
     }
 
@@ -44,7 +44,7 @@ class TestAT24C0XCPolicy {
     auto i2c_write(uint8_t addr, uint8_t data_addr) {
         // Ignore address for test purposes
         static_cast<void>(addr);
-        if(data_addr < _buffer.size()) {
+        if (data_addr < _buffer.size()) {
             _data_pointer = data_addr;
             return true;
         }
@@ -56,16 +56,21 @@ class TestAT24C0XCPolicy {
         // Ignore address for test purposes
         static_cast<void>(addr);
         // Data pointer is held over from the last transaction
-        for(auto &itr : data) {
-            *itr = _buffer[_data_pointer++];
+        for (auto &itr : data) {
+            itr = _buffer[_data_pointer++];
             // Wraparound is at memory limit instead of page boundary
-            if(_data_pointer == _buffer.size()) {
+            if (_data_pointer == _buffer.size()) {
                 _data_pointer = 0;
             }
         }
         return true;
     }
 
+    auto set_write_protect(bool write_protect) -> void {
+        _write_protect = write_protect;
+    }
+
     Buffer _buffer;
     size_t _data_pointer;
+    bool _write_protect;
 };

--- a/stm32-modules/include/thermocycler-refresh/firmware/thermal_hardware.h
+++ b/stm32-modules/include/thermocycler-refresh/firmware/thermal_hardware.h
@@ -55,6 +55,28 @@ bool thermal_i2c_write_16(uint16_t addr, uint8_t reg, uint16_t val);
 bool thermal_i2c_read_16(uint16_t addr, uint8_t reg, uint16_t *val);
 
 /**
+ * @brief Writes an arbitrary array of data to a device
+ * @note Thread safe
+ *
+ * @param addr I2C device address to write to
+ * @param data Pointer to array of data to write
+ * @param len Number of bytes in \c data
+ * @return True if the write was succesful, false otherwise
+ */
+bool thermal_i2c_write_data(uint16_t addr, uint8_t *data, uint16_t len);
+
+/**
+ * @brief Reads an arbitrary string of data from a device
+ * @note Thread safe
+ *
+ * @param addr I2C device address to reaad from
+ * @param data Pointer to array to store read data
+ * @param len Number of bytes to read into \c data
+ * @return True if the read was succesful, false otherwise
+ */
+bool thermal_i2c_read_data(uint16_t addr, uint8_t *data, uint16_t len);
+
+/**
  * @brief Configures one of the ADC Alert monitoring pins to be ready
  * to signal the correct task after a conversion-complete signals is raised.
  * @param[in] id The ADC to arm the callback for.
@@ -65,6 +87,12 @@ bool thermal_arm_adc_for_read(ADC_ITR_T id);
  * @brief Callback when an ADC READY pin interrupt is triggered (falling edge)
  */
 void thermal_adc_ready_callback(ADC_ITR_T id);
+
+/**
+ * @brief Set the write enable pin on the EEPROM
+ * @param[in] protect True to enable write protect, false to disable it
+ */
+void thermal_eeprom_set_write_protect(bool protect);
 
 /**
  * @brief This function handles I2C2 event interrupt / I2C2 wake-up interrupt

--- a/stm32-modules/include/thermocycler-refresh/firmware/thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/thermal_plate_policy.hpp
@@ -8,6 +8,14 @@
 #include "firmware/thermal_hardware.h"
 #include "thermocycler-refresh/thermal_general.hpp"
 
+namespace plate_policy {
+
+template <typename Iter>
+concept ByteIterator = requires {
+    {std::forward_iterator<Iter>};
+    {std::is_same_v<std::iter_value_t<Iter>, uint8_t>};
+};
+
 class ThermalPlatePolicy {
   public:
     ThermalPlatePolicy() = default;
@@ -27,13 +35,15 @@ class ThermalPlatePolicy {
 
     auto i2c_write(uint8_t addr, uint8_t data) -> bool;
 
-    template <size_t Length>
-    auto i2c_write(uint8_t addr, std::array<uint8_t, Length> &data) -> bool {
-        return thermal_i2c_write_data(addr, data.data(), Length);
+    template <ByteIterator Input>
+    auto i2c_write(uint8_t addr, Input data, size_t length) -> bool {
+        return thermal_i2c_write_data(addr, &(*data), length);
     }
 
-    template <size_t Length>
-    auto i2c_read(uint8_t addr, std::array<uint8_t, Length> &data) -> bool {
-        return thermal_i2c_read_data(addr, data.data(), Length);
+    template <ByteIterator Output>
+    auto i2c_read(uint8_t addr, Output data, size_t length) -> bool {
+        return thermal_i2c_read_data(addr, &(*data), length);
     }
 };
+
+}  // namespace plate_policy

--- a/stm32-modules/include/thermocycler-refresh/firmware/thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/thermal_plate_policy.hpp
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include "firmware/thermal_hardware.h"
 #include "thermocycler-refresh/thermal_general.hpp"
 
 class ThermalPlatePolicy {
@@ -21,4 +22,20 @@ class ThermalPlatePolicy {
     auto set_fan(double power) -> bool;
 
     auto get_fan() -> double;
+
+    auto set_write_protect(bool write_protect) -> void;
+
+    template <size_t Length>
+    auto i2c_write(uint8_t addr, std::array<uint8_t, Length> &data) -> bool {
+        return thermal_i2c_write_data(addr, data.data(), Length);
+    }
+
+    auto i2c_write(uint8_t addr, uint8_t data) -> bool {
+        return thermal_i2c_write_data(addr, &data, 1);
+    }
+
+    template <size_t Length>
+    auto i2c_read(uint8_t addr, std::array<uint8_t, Length> &data) -> bool {
+        return thermal_i2c_read_data(addr, data.data(), Length);
+    }
 };

--- a/stm32-modules/include/thermocycler-refresh/firmware/thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/thermal_plate_policy.hpp
@@ -25,13 +25,11 @@ class ThermalPlatePolicy {
 
     auto set_write_protect(bool write_protect) -> void;
 
+    auto i2c_write(uint8_t addr, uint8_t data) -> bool;
+
     template <size_t Length>
     auto i2c_write(uint8_t addr, std::array<uint8_t, Length> &data) -> bool {
         return thermal_i2c_write_data(addr, data.data(), Length);
-    }
-
-    auto i2c_write(uint8_t addr, uint8_t data) -> bool {
-        return thermal_i2c_write_data(addr, &data, 1);
     }
 
     template <size_t Length>

--- a/stm32-modules/include/thermocycler-refresh/test/test_thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_thermal_plate_policy.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "test/test_at24c0xc_policy.hpp"
 #include "thermocycler-refresh/thermal_general.hpp"
 
 struct TestPeltier {
@@ -13,8 +14,10 @@ struct TestPeltier {
     }
 };
 
-class TestThermalPlatePolicy {
+class TestThermalPlatePolicy : public TestAT24C0XCPolicy<32> {
   public:
+    TestThermalPlatePolicy() : TestAT24C0XCPolicy<32>() {}
+
     auto set_enabled(bool enabled) -> void {
         _enabled = enabled;
         if (!enabled) {

--- a/stm32-modules/include/thermocycler-refresh/test/test_thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/test/test_thermal_plate_policy.hpp
@@ -14,9 +14,10 @@ struct TestPeltier {
     }
 };
 
-class TestThermalPlatePolicy : public TestAT24C0XCPolicy<32> {
+class TestThermalPlatePolicy
+    : public at24c0xc_test_policy::TestAT24C0XCPolicy<32> {
   public:
-    TestThermalPlatePolicy() : TestAT24C0XCPolicy<32>() {}
+    TestThermalPlatePolicy() : at24c0xc_test_policy::TestAT24C0XCPolicy<32>() {}
 
     auto set_enabled(bool enabled) -> void {
         _enabled = enabled;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -107,7 +107,7 @@ class ThermalPlateTask {
     static constexpr const double CONTROL_PERIOD_SECONDS =
         CONTROL_PERIOD_TICKS * 0.001;
     static constexpr size_t EEPROM_PAGES = 32;
-    static constexpr uint8_t EEPROM_ADDRESS = 0b1010001;
+    static constexpr uint8_t EEPROM_ADDRESS = 0b1010010;
 
     explicit ThermalPlateTask(Queue& q)
         : _message_queue(q),
@@ -221,9 +221,6 @@ class ThermalPlateTask {
         // This is the call down to the provided queue. It will block for
         // anywhere up to the provided timeout, which drives the controller
         // frequency.
-
-        auto count = _eeprom.read_value<int>(31, policy);
-        _eeprom.write_value(31, count + 1, policy);
 
         static_cast<void>(_message_queue.recv(&message));
         std::visit(

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <variant>
 
+#include "core/at24c0xc.hpp"
 #include "core/pid.hpp"
 #include "core/thermistor_conversion.hpp"
 #include "hal/message_queue.hpp"
@@ -48,7 +49,8 @@ concept ThermalPlateExecutionPolicy = requires(Policy& p, PeltierID id,
     { p.set_fan(1.0F) } -> std::same_as<bool>;
     // A function to get the current power of the heatsink fan.
     { p.get_fan() } -> std::same_as<double>;
-};
+}
+&&at24c0xc::AT24C0xC_Policy<Policy>;
 
 /** Just used for initialization assignment of error bits.*/
 constexpr auto thermistorErrorBit(const ThermistorID id) -> uint16_t {
@@ -104,6 +106,8 @@ class ThermalPlateTask {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     static constexpr const double CONTROL_PERIOD_SECONDS =
         CONTROL_PERIOD_TICKS * 0.001;
+    static constexpr size_t EEPROM_PAGES = 32;
+    static constexpr uint8_t EEPROM_ADDRESS = 0b1010001;
 
     explicit ThermalPlateTask(Queue& q)
         : _message_queue(q),
@@ -183,7 +187,8 @@ class ThermalPlateTask {
                      false),
           _state{.system_status = State::IDLE, .error_bitmap = 0},
           _plate_control(_peltier_left, _peltier_right, _peltier_center, _fans,
-                         CONTROL_PERIOD_SECONDS) {}
+                         CONTROL_PERIOD_SECONDS),
+          _eeprom() {}
     ThermalPlateTask(const ThermalPlateTask& other) = delete;
     auto operator=(const ThermalPlateTask& other) -> ThermalPlateTask& = delete;
     ThermalPlateTask(ThermalPlateTask&& other) noexcept = delete;
@@ -216,6 +221,9 @@ class ThermalPlateTask {
         // This is the call down to the provided queue. It will block for
         // anywhere up to the provided timeout, which drives the controller
         // frequency.
+
+        auto count = _eeprom.read_value<int>(31, policy);
+        _eeprom.write_value(31, count + 1, policy);
 
         static_cast<void>(_message_queue.recv(&message));
         std::visit(
@@ -778,6 +786,7 @@ class ThermalPlateTask {
     thermistor_conversion::Conversion<lookups::KS103J2G> _converter;
     State _state;
     plate_control::PlateControl _plate_control;
+    at24c0xc::AT24C0xC<EEPROM_PAGES, EEPROM_ADDRESS> _eeprom;
 };
 
 }  // namespace thermal_plate_task

--- a/stm32-modules/thermocycler-refresh/firmware/system/freertos_idle_timer_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/freertos_idle_timer_task.cpp
@@ -39,3 +39,10 @@ extern "C" void vApplicationGetTimerTaskMemory(
     *ppxTimerTaskStackBuffer = idle_timer_stack.data();
     *pulTimerTaskStackSize = idle_timer_stack.size();
 }
+
+extern "C" void vApplicationStackOverflowHook(
+        TaskHandle_t xTask,
+        signed char *pcTaskName ) {
+    // Lock the processor forever
+    configASSERT(0);
+}

--- a/stm32-modules/thermocycler-refresh/firmware/system/freertos_idle_timer_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/freertos_idle_timer_task.cpp
@@ -40,9 +40,14 @@ extern "C" void vApplicationGetTimerTaskMemory(
     *pulTimerTaskStackSize = idle_timer_stack.size();
 }
 
+// We are matching the definition of this function in FreeRTOS, and thus
+// keep the function signature the same
 extern "C" void vApplicationStackOverflowHook(
-        TaskHandle_t xTask,
-        signed char *pcTaskName ) {
+    TaskHandle_t xTask,
+    // NOLINTNEXTLINE(readability-non-const-parameter)
+    signed char *pcTaskName) {
+    static_cast<void>(xTask);
+    static_cast<void>(pcTaskName);
     // Lock the processor forever
     configASSERT(0);
 }

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -91,7 +91,7 @@ static void run(void *param) {
     thermal_hardware_wait_for_init();
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto *task = reinterpret_cast<decltype(_main_task) *>(param);
-    auto policy = ThermalPlatePolicy();
+    auto policy = plate_policy::ThermalPlatePolicy();
     while (true) {
         task->run_once(policy);
     }

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_hardware.c
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_hardware.c
@@ -59,7 +59,7 @@
 #define ADC_READY_ITR_PRIO (10)
 
 /** EEPROM write protect pin */
-#define EEPROM_WRITE_PROTECT_PIN  (10)
+#define EEPROM_WRITE_PROTECT_PIN  (GPIO_PIN_10)
 /** EEPROM write protect port */
 #define EEPROM_WRITE_PROTECT_PORT (GPIOC)
 
@@ -267,6 +267,7 @@ bool thermal_i2c_write_data(uint16_t addr, uint8_t *data, uint16_t len) {
         xSemaphoreGive(_i2c_semaphore);
         return false;
     }
+    _i2c_task_to_notify = xTaskGetCurrentTaskHandle();
 
     hal_ret = HAL_I2C_Master_Transmit_IT(&_i2c_handle, addr, data, len);
 
@@ -301,6 +302,7 @@ bool thermal_i2c_read_data(uint16_t addr, uint8_t *data, uint16_t len) {
         xSemaphoreGive(_i2c_semaphore);
         return false;
     }
+    _i2c_task_to_notify = xTaskGetCurrentTaskHandle();
 
     hal_ret = HAL_I2C_Master_Receive_IT(&_i2c_handle, addr, data, len);
 

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
@@ -44,3 +44,8 @@ auto ThermalPlatePolicy::set_fan(double power) -> bool {
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPlatePolicy::get_fan() -> double { return thermal_fan_get_power(); }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto ThermalPlatePolicy::set_write_protect(bool write_protect) -> void {
+    thermal_eeprom_set_write_protect(write_protect);
+}

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
@@ -49,3 +49,8 @@ auto ThermalPlatePolicy::get_fan() -> double { return thermal_fan_get_power(); }
 auto ThermalPlatePolicy::set_write_protect(bool write_protect) -> void {
     thermal_eeprom_set_write_protect(write_protect);
 }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto ThermalPlatePolicy::i2c_write(uint8_t addr, uint8_t data) -> bool {
+    return thermal_i2c_write_data(addr, &data, 1);
+}

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
@@ -4,6 +4,8 @@
 #include "firmware/thermal_peltier_hardware.h"
 #include "systemwide.h"
 
+using namespace plate_policy;
+
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPlatePolicy::set_enabled(bool enabled) -> void {
     thermal_peltier_set_enable(enabled);

--- a/stm32-modules/thermocycler-refresh/simulator/thermal_plate_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/thermal_plate_thread.cpp
@@ -22,6 +22,8 @@ struct SimPeltier {
     }
 };
 
+using namespace at24c0xc_sim_policy;
+
 struct SimThermalPlatePolicy
     : public SimAT24C0XCPolicy<SimThermalPlateTask::EEPROM_PAGES> {
   private:

--- a/stm32-modules/thermocycler-refresh/simulator/thermal_plate_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/thermal_plate_thread.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <stop_token>
 
+#include "simulator/sim_at24c0xc_policy.hpp"
 #include "systemwide.h"
 #include "thermocycler-refresh/errors.hpp"
 #include "thermocycler-refresh/tasks.hpp"
@@ -21,7 +22,8 @@ struct SimPeltier {
     }
 };
 
-struct SimThermalPlatePolicy {
+struct SimThermalPlatePolicy
+    : public SimAT24C0XCPolicy<SimThermalPlateTask::EEPROM_PAGES> {
   private:
     bool _enabled = false;
     SimPeltier _left = SimPeltier();
@@ -44,6 +46,10 @@ struct SimThermalPlatePolicy {
     }
 
   public:
+    using EepromPolicy = SimAT24C0XCPolicy<SimThermalPlateTask::EEPROM_PAGES>;
+
+    SimThermalPlatePolicy() : EepromPolicy() {}
+
     auto set_enabled(bool enabled) -> void {
         _enabled = enabled;
         if (!enabled) {


### PR DESCRIPTION
### Summary

Adds a driver for the AT24C02C EEPROM used on the Thermocycler Refresh board. 
- EEPROM driver reads & writes in terms of 8-byte pages, with support for writing arbitrary data types to each page.
- Tested the firmware portions by temporarily modifying the GetPlateTemp response to read a page in the EEPROM as a `double`, report that number back in the response, and then write the number it read + 1 back to the EEPROM. The number incremented as expected.