### PR TITLE
feat(thermocycler-refresh): Plate to Thermistor Offset Configuration

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/eeprom.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/eeprom.hpp
@@ -1,0 +1,158 @@
+/**
+ * @file eeprom.hpp
+ * @brief Implements an EEPROm class that is specialized towards
+ * holding the Thermal Offset Constants for the Thermocycler plate.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#include "core/at24c0xc.hpp"
+
+namespace eeprom {
+
+/**
+ * @brief Constant values used for calculating the offset between
+ * the physical thermistors on the system and the actual temperature on
+ * the Thermocycler's plate.
+ * @details
+ * The temperature difference between the thermistors and the surface
+ * of the thermocycler tends to scale with the magnitude of the thermistor
+ * readings. Using two constants, B and C (for legacy purposes), the
+ * resulting temperature relationship can be summarized as follows:
+ *
+ * > Plate Temp = ((B + 1) * Measured Temp) + C
+ *
+ * One of the EEPROM pages is reserved for a flag to indicate whether
+ * the values have been written. The \ref EEPROMFlag enum captures the
+ * valid states of this page. The page indicates what error detection,
+ * if any, is included with the EEPROM constant values.
+ *
+ */
+struct OffsetConstants {
+    // The value of the constants B and C
+    double b, c;
+};
+
+/**
+ * @brief Encapsulates interactions with the EEPROM on the Thermocycler
+ * mainboard. Allows reading and writing the thermal offset constants.
+ *
+ */
+class Eeprom {
+  public:
+    Eeprom() : _eeprom(), _initialized(false) {}
+
+    template <at24c0xc::AT24C0xC_Policy Policy>
+    [[nodiscard]] auto get_offset_constants(Policy& policy) -> OffsetConstants {
+        OffsetConstants ret = {.b = OFFSET_DEFAULT_CONST,
+                               .c = OFFSET_DEFAULT_CONST};
+        // Read the constantsss
+        auto flag = read_const_flag(policy);
+
+        if (flag == EEPROMFlag::WRITTEN_NO_CHECKSUM) {
+            ret.b = read_const(EEPROMPageMap::CONST_B, policy);
+            ret.c = read_const(EEPROMPageMap::CONST_C, policy);
+        }
+        return ret;
+    }
+
+    template <at24c0xc::AT24C0xC_Policy Policy>
+    auto write_offset_constants(OffsetConstants constants, Policy& policy)
+        -> bool {
+        // Write the constants
+        if (!_eeprom.write_value(EEPROMPageMap::CONST_B, constants.b, policy)) {
+            // Attempt to flag that the constants are not valid
+            static_cast<void>(_eeprom.write_value(
+                EEPROMPageMap::CONST_FLAG,
+                static_cast<uint32_t>(EEPROMFlag::INVALID), policy));
+            return false;
+        }
+        if (!_eeprom.write_value(EEPROMPageMap::CONST_C, constants.c, policy)) {
+            // Attempt to flag that the constants are not valid
+            static_cast<void>(_eeprom.write_value(
+                EEPROMPageMap::CONST_FLAG,
+                static_cast<uint32_t>(EEPROMFlag::INVALID), policy));
+            return false;
+        }
+        // Flag that the constants are good
+        return _eeprom.write_value(
+            EEPROMPageMap::CONST_FLAG,
+            static_cast<uint32_t>(EEPROMFlag::WRITTEN_NO_CHECKSUM), policy);
+    }
+
+    [[nodiscard]] auto initialized() const -> bool { return _initialized; }
+
+  private:
+    // Enumeration of memory locations to be used on the EEPROM
+    enum class EEPROMPageMap : uint8_t {
+        CONST_B = 0,  // Value of the B constant
+        CONST_C = 1,  // Value of the C constant
+        // Flag indicating whether constants have been written.
+        // Set to 1 to mark that constants are written with no checksum
+        CONST_FLAG = 2
+    };
+
+    // Enumeration of the EEPROM_CONST_FLAG values
+    enum class EEPROMFlag { WRITTEN_NO_CHECKSUM = 1, INVALID = 0xFF };
+
+    static_assert(sizeof(EEPROMPageMap) == sizeof(uint8_t),
+                  "EEPROM API requires uint8_t page address");
+
+    static constexpr size_t EEPROM_PAGES = 32;
+    static constexpr uint8_t EEPROM_ADDRESS = 0b1010010;
+    static constexpr double OFFSET_DEFAULT_CONST = 0.0F;
+
+    /**
+     * @brief Read one of the constants on the device
+     *
+     * @tparam Policy class for reading from the eeprom
+     * @param page Which page to read. Must be CONST_B or CONST_C
+     * @param policy Instance of Policy for reading
+     * @return double containing the constant
+     */
+    template <at24c0xc::AT24C0xC_Policy Policy>
+    [[nodiscard]] auto read_const(EEPROMPageMap page, Policy& policy)
+        -> double {
+        if (page != EEPROMPageMap::CONST_FLAG) {
+            auto val = _eeprom.read_value<double>(
+                static_cast<uint8_t>(page), policy);
+            if(val.has_value()) {
+                return val.value();
+            }
+        }
+        return OFFSET_DEFAULT_CONST;
+    };
+
+    /**
+     * @brief Read the Constants Flag in the EEPROM. This flag provides the
+     * validity of the constants in memory.
+     * 
+     * @tparam Policy class for reading from the eeprom
+     * @param policy Instance of Policy for reading
+     * @return EEPROMFlag containing the state of the constants in EEPROM
+     */
+    template <at24c0xc::AT24C0xC_Policy Policy>
+    [[nodiscard]] auto read_const_flag(Policy& policy) -> EEPROMFlag {
+        auto val =
+            _eeprom.read_value<uint32_t>(static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG), policy);
+        if (val.has_value()) {
+            auto flag = val.value();
+            if (flag == static_cast<uint32_t>(EEPROMFlag::WRITTEN_NO_CHECKSUM)) {
+                return EEPROMFlag::WRITTEN_NO_CHECKSUM;
+            }
+        }
+        // Default
+        return EEPROMFlag::INVALID;
+    }
+
+    at24c0xc::AT24C0xC<EEPROM_PAGES, EEPROM_ADDRESS> _eeprom;
+    // Whether the constants have been read from the EEPROM since startup.
+    // Even if the EEPROM is empty, this flag is set after attempting
+    // to read so that the firmware doesn't try to keep making redundant
+    // reads.
+    bool _initialized;
+};
+
+}  // namespace eeprom

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/eeprom.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/eeprom.hpp
@@ -128,6 +128,7 @@ class Eeprom {
     static_assert(sizeof(EEPROMPageMap) == sizeof(uint8_t),
                   "EEPROM API requires uint8_t page address");
 
+    /** Default value for all constants.*/
     static constexpr double OFFSET_DEFAULT_CONST = 0.0F;
 
     /**

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/eeprom.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/eeprom.hpp
@@ -43,7 +43,7 @@ struct OffsetConstants {
 template <size_t PAGES, uint8_t ADDRESS>
 class Eeprom {
   public:
-    Eeprom() : _eeprom(), _initialized(false) {}
+    Eeprom() : _eeprom() {}
 
     /**
      * @brief Get the offset constants from the EEPROM
@@ -180,7 +180,7 @@ class Eeprom {
     // Even if the EEPROM is empty, this flag is set after attempting
     // to read so that the firmware doesn't try to keep making redundant
     // reads.
-    bool _initialized;
+    bool _initialized = false;
 };
 
 }  // namespace eeprom

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/errors.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/errors.hpp
@@ -42,6 +42,7 @@ enum class ErrorCode {
     // 3xx - System General
     SYSTEM_SERIAL_NUMBER_INVALID = 301,
     SYSTEM_SERIAL_NUMBER_HAL_ERROR = 302,
+    SYSTEM_EEPROM_ERROR = 303,
     // 4xx - Thermal subsystem errors
     THERMAL_PLATE_BUSY = 401,
     THERMAL_PELTIER_ERROR = 402,

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -1248,4 +1248,126 @@ struct SetPIDConstants {
     }
 };
 
+/**
+ * Uses M116, as defined on Gen 1 thermocyclers.
+ * 
+ * Accepts two optional constants, B and C. These are
+ * used in the calculation of the plate temperature for
+ * each thermistor on the system with the following equation:
+ * 
+ * > temp = (1+B)*(measured temp) + C
+ * 
+ * Format: M116 B0.102 C-0.245\n
+ * 
+ */
+struct SetOffsetConstants {
+    using ParseResult = std::optional<SetOffsetConstants>;
+    static constexpr auto prefix = std::array{'M', '1', '1', '6'};
+    static constexpr auto prefix_b = std::array{' ', 'B'};
+    static constexpr auto prefix_c = std::array{' ', 'C'};
+    static constexpr const char* response = "M116 OK\n";
+
+    /**
+     * Each constant is optional. In order to maintain simplicity
+     * of this structure, rather than using std::optional we define
+     * a field \c defined for each of the parameters.
+     */
+    struct OffsetConstant {
+        bool defined;
+        double value;
+    };
+
+    OffsetConstant const_b = {.defined = false, .value = 0.0F};
+    OffsetConstant const_c = {.defined = false, .value = 0.0F};
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        // Prefix with no variables is technically allowed
+        auto working = prefix_matches(input, limit, prefix);
+        if(working == input) {
+            return std::make_pair(std::nullopt, input);
+        }
+        auto old_working = working;
+        auto ret = SetOffsetConstants();
+        working = prefix_matches(old_working, limit, prefix_b);
+        if(working != old_working) {
+            old_working = working;
+            auto b = parse_value<float>(working, limit);
+            if(!b.first.has_value()) {
+                return std::make_pair(std::nullopt, input);
+            }
+            ret.const_b.defined = true;
+            ret.const_b.value = b.first.value();
+            working = b.second;
+        }
+        old_working = working;
+
+        working = prefix_matches(old_working, limit, prefix_c);
+        if(working != old_working) {
+            old_working = working;
+            auto c = parse_value<float>(working, limit);
+            if(!c.first.has_value()) {
+                return std::make_pair(std::nullopt, input);
+            }
+            ret.const_c.defined = true;
+            ret.const_c.value = c.first.value();
+            working = c.second;
+        }
+        return std::make_pair(ParseResult(ret), working);
+    }
+};
+
+/**
+ * Uses M117, as defined on Gen 1 thermocyclers.
+ * 
+ * Returns the programmed offset constants on the device, B and C.
+ * 
+ * Format: M117\n
+ * 
+ * Returns: M117 B:[B value] C:[C value] OK\n
+ * 
+ */
+struct GetOffsetConstants {
+    using ParseResult = std::optional<GetOffsetConstants>;
+    static constexpr auto prefix = std::array{'M', '1', '1', '7'};
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(GetOffsetConstants()), working);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    static auto write_response_into(InputIt buf, InputLimit limit,
+        double b, double c) -> InputIt {
+
+        auto res = snprintf(&*buf, (limit - buf), "M117 B:%0.2f C:%0.2f OK\n", 
+            static_cast<float>(b), static_cast<float>(c));
+        if (res <= 0) {
+            return buf;
+        }
+        return buf + res;
+    }
+
+};
+
+
 }  // namespace gcode

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -1250,15 +1250,15 @@ struct SetPIDConstants {
 
 /**
  * Uses M116, as defined on Gen 1 thermocyclers.
- * 
+ *
  * Accepts two optional constants, B and C. These are
  * used in the calculation of the plate temperature for
  * each thermistor on the system with the following equation:
- * 
+ *
  * > temp = (1+B)*(measured temp) + C
- * 
+ *
  * Format: M116 B0.102 C-0.245\n
- * 
+ *
  */
 struct SetOffsetConstants {
     using ParseResult = std::optional<SetOffsetConstants>;
@@ -1294,16 +1294,16 @@ struct SetOffsetConstants {
         -> std::pair<ParseResult, InputIt> {
         // Prefix with no variables is technically allowed
         auto working = prefix_matches(input, limit, prefix);
-        if(working == input) {
+        if (working == input) {
             return std::make_pair(std::nullopt, input);
         }
         auto old_working = working;
         auto ret = SetOffsetConstants();
         working = prefix_matches(old_working, limit, prefix_b);
-        if(working != old_working) {
+        if (working != old_working) {
             old_working = working;
             auto b = parse_value<float>(working, limit);
-            if(!b.first.has_value()) {
+            if (!b.first.has_value()) {
                 return std::make_pair(std::nullopt, input);
             }
             ret.const_b.defined = true;
@@ -1313,10 +1313,10 @@ struct SetOffsetConstants {
         old_working = working;
 
         working = prefix_matches(old_working, limit, prefix_c);
-        if(working != old_working) {
+        if (working != old_working) {
             old_working = working;
             auto c = parse_value<float>(working, limit);
-            if(!c.first.has_value()) {
+            if (!c.first.has_value()) {
                 return std::make_pair(std::nullopt, input);
             }
             ret.const_c.defined = true;
@@ -1329,13 +1329,13 @@ struct SetOffsetConstants {
 
 /**
  * Uses M117, as defined on Gen 1 thermocyclers.
- * 
+ *
  * Returns the programmed offset constants on the device, B and C.
- * 
+ *
  * Format: M117\n
- * 
+ *
  * Returns: M117 B:[B value] C:[C value] OK\n
- * 
+ *
  */
 struct GetOffsetConstants {
     using ParseResult = std::optional<GetOffsetConstants>;
@@ -1356,18 +1356,15 @@ struct GetOffsetConstants {
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputLimit, InputIt>
-    static auto write_response_into(InputIt buf, InputLimit limit,
-        double b, double c) -> InputIt {
-
-        auto res = snprintf(&*buf, (limit - buf), "M117 B:%0.2f C:%0.2f OK\n", 
-            static_cast<float>(b), static_cast<float>(c));
+    static auto write_response_into(InputIt buf, InputLimit limit, double b,
+                                    double c) -> InputIt {
+        auto res = snprintf(&*buf, (limit - buf), "M117 B:%0.2f C:%0.2f OK\n",
+                            static_cast<float>(b), static_cast<float>(c));
         if (res <= 0) {
             return buf;
         }
         return buf + res;
     }
-
 };
-
 
 }  // namespace gcode

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -261,6 +261,23 @@ struct SetPIDConstantsMessage {
     double d;
 };
 
+struct SetOffsetConstantsMessage {
+    uint32_t id;
+    bool b_set;
+    double const_b;
+    bool c_set;
+    double const_c;
+};
+
+struct GetOffsetConstantsMessage {
+    uint32_t id;
+};
+
+struct GetOffsetConstantsResponse {
+    uint32_t responding_to_id;
+    double const_b, const_c;
+};
+
 struct UpdateUIMessage {
     // Empty struct
 };
@@ -313,19 +330,22 @@ using SystemMessage =
                    SetSerialNumberMessage, GetSystemInfoMessage,
                    UpdateUIMessage, SetLedMode, UpdateTaskErrorState,
                    UpdatePlateState>;
-using HostCommsMessage = ::std::variant<
-    std::monostate, IncomingMessageFromHost, AcknowledgePrevious, ErrorMessage,
-    ForceUSBDisconnectMessage, GetSystemInfoResponse,
-    GetLidTemperatureDebugResponse, GetPlateTemperatureDebugResponse,
-    GetPlateTempResponse, GetLidTempResponse, GetSealDriveStatusResponse,
-    GetLidStatusResponse, GetPlatePowerResponse, GetLidPowerResponse>;
+using HostCommsMessage =
+    ::std::variant<std::monostate, IncomingMessageFromHost, AcknowledgePrevious,
+                   ErrorMessage, ForceUSBDisconnectMessage,
+                   GetSystemInfoResponse, GetLidTemperatureDebugResponse,
+                   GetPlateTemperatureDebugResponse, GetPlateTempResponse,
+                   GetLidTempResponse, GetSealDriveStatusResponse,
+                   GetLidStatusResponse, GetPlatePowerResponse,
+                   GetLidPowerResponse, GetOffsetConstantsResponse>;
 using ThermalPlateMessage =
     ::std::variant<std::monostate, ThermalPlateTempReadComplete,
                    GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,
                    SetFanManualMessage, GetPlateTempMessage,
                    SetPlateTemperatureMessage, DeactivatePlateMessage,
                    SetPIDConstantsMessage, SetFanAutomaticMessage,
-                   GetThermalPowerMessage>;
+                   GetThermalPowerMessage, SetOffsetConstantsMessage,
+                   GetOffsetConstantsMessage>;
 using LidHeaterMessage =
     ::std::variant<std::monostate, LidTempReadComplete,
                    GetLidTemperatureDebugMessage, SetHeaterDebugMessage,

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -190,6 +190,7 @@ class ThermalPlateTask {
           _state{.system_status = State::IDLE, .error_bitmap = 0},
           _plate_control(_peltier_left, _peltier_right, _peltier_center, _fans,
                          CONTROL_PERIOD_SECONDS),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
           _eeprom(),
           _offset_constants{.b = OFFSET_DEFAULT_CONST_B,
                             .c = OFFSET_DEFAULT_CONST_C} {}
@@ -832,7 +833,7 @@ class ThermalPlateTask {
      * applied.
      * @return double containing the
      */
-    [[nodiscard]] auto const calculate_thermistor_offset(double temp)
+    [[nodiscard]] auto calculate_thermistor_offset(double temp) const
         -> double {
         if (!_eeprom.initialized()) {
             return temp;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -577,6 +577,28 @@ class ThermalPlateTask {
             _task_registry->comms->get_message_queue().try_send(response));
     }
 
+    template <ThermalPlateExecutionPolicy Policy>
+    auto visit_message(const messages::SetOffsetConstantsMessage& msg,
+                       Policy& policy) -> void {
+        static_cast<void>(policy);
+        auto response =
+            messages::AcknowledgePrevious{.responding_to_id = msg.id};
+
+        static_cast<void>(
+            _task_registry->comms->get_message_queue().try_send(response));
+    }
+
+    template <ThermalPlateExecutionPolicy Policy>
+    auto visit_message(const messages::GetOffsetConstantsMessage& msg,
+                       Policy& policy) -> void {
+        static_cast<void>(policy);
+        auto response = messages::GetOffsetConstantsResponse{
+            .responding_to_id = msg.id, .const_b = 10.0, .const_c = 12.0};
+
+        static_cast<void>(
+            _task_registry->comms->get_message_queue().try_send(response));
+    }
+
     auto handle_temperature_conversion(uint16_t conversion_result,
                                        Thermistor& thermistor) -> void {
         auto visitor = [this, &thermistor](const auto value) -> void {

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -614,7 +614,7 @@ class ThermalPlateTask {
     template <ThermalPlateExecutionPolicy Policy>
     auto visit_message(const messages::GetOffsetConstantsMessage& msg,
                        Policy& policy) -> void {
-        static_cast<void>(policy);
+        _offset_constants = _eeprom.get_offset_constants(policy);
         auto response = messages::GetOffsetConstantsResponse{
             .responding_to_id = msg.id,
             .const_b = _offset_constants.b,

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
@@ -56,7 +56,8 @@ auto ThermalPlatePolicy::set_write_protect(bool write_protect) -> void {
         // When done writing to the EEPROM, it needs some time to perform
         // the write. We could poll the I2C bus, or we can just add a short
         // delay since this won't happen during any critical sections.
-        vTaskDelay(10);
+        static constexpr const TickType_t delay_ticks = pdMS_TO_TICKS(10);
+        vTaskDelay(delay_ticks);
     }
 }
 

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/thermal_plate_policy.cpp
@@ -1,8 +1,10 @@
 #include "firmware/thermal_plate_policy.hpp"
 
+#include "FreeRTOS.h"
 #include "firmware/thermal_fan_hardware.h"
 #include "firmware/thermal_peltier_hardware.h"
 #include "systemwide.h"
+#include "task.h"
 
 using namespace plate_policy;
 
@@ -50,6 +52,12 @@ auto ThermalPlatePolicy::get_fan() -> double { return thermal_fan_get_power(); }
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPlatePolicy::set_write_protect(bool write_protect) -> void {
     thermal_eeprom_set_write_protect(write_protect);
+    if (!write_protect) {
+        // When done writing to the EEPROM, it needs some time to perform
+        // the write. We could poll the I2C bus, or we can just add a short
+        // delay since this won't happen during any critical sections.
+        vTaskDelay(10);
+    }
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -256,6 +256,26 @@ def get_lid_status(ser: serial.Serial) -> Tuple[PositionStatus, PositionStatus]:
         ret[0] = PositionStatus.Open
     return ret
 
+# Function to set offset constants
+def set_offset_constants(ser: serial.Serial, const_b = None, const_c = None):
+    b_str = ''
+    if const_b != None:
+        b_str = f' B{const_b}'
+    c_str = ''
+    if const_c != None:
+        c_str = f' C{const_c}'
+    print(f'Setting constants{b_str}{c_str}\n')
+    ser.write(f'M116{b_str}{c_str}\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M116 OK\n')
+    print(res)
+
+def get_offset_constants(ser: serial.Serial):
+    ser.write('M117\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M117 B:')
+    print(res)
+
 # Function to fully open the lid
 def open_lid(ser: serial.Serial):
     lid_status = get_lid_status(ser)[0]

--- a/stm32-modules/thermocycler-refresh/src/errors.cpp
+++ b/stm32-modules/thermocycler-refresh/src/errors.cpp
@@ -59,6 +59,8 @@ const char* const SYSTEM_SERIAL_NUMBER_INVALID =
     "ERR301:system:serial number invalid format\n";
 const char* const SYSTEM_SERIAL_NUMBER_HAL_ERROR =
     "ERR302:system:HAL error, busy, or timeout\n";
+const char* const SYSTEM_EEPROM_ERROR =
+    "ERR303:system:EEPROM communication error\n";
 const char* const THERMAL_PLATE_BUSY = "ERR401:thermal:Thermal plate busy\n";
 const char* const THERMAL_PELTIER_ERROR =
     "ERR402:thermal:Could not activate peltier\n";
@@ -119,6 +121,7 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(THERMISTOR_LID_OVERTEMP);
         HANDLE_CASE(SYSTEM_SERIAL_NUMBER_INVALID);
         HANDLE_CASE(SYSTEM_SERIAL_NUMBER_HAL_ERROR);
+        HANDLE_CASE(SYSTEM_EEPROM_ERROR);
         HANDLE_CASE(THERMAL_PLATE_BUSY);
         HANDLE_CASE(THERMAL_PELTIER_ERROR);
         HANDLE_CASE(THERMAL_HEATSINK_FAN_ERROR);

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -30,6 +30,8 @@ add_executable(${TARGET_MODULE_NAME}
     test_m106.cpp
     test_m107.cpp
     test_m108.cpp
+    test_m116.cpp
+    test_m117.cpp
     test_m119.cpp
     test_m140.cpp
     test_m140d.cpp

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_colors.cpp
     test_motor_task.cpp
     test_motor_utils.cpp
+    test_eeprom.cpp
     # GCode parse tests
     test_m14.cpp
     test_m103d.cpp

--- a/stm32-modules/thermocycler-refresh/tests/test_eeprom.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_eeprom.cpp
@@ -40,7 +40,7 @@ TEST_CASE("eeprom reading and writing") {
         OffsetConstants constants = {.b = 10.0F, .c = -12.0F};
         WHEN("writing the constants") {
             REQUIRE(eeprom.write_offset_constants(constants, policy));
-            AND_THEN("readinb back the constants") {
+            AND_THEN("reading back the constants") {
                 auto readback = eeprom.get_offset_constants(policy);
                 THEN("the constants match") {
                     REQUIRE_THAT(readback.b,

--- a/stm32-modules/thermocycler-refresh/tests/test_eeprom.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_eeprom.cpp
@@ -1,0 +1,54 @@
+#include "catch2/catch.hpp"
+#include "test/test_at24c0xc_policy.hpp"
+#include "thermocycler-refresh/eeprom.hpp"
+
+using namespace at24c0xc_test_policy;
+using namespace eeprom;
+
+TEST_CASE("eeprom class initialization tracking") {
+    GIVEN("an EEPROM") {
+        auto policy = TestAT24C0XCPolicy<32>();
+        auto eeprom = Eeprom<32, 0x10>();
+        THEN("it starts as noninitialized") { REQUIRE(!eeprom.initialized()); }
+        WHEN("reading from the EEPROM") {
+            static_cast<void>(eeprom.get_offset_constants(policy));
+            THEN("the EEPROM now shows as initialized") {
+                REQUIRE(eeprom.initialized());
+            }
+        }
+    }
+}
+
+TEST_CASE("blank eeprom reading") {
+    GIVEN("an EEPROM") {
+        auto policy = TestAT24C0XCPolicy<32>();
+        auto eeprom = Eeprom<32, 0x10>();
+        WHEN("reading before writing anything") {
+            auto readback = eeprom.get_offset_constants(policy);
+            THEN("the resulting constants are 0") {
+                REQUIRE_THAT(readback.b, Catch::Matchers::WithinAbs(0, 0.01));
+                REQUIRE_THAT(readback.c, Catch::Matchers::WithinAbs(0, 0.01));
+            }
+        }
+    }
+}
+
+TEST_CASE("eeprom reading and writing") {
+    GIVEN("an EEPROM and constants B = 10 and C = -12") {
+        auto policy = TestAT24C0XCPolicy<32>();
+        auto eeprom = Eeprom<32, 0x10>();
+        OffsetConstants constants = {.b = 10.0F, .c = -12.0F};
+        WHEN("writing the constants") {
+            REQUIRE(eeprom.write_offset_constants(constants, policy));
+            AND_THEN("readinb back the constants") {
+                auto readback = eeprom.get_offset_constants(policy);
+                THEN("the constants match") {
+                    REQUIRE_THAT(readback.b,
+                                 Catch::Matchers::WithinAbs(constants.b, 0.01));
+                    REQUIRE_THAT(readback.c,
+                                 Catch::Matchers::WithinAbs(constants.c, 0.01));
+                }
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -1804,6 +1804,130 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                 }
             }
         }
+        WHEN("sending a SetOffsetConstants message") {
+            auto message_text = std::string("M116\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass on the message and not immediately ack") {
+                REQUIRE(tasks->get_thermal_plate_queue().has_message());
+                auto plate_msg =
+                    tasks->get_thermal_plate_queue().backing_deque.front();
+                REQUIRE(
+                    std::holds_alternative<messages::SetOffsetConstantsMessage>(
+                        plate_msg));
+                auto message =
+                    std::get<messages::SetOffsetConstantsMessage>(plate_msg);
+                REQUIRE(!tasks->get_host_comms_queue().has_message());
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(!message.b_set);
+                REQUIRE(!message.c_set);
+                AND_WHEN("sending good response back") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{.responding_to_id =
+                                                          message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        auto response = "M116 OK\n";
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith(response));
+                        REQUIRE(written_secondpass ==
+                                tx_buf.begin() + strlen(response));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending invalid ID back to comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{.responding_to_id =
+                                                          message.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
+        WHEN("sending a GetOffsetConstants message") {
+            auto message_text = std::string("M117\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass on the message and not immediately ack") {
+                REQUIRE(tasks->get_thermal_plate_queue().has_message());
+                auto plate_msg =
+                    tasks->get_thermal_plate_queue().backing_deque.front();
+                REQUIRE(
+                    std::holds_alternative<messages::GetOffsetConstantsMessage>(
+                        plate_msg));
+                auto message =
+                    std::get<messages::GetOffsetConstantsMessage>(plate_msg);
+                REQUIRE(!tasks->get_host_comms_queue().has_message());
+                REQUIRE(written_firstpass == tx_buf.begin());
+                AND_WHEN("sending good response back") {
+                    auto response = messages::HostCommsMessage(
+                        messages::GetOffsetConstantsResponse{
+                            .responding_to_id = message.id,
+                            .const_b = 10.0,
+                            .const_c = 15.0});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        auto response = "M117 B:10.00 C:15.00 OK\n";
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith(response));
+                        REQUIRE(written_secondpass ==
+                                tx_buf.begin() + strlen(response));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending invalid ID back to comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::GetOffsetConstantsResponse{
+                            .responding_to_id = message.id + 1,
+                            .const_b = 10.0,
+                            .const_c = 15.0});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/stm32-modules/thermocycler-refresh/tests/test_m116.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m116.cpp
@@ -1,0 +1,99 @@
+#include "catch2/catch.hpp"
+#include "thermocycler-refresh/gcodes.hpp"
+
+SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(64, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetOffsetConstants::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M116 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetOffsetConstants::write_response_into(
+                buffer.begin(), buffer.begin() + 6);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M116 Occcccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("input to set no constants") {
+        std::string input = "M116\n";
+        WHEN("parsing") {
+            auto parsed = gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            THEN("parsing should be succesful") {
+                REQUIRE(parsed.second != input.begin());
+                REQUIRE(parsed.first.has_value());
+                auto &val = parsed.first.value();
+                REQUIRE(!val.const_b.defined);
+                REQUIRE(!val.const_c.defined);
+            }
+        }
+    }
+    GIVEN("input to set B constant") {
+        std::string input = "M116 B-0.543\n";
+        WHEN("parsing") {
+            auto parsed = gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            THEN("parsing should be succesful") {
+                REQUIRE(parsed.second != input.begin());
+                REQUIRE(parsed.first.has_value());
+                auto &val = parsed.first.value();
+                REQUIRE(val.const_b.defined);
+                REQUIRE_THAT(val.const_b.value,
+                             Catch::Matchers::WithinAbs(-0.543, 0.01));
+                REQUIRE(!val.const_c.defined);
+            }
+        }
+    }
+    GIVEN("input to set C constant") {
+        std::string input = "M116 C123.5\n";
+        WHEN("parsing") {
+            auto parsed = gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            THEN("parsing should be succesful") {
+                REQUIRE(parsed.second != input.begin());
+                REQUIRE(parsed.first.has_value());
+                auto &val = parsed.first.value();
+                REQUIRE(!val.const_b.defined);
+                REQUIRE(val.const_c.defined);
+                REQUIRE_THAT(val.const_c.value,
+                             Catch::Matchers::WithinAbs(123.5, 0.01));
+            }
+        }
+    }
+    GIVEN("input to set both constants") {
+        std::string input = "M116 B543 C123.5\n";
+        WHEN("parsing") {
+            auto parsed = gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            THEN("parsing should be succesful") {
+                REQUIRE(parsed.second != input.begin());
+                REQUIRE(parsed.first.has_value());
+                auto &val = parsed.first.value();
+                REQUIRE(val.const_b.defined);
+                REQUIRE_THAT(val.const_b.value,
+                             Catch::Matchers::WithinAbs(543, 0.01));
+                REQUIRE(val.const_c.defined);
+                REQUIRE_THAT(val.const_c.value,
+                             Catch::Matchers::WithinAbs(123.5, 0.01));
+            }
+        }
+    }
+    GIVEN("invalid input") {
+        std::string input = "M1116\n";
+        WHEN("parsing") {
+            auto parsed = gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            THEN("parsing should not be succesful") {
+                REQUIRE(parsed.second == input.begin());
+                REQUIRE(!parsed.first.has_value());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_m116.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m116.cpp
@@ -29,7 +29,8 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
     GIVEN("input to set no constants") {
         std::string input = "M116\n";
         WHEN("parsing") {
-            auto parsed = gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            auto parsed =
+                gcode::SetOffsetConstants::parse(input.begin(), input.end());
             THEN("parsing should be succesful") {
                 REQUIRE(parsed.second != input.begin());
                 REQUIRE(parsed.first.has_value());
@@ -42,7 +43,8 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
     GIVEN("input to set B constant") {
         std::string input = "M116 B-0.543\n";
         WHEN("parsing") {
-            auto parsed = gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            auto parsed =
+                gcode::SetOffsetConstants::parse(input.begin(), input.end());
             THEN("parsing should be succesful") {
                 REQUIRE(parsed.second != input.begin());
                 REQUIRE(parsed.first.has_value());
@@ -57,7 +59,8 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
     GIVEN("input to set C constant") {
         std::string input = "M116 C123.5\n";
         WHEN("parsing") {
-            auto parsed = gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            auto parsed =
+                gcode::SetOffsetConstants::parse(input.begin(), input.end());
             THEN("parsing should be succesful") {
                 REQUIRE(parsed.second != input.begin());
                 REQUIRE(parsed.first.has_value());
@@ -72,7 +75,8 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
     GIVEN("input to set both constants") {
         std::string input = "M116 B543 C123.5\n";
         WHEN("parsing") {
-            auto parsed = gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            auto parsed =
+                gcode::SetOffsetConstants::parse(input.begin(), input.end());
             THEN("parsing should be succesful") {
                 REQUIRE(parsed.second != input.begin());
                 REQUIRE(parsed.first.has_value());
@@ -89,7 +93,8 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
     GIVEN("invalid input") {
         std::string input = "M1116\n";
         WHEN("parsing") {
-            auto parsed = gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            auto parsed =
+                gcode::SetOffsetConstants::parse(input.begin(), input.end());
             THEN("parsing should not be succesful") {
                 REQUIRE(parsed.second == input.begin());
                 REQUIRE(!parsed.first.has_value());

--- a/stm32-modules/thermocycler-refresh/tests/test_m117.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m117.cpp
@@ -1,0 +1,58 @@
+#include "catch2/catch.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-refresh/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("GetOffsetConstants (M105.D) parser works",
+         "[gcode][parse][m105.d]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetOffsetConstants::write_response_into(
+                buffer.begin(), buffer.end(), 10.0, 15.0);
+            THEN("the response should be written in full") {
+                auto response_str = "M117 B:10.00 C:15.00 OK\n";
+                REQUIRE_THAT(
+                    buffer,
+                    Catch::Matchers::StartsWith(
+                        response_str));
+                REQUIRE(written == buffer.begin() + strlen(response_str));
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetOffsetConstants::write_response_into(
+                buffer.begin(), buffer.begin() + 7, 10.0, 15.0);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M117 Bcccccccccc";
+                response.at(6) = '\0';
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("a valid input") {
+        std::string buffer = "M117\n";
+        WHEN("parsing") {
+            auto res = gcode::GetOffsetConstants::parse(buffer.begin(), buffer.end());
+            THEN("a valid gcode should be produced") {
+                REQUIRE(res.first.has_value());
+                REQUIRE(res.second != buffer.begin());
+            }
+        }
+    }
+    GIVEN("an invalid input") {
+        std::string buffer = "M 117\n";
+        WHEN("parsing") {
+            auto res = gcode::GetOffsetConstants::parse(buffer.begin(), buffer.end());
+            THEN("an error should be produced") {
+                REQUIRE(!res.first.has_value());
+                REQUIRE(res.second == buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_m117.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m117.cpp
@@ -4,8 +4,7 @@
 #include "thermocycler-refresh/gcodes.hpp"
 #pragma GCC diagnostic pop
 
-SCENARIO("GetOffsetConstants (M105.D) parser works",
-         "[gcode][parse][m105.d]") {
+SCENARIO("GetOffsetConstants (M105.D) parser works", "[gcode][parse][m105.d]") {
     GIVEN("a response buffer large enough for the formatted response") {
         std::string buffer(256, 'c');
         WHEN("filling response") {
@@ -13,10 +12,7 @@ SCENARIO("GetOffsetConstants (M105.D) parser works",
                 buffer.begin(), buffer.end(), 10.0, 15.0);
             THEN("the response should be written in full") {
                 auto response_str = "M117 B:10.00 C:15.00 OK\n";
-                REQUIRE_THAT(
-                    buffer,
-                    Catch::Matchers::StartsWith(
-                        response_str));
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(response_str));
                 REQUIRE(written == buffer.begin() + strlen(response_str));
             }
         }
@@ -38,7 +34,8 @@ SCENARIO("GetOffsetConstants (M105.D) parser works",
     GIVEN("a valid input") {
         std::string buffer = "M117\n";
         WHEN("parsing") {
-            auto res = gcode::GetOffsetConstants::parse(buffer.begin(), buffer.end());
+            auto res =
+                gcode::GetOffsetConstants::parse(buffer.begin(), buffer.end());
             THEN("a valid gcode should be produced") {
                 REQUIRE(res.first.has_value());
                 REQUIRE(res.second != buffer.begin());
@@ -48,7 +45,8 @@ SCENARIO("GetOffsetConstants (M105.D) parser works",
     GIVEN("an invalid input") {
         std::string buffer = "M 117\n";
         WHEN("parsing") {
-            auto res = gcode::GetOffsetConstants::parse(buffer.begin(), buffer.end());
+            auto res =
+                gcode::GetOffsetConstants::parse(buffer.begin(), buffer.end());
             THEN("an error should be produced") {
                 REQUIRE(!res.first.has_value());
                 REQUIRE(res.second == buffer.begin());

--- a/stm32-modules/thermocycler-refresh/tests/test_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_thermal_plate_task.cpp
@@ -141,6 +141,134 @@ SCENARIO("thermal plate task message passing") {
                 }
             }
         }
+        WHEN(
+            "setting the C offset to 6 and B offset to 1 and then re-sending "
+            "the temperature readings") {
+            auto offset_set_msg =
+                messages::SetOffsetConstantsMessage{.id = 456,
+                                                    .b_set = true,
+                                                    .const_b = 1.0,
+                                                    .c_set = true,
+                                                    .const_c = 6.0};
+            tasks->get_thermal_plate_queue().backing_deque.push_back(
+                messages::ThermalPlateMessage(offset_set_msg));
+            tasks->get_host_comms_queue().backing_deque.clear();
+            tasks->run_thermal_plate_task();
+            // Send temperatures to refresh calculations
+            tasks->get_thermal_plate_queue().backing_deque.push_back(
+                messages::ThermalPlateMessage(read_message));
+            tasks->run_thermal_plate_task();
+            THEN("the task should get the message") {
+                REQUIRE(tasks->get_thermal_plate_queue().backing_deque.empty());
+                AND_THEN("the task should respond to the messsage") {
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
+                    auto response =
+                        tasks->get_host_comms_queue().backing_deque.front();
+                    tasks->get_host_comms_queue().backing_deque.pop_front();
+                    REQUIRE(
+                        std::holds_alternative<messages::AcknowledgePrevious>(
+                            response));
+                    auto ack_msg =
+                        std::get<messages::AcknowledgePrevious>(response);
+                    REQUIRE(ack_msg.responding_to_id == offset_set_msg.id);
+                }
+            }
+            AND_WHEN("sending a get-plate-temperature-debug message") {
+                auto message =
+                    messages::GetPlateTemperatureDebugMessage{.id = 123};
+                tasks->get_thermal_plate_queue().backing_deque.push_back(
+                    messages::ThermalPlateMessage(message));
+                tasks->get_host_comms_queue().backing_deque.clear();
+                tasks->run_thermal_plate_task();
+                THEN("the task should get the message") {
+                    REQUIRE(
+                        tasks->get_thermal_plate_queue().backing_deque.empty());
+                    AND_THEN(
+                        "the temperature should be changed by the offset") {
+                        double adjusted_temp = (2.0 * _valid_temp) + 6.0F;
+                        REQUIRE(!tasks->get_host_comms_queue()
+                                     .backing_deque.empty());
+                        auto response =
+                            tasks->get_host_comms_queue().backing_deque.front();
+                        tasks->get_host_comms_queue().backing_deque.pop_front();
+                        REQUIRE(std::holds_alternative<
+                                messages::GetPlateTemperatureDebugResponse>(
+                            response));
+                        auto gettemp = std::get<
+                            messages::GetPlateTemperatureDebugResponse>(
+                            response);
+
+                        REQUIRE(gettemp.responding_to_id == message.id);
+
+                        REQUIRE_THAT(
+                            gettemp.heat_sink_temp,
+                            Catch::Matchers::WithinAbs(_valid_temp, 0.1));
+                        REQUIRE(gettemp.heat_sink_adc == valid_adc);
+
+                        REQUIRE_THAT(
+                            gettemp.front_right_temp,
+                            Catch::Matchers::WithinAbs(adjusted_temp, 0.01));
+                        REQUIRE(gettemp.front_right_adc == valid_adc);
+
+                        REQUIRE_THAT(
+                            gettemp.front_center_temp,
+                            Catch::Matchers::WithinAbs(adjusted_temp, 0.01));
+                        REQUIRE(gettemp.front_center_adc == valid_adc);
+
+                        REQUIRE_THAT(
+                            gettemp.front_left_temp,
+                            Catch::Matchers::WithinAbs(adjusted_temp, 0.01));
+                        REQUIRE(gettemp.front_left_adc == valid_adc);
+
+                        REQUIRE_THAT(
+                            gettemp.back_right_temp,
+                            Catch::Matchers::WithinAbs(adjusted_temp, 0.01));
+                        REQUIRE(gettemp.back_right_adc == valid_adc);
+
+                        REQUIRE_THAT(
+                            gettemp.back_center_temp,
+                            Catch::Matchers::WithinAbs(adjusted_temp, 0.01));
+                        REQUIRE(gettemp.back_center_adc == valid_adc);
+
+                        REQUIRE_THAT(
+                            gettemp.back_left_temp,
+                            Catch::Matchers::WithinAbs(adjusted_temp, 0.01));
+                        REQUIRE(gettemp.back_left_adc == valid_adc);
+                    }
+                }
+            }
+            AND_WHEN("sending a get-offset-constants message") {
+                auto get_offsets =
+                    messages::GetOffsetConstantsMessage{.id = 654};
+                tasks->get_thermal_plate_queue().backing_deque.push_back(
+                    messages::ThermalPlateMessage(get_offsets));
+                tasks->get_host_comms_queue().backing_deque.clear();
+                tasks->run_thermal_plate_task();
+                THEN("the task should get the message") {
+                    REQUIRE(
+                        tasks->get_thermal_plate_queue().backing_deque.empty());
+                    AND_THEN("the response should have B=1 and C=6") {
+                        REQUIRE(!tasks->get_host_comms_queue()
+                                     .backing_deque.empty());
+                        auto response =
+                            tasks->get_host_comms_queue().backing_deque.front();
+                        tasks->get_host_comms_queue().backing_deque.pop_front();
+                        REQUIRE(std::holds_alternative<
+                                messages::GetOffsetConstantsResponse>(
+                            response));
+                        auto constants =
+                            std::get<messages::GetOffsetConstantsResponse>(
+                                response);
+                        REQUIRE(constants.responding_to_id == get_offsets.id);
+                        REQUIRE_THAT(constants.const_b,
+                                     Catch::Matchers::WithinAbs(1.0F, 0.01F));
+                        REQUIRE_THAT(constants.const_c,
+                                     Catch::Matchers::WithinAbs(6.0F, 0.01F));
+                    }
+                }
+            }
+        }
         WHEN("sending a SetPeltierDebug message to turn on all peltiers") {
             auto message = messages::SetPeltierDebugMessage{
                 .id = 123,


### PR DESCRIPTION
### Summary

The temperature measured by the thermistors on the plate PCB is not the same as the temperature on the actual plate. Early testing shows that a simple linear regression based off of the current temperature of a thermistor can approximate (within spec) the temperature on the plate.

- Adds a dedicated `Eeprom` class for reading/writing offsets to the onboard EEPROM. Includes a flag on one of the pages to mark whether the data should be "good" or not, and in the future can mark whether a checksum is included
- Adds calculation of the expected temperature for the 6 plate thermistors.
- Adds a short FreeRTOS delay after setting the write protect pin on the EEPROM. The EEPROM needs time after each write and the datasheet suggest polling the bus, but it's a fixed time and a delay gets the job done. Earlier testing had all been with a single write at a time, so no failures popped up until now.

Tested on hardware that:
- Setting constants affects the reported temperature as expected
- Constants are persistent across power cycles