### PR TITLE
feat(thermocycler-refresh): Open and Close Lid Commands

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/firmware/motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-refresh/firmware/motor_policy.hpp
@@ -33,6 +33,7 @@ class MotorPolicy {
      *
      * @param steps Number of steps to move. Can be positive or negative
      * to indicate direction.
+     * @param overdrive True to ignore the endstop switches for this movement
      */
     auto lid_stepper_start(int32_t steps, bool overdrive) -> void;
     /**

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -791,7 +791,7 @@ struct GetLidStatus {
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputLimit, InputIt>
     static auto write_response_into(InputIt buf, InputLimit limit,
-                                    motor_util::LidStepper::Status lid,
+                                    motor_util::LidStepper::Position lid,
                                     motor_util::SealStepper::Status seal)
         -> InputIt {
         int res = 0;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -1367,4 +1367,62 @@ struct GetOffsetConstants {
     }
 };
 
+/**
+ * @brief Uses M126, same as gen 1 thermocycler. Opens the lid.
+ *
+ */
+struct OpenLid {
+    using ParseResult = std::optional<OpenLid>;
+    static constexpr auto prefix = std::array{'M', '1', '2', '6'};
+    static constexpr const char* response = "M126 OK\n";
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(OpenLid()), working);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+};
+
+/**
+ * @brief Uses M127, same as gen 1 thermocycler. Closes the lid.
+ *
+ */
+struct CloseLid {
+    using ParseResult = std::optional<CloseLid>;
+    static constexpr auto prefix = std::array{'M', '1', '2', '7'};
+    static constexpr const char* response = "M127 OK\n";
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(CloseLid()), working);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+};
+
 }  // namespace gcode

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
@@ -48,7 +48,7 @@ class HostCommsTask {
         gcode::SetFanAutomatic, gcode::ActuateSealStepperDebug,
         gcode::GetSealDriveStatus, gcode::SetSealParameter, gcode::GetLidStatus,
         gcode::GetThermalPowerDebug, gcode::SetOffsetConstants,
-        gcode::GetOffsetConstants>;
+        gcode::GetOffsetConstants, gcode::OpenLid, gcode::CloseLid>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::ActuateSolenoid, gcode::ActuateLidStepperDebug,
@@ -57,7 +57,8 @@ class HostCommsTask {
                  gcode::DeactivateLidHeating, gcode::SetPIDConstants,
                  gcode::SetPlateTemperature, gcode::DeactivatePlate,
                  gcode::SetFanAutomatic, gcode::ActuateSealStepperDebug,
-                 gcode::SetSealParameter, gcode::SetOffsetConstants>;
+                 gcode::SetSealParameter, gcode::SetOffsetConstants,
+                 gcode::OpenLid, gcode::CloseLid>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetLidTempDebugCache = AckCache<8, gcode::GetLidTemperatureDebug>;
     using GetPlateTempDebugCache = AckCache<8, gcode::GetPlateTemperatureDebug>;
@@ -638,7 +639,7 @@ class HostCommsTask {
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
-            ack_only_cache.remove_if_present(id);
+            get_lid_temp_debug_cache.remove_if_present(id);
             return std::make_pair(false, wrote_to);
         }
 
@@ -662,7 +663,7 @@ class HostCommsTask {
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
-            ack_only_cache.remove_if_present(id);
+            get_lid_temp_cache.remove_if_present(id);
             return std::make_pair(false, wrote_to);
         }
 
@@ -687,7 +688,7 @@ class HostCommsTask {
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
-            ack_only_cache.remove_if_present(id);
+            get_plate_temp_debug_cache.remove_if_present(id);
             return std::make_pair(false, wrote_to);
         }
 
@@ -729,7 +730,7 @@ class HostCommsTask {
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
-            ack_only_cache.remove_if_present(id);
+            get_plate_temp_cache.remove_if_present(id);
             return std::make_pair(false, wrote_to);
         }
 
@@ -1037,7 +1038,7 @@ class HostCommsTask {
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
-            ack_only_cache.remove_if_present(id);
+            get_seal_drive_status_cache.remove_if_present(id);
             return std::make_pair(false, wrote_to);
         }
         return std::make_pair(true, tx_into);
@@ -1082,7 +1083,7 @@ class HostCommsTask {
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
-            ack_only_cache.remove_if_present(id);
+            get_lid_status_cache.remove_if_present(id);
             return std::make_pair(false, wrote_to);
         }
         return std::make_pair(true, tx_into);
@@ -1104,7 +1105,7 @@ class HostCommsTask {
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
-            ack_only_cache.remove_if_present(id);
+            get_thermal_power_cache.remove_if_present(id);
             return std::make_pair(false, wrote_to);
         }
         return std::make_pair(true, tx_into);
@@ -1151,6 +1152,50 @@ class HostCommsTask {
         }
         auto message = messages::GetOffsetConstantsMessage{.id = id};
         if (!task_registry->thermal_plate->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            get_offset_constants_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::CloseLid& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::CloseLidMessage{.id = id};
+        if (!task_registry->motor->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::OpenLid& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::OpenLidMessage{.id = id};
+        if (!task_registry->motor->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -321,7 +321,7 @@ struct GetLidStatusMessage {
 
 struct GetLidStatusResponse {
     uint32_t responding_to_id;
-    motor_util::LidStepper::Status lid;
+    motor_util::LidStepper::Position lid;
     motor_util::SealStepper::Status seal;
 };
 

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -325,6 +325,14 @@ struct GetLidStatusResponse {
     motor_util::SealStepper::Status seal;
 };
 
+struct OpenLidMessage {
+    uint32_t id;
+};
+
+struct CloseLidMessage {
+    uint32_t id;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage,
@@ -352,8 +360,10 @@ using LidHeaterMessage =
                    GetLidTempMessage, SetLidTemperatureMessage,
                    DeactivateLidHeatingMessage, SetPIDConstantsMessage,
                    GetThermalPowerMessage>;
-using MotorMessage = ::std::variant<
-    std::monostate, ActuateSolenoidMessage, LidStepperDebugMessage,
-    LidStepperComplete, SealStepperDebugMessage, SealStepperComplete,
-    GetSealDriveStatusMessage, SetSealParameterMessage, GetLidStatusMessage>;
+using MotorMessage =
+    ::std::variant<std::monostate, ActuateSolenoidMessage,
+                   LidStepperDebugMessage, LidStepperComplete,
+                   SealStepperDebugMessage, SealStepperComplete,
+                   GetSealDriveStatusMessage, SetSealParameterMessage,
+                   GetLidStatusMessage, OpenLidMessage, CloseLidMessage>;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
@@ -97,7 +97,7 @@ struct LidStepperState {
     constexpr static double CLOSE_OVERDRIVE_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(-5);
     // Default run current is 1200 milliamperes
-    constexpr static double DEFAULT_RUN_CURRENT = 
+    constexpr static double DEFAULT_RUN_CURRENT =
         motor_util::LidStepper::current_to_dac(1200);
     // States for lid stepper
     enum Status {
@@ -422,8 +422,7 @@ class MotorTask {
             lid = motor_util::LidStepper::Status::CLOSED;
         } else if (policy.lid_read_open_switch()) {
             lid = motor_util::LidStepper::Status::OPEN;
-        } else if (_lid_stepper_state.status !=
-                   LidStepperState::Status::IDLE) {
+        } else if (_lid_stepper_state.status != LidStepperState::Status::IDLE) {
             lid = motor_util::LidStepper::Status::BETWEEN;
         }
 

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
@@ -83,7 +83,7 @@ struct LidStepperState {
     // distance is 120 degrees which is far wider than the actual travel angle.
     constexpr static double FULL_OPEN_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(120);
-    // After opening to the open switch, the lid must close ~5º to
+    // After opening to the open switch, the lid must close a few degrees to
     // be at the 90º position
     constexpr static double OPEN_BACK_TO_90_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(-17);

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_utils.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_utils.hpp
@@ -37,21 +37,21 @@ class LidStepper {
 
   public:
     /** Possible states of the lid stepper.*/
-    enum class Status { BETWEEN, CLOSED, OPEN, UNKNOWN };
+    enum class Position { BETWEEN, CLOSED, OPEN, UNKNOWN };
 
-    [[nodiscard]] constexpr static auto status_to_string(Status status) -> const
-        char* {
+    [[nodiscard]] constexpr static auto status_to_string(Position status)
+        -> const char* {
         switch (status) {
-            case Status::BETWEEN:
+            case Position::BETWEEN:
                 return "in_between";
                 break;
-            case Status::CLOSED:
+            case Position::CLOSED:
                 return "closed";
                 break;
-            case Status::OPEN:
+            case Position::OPEN:
                 return "open";
                 break;
-            case Status::UNKNOWN:
+            case Position::UNKNOWN:
                 return "unknown";
                 break;
         }

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_utils.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_utils.hpp
@@ -39,7 +39,8 @@ class LidStepper {
     /** Possible states of the lid stepper.*/
     enum class Status { BETWEEN, CLOSED, OPEN, UNKNOWN };
 
-    [[nodiscard]] static auto status_to_string(Status status) -> const char* {
+    [[nodiscard]] constexpr static auto status_to_string(Status status) -> const
+        char* {
         switch (status) {
             case Status::BETWEEN:
                 return "in_between";
@@ -63,7 +64,8 @@ class LidStepper {
      * @param mamps Milliampere drive value to set for the current control
      * @return uint8_t containing the DAC register value for this voltage
      */
-    static auto current_to_dac(double mamps) -> uint8_t {
+    [[nodiscard]] constexpr static auto current_to_dac(double mamps)
+        -> uint8_t {
         // hardware has a 1ohm sense resistor and the driver has an implicit 10x
         // divider. the dac can express a max of 3.3V, so the maximum current we
         // can drive is 330mA at 3.3V/dac fullscale of 255. we can therefore
@@ -84,7 +86,8 @@ class LidStepper {
      * @param angle The angle in degrees. Can be positive or negative
      * @return int32_t count of steps to reach this angle
      */
-    static auto angle_to_microsteps(double angle) -> int32_t {
+    [[nodiscard]] constexpr static auto angle_to_microsteps(double angle)
+        -> int32_t {
         return static_cast<int32_t>(angle * DEGREES_TO_MICROSTEPS);
     }
 };

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -283,10 +283,10 @@ def open_lid(ser: serial.Serial):
         print('Lid already open')
         return
     print('Opening lid')
-    set_solenoid(True, ser)
-    move_lid_angle(120, False, ser)
-    move_lid_angle(3, True, ser)
-    set_solenoid(False, ser)
+    ser.write('M126\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M126 OK\n')
+    print(res)
 
 # Function to fully close the lid
 def close_lid(ser: serial.Serial):
@@ -295,8 +295,10 @@ def close_lid(ser: serial.Serial):
         print('Lid already closed')
         return
     print('Closing lid')
-    move_lid_angle(-120, False, ser)
-    move_lid_angle(-3, True, ser)
+    ser.write('M127\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M127 OK\n')
+    print(res)
     
 # UTILITIES FOR STEP RESPONSE
 

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -34,6 +34,8 @@ add_executable(${TARGET_MODULE_NAME}
     test_m116.cpp
     test_m117.cpp
     test_m119.cpp
+    test_m126.cpp 
+    test_m127.cpp
     test_m140.cpp
     test_m140d.cpp
     test_m141.cpp

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -1928,6 +1928,154 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                 }
             }
         }
+        WHEN("sending an OpenLid message") {
+            std::string message_text = std::string("M126\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the motor task "
+                "and not immediately ack") {
+                REQUIRE(tasks->get_motor_queue().backing_deque.size() != 0);
+                auto motor_message =
+                    tasks->get_motor_queue().backing_deque.front();
+                auto lid_motor_message =
+                    std::get<messages::OpenLidMessage>(motor_message);
+                tasks->get_motor_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = lid_motor_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("M126 OK\n"));
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending a bad response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = lid_motor_message.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending an ack with error back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = lid_motor_message.id,
+                            .with_error = errors::ErrorCode::LID_MOTOR_BUSY});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should print the error rather than ack") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR501:"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                    }
+                }
+            }
+        }
+        WHEN("sending a CloseLid message") {
+            std::string message_text = std::string("M127\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the motor task "
+                "and not immediately ack") {
+                REQUIRE(tasks->get_motor_queue().backing_deque.size() != 0);
+                auto motor_message =
+                    tasks->get_motor_queue().backing_deque.front();
+                auto lid_motor_message =
+                    std::get<messages::CloseLidMessage>(motor_message);
+                tasks->get_motor_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = lid_motor_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("M127 OK\n"));
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending a bad response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = lid_motor_message.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending an ack with error back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = lid_motor_message.id,
+                            .with_error = errors::ErrorCode::LID_MOTOR_BUSY});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should print the error rather than ack") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR501:"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -1650,7 +1650,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     auto response = messages::HostCommsMessage(
                         messages::GetLidStatusResponse{
                             .responding_to_id = lid_message.id,
-                            .lid = motor_util::LidStepper::Status::UNKNOWN,
+                            .lid = motor_util::LidStepper::Position::UNKNOWN,
                             .seal = motor_util::SealStepper::Status::UNKNOWN});
                     tasks->get_host_comms_queue().backing_deque.push_back(
                         response);
@@ -1672,7 +1672,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     auto response = messages::HostCommsMessage(
                         messages::GetLidStatusResponse{
                             .responding_to_id = lid_message.id + 1,
-                            .lid = motor_util::LidStepper::Status::UNKNOWN,
+                            .lid = motor_util::LidStepper::Position::UNKNOWN,
                             .seal = motor_util::SealStepper::Status::UNKNOWN});
                     tasks->get_host_comms_queue().backing_deque.push_back(
                         response);

--- a/stm32-modules/thermocycler-refresh/tests/test_m119.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m119.cpp
@@ -13,7 +13,7 @@ SCENARIO("GetLidStatus (M119) parser works", "[gcode][parse][m119]") {
     GIVEN("a response buffer large enough for the formatted response") {
         std::string buffer(256, 'c');
         WHEN("filling response") {
-            auto lid = motor_util::LidStepper::Status::UNKNOWN;
+            auto lid = motor_util::LidStepper::Position::UNKNOWN;
             auto seal = motor_util::SealStepper::Status::UNKNOWN;
             auto written = gcode::GetLidStatus::write_response_into(
                 buffer.begin(), buffer.end(), lid, seal);

--- a/stm32-modules/thermocycler-refresh/tests/test_m126.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m126.cpp
@@ -1,0 +1,56 @@
+#include "catch2/catch.hpp"
+
+// Push this diagnostic to avoid a compiler error about printing to too
+// small of a buffer... which we're doing on purpose!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-refresh/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("OpenLid (M126) parser works", "[gcode][parse][m126]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::OpenLid::write_response_into(buffer.begin(),
+                                                               buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M126 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::OpenLid::write_response_into(
+                buffer.begin(), buffer.begin() + 5);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M126 ccccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a valid input") {
+        std::string buffer = "M126\n";
+        WHEN("parsing") {
+            auto res = gcode::OpenLid::parse(buffer.begin(), buffer.end());
+            THEN("a valid gcode should be produced") {
+                REQUIRE(res.first.has_value());
+                REQUIRE(res.second != buffer.begin());
+            }
+        }
+    }
+    GIVEN("an invalid input") {
+        std::string buffer = "M 126\n";
+        WHEN("parsing") {
+            auto res = gcode::OpenLid::parse(buffer.begin(), buffer.end());
+            THEN("an error should be produced") {
+                REQUIRE(!res.first.has_value());
+                REQUIRE(res.second == buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_m127.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m127.cpp
@@ -1,0 +1,56 @@
+#include "catch2/catch.hpp"
+
+// Push this diagnostic to avoid a compiler error about printing to too
+// small of a buffer... which we're doing on purpose!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-refresh/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("CloseLid (M127) parser works", "[gcode][parse][m127]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::CloseLid::write_response_into(buffer.begin(),
+                                                                buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M127 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::CloseLid::write_response_into(
+                buffer.begin(), buffer.begin() + 5);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M127 ccccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a valid input") {
+        std::string buffer = "M127\n";
+        WHEN("parsing") {
+            auto res = gcode::CloseLid::parse(buffer.begin(), buffer.end());
+            THEN("a valid gcode should be produced") {
+                REQUIRE(res.first.has_value());
+                REQUIRE(res.second != buffer.begin());
+            }
+        }
+    }
+    GIVEN("an invalid input") {
+        std::string buffer = "M 127\n";
+        WHEN("parsing") {
+            auto res = gcode::CloseLid::parse(buffer.begin(), buffer.end());
+            THEN("an error should be produced") {
+                REQUIRE(!res.first.has_value());
+                REQUIRE(res.second == buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
@@ -363,5 +363,115 @@ SCENARIO("motor task message passing") {
                 }
             }
         }
+        WHEN("sending OpenLid command") {
+            tasks->get_motor_queue().backing_deque.push_back(
+                messages::OpenLidMessage{.id = 123});
+            tasks->run_motor_task();
+            THEN("the lid starts moving to the endstop") {
+                REQUIRE(motor_policy.solenoid_engaged());
+                REQUIRE(!motor_policy.get_lid_overdrive());
+                REQUIRE(motor_policy.get_angle() > 0);
+                REQUIRE(motor_policy.get_vref() > 0);
+            }
+            auto position_full_open = motor_policy.get_angle();
+            AND_WHEN("the first movement completes") {
+                tasks->get_motor_queue().backing_deque.push_back(
+                    messages::LidStepperComplete());
+                tasks->run_motor_task();
+                THEN("the lid is moved back to 90º") {
+                    REQUIRE(motor_policy.get_angle() < position_full_open);
+                    REQUIRE(motor_policy.get_vref() > 0);
+                    REQUIRE(!motor_policy.get_lid_overdrive());
+                }
+                AND_WHEN("the second movement completes") {
+                    tasks->get_motor_queue().backing_deque.push_back(
+                        messages::LidStepperComplete());
+                    tasks->run_motor_task();
+                    THEN("the movement ends") {
+                        REQUIRE(motor_policy.get_vref() == 0);
+                    }
+                    THEN("an ACK is sent to the host comms task") {
+                        REQUIRE(!motor_policy.solenoid_engaged());
+                        REQUIRE(tasks->get_host_comms_queue().has_message());
+                        auto msg =
+                            tasks->get_host_comms_queue().backing_deque.front();
+                        auto reply_msg =
+                            std::get<messages::AcknowledgePrevious>(msg);
+                        REQUIRE(reply_msg.responding_to_id == 123);
+                        REQUIRE(reply_msg.with_error ==
+                                errors::ErrorCode::NO_ERROR);
+                    }
+                }
+            }
+            AND_WHEN("sending another OpenLid command immediately") {
+                tasks->get_motor_queue().backing_deque.push_back(
+                    messages::OpenLidMessage{.id = 456});
+                tasks->run_motor_task();
+                THEN("the second command is ignored with an error") {
+                    REQUIRE(tasks->get_host_comms_queue().has_message());
+                    auto msg =
+                        tasks->get_host_comms_queue().backing_deque.front();
+                    auto reply_msg =
+                        std::get<messages::AcknowledgePrevious>(msg);
+                    REQUIRE(reply_msg.responding_to_id == 456);
+                    REQUIRE(reply_msg.with_error ==
+                            errors::ErrorCode::LID_MOTOR_BUSY);
+                }
+            }
+        }
+        WHEN("sending CloseLid command") {
+            tasks->get_motor_queue().backing_deque.push_back(
+                messages::CloseLidMessage{.id = 123});
+            tasks->run_motor_task();
+            THEN("the lid starts moving to the endstop") {
+                REQUIRE(!motor_policy.get_lid_overdrive());
+                REQUIRE(motor_policy.get_angle() < 0);
+                REQUIRE(motor_policy.get_vref() > 0);
+            }
+            auto position_full_closed = motor_policy.get_angle();
+            AND_WHEN("the first movement completes") {
+                tasks->get_motor_queue().backing_deque.push_back(
+                    messages::LidStepperComplete());
+                tasks->run_motor_task();
+                THEN("the lid is overdriven a few degrees") {
+                    REQUIRE(motor_policy.get_angle() < position_full_closed);
+                    REQUIRE(motor_policy.get_vref() > 0);
+                    REQUIRE(motor_policy.get_lid_overdrive());
+                }
+                AND_WHEN("the second movement completes") {
+                    tasks->get_motor_queue().backing_deque.push_back(
+                        messages::LidStepperComplete());
+                    tasks->run_motor_task();
+                    THEN("the movement ends") {
+                        REQUIRE(motor_policy.get_vref() == 0);
+                    }
+                    THEN("an ACK is sent to the host comms task") {
+                        REQUIRE(tasks->get_host_comms_queue().has_message());
+                        auto msg =
+                            tasks->get_host_comms_queue().backing_deque.front();
+                        auto reply_msg =
+                            std::get<messages::AcknowledgePrevious>(msg);
+                        REQUIRE(reply_msg.responding_to_id == 123);
+                        REQUIRE(reply_msg.with_error ==
+                                errors::ErrorCode::NO_ERROR);
+                    }
+                }
+            }
+            AND_WHEN("sending another CloseLid command immediately") {
+                tasks->get_motor_queue().backing_deque.push_back(
+                    messages::CloseLidMessage{.id = 456});
+                tasks->run_motor_task();
+                THEN("the second command is ignored with an error") {
+                    REQUIRE(tasks->get_host_comms_queue().has_message());
+                    auto msg =
+                        tasks->get_host_comms_queue().backing_deque.front();
+                    auto reply_msg =
+                        std::get<messages::AcknowledgePrevious>(msg);
+                    REQUIRE(reply_msg.responding_to_id == 456);
+                    REQUIRE(reply_msg.with_error ==
+                            errors::ErrorCode::LID_MOTOR_BUSY);
+                }
+            }
+        }
     }
 }

--- a/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
@@ -106,7 +106,7 @@ SCENARIO("motor task message passing") {
                     auto response =
                         std::get<messages::GetLidStatusResponse>(msg);
                     REQUIRE(response.lid ==
-                            motor_util::LidStepper::Status::BETWEEN);
+                            motor_util::LidStepper::Position::BETWEEN);
                 }
             }
         }
@@ -326,7 +326,7 @@ SCENARIO("motor task message passing") {
                 auto response = std::get<messages::GetLidStatusResponse>(msg);
                 REQUIRE(response.responding_to_id == message.id);
                 REQUIRE(response.lid ==
-                        motor_util::LidStepper::Status::UNKNOWN);
+                        motor_util::LidStepper::Position::UNKNOWN);
                 REQUIRE(response.seal ==
                         motor_util::SealStepper::Status::UNKNOWN);
             }
@@ -343,7 +343,7 @@ SCENARIO("motor task message passing") {
                     auto response =
                         std::get<messages::GetLidStatusResponse>(msg);
                     REQUIRE(response.lid ==
-                            motor_util::LidStepper::Status::CLOSED);
+                            motor_util::LidStepper::Position::CLOSED);
                 }
             }
         }
@@ -359,7 +359,7 @@ SCENARIO("motor task message passing") {
                     auto response =
                         std::get<messages::GetLidStatusResponse>(msg);
                     REQUIRE(response.lid ==
-                            motor_util::LidStepper::Status::OPEN);
+                            motor_util::LidStepper::Position::OPEN);
                 }
             }
         }
@@ -400,6 +400,22 @@ SCENARIO("motor task message passing") {
                         REQUIRE(reply_msg.responding_to_id == 123);
                         REQUIRE(reply_msg.with_error ==
                                 errors::ErrorCode::NO_ERROR);
+                    }
+                    AND_WHEN("querying the lid position") {
+                        tasks->get_host_comms_queue().backing_deque.clear();
+                        tasks->get_motor_queue().backing_deque.push_back(
+                            messages::GetLidStatusMessage{.id = 10});
+                        tasks->run_motor_task();
+                        THEN(
+                            "the position is Open even though the switch "
+                            "doesn't detect it") {
+                            auto msg = tasks->get_host_comms_queue()
+                                           .backing_deque.front();
+                            auto reply_msg =
+                                std::get<messages::GetLidStatusResponse>(msg);
+                            REQUIRE(reply_msg.lid ==
+                                    motor_util::LidStepper::Position::OPEN);
+                        }
                     }
                 }
             }
@@ -454,6 +470,22 @@ SCENARIO("motor task message passing") {
                         REQUIRE(reply_msg.responding_to_id == 123);
                         REQUIRE(reply_msg.with_error ==
                                 errors::ErrorCode::NO_ERROR);
+                    }
+                    AND_WHEN("querying the lid position") {
+                        tasks->get_host_comms_queue().backing_deque.clear();
+                        tasks->get_motor_queue().backing_deque.push_back(
+                            messages::GetLidStatusMessage{.id = 10});
+                        tasks->run_motor_task();
+                        THEN(
+                            "the position is Closed even though the switch "
+                            "doesn't detect it") {
+                            auto msg = tasks->get_host_comms_queue()
+                                           .backing_deque.front();
+                            auto reply_msg =
+                                std::get<messages::GetLidStatusResponse>(msg);
+                            REQUIRE(reply_msg.lid ==
+                                    motor_util::LidStepper::Position::CLOSED);
+                        }
                     }
                 }
             }

--- a/stm32-modules/thermocycler-refresh/tests/test_motor_utils.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_motor_utils.cpp
@@ -78,7 +78,7 @@ SCENARIO("Lid stepper microstep conversion works") {
 }
 
 SCENARIO("lid status stringification works") {
-    using Status = motor_util::LidStepper::Status;
+    using Status = motor_util::LidStepper::Position;
     std::array<Status, 4> inputs = {Status::BETWEEN, Status::CLOSED,
                                     Status::OPEN, Status::UNKNOWN};
     std::array<std::string, 4> outputs = {"in_between", "closed", "open",


### PR DESCRIPTION
### Summary

Adds M126 and M127 from the original thermocycler to Open and Close the lid, respectively.  

- Reporting of the lid position (open/closed/unknown) is now dependent on the last command sent for the lid rather than just the switches. This is required because the resting positions for open & closed may not necessarily trigger the endstop switches.
- The state machines for each command are TBD to a certain extent, but they are tested and working correctly on the 1.4 units (most recent prototypes).
- Edited the Python utils to use the new commands instead of chaining together individual commands.

Tested on prototype 1.4A