### PR TITLE
feat(thermocycler-refresh): front button controls the lid

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -333,6 +333,8 @@ struct CloseLidMessage {
     uint32_t id;
 };
 
+struct FrontButtonPressMessage {};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage,
@@ -360,10 +362,9 @@ using LidHeaterMessage =
                    GetLidTempMessage, SetLidTemperatureMessage,
                    DeactivateLidHeatingMessage, SetPIDConstantsMessage,
                    GetThermalPowerMessage>;
-using MotorMessage =
-    ::std::variant<std::monostate, ActuateSolenoidMessage,
-                   LidStepperDebugMessage, LidStepperComplete,
-                   SealStepperDebugMessage, SealStepperComplete,
-                   GetSealDriveStatusMessage, SetSealParameterMessage,
-                   GetLidStatusMessage, OpenLidMessage, CloseLidMessage>;
+using MotorMessage = ::std::variant<
+    std::monostate, ActuateSolenoidMessage, LidStepperDebugMessage,
+    LidStepperComplete, SealStepperDebugMessage, SealStepperComplete,
+    GetSealDriveStatusMessage, SetSealParameterMessage, GetLidStatusMessage,
+    OpenLidMessage, CloseLidMessage, FrontButtonPressMessage>;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/system_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/system_task.hpp
@@ -299,6 +299,14 @@ class SystemTask {
             get_message_queue().try_send(messages::UpdateUIMessage()));
     }
 
+    // Should be provided to the front button timer to send Front Button
+    // messages. Ensure the timer implementation does NOT execute in an
+    // interrupt context.
+    auto front_button_callback() -> void {
+        static_cast<void>(_task_registry->motor->get_message_queue().try_send(
+            messages::FrontButtonPressMessage()));
+    }
+
     // To be used for tests
     [[nodiscard]] auto get_led_state() -> LedState& { return _led_state; }
 

--- a/stm32-modules/thermocycler-refresh/firmware/system/freertos_system_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/system/freertos_system_task.cpp
@@ -49,15 +49,8 @@ static timer::GenericTimer<freertos_timer::FreeRTOSTimer> _led_timer(
 // One shot timer for front button events.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static freertos_timer::FreeRTOSTimer _front_button_timer(
-    "button timer", FRONT_BUTTON_DEBOUNCE_MS, false, [] {
-        // TODO(Frank, 2/14/2022): Update this to send a message to the
-        // system task instead of just turning the button on/off
-        auto pressed = system_front_button_pressed();
-        system_front_button_led_set(!pressed);
-        if (pressed) {
-            _front_button_timer.start();
-        }
-    });
+    "button timer", FRONT_BUTTON_DEBOUNCE_MS, false,
+    [ObjectPtr = &_task] { ObjectPtr->front_button_callback(); });
 
 /**
  * @brief This is the DIRECT callback from .c file that will start the

--- a/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
@@ -505,5 +505,43 @@ SCENARIO("motor task message passing") {
                 }
             }
         }
+        WHEN("sending a Front Button message with lid in unknown position") {
+            tasks->get_motor_queue().backing_deque.push_back(
+                messages::FrontButtonPressMessage());
+            tasks->run_motor_task();
+            THEN("the lid starts to open") {
+                REQUIRE(motor_policy.solenoid_engaged());
+                REQUIRE(!motor_policy.get_lid_overdrive());
+                REQUIRE(motor_policy.get_angle() > 0);
+                REQUIRE(motor_policy.get_vref() > 0);
+            }
+        }
+        GIVEN("lid closed sensor triggered") {
+            motor_policy.set_lid_closed_switch(true);
+            WHEN("sending a Front Button message") {
+                tasks->get_motor_queue().backing_deque.push_back(
+                    messages::FrontButtonPressMessage());
+                tasks->run_motor_task();
+                THEN("the lid starts to open") {
+                    REQUIRE(motor_policy.solenoid_engaged());
+                    REQUIRE(!motor_policy.get_lid_overdrive());
+                    REQUIRE(motor_policy.get_angle() > 0);
+                    REQUIRE(motor_policy.get_vref() > 0);
+                }
+            }
+        }
+        GIVEN("lid open sensor triggered") {
+            motor_policy.set_lid_open_switch(true);
+            WHEN("sending a Front Button message") {
+                tasks->get_motor_queue().backing_deque.push_back(
+                    messages::FrontButtonPressMessage());
+                tasks->run_motor_task();
+                THEN("the lid starts to close") {
+                    REQUIRE(!motor_policy.get_lid_overdrive());
+                    REQUIRE(motor_policy.get_angle() < 0);
+                    REQUIRE(motor_policy.get_vref() > 0);
+                }
+            }
+        }
     }
 }

--- a/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
@@ -326,7 +326,7 @@ SCENARIO("motor task message passing") {
                 auto response = std::get<messages::GetLidStatusResponse>(msg);
                 REQUIRE(response.responding_to_id == message.id);
                 REQUIRE(response.lid ==
-                        motor_util::LidStepper::Position::UNKNOWN);
+                        motor_util::LidStepper::Position::BETWEEN);
                 REQUIRE(response.seal ==
                         motor_util::SealStepper::Status::UNKNOWN);
             }

--- a/stm32-modules/thermocycler-refresh/tests/test_system_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_system_task.cpp
@@ -51,6 +51,16 @@ SCENARIO("system task message passing") {
             }
         }
 
+        WHEN("calling button press callback") {
+            tasks->get_system_task().front_button_callback();
+            THEN("a Front Button message is sent to motor task") {
+                REQUIRE(tasks->get_motor_queue().has_message());
+                REQUIRE(
+                    std::holds_alternative<messages::FrontButtonPressMessage>(
+                        tasks->get_motor_queue().backing_deque.front()));
+            }
+        }
+
         WHEN("sending a set-serial-number message as if from the host comms") {
             auto message = messages::SetSerialNumberMessage{
                 .id = 123,


### PR DESCRIPTION
### Summary

This PR makes the front button control the lid. Pressing the button while the lid is fully open will close the lid, and pressing it at any other time will close the lid. If both of the endstop switches sense the lid, nothing happens because something is broken.

Tested on 1.4A.