### PR TITLE
feat(thermocycler-refresh): Hold time tracking and more detailed GetPlateTemp response

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -200,15 +200,26 @@ struct GetPlateTemp {
         std::sized_sentinel_for<InputIt, InLimit>
     static auto write_response_into(InputIt buf, InLimit limit,
                                     double current_temperature,
-                                    double setpoint_temperature) -> InputIt {
+                                    double setpoint_temperature = 0.0F,
+                                    double remaining_hold = 0.0F,
+                                    double total_hold = 0.0F,
+                                    bool at_target = false) -> InputIt {
         int res = 0;
         if (setpoint_temperature == 0.0F) {
-            res = snprintf(&*buf, (limit - buf), "M105 T:none C:%0.2f OK\n",
-                           static_cast<float>(current_temperature));
+            // Active setpoint response
+            res = snprintf(
+                &*buf, (limit - buf),
+                "M105 T:none C:%0.2f H:none Total_H:none At_target?:0 OK\n",
+                static_cast<float>(current_temperature));
         } else {
-            res = snprintf(&*buf, (limit - buf), "M105 T:%0.2f C:%0.2f OK\n",
-                           static_cast<float>(setpoint_temperature),
-                           static_cast<float>(current_temperature));
+            // No active setpoint response
+            res = snprintf(
+                &*buf, (limit - buf),
+                "M105 T:%0.2f C:%0.2f H:%0.2f Total_H:%0.2f At_target?:%i OK\n",
+                static_cast<float>(setpoint_temperature),
+                static_cast<float>(current_temperature),
+                static_cast<float>(remaining_hold),
+                static_cast<float>(total_hold), at_target ? 1 : 0);
         }
         if (res <= 0) {
             return buf;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/host_comms_task.hpp
@@ -391,7 +391,8 @@ class HostCommsTask {
                 } else {
                     return cache_element.write_response_into(
                         tx_into, tx_limit, response.current_temp,
-                        response.set_temp);
+                        response.set_temp, response.time_remaining,
+                        response.total_time, response.at_target);
                 }
             },
             cache_entry);

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -191,6 +191,9 @@ struct GetPlateTempResponse {
     uint32_t responding_to_id;
     double current_temp;
     double set_temp;
+    double time_remaining;
+    double total_time;
+    bool at_target;
 };
 
 struct SetPeltierDebugMessage {

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -498,7 +498,7 @@ class ThermalPlateTask {
             _state.system_status = State::IDLE;
             policy.set_enabled(false);
         } else {
-            if (_plate_control.set_new_target(msg.setpoint)) {
+            if (_plate_control.set_new_target(msg.setpoint, msg.hold_time)) {
                 _state.system_status = State::CONTROLLING;
             } else {
                 response.with_error = errors::ErrorCode::THERMAL_TARGET_BAD;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <concepts>
 #include <cstddef>
+#include <tuple>
 #include <variant>
 
 #include "core/pid.hpp"
@@ -335,7 +336,14 @@ class ThermalPlateTask {
         auto response = messages::GetPlateTempResponse{
             .responding_to_id = msg.id,
             .current_temp = average_plate_temp(),
-            .set_temp = _plate_control.setpoint()};
+            .set_temp = _plate_control.setpoint(),
+            .time_remaining = 0,
+            .total_time = 0,
+            .at_target = _plate_control.temp_within_setpoint()};
+
+        std::tie(response.time_remaining, response.total_time) =
+            _plate_control.get_hold_time();
+
         if (_state.system_status != State::CONTROLLING) {
             response.set_temp = 0.0F;
         }

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -82,14 +82,16 @@ def get_thermal_power(ser: serial.Serial) -> Tuple[float, float, float, float, f
     print(res)
     return left, center, right, heater, fans
 
-_PLATE_TEMP_RE = re.compile('^M105 T:(?P<target>.+) C:(?P<temp>.+) OK\n')
+_PLATE_TEMP_RE = re.compile('^M105 T:(?P<target>.+) C:(?P<temp>.+) H:(?P<hold>.+) Total_H:(?P<total_hold>.+) At_target\?:(?P<at_target>.+) OK\n')
 # JUST gets the base temperature of the plate
-def get_plate_temperature(ser: serial.Serial) -> float:
+def get_plate_temperature(ser: serial.Serial, debug_print = False) -> float:
     ser.write(b'M105\n')
     res = ser.readline()
     guard_error(res, b'M105')
     res_s = res.decode()
     match = re.match(_PLATE_TEMP_RE, res_s)
+    if debug_print:
+        print(res)
     return float(match.group('temp'))
 
 # Sets peltier PWM as a percentage. Be careful!!!!!
@@ -162,9 +164,9 @@ def set_heater_pid(p: float, i: float, d: float, ser: serial.Serial):
     print(res)
 
 # Sets the plate target as a temperature in celsius
-def set_plate_temperature(temperature: float, ser: serial.Serial):
-    print(f'Setting plate temperature target to {temperature}C')
-    ser.write(f'M104 S{temperature}\n'.encode())
+def set_plate_temperature(temperature: float, ser: serial.Serial, hold_time: float = 0):
+    print(f'Setting plate temperature target to {temperature}C and hold time to {hold_time} sec')
+    ser.write(f'M104 S{temperature} H{hold_time}\n'.encode())
     res = ser.readline()
     guard_error(res, b'M104 OK')
     print(res)

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -1078,7 +1078,11 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     auto response = messages::HostCommsMessage(
                         messages::GetPlateTempResponse{
                             .responding_to_id = get_plate_temp_message.id,
-                            .current_temp = 30.0F});
+                            .current_temp = 30.0F,
+                            .set_temp = 35.0F,
+                            .time_remaining = 10.0F,
+                            .total_time = 15.0F,
+                            .at_target = true});
                     tasks->get_host_comms_queue().backing_deque.push_back(
                         response);
                     auto written_secondpass =
@@ -1086,8 +1090,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                                                               tx_buf.end());
                     THEN("the task should ack the previous message") {
                         const char* reply =
-                            "M105 T:none C:30.00 H:none Total_H:none "
-                            "At_target?:0 OK\n";
+                            "M105 T:35.00 C:30.00 H:10.00 Total_H:15.00 "
+                            "At_target?:1 OK\n";
                         REQUIRE_THAT(tx_buf,
                                      Catch::Matchers::StartsWith(reply));
                         REQUIRE(written_secondpass ==

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -1078,17 +1078,20 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     auto response = messages::HostCommsMessage(
                         messages::GetPlateTempResponse{
                             .responding_to_id = get_plate_temp_message.id,
-                            .current_temp = 30.0F,
-                            .set_temp = 35.0F});
+                            .current_temp = 30.0F});
                     tasks->get_host_comms_queue().backing_deque.push_back(
                         response);
                     auto written_secondpass =
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should ack the previous message") {
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "M105 T:35.00 C:30.00 OK\n"));
-                        REQUIRE(written_secondpass == tx_buf.begin() + 24);
+                        const char* reply =
+                            "M105 T:none C:30.00 H:none Total_H:none "
+                            "At_target?:0 OK\n";
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith(reply));
+                        REQUIRE(written_secondpass ==
+                                tx_buf.begin() + strlen(reply));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }

--- a/stm32-modules/thermocycler-refresh/tests/test_m105.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m105.cpp
@@ -12,19 +12,21 @@ SCENARIO("GetPlateTemperature (M105) parser works", "[gcode][parse][M105]") {
         std::string buffer(256, 'c');
         WHEN("filling response") {
             auto written = gcode::GetPlateTemp::write_response_into(
-                buffer.begin(), buffer.end(), 10.0, 40);
+                buffer.begin(), buffer.end(), 10.0, 40, 30.0, 40.0, true);
             THEN("the response should be written in full") {
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
-                                         "M105 T:40.00 C:10.00 OK\n"));
+                                         "M105 T:40.00 C:10.00 H:30.00 "
+                                         "Total_H:40.00 At_target?:1 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }
         WHEN("filling response with no target temp") {
             auto written = gcode::GetPlateTemp::write_response_into(
-                buffer.begin(), buffer.end(), 10.0, 0);
+                buffer.begin(), buffer.end(), 10.0);
             THEN("the response should be written in full") {
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
-                                         "M105 T:none C:10.00 OK\n"));
+                                         "M105 T:none C:10.00 H:none "
+                                         "Total_H:none At_target?:0 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }

--- a/stm32-modules/thermocycler-refresh/tests/test_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_thermal_plate_task.cpp
@@ -506,10 +506,19 @@ SCENARIO("thermal plate task message passing") {
                         THEN("the response should have the new setpoint") {
                             REQUIRE(!tasks->get_host_comms_queue()
                                          .backing_deque.empty());
-                            REQUIRE(std::get<messages::GetPlateTempResponse>(
-                                        tasks->get_host_comms_queue()
-                                            .backing_deque.front())
-                                        .set_temp == message.setpoint);
+                            auto temperature_message =
+                                std::get<messages::GetPlateTempResponse>(
+                                    tasks->get_host_comms_queue()
+                                        .backing_deque.front());
+                            REQUIRE(temperature_message.set_temp ==
+                                    message.setpoint);
+                            REQUIRE_THAT(
+                                temperature_message.time_remaining,
+                                Catch::Matchers::WithinAbs(10.0F, 0.01));
+                            REQUIRE_THAT(
+                                temperature_message.total_time,
+                                Catch::Matchers::WithinAbs(10.0F, 0.01));
+                            REQUIRE(!temperature_message.at_target);
                         }
                     }
                 }


### PR DESCRIPTION
### Summary

Adds hold time tracking for plate targets. The firmware tracks the amount of time that has passed once the target temperature is hit. This doesn't actually control anything in the firmware, but it's reported back to the host computer.

- Updated the python utilities to grab new information from the GetPlateTemp response
- Tested on 1.4A unit, and unit tests were updated to check for new functionality