### PR TITLE
chore(thermocycler-refresh): better PID and hold timing

### DIFF
--- a/stm32-modules/common/src/pid.cpp
+++ b/stm32-modules/common/src/pid.cpp
@@ -51,6 +51,11 @@ auto PID::compute(double error) -> double {
     return pterm + iterm + dterm;
 }
 
+auto PID::compute(double error, double sampletime) -> double {
+    _sampletime = sampletime;
+    return compute(error);
+}
+
 auto PID::reset() -> void {
     _last_error = 0;
     _last_iterm = 0;

--- a/stm32-modules/common/tests/test_pid.cpp
+++ b/stm32-modules/common/tests/test_pid.cpp
@@ -76,9 +76,10 @@ SCENARIO("PID controller") {
         WHEN("calculating controls with varied sample times") {
             std::vector<float> results(5);
             std::vector<float> inputs = {0.1, 0.2, 0.3, 0.4, 0.5};
-            std::transform(
-                inputs.cbegin(), inputs.cend(), results.begin(),
-                [&p](const float& sampletime) { return p.compute(1.0, sampletime); });
+            std::transform(inputs.cbegin(), inputs.cend(), results.begin(),
+                           [&p](const float& sampletime) {
+                               return p.compute(1.0, sampletime);
+                           });
             THEN("the sample time should not affect the output") {
                 std::vector<float> intended(5);
                 std::transform(inputs.cbegin(), inputs.cend(), intended.begin(),
@@ -136,13 +137,12 @@ SCENARIO("PID controller") {
                                p.reset();
                                return p.compute(error, 0.5);
                            });
-            THEN("the result should always calculate a difference from 0, "
-                 "divided by the sample time of 0.5") {
+            THEN(
+                "the result should always calculate a difference from 0, "
+                "divided by the sample time of 0.5") {
                 std::vector<float> expected(8);
                 std::transform(inputs.cbegin(), inputs.cend(), expected.begin(),
-                            [](const float& error) {
-                                return error / 0.5;
-                            });
+                               [](const float& error) { return error / 0.5; });
                 REQUIRE_THAT(results, Catch::Matchers::Equals(expected));
             }
         }

--- a/stm32-modules/include/common/core/pid.hpp
+++ b/stm32-modules/include/common/core/pid.hpp
@@ -1,12 +1,52 @@
 #pragma once
 
+/**
+ * @brief Implements a starndard PID controller.
+ */
 class PID {
   public:
     PID() = delete;
+    /** 
+     * @brief Create a PID controller without windup limits.
+     * 
+     * @param[in] kp Proportional constant
+     * @param[in] ki Integral constant
+     * @param[in] kd Derivative constant
+     * @param[in] sampletime The time between each sample, in seconds
+     */
     PID(double kp, double ki, double kd, double sampletime);
+    /** 
+     * @brief Create a PID controller without windup limits.
+     * 
+     * @param[in] kp Proportional constant
+     * @param[in] ki Integral constant
+     * @param[in] kd Derivative constant
+     * @param[in] sampletime The time between each sample, in seconds
+     * @param[in] windup_limit_high High windup limit - the max positive
+     * buildup of the integral term.
+     * @param[in] windup_limit_low Low windup limit - the max negative
+     * buildup of the integral term.
+     */
     PID(double kp, double ki, double kd, double sampletime,
         double windup_limit_high, double windup_limit_low);
+    /**
+     * @brief Compute the output of the PID controller from a new
+     * error value. Uses the last configured value of \ref sampletime
+     * 
+     * @param[in] error The error in the input
+     * @return double containing the output for the controller
+     */
     auto compute(double error) -> double;
+    /**
+     * @brief Compute the output of the PID controller from a new
+     * error value. The amount of time from the last error value
+     * is used to scale the parameters
+     * 
+     * @param[in] error The error in the input
+     * @param[in] sampletime The time since the last input, in seconds
+     * @return double containing the output for the controller
+     */
+    auto compute(double error, double sampletime) -> double;
     auto reset() -> void;
     [[nodiscard]] auto kp() const -> double;
     [[nodiscard]] auto ki() const -> double;

--- a/stm32-modules/include/common/core/pid.hpp
+++ b/stm32-modules/include/common/core/pid.hpp
@@ -6,18 +6,18 @@
 class PID {
   public:
     PID() = delete;
-    /** 
+    /**
      * @brief Create a PID controller without windup limits.
-     * 
+     *
      * @param[in] kp Proportional constant
      * @param[in] ki Integral constant
      * @param[in] kd Derivative constant
      * @param[in] sampletime The time between each sample, in seconds
      */
     PID(double kp, double ki, double kd, double sampletime);
-    /** 
+    /**
      * @brief Create a PID controller without windup limits.
-     * 
+     *
      * @param[in] kp Proportional constant
      * @param[in] ki Integral constant
      * @param[in] kd Derivative constant
@@ -32,7 +32,7 @@ class PID {
     /**
      * @brief Compute the output of the PID controller from a new
      * error value. Uses the last configured value of \ref sampletime
-     * 
+     *
      * @param[in] error The error in the input
      * @return double containing the output for the controller
      */
@@ -41,7 +41,7 @@ class PID {
      * @brief Compute the output of the PID controller from a new
      * error value. The amount of time from the last error value
      * is used to scale the parameters
-     * 
+     *
      * @param[in] error The error in the input
      * @param[in] sampletime The time since the last input, in seconds
      * @return double containing the output for the controller

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -62,6 +62,7 @@ class LidHeaterTask {
   public:
     using Queue = QueueImpl<Message>;
     using Milliseconds = uint32_t;
+    static constexpr const double MILLISECONDS_PER_SECOND = 1000.0;
     static constexpr const uint32_t CONTROL_PERIOD_TICKS = 100;
     static constexpr double THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM = 10.0;
     static constexpr uint16_t ADC_BIT_MAX = 0x5DC0;
@@ -165,10 +166,11 @@ class LidHeaterTask {
 
         // If we're in a controlling state, we now update the heater output
         if (_state.system_status == State::CONTROLLING) {
-            auto ret = policy.set_heater_power(_pid.compute(
-                _setpoint_c - _thermistor.temp_c,
-                // Convert millisecond time to seconds
-                static_cast<double>(current_time - _last_update) / 1000.0));
+            auto ret = policy.set_heater_power(
+                _pid.compute(_setpoint_c - _thermistor.temp_c,
+                             // Convert millisecond time to seconds
+                             static_cast<double>(current_time - _last_update) /
+                                 MILLISECONDS_PER_SECOND));
             if (!ret) {
                 policy.set_heater_power(0.0F);
                 _state.system_status = State::ERROR;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -91,10 +91,12 @@ struct ThermalPlateTempReadComplete {
     uint16_t back_right;
     uint16_t back_center;
     uint16_t back_left;
+    uint32_t timestamp_ms;
 };
 
 struct LidTempReadComplete {
     uint16_t lid_temp;
+    uint32_t timestamp_ms;
 };
 
 struct GetLidTemperatureDebugMessage {

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/plate_control.hpp
@@ -71,18 +71,12 @@ class PlateControl {
      * @param[in] right Right peltier reference
      * @param[in] center Center peltier reference
      * @param[in] fan Fan control reference
-     * @param[in] update_rate Expected number of seconds between each call to
-     * \c update_control()
      */
     PlateControl(thermal_general::Peltier &left,
                  thermal_general::Peltier &right,
                  thermal_general::Peltier &center,
-                 thermal_general::HeatsinkFan &fan, Seconds update_rate)
-        : _left(left),
-          _right(right),
-          _center(center),
-          _fan(fan),
-          _update_rate(update_rate) {}
+                 thermal_general::HeatsinkFan &fan)
+        : _left(left), _right(right), _center(center), _fan(fan) {}
 
     /**
      * @brief Updates the power settings for the peltiers fans. The current
@@ -93,10 +87,11 @@ class PlateControl {
      * \c manual_control variable in the fan handle. This function will set the
      * flag to \c false if the fan temperature exceeds a safety thershold.
      * @pre Update the current temperature of each thermistor for each peltier
-     * @param setpoint The setpoint to drive the peltiers towards
+     * @param time The amount of time that has elapsed since the function was
+     * last called, in seconds
      * @return A set of updated power outputs, or nothing if an error occurs
      */
-    auto update_control() -> UpdateRet;
+    auto update_control(Seconds time) -> UpdateRet;
     /**
      * @brief Set a new target temperature, with configurable ramp rate
      * and hold times
@@ -152,19 +147,22 @@ class PlateControl {
     /**
      * @brief Apply a ramp to the target temperature of an element.
      * @param[in] peltier The peltier to ramp target temperature of
+     * @param[in] time The time that has passed since the last update
      */
-    auto update_ramp(thermal_general::Peltier &peltier) -> void;
+    auto update_ramp(thermal_general::Peltier &peltier, Seconds time) -> void;
     /**
      * @brief Update the PID control of a single peltier
      * @param[in] peltier The peltier to update
+     * @param[in] time The time that has passed since the last update
      * @return The new power value for the element
      */
-    auto update_pid(thermal_general::Peltier &peltier) -> double;
+    auto update_pid(thermal_general::Peltier &peltier, Seconds time) -> double;
     /**
      * @brief Update the control of the heatsink fan during active control
+     * @param[in] time The time that has passed since the last update
      * @return The new power value for the fan
      */
-    auto update_fan() -> double;
+    auto update_fan(Seconds time) -> double;
     /**
      * @brief Reset a peltier for a new setpoint. Sets the target
      * temperature to the current average plate temperature and
@@ -186,8 +184,6 @@ class PlateControl {
     thermal_general::Peltier &_right;
     thermal_general::Peltier &_center;
     thermal_general::HeatsinkFan &_fan;
-    // This is the update rate in seconds/tick
-    const Seconds _update_rate;
 
     double _setpoint = 0.0F;
     double _ramp_rate = 0.0F;

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -86,6 +86,8 @@ requires MessageQueue<QueueImpl<Message>, Message>
 class ThermalPlateTask {
   public:
     using Queue = QueueImpl<Message>;
+    using Milliseconds = uint32_t;
+    using Seconds = double;
     static constexpr const uint32_t CONTROL_PERIOD_TICKS = 50;
     static constexpr double THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM = 10.0;
     static constexpr uint16_t ADC_BIT_MAX = 0x5DC0;
@@ -189,12 +191,12 @@ class ThermalPlateTask {
           _converter(THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM, ADC_BIT_MAX,
                      false),
           _state{.system_status = State::IDLE, .error_bitmap = 0},
-          _plate_control(_peltier_left, _peltier_right, _peltier_center, _fans,
-                         CONTROL_PERIOD_SECONDS),
+          _plate_control(_peltier_left, _peltier_right, _peltier_center, _fans),
           // NOLINTNEXTLINE(readability-redundant-member-init)
           _eeprom(),
           _offset_constants{.b = OFFSET_DEFAULT_CONST_B,
-                            .c = OFFSET_DEFAULT_CONST_C} {}
+                            .c = OFFSET_DEFAULT_CONST_C},
+          _last_update(0) {}
     ThermalPlateTask(const ThermalPlateTask& other) = delete;
     auto operator=(const ThermalPlateTask& other) -> ThermalPlateTask& = delete;
     ThermalPlateTask(ThermalPlateTask&& other) noexcept = delete;
@@ -255,6 +257,7 @@ class ThermalPlateTask {
     auto visit_message(const messages::ThermalPlateTempReadComplete& msg,
                        Policy& policy) -> void {
         auto old_error_bitmap = _state.error_bitmap;
+        Milliseconds current_time = msg.timestamp_ms;
 
         // Peltier temperatures are implicitly updated by updating the values
         // in the thermistors
@@ -286,7 +289,9 @@ class ThermalPlateTask {
         }
 
         if (_state.system_status == State::CONTROLLING) {
-            update_control(policy);
+            update_control(
+                policy,
+                static_cast<double>(current_time - _last_update) / 1000.0);
             send_current_state();
         } else if (_state.system_status == State::IDLE) {
             send_current_state();
@@ -302,6 +307,10 @@ class ThermalPlateTask {
         if (_state.system_status == State::ERROR) {
             policy.set_enabled(false);
         }
+
+        // Cache the timestamp from this message so the time difference for
+        // the next reading is correct
+        _last_update = current_time;
     }
 
     template <typename Policy>
@@ -724,12 +733,14 @@ class ThermalPlateTask {
      * closed-loop-control mode. Call this when the state is CONTROLLING
      * and new temperatures have been stored in the thermistor handles.
      * @param[in] policy The thermal plate policy
+     * @param[in] elapsed_time The amount of time that has passed since the
+     * last thermistor reading, in seconds
      * @return True if outputs are updated fine, false if any error occurs
      */
     template <ThermalPlateExecutionPolicy Policy>
-    auto update_control(Policy& policy) -> bool {
+    auto update_control(Policy& policy, Seconds elapsed_time) -> bool {
         policy.set_enabled(true);
-        auto values = _plate_control.update_control();
+        auto values = _plate_control.update_control(elapsed_time);
         auto ret = values.has_value();
         if (ret) {
             ret = set_peltier_power(_peltier_left, values.value().left_power,
@@ -861,6 +872,7 @@ class ThermalPlateTask {
     plate_control::PlateControl _plate_control;
     eeprom::Eeprom<EEPROM_PAGES, EEPROM_ADDRESS> _eeprom;
     eeprom::OffsetConstants _offset_constants;
+    Milliseconds _last_update;
 };
 
 }  // namespace thermal_plate_task

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -88,6 +88,7 @@ class ThermalPlateTask {
     using Queue = QueueImpl<Message>;
     using Milliseconds = uint32_t;
     using Seconds = double;
+    static constexpr const double MILLISECONDS_PER_SECOND = 1000.0;
     static constexpr const uint32_t CONTROL_PERIOD_TICKS = 50;
     static constexpr double THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM = 10.0;
     static constexpr uint16_t ADC_BIT_MAX = 0x5DC0;
@@ -289,9 +290,9 @@ class ThermalPlateTask {
         }
 
         if (_state.system_status == State::CONTROLLING) {
-            update_control(
-                policy,
-                static_cast<double>(current_time - _last_update) / 1000.0);
+            update_control(policy,
+                           static_cast<double>(current_time - _last_update) /
+                               MILLISECONDS_PER_SECOND);
             send_current_state();
         } else if (_state.system_status == State::IDLE) {
             send_current_state();

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_lid_heater_task.cpp
@@ -60,6 +60,7 @@ static void run(void *param) {
  * the message sent by updating its control loop.
  */
 static void run_thermistor_task(void *param) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     static_assert(configTICK_RATE_HZ == 1000,
                   "FreeRTOS tickrate must be at 1000 Hz");
     static_cast<void>(param);

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_lid_heater_task.cpp
@@ -60,6 +60,8 @@ static void run(void *param) {
  * the message sent by updating its control loop.
  */
 static void run_thermistor_task(void *param) {
+    static_assert(configTICK_RATE_HZ == 1000,
+                  "FreeRTOS tickrate must be at 1000 Hz");
     static_cast<void>(param);
     thermal_hardware_setup();
     ADS1115::ADC adc(_adc_address, ADC2_ITR);
@@ -77,6 +79,7 @@ static void run_thermistor_task(void *param) {
         } else {
             readings.lid_temp = std::get<uint16_t>(result);
         }
+        readings.timestamp_ms = xTaskGetTickCount();
         auto send_ret = _main_task.get_message_queue().try_send(readings);
         static_cast<void>(
             send_ret);  // Not much we can do if messages won't send

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -103,6 +103,8 @@ static void run(void *param) {
  * the message sent by updating its control loop.
  */
 static void run_thermistor_task(void *param) {
+    static_assert(configTICK_RATE_HZ == 1000,
+                  "FreeRTOS tickrate must be at 1000 Hz");
     static_cast<void>(param);
     thermal_hardware_setup();
     _adc[ADC_FRONT].initialize();
@@ -129,6 +131,7 @@ static void run_thermistor_task(void *param) {
             _adc_map[thermal_general::ThermistorID::THERM_BACK_CENTER]);
         readings.heat_sink = read_thermistor(
             _adc_map[thermal_general::ThermistorID::THERM_HEATSINK]);
+        readings.timestamp_ms = xTaskGetTickCount();
 
         auto send_ret = _main_task.get_message_queue().try_send(readings);
         static_cast<void>(

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -103,6 +103,7 @@ static void run(void *param) {
  * the message sent by updating its control loop.
  */
 static void run_thermistor_task(void *param) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     static_assert(configTICK_RATE_HZ == 1000,
                   "FreeRTOS tickrate must be at 1000 Hz");
     static_cast<void>(param);


### PR DESCRIPTION
### Summary

Previously, the code would set a fixed frequency for thermistor readings to be polled at and would update all of the control loops under the assumption that the time was always the same. This PR adds a timestamp to the internal thermistor messages to give the tasks an actual idea of how long the readings take.

Tested on a TCR board polling thermistors by checking in the debugger that the timestamps increase at the right amount for each reading.