### PR TITLE
feat(thermocycler-refresh): Report actual steps moved after seal stepper movements

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -826,7 +826,6 @@ struct ActuateSealStepperDebug {
     using ParseResult = std::optional<ActuateSealStepperDebug>;
     static constexpr auto prefix =
         std::array{'M', '2', '4', '1', '.', 'D', ' '};
-    static constexpr const char* response = "M241.D OK\n";
 
     long distance;
 
@@ -851,8 +850,13 @@ struct ActuateSealStepperDebug {
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputLimit, InputIt>
-    static auto write_response_into(InputIt buf, InputLimit limit) -> InputIt {
-        return write_string_to_iterpair(buf, limit, response);
+    static auto write_response_into(InputIt buf, InputLimit limit, long steps)
+        -> InputIt {
+        auto res = snprintf(&*buf, (limit - buf), "M241.D S:%li OK\n", steps);
+        if (res <= 0) {
+            return buf;
+        }
+        return buf + res;
     }
 };
 

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -160,6 +160,12 @@ struct SealStepperDebugMessage {
     long int steps;
 };
 
+struct SealStepperDebugResponse {
+    uint32_t responding_to_id;
+    long int steps_taken;
+    errors::ErrorCode with_error = errors::ErrorCode::NO_ERROR;
+};
+
 struct SealStepperComplete {
     enum class CompletionReason {
         ERROR,  // There was an error flag
@@ -345,14 +351,13 @@ using SystemMessage =
                    SetSerialNumberMessage, GetSystemInfoMessage,
                    UpdateUIMessage, SetLedMode, UpdateTaskErrorState,
                    UpdatePlateState>;
-using HostCommsMessage =
-    ::std::variant<std::monostate, IncomingMessageFromHost, AcknowledgePrevious,
-                   ErrorMessage, ForceUSBDisconnectMessage,
-                   GetSystemInfoResponse, GetLidTemperatureDebugResponse,
-                   GetPlateTemperatureDebugResponse, GetPlateTempResponse,
-                   GetLidTempResponse, GetSealDriveStatusResponse,
-                   GetLidStatusResponse, GetPlatePowerResponse,
-                   GetLidPowerResponse, GetOffsetConstantsResponse>;
+using HostCommsMessage = ::std::variant<
+    std::monostate, IncomingMessageFromHost, AcknowledgePrevious, ErrorMessage,
+    ForceUSBDisconnectMessage, GetSystemInfoResponse,
+    GetLidTemperatureDebugResponse, GetPlateTemperatureDebugResponse,
+    GetPlateTempResponse, GetLidTempResponse, GetSealDriveStatusResponse,
+    GetLidStatusResponse, GetPlatePowerResponse, GetLidPowerResponse,
+    GetOffsetConstantsResponse, SealStepperDebugResponse>;
 using ThermalPlateMessage =
     ::std::variant<std::monostate, ThermalPlateTempReadComplete,
                    GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
@@ -319,8 +319,10 @@ class MotorTask {
             }
             _seal_stepper_state.status = SealStepperState::Status::IDLE;
             if (_seal_stepper_state.response_id != INVALID_ID) {
-                auto response = messages::AcknowledgePrevious{
+                auto response = messages::SealStepperDebugResponse{
                     .responding_to_id = _seal_stepper_state.response_id,
+                    .steps_taken =
+                        static_cast<long int>(_seal_profile.current_distance()),
                     .with_error = with_error};
                 static_cast<void>(
                     _task_registry->comms->get_message_queue().try_send(

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_task.hpp
@@ -306,8 +306,9 @@ class MotorTask {
             auto with_error = errors::ErrorCode::NO_ERROR;
             switch (msg.reason) {
                 case SealStepperComplete::CompletionReason::STALL:
-                    // TODO: during some movements a stall is expected
-                    with_error = errors::ErrorCode::SEAL_MOTOR_STALL;
+                    // Don't send an error because a stall is expected in some
+                    // conditions. The number of steps will tell whether this
+                    // stall was too early or not.
                     break;
                 case SealStepperComplete::CompletionReason::ERROR:
                     // TODO clear the error

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_utils.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/motor_utils.hpp
@@ -213,43 +213,9 @@ class MovementProfile {
      */
     MovementProfile(uint32_t ticks_per_second, double start_velocity,
                     double peak_velocity, double acceleration,
-                    MovementType type, ticks distance)
-        : _ticks_per_second(ticks_per_second),
-          _type(type),
-          _target_distance(distance) {
-        // Clamp ticks_per_second to at least 1
-        _ticks_per_second =
-            std::max(_ticks_per_second, static_cast<uint32_t>(1));
+                    MovementType type, ticks distance);
 
-        auto tick_freq = static_cast<double>(_ticks_per_second);
-
-        // Clamp the peak velocity so it is not under start velocity
-        start_velocity = std::max(start_velocity, static_cast<double>(0.0F));
-        acceleration = std::max(acceleration, static_cast<double>(0.0F));
-        peak_velocity = std::max(start_velocity, peak_velocity);
-
-        // Convert velocities by just dividing by the tick frequency
-        _start_velocity =
-            convert_to_fixed_point(start_velocity / tick_freq, radix);
-        _peak_velocity =
-            convert_to_fixed_point(peak_velocity / tick_freq, radix);
-        // Acceleration must be dividied by (tick/sec)^2 for unit conversion
-        _acceleration = convert_to_fixed_point(
-            acceleration / (tick_freq * tick_freq), radix);
-
-        if (_acceleration <= 0) {
-            _start_velocity = _peak_velocity;
-        }
-
-        // Ensures that all movement variables are initialized properly
-        reset();
-    }
-
-    auto reset() -> void {
-        _velocity = _start_velocity;
-        _current_distance = 0;
-        _tick_tracker = 0;
-    }
+    auto reset() -> void;
 
     /**
      * @brief Call this function for every timer interrupt signalling a tick,
@@ -260,32 +226,16 @@ class MovementProfile {
      *
      * @return TickReturn with information for how hardware driver should act
      */
-    auto tick() -> TickReturn {
-        bool step = false;
-        // Acceleration gets clamped to _peak_velocity
-        if (_velocity < _peak_velocity) {
-            _velocity += _acceleration;
-            if (_velocity > _peak_velocity) {
-                _velocity = _peak_velocity;
-            }
-        }
-        auto old_tick_track = _tick_tracker;
-        _tick_tracker += _velocity;
-        // The bit _tick_flag represents a "whole" step. Once this flips,
-        // the code signals that a step should occur
-        if (((old_tick_track ^ _tick_tracker) & _tick_flag) != 0U) {
-            step = true;
-            ++_current_distance;
-        }
-        return TickReturn{.done = (_current_distance >= _target_distance &&
-                                   _type == MovementType::FixedDistance),
-                          .step = step};
-    }
+    auto tick() -> TickReturn;
 
     /** Returns the current motor velocity in steps_per_tick.*/
-    [[nodiscard]] auto current_velocity() const -> steps_per_tick {
-        return _velocity;
-    }
+    [[nodiscard]] auto current_velocity() const -> steps_per_tick;
+
+    /** Returns the target number of ticks for this movement.*/
+    [[nodiscard]] auto target_distance() const -> ticks;
+
+    /** Returns the number of ticks that have been taken.*/
+    [[nodiscard]] auto current_distance() const -> ticks;
 
   private:
     uint32_t _ticks_per_second;           // Tick frequency

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -213,7 +213,7 @@ def move_seal_steps(steps: int, ser: serial.Serial):
     print(f'Moving seal by {steps} steps')
     ser.write(f'M241.D {steps}\n'.encode())
     res = ser.readline()
-    guard_error(res, b'M241.D OK')
+    guard_error(res, b'M241.D S:')
     print(res)
 
 class SealParam(Enum):

--- a/stm32-modules/thermocycler-refresh/src/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/src/CMakeLists.txt
@@ -59,6 +59,7 @@ set(CORE_LINTABLE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/plate_control.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/board_revision.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/colors.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/motor_utils.cpp
   )
 set(CORE_NONLINTABLE_SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/thermistor_lookups.cpp

--- a/stm32-modules/thermocycler-refresh/src/motor_utils.cpp
+++ b/stm32-modules/thermocycler-refresh/src/motor_utils.cpp
@@ -1,0 +1,77 @@
+#include "thermocycler-refresh/motor_utils.hpp"
+
+using namespace motor_util;
+
+MovementProfile::MovementProfile(uint32_t ticks_per_second,
+                                 double start_velocity, double peak_velocity,
+                                 double acceleration, MovementType type,
+                                 ticks distance)
+    : _ticks_per_second(ticks_per_second),
+      _type(type),
+      _target_distance(distance) {
+    // Clamp ticks_per_second to at least 1
+    _ticks_per_second = std::max(_ticks_per_second, static_cast<uint32_t>(1));
+
+    auto tick_freq = static_cast<double>(_ticks_per_second);
+
+    // Clamp the peak velocity so it is not under start velocity
+    start_velocity = std::max(start_velocity, static_cast<double>(0.0F));
+    acceleration = std::max(acceleration, static_cast<double>(0.0F));
+    peak_velocity = std::max(start_velocity, peak_velocity);
+
+    // Convert velocities by just dividing by the tick frequency
+    _start_velocity = convert_to_fixed_point(start_velocity / tick_freq, radix);
+    _peak_velocity = convert_to_fixed_point(peak_velocity / tick_freq, radix);
+    // Acceleration must be dividied by (tick/sec)^2 for unit conversion
+    _acceleration =
+        convert_to_fixed_point(acceleration / (tick_freq * tick_freq), radix);
+
+    if (_acceleration <= 0) {
+        _start_velocity = _peak_velocity;
+    }
+
+    // Ensures that all movement variables are initialized properly
+    reset();
+}
+
+auto MovementProfile::reset() -> void {
+    _velocity = _start_velocity;
+    _current_distance = 0;
+    _tick_tracker = 0;
+}
+
+auto MovementProfile::tick() -> TickReturn {
+    bool step = false;
+    // Acceleration gets clamped to _peak_velocity
+    if (_velocity < _peak_velocity) {
+        _velocity += _acceleration;
+        if (_velocity > _peak_velocity) {
+            _velocity = _peak_velocity;
+        }
+    }
+    auto old_tick_track = _tick_tracker;
+    _tick_tracker += _velocity;
+    // The bit _tick_flag represents a "whole" step. Once this flips,
+    // the code signals that a step should occur
+    if (((old_tick_track ^ _tick_tracker) & _tick_flag) != 0U) {
+        step = true;
+        ++_current_distance;
+    }
+    return TickReturn{.done = (_current_distance >= _target_distance &&
+                               _type == MovementType::FixedDistance),
+                      .step = step};
+}
+
+[[nodiscard]] auto MovementProfile::current_velocity() const -> steps_per_tick {
+    return _velocity;
+}
+
+/** Returns the number of ticks that have been taken.*/
+[[nodiscard]] auto MovementProfile::target_distance() const -> ticks {
+    return _target_distance;
+}
+
+/** Returns the number of ticks that have been taken.*/
+[[nodiscard]] auto MovementProfile::current_distance() const -> ticks {
+    return _current_distance;
+}

--- a/stm32-modules/thermocycler-refresh/tests/test_m241d.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m241d.cpp
@@ -1,15 +1,18 @@
 #include "catch2/catch.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
 #include "thermocycler-refresh/gcodes.hpp"
+#pragma GCC diagnostic pop
 
 SCENARIO("gcode m241.d works", "[gcode][parse][m241d]") {
     GIVEN("a response buffer large enough for the formatted response") {
         std::string buffer(64, 'c');
         WHEN("filling response") {
             auto written = gcode::ActuateSealStepperDebug::write_response_into(
-                buffer.begin(), buffer.end());
+                buffer.begin(), buffer.end(), -1000);
             THEN("the response should be written in full") {
-                REQUIRE_THAT(buffer,
-                             Catch::Matchers::StartsWith("M241.D OK\n"));
+                REQUIRE_THAT(
+                    buffer, Catch::Matchers::StartsWith("M241.D S:-1000 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }
@@ -18,9 +21,10 @@ SCENARIO("gcode m241.d works", "[gcode][parse][m241d]") {
         std::string buffer(16, 'c');
         WHEN("filling response") {
             auto written = gcode::ActuateSealStepperDebug::write_response_into(
-                buffer.begin(), buffer.begin() + 8);
+                buffer.begin(), buffer.begin() + 7, -1000);
             THEN("the response should write only up to the available space") {
-                std::string response = "M241.D Occcccccc";
+                std::string response = "M241.Dcccccccccc";
+                response.at(6) = '\0';
                 REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
                 REQUIRE(written != buffer.begin());
             }

--- a/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
@@ -179,11 +179,12 @@ SCENARIO("motor task message passing") {
                         !tasks->get_host_comms_queue().backing_deque.empty());
                     auto ack =
                         tasks->get_host_comms_queue().backing_deque.front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            ack));
-                    auto ack_msg = std::get<messages::AcknowledgePrevious>(ack);
+                    REQUIRE(std::holds_alternative<
+                            messages::SealStepperDebugResponse>(ack));
+                    auto ack_msg =
+                        std::get<messages::SealStepperDebugResponse>(ack);
                     REQUIRE(ack_msg.responding_to_id == 123);
+                    REQUIRE(ack_msg.steps_taken == 0);
                     REQUIRE(ack_msg.with_error ==
                             errors::ErrorCode::SEAL_MOTOR_STALL);
                 }
@@ -202,11 +203,12 @@ SCENARIO("motor task message passing") {
                         !tasks->get_host_comms_queue().backing_deque.empty());
                     auto ack =
                         tasks->get_host_comms_queue().backing_deque.front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            ack));
-                    auto ack_msg = std::get<messages::AcknowledgePrevious>(ack);
+                    REQUIRE(std::holds_alternative<
+                            messages::SealStepperDebugResponse>(ack));
+                    auto ack_msg =
+                        std::get<messages::SealStepperDebugResponse>(ack);
                     REQUIRE(ack_msg.responding_to_id == 123);
+                    REQUIRE(ack_msg.steps_taken == 0);
                     REQUIRE(ack_msg.with_error ==
                             errors::ErrorCode::SEAL_MOTOR_FAULT);
                 }
@@ -258,10 +260,11 @@ SCENARIO("motor task message passing") {
                         auto ack =
                             tasks->get_host_comms_queue().backing_deque.front();
                         REQUIRE(std::holds_alternative<
-                                messages::AcknowledgePrevious>(ack));
+                                messages::SealStepperDebugResponse>(ack));
                         auto ack_msg =
-                            std::get<messages::AcknowledgePrevious>(ack);
+                            std::get<messages::SealStepperDebugResponse>(ack);
                         REQUIRE(ack_msg.responding_to_id == 123);
+                        REQUIRE(ack_msg.steps_taken == STEPS);
                         REQUIRE(ack_msg.with_error ==
                                 errors::ErrorCode::NO_ERROR);
                     }

--- a/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
@@ -136,8 +136,8 @@ SCENARIO("motor task message passing") {
                 }
             }
         }
-        WHEN("sending a SealStepperDebugMessage") {
-            static constexpr uint32_t STEPS = 10;
+        WHEN("sending a SealStepperDebugMessage with positive steps") {
+            static constexpr int32_t STEPS = 10;
             auto message =
                 messages::SealStepperDebugMessage{.id = 123, .steps = STEPS};
             motor_queue.backing_deque.push_back(message);
@@ -244,6 +244,47 @@ SCENARIO("motor task message passing") {
                 }
                 THEN("the seal motor has moved 10 steps") {
                     REQUIRE(motor_policy.get_tmc2130_steps() == 10);
+                }
+                THEN("a SealStepperComplete message is received") {
+                    REQUIRE(!motor_queue.backing_deque.empty());
+                    auto msg = motor_queue.backing_deque.front();
+                    REQUIRE(
+                        std::holds_alternative<messages::SealStepperComplete>(
+                            msg));
+                }
+                WHEN("running the task") {
+                    tasks->run_motor_task();
+                    THEN("an ack is received by the host task") {
+                        REQUIRE(motor_queue.backing_deque.empty());
+                        REQUIRE(!tasks->get_host_comms_queue()
+                                     .backing_deque.empty());
+                        auto ack =
+                            tasks->get_host_comms_queue().backing_deque.front();
+                        REQUIRE(std::holds_alternative<
+                                messages::SealStepperDebugResponse>(ack));
+                        auto ack_msg =
+                            std::get<messages::SealStepperDebugResponse>(ack);
+                        REQUIRE(ack_msg.responding_to_id == 123);
+                        REQUIRE(ack_msg.steps_taken == STEPS);
+                        REQUIRE(ack_msg.with_error ==
+                                errors::ErrorCode::NO_ERROR);
+                    }
+                }
+            }
+        }
+        WHEN("sending a SealStepperDebugMessage with negative steps") {
+            static constexpr int32_t STEPS = -10;
+            auto message =
+                messages::SealStepperDebugMessage{.id = 123, .steps = STEPS};
+            motor_queue.backing_deque.push_back(message);
+            tasks->run_motor_task();
+            AND_WHEN("incrementing the tick for up to a second") {
+                uint32_t i = 0;
+                for (; i < motor_policy.MotorTickFrequency; ++i) {
+                    motor_policy.tick();
+                    if (!motor_policy.seal_moving()) {
+                        break;
+                    }
                 }
                 THEN("a SealStepperComplete message is received") {
                     REQUIRE(!motor_queue.backing_deque.empty());

--- a/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_motor_task.cpp
@@ -174,7 +174,9 @@ SCENARIO("motor task message passing") {
                     .reason = SealStepperComplete::CompletionReason::STALL};
                 motor_queue.backing_deque.push_back(stall_msg);
                 tasks->run_motor_task();
-                THEN("the original message is ACK'd with an error") {
+                THEN(
+                    "the original message is ACK'd with a reduced step count "
+                    "and no error") {
                     REQUIRE(
                         !tasks->get_host_comms_queue().backing_deque.empty());
                     auto ack =
@@ -185,8 +187,7 @@ SCENARIO("motor task message passing") {
                         std::get<messages::SealStepperDebugResponse>(ack);
                     REQUIRE(ack_msg.responding_to_id == 123);
                     REQUIRE(ack_msg.steps_taken == 0);
-                    REQUIRE(ack_msg.with_error ==
-                            errors::ErrorCode::SEAL_MOTOR_STALL);
+                    REQUIRE(ack_msg.with_error == errors::ErrorCode::NO_ERROR);
                 }
                 THEN("the seal motor was stopped") {
                     REQUIRE(!motor_policy.seal_moving());


### PR DESCRIPTION
### Summary

Testing with the seal stepper needs the ability to see the actual number of steps that a movement ended up taking. This will be used to evaluate repeatability and accuracy of the stall system.

- Added the number of steps taken as a response to the M241.D command used for seal stepper debug movement
- Removed the error response if a stall occurs during a seal stepper movement - this is expected and whether it's an error or not can be inferred from the step count

Tested by sending M241.D for both full movements and stalled movements, confirmed that both positive and negative step counts are reported reliably.