### PR TITLE
feat(heater-shaker): added thermal offset read precision

### DIFF
--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -1285,7 +1285,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should ack the previous message") {
-                        auto response = "M117 B:10.00 C:15.00 OK\n";
+                        auto response = "M117 B:10.000 C:15.000 OK\n";
                         REQUIRE_THAT(tx_buf,
                                      Catch::Matchers::StartsWith(response));
                         REQUIRE(written_secondpass ==

--- a/stm32-modules/heater-shaker/tests/test_m117.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m117.cpp
@@ -11,7 +11,7 @@ SCENARIO("GetOffsetConstants (M117) parser works", "[gcode][parse][m117]") {
             auto written = gcode::GetOffsetConstants::write_response_into(
                 buffer.begin(), buffer.end(), 10.0, 15.0);
             THEN("the response should be written in full") {
-                auto response_str = "M117 B:10.000 C:15.000 OK\n"; 
+                auto response_str = "M117 B:10.000 C:15.000 OK\n";
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(response_str));
                 REQUIRE(written == buffer.begin() + strlen(response_str));
             }

--- a/stm32-modules/heater-shaker/tests/test_m117.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m117.cpp
@@ -11,7 +11,7 @@ SCENARIO("GetOffsetConstants (M117) parser works", "[gcode][parse][m117]") {
             auto written = gcode::GetOffsetConstants::write_response_into(
                 buffer.begin(), buffer.end(), 10.0, 15.0);
             THEN("the response should be written in full") {
-                auto response_str = "M117 B:10.00 C:15.00 OK\n";
+                auto response_str = "M117 B:10.000 C:15.000 OK\n";
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(response_str));
                 REQUIRE(written == buffer.begin() + strlen(response_str));
             }

--- a/stm32-modules/heater-shaker/tests/test_m117.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m117.cpp
@@ -11,7 +11,7 @@ SCENARIO("GetOffsetConstants (M117) parser works", "[gcode][parse][m117]") {
             auto written = gcode::GetOffsetConstants::write_response_into(
                 buffer.begin(), buffer.end(), 10.0, 15.0);
             THEN("the response should be written in full") {
-                auto response_str = "M117 B:10.000 C:15.000 OK\n";
+                auto response_str = "M117 B:10.000 C:15.000 OK\n"; 
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(response_str));
                 REQUIRE(written == buffer.begin() + strlen(response_str));
             }

--- a/stm32-modules/include/heater-shaker/heater-shaker/gcodes.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/gcodes.hpp
@@ -1120,7 +1120,7 @@ struct GetOffsetConstants {
         std::sized_sentinel_for<InputLimit, InputIt>
     static auto write_response_into(InputIt buf, InputLimit limit, double b,
                                     double c) -> InputIt {
-        auto res = snprintf(&*buf, (limit - buf), "M117 B:%0.2f C:%0.2f OK\n",
+        auto res = snprintf(&*buf, (limit - buf), "M117 B:%0.3f C:%0.3f OK\n",
                             static_cast<float>(b), static_cast<float>(c));
         if (res <= 0) {
             return buf;


### PR DESCRIPTION
Linear fit of temperature data requires constant value with three decimal places of precision. This allows the reading of those constants at that precision.