### PR TITLE
feat(thermocycler-refresh): Deactivate All command

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/gcodes.hpp
@@ -1440,4 +1440,29 @@ struct CloseLid {
     }
 };
 
+struct DeactivateAll {
+    using ParseResult = std::optional<DeactivateAll>;
+    static constexpr auto prefix = std::array{'M', '1', '8'};
+    static constexpr const char* response = "M18 OK\n";
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(DeactivateAll()), working);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+};
+
 }  // namespace gcode

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/lid_heater_task.hpp
@@ -311,6 +311,19 @@ class LidHeaterTask {
     }
 
     template <LidHeaterExecutionPolicy Policy>
+    auto visit_message(const messages::DeactivateAllMessage& msg,
+                       Policy& policy) -> void {
+        auto response =
+            messages::DeactivateAllResponse{.responding_to_id = msg.id};
+
+        static_cast<void>(policy.set_heater_power(0.0F));
+        _state.system_status = State::IDLE;
+
+        static_cast<void>(
+            _task_registry->comms->get_message_queue().try_send(response));
+    }
+
+    template <LidHeaterExecutionPolicy Policy>
     auto visit_message(const messages::SetPIDConstantsMessage& msg,
                        Policy& policy) -> void {
         static_cast<void>(policy);

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/messages.hpp
@@ -346,18 +346,30 @@ struct CloseLidMessage {
 
 struct FrontButtonPressMessage {};
 
+// This is a two-stage message that is first sent to the Plate task,
+// and then the Lid task.
+struct DeactivateAllMessage {
+    uint32_t id;
+};
+
+struct DeactivateAllResponse {
+    uint32_t responding_to_id;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage,
                    UpdateUIMessage, SetLedMode, UpdateTaskErrorState,
                    UpdatePlateState>;
-using HostCommsMessage = ::std::variant<
-    std::monostate, IncomingMessageFromHost, AcknowledgePrevious, ErrorMessage,
-    ForceUSBDisconnectMessage, GetSystemInfoResponse,
-    GetLidTemperatureDebugResponse, GetPlateTemperatureDebugResponse,
-    GetPlateTempResponse, GetLidTempResponse, GetSealDriveStatusResponse,
-    GetLidStatusResponse, GetPlatePowerResponse, GetLidPowerResponse,
-    GetOffsetConstantsResponse, SealStepperDebugResponse>;
+using HostCommsMessage =
+    ::std::variant<std::monostate, IncomingMessageFromHost, AcknowledgePrevious,
+                   ErrorMessage, ForceUSBDisconnectMessage,
+                   GetSystemInfoResponse, GetLidTemperatureDebugResponse,
+                   GetPlateTemperatureDebugResponse, GetPlateTempResponse,
+                   GetLidTempResponse, GetSealDriveStatusResponse,
+                   GetLidStatusResponse, GetPlatePowerResponse,
+                   GetLidPowerResponse, GetOffsetConstantsResponse,
+                   SealStepperDebugResponse, DeactivateAllResponse>;
 using ThermalPlateMessage =
     ::std::variant<std::monostate, ThermalPlateTempReadComplete,
                    GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,
@@ -365,13 +377,13 @@ using ThermalPlateMessage =
                    SetPlateTemperatureMessage, DeactivatePlateMessage,
                    SetPIDConstantsMessage, SetFanAutomaticMessage,
                    GetThermalPowerMessage, SetOffsetConstantsMessage,
-                   GetOffsetConstantsMessage>;
+                   GetOffsetConstantsMessage, DeactivateAllMessage>;
 using LidHeaterMessage =
     ::std::variant<std::monostate, LidTempReadComplete,
                    GetLidTemperatureDebugMessage, SetHeaterDebugMessage,
                    GetLidTempMessage, SetLidTemperatureMessage,
                    DeactivateLidHeatingMessage, SetPIDConstantsMessage,
-                   GetThermalPowerMessage>;
+                   GetThermalPowerMessage, DeactivateAllMessage>;
 using MotorMessage = ::std::variant<
     std::monostate, ActuateSolenoidMessage, LidStepperDebugMessage,
     LidStepperComplete, SealStepperDebugMessage, SealStepperComplete,

--- a/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-refresh/thermocycler-refresh/thermal_plate_task.hpp
@@ -539,6 +539,19 @@ class ThermalPlateTask {
     }
 
     template <ThermalPlateExecutionPolicy Policy>
+    auto visit_message(const messages::DeactivateAllMessage& msg,
+                       Policy& policy) -> void {
+        auto response =
+            messages::DeactivateAllResponse{.responding_to_id = msg.id};
+
+        policy.set_enabled(false);
+        _state.system_status = State::IDLE;
+
+        static_cast<void>(
+            _task_registry->comms->get_message_queue().try_send(response));
+    }
+
+    template <ThermalPlateExecutionPolicy Policy>
     auto visit_message(const messages::SetPIDConstantsMessage& msg,
                        Policy& policy) -> void {
         static_cast<void>(policy);

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_lid_heater_task.cpp
@@ -28,12 +28,12 @@ static FreeRTOSMessageQueue<lid_heater_task::Message>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _main_task = lid_heater_task::LidHeaterTask(_lid_heater_queue);
 
-static constexpr uint32_t _stack_size = 500;
+static constexpr uint32_t _stack_size = 512;
 // Stack as a std::array because why not. Quiet lint because, well, we have to
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static std::array<StackType_t, _stack_size> _stack;
 
-static constexpr uint32_t _thermistor_stack_size = 128;
+static constexpr uint32_t _thermistor_stack_size = 256;
 // Stack as a std::array because why not. Quiet lint because, well, we have to
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static std::array<StackType_t, _thermistor_stack_size> _thermistor_stack;

--- a/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-refresh/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -38,12 +38,12 @@ static FreeRTOSMessageQueue<thermal_plate_task::Message>
 static auto _main_task =
     thermal_plate_task::ThermalPlateTask(_thermal_plate_queue);
 
-static constexpr uint32_t _stack_size = 500;
+static constexpr uint32_t _stack_size = 512;
 // Stack as a std::array because why not. Quiet lint because, well, we have to
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static std::array<StackType_t, _stack_size> _stack;
 
-static constexpr uint32_t _thermistor_stack_size = 128;
+static constexpr uint32_t _thermistor_stack_size = 256;
 // Stack as a std::array because why not. Quiet lint because, well, we have to
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static std::array<StackType_t, _thermistor_stack_size> _thermistor_stack;

--- a/stm32-modules/thermocycler-refresh/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-refresh/scripts/test_utils.py
@@ -41,6 +41,13 @@ def guard_error(res: bytes, prefix: bytes=  None):
     if prefix and not res.startswith(prefix):
         raise RuntimeError(f'incorrect response: {res} (expected prefix {prefix})')
 
+# Turn off the plate and the heater!
+def deactivate_all(ser: serial.Serial):
+    print('Deactivating all')
+    ser.write('M18\n'.encode())
+    res = ser.readline()
+    guard_error(res, b'M18 OK')
+    print(res)
 
 _TEMP_RE = re.compile('^M141 T:(?P<target>.+) C:(?P<temp>.+) OK\n')
 def get_lid_temperature(ser: serial.Serial) -> float:

--- a/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_eeprom.cpp
     # GCode parse tests
     test_m14.cpp
+    test_m18.cpp
     test_m103d.cpp
     test_m104.cpp
     test_m105.cpp

--- a/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_host_comms_task.cpp
@@ -629,6 +629,109 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                 }
             }
         }
+        WHEN("sending a DeactivateAll command") {
+            auto message_text = std::string("M18\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task shoudl pass the message on to the plate task and not "
+                "immediately ack") {
+                REQUIRE(tasks->get_thermal_plate_queue().backing_deque.size() !=
+                        0);
+                auto plate_message =
+                    tasks->get_thermal_plate_queue().backing_deque.front();
+                REQUIRE(std::holds_alternative<messages::DeactivateAllMessage>(
+                    plate_message));
+                auto get_plate_message =
+                    std::get<messages::DeactivateAllMessage>(plate_message);
+                AND_WHEN("sending a good response to host comms") {
+                    auto response = messages::HostCommsMessage(
+                        messages::DeactivateAllResponse{
+                            .responding_to_id = get_plate_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should not ack the message yet") {
+                        REQUIRE(written_secondpass == written_firstpass);
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                    THEN("the task passes the message to the lid task") {
+                        REQUIRE(tasks->get_lid_heater_queue().has_message());
+                        auto lid_message =
+                            tasks->get_lid_heater_queue().backing_deque.front();
+                        REQUIRE(std::holds_alternative<
+                                messages::DeactivateAllMessage>(lid_message));
+                        auto get_lid_message =
+                            std::get<messages::DeactivateAllMessage>(
+                                lid_message);
+                        AND_WHEN("sending good response to comms") {
+                            auto response = messages::HostCommsMessage(
+                                messages::DeactivateAllResponse{
+                                    .responding_to_id = get_lid_message.id});
+                            tasks->get_host_comms_queue()
+                                .backing_deque.push_back(response);
+                            auto written_thirdpass =
+                                tasks->get_host_comms_task().run_once(
+                                    tx_buf.begin(), tx_buf.end());
+                            THEN("the task should ack the previous message") {
+                                const char response_msg[] = "M18 OK\n";
+                                REQUIRE_THAT(
+                                    tx_buf,
+                                    Catch::Matchers::StartsWith(response_msg));
+                                REQUIRE(written_thirdpass ==
+                                        tx_buf.begin() + strlen(response_msg));
+                                REQUIRE(!tasks->get_host_comms_queue()
+                                             .has_message());
+                            }
+                        }
+                        AND_WHEN("sending a bad response to host comms") {
+                            auto response = messages::HostCommsMessage(
+                                messages::GetLidPowerResponse{
+                                    .responding_to_id =
+                                        get_lid_message.id + 1});
+                            tasks->get_host_comms_queue()
+                                .backing_deque.push_back(response);
+                            auto written_thirdpass =
+                                tasks->get_host_comms_task().run_once(
+                                    tx_buf.begin(), tx_buf.end());
+                            THEN("an error is written") {
+                                REQUIRE(!tasks->get_host_comms_queue()
+                                             .has_message());
+                                REQUIRE_THAT(
+                                    tx_buf,
+                                    Catch::Matchers::StartsWith("ERR005"));
+                                REQUIRE(written_thirdpass > written_secondpass);
+                            }
+                        }
+                    }
+                }
+
+                AND_WHEN("sending a bad response to host comms") {
+                    auto response = messages::HostCommsMessage(
+                        messages::DeactivateAllResponse{
+                            .responding_to_id = get_plate_message.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("an error is written") {
+                        REQUIRE(!tasks->get_host_comms_queue().has_message());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(!tasks->get_lid_heater_queue().has_message());
+                        REQUIRE(written_secondpass > written_firstpass);
+                    }
+                }
+            }
+        }
         WHEN("sending a SetPIDConstants message for the heaters") {
             std::string message_text = std::string("M301 SH P1 I1 D1\n");
             auto message_obj =

--- a/stm32-modules/thermocycler-refresh/tests/test_m18.cpp
+++ b/stm32-modules/thermocycler-refresh/tests/test_m18.cpp
@@ -1,0 +1,58 @@
+#include "catch2/catch.hpp"
+
+// Push this diagnostic to avoid a compiler error about printing to too
+// small of a buffer... which we're doing on purpose!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-refresh/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("DeactivateAll (M18) parser works", "[gcode][parse][m18]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::DeactivateAll::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M18 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::DeactivateAll::write_response_into(
+                buffer.begin(), buffer.begin() + 5);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M18 Occccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a valid input") {
+        std::string buffer = "M18\n";
+        WHEN("parsing") {
+            auto res =
+                gcode::DeactivateAll::parse(buffer.begin(), buffer.end());
+            THEN("a valid gcode should be produced") {
+                REQUIRE(res.first.has_value());
+                REQUIRE(res.second != buffer.begin());
+            }
+        }
+    }
+    GIVEN("an invalid input") {
+        std::string buffer = "M 127\n";
+        WHEN("parsing") {
+            auto res =
+                gcode::DeactivateAll::parse(buffer.begin(), buffer.end());
+            THEN("an error should be produced") {
+                REQUIRE(!res.first.has_value());
+                REQUIRE(res.second == buffer.begin());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds command M18 to deactivate both the plate and the heater for backwards compatibility with the TC Gen 1. Similarly to Get Thermal Power, this gcode gets bounced to two separate tasks using the ack cache in a kind of kludgy way. 

Tested on my home setup.

Also bumped up the stack size of a few tasks, most importantly the Plate Thermistor reading task that was encountering stack overflow issues.