### PR TITLE
feat(thermocycler-refresh): add simulated temperature

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/simulator/cli_parser.hpp
+++ b/stm32-modules/include/thermocycler-refresh/simulator/cli_parser.hpp
@@ -4,14 +4,14 @@
 #include "simulator/sim_driver.hpp"
 
 namespace cli_parser {
-/** 
+/**
  * First value is the sim input driver, second input is a boolean
  * set to true if the sim should run in realtime and false if it
  * should run in simulated time
  */
 using RT = std::pair<std::shared_ptr<sim_driver::SimDriver>, bool>;
 
-/** 
+/**
  * Parse the inputs and determine 1) what kind of input should be
  * used 2) whether the simulation should be realtime or accelerated
  */

--- a/stm32-modules/include/thermocycler-refresh/simulator/cli_parser.hpp
+++ b/stm32-modules/include/thermocycler-refresh/simulator/cli_parser.hpp
@@ -4,6 +4,16 @@
 #include "simulator/sim_driver.hpp"
 
 namespace cli_parser {
+/** 
+ * First value is the sim input driver, second input is a boolean
+ * set to true if the sim should run in realtime and false if it
+ * should run in simulated time
+ */
 using RT = std::pair<std::shared_ptr<sim_driver::SimDriver>, bool>;
+
+/** 
+ * Parse the inputs and determine 1) what kind of input should be
+ * used 2) whether the simulation should be realtime or accelerated
+ */
 RT get_sim_driver(int, char**);
 }  // namespace cli_parser

--- a/stm32-modules/include/thermocycler-refresh/simulator/cli_parser.hpp
+++ b/stm32-modules/include/thermocycler-refresh/simulator/cli_parser.hpp
@@ -4,5 +4,6 @@
 #include "simulator/sim_driver.hpp"
 
 namespace cli_parser {
-std::shared_ptr<sim_driver::SimDriver> get_sim_driver(int, char**);
-}
+using RT = std::pair<std::shared_ptr<sim_driver::SimDriver>, bool>;
+RT get_sim_driver(int, char**);
+}  // namespace cli_parser

--- a/stm32-modules/include/thermocycler-refresh/simulator/lid_heater_thread.hpp
+++ b/stm32-modules/include/thermocycler-refresh/simulator/lid_heater_thread.hpp
@@ -10,6 +10,7 @@
 namespace lid_heater_thread {
 using SimLidHeaterTask = lid_heater_task::LidHeaterTask<SimulatorMessageQueue>;
 struct TaskControlBlock;
-auto build(periodic_data_thread::PeriodicDataThread *periodic_data)
+auto build(
+    std::shared_ptr<periodic_data_thread::PeriodicDataThread> periodic_data)
     -> tasks::Task<std::unique_ptr<std::jthread>, SimLidHeaterTask>;
 };  // namespace lid_heater_thread

--- a/stm32-modules/include/thermocycler-refresh/simulator/lid_heater_thread.hpp
+++ b/stm32-modules/include/thermocycler-refresh/simulator/lid_heater_thread.hpp
@@ -2,6 +2,7 @@
 #include <memory>
 #include <thread>
 
+#include "simulator/periodic_data_thread.hpp"
 #include "simulator/simulator_queue.hpp"
 #include "thermocycler-refresh/lid_heater_task.hpp"
 #include "thermocycler-refresh/tasks.hpp"
@@ -9,5 +10,6 @@
 namespace lid_heater_thread {
 using SimLidHeaterTask = lid_heater_task::LidHeaterTask<SimulatorMessageQueue>;
 struct TaskControlBlock;
-auto build() -> tasks::Task<std::unique_ptr<std::jthread>, SimLidHeaterTask>;
+auto build(periodic_data_thread::PeriodicDataThread *periodic_data)
+    -> tasks::Task<std::unique_ptr<std::jthread>, SimLidHeaterTask>;
 };  // namespace lid_heater_thread

--- a/stm32-modules/include/thermocycler-refresh/simulator/periodic_data_thread.hpp
+++ b/stm32-modules/include/thermocycler-refresh/simulator/periodic_data_thread.hpp
@@ -74,7 +74,7 @@ class PeriodicDataThread {
     std::atomic_bool _init_latch;
 };
 
-auto build(bool realtime)
-    -> tasks::Task<std::unique_ptr<std::jthread>, PeriodicDataThread>;
+auto build(bool realtime) -> std::pair<std::unique_ptr<std::jthread>,
+                                       std::shared_ptr<PeriodicDataThread>>;
 
 };  // namespace periodic_data_thread

--- a/stm32-modules/include/thermocycler-refresh/simulator/periodic_data_thread.hpp
+++ b/stm32-modules/include/thermocycler-refresh/simulator/periodic_data_thread.hpp
@@ -1,0 +1,80 @@
+/**
+ * @file periodic_data_thread.hpp
+ * @brief Interface for the Periodic Data task, which generates any periodic
+ * simulated message data for the Thermocycler simulator.
+ */
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <variant>
+
+#include "simulator/simulator_queue.hpp"
+#include "thermocycler-refresh/tasks.hpp"
+
+namespace periodic_data_thread {
+
+using Power = double;        // Percentage from -1 to +1
+using Temperature = double;  // Celsius
+
+struct HeatPadPower {
+    Power power;
+};
+
+struct PeltierPower {
+    Power left, center, right;
+};
+
+struct StartMotorMovement {};
+
+using PeriodicDataMessage = std::variant<std::monostate, HeatPadPower,
+                                         PeltierPower, StartMotorMovement>;
+
+using PeriodicDataQueue = SimulatorMessageQueue<PeriodicDataMessage>;
+
+class PeriodicDataThread {
+  public:
+    PeriodicDataThread(bool realtime = true);
+
+    // Send a message to this PeriodicDataThread
+    auto send_message(PeriodicDataMessage msg) -> bool;
+
+    // Provides the task info to send data properly
+    auto provide_tasks(tasks::Tasks<SimulatorMessageQueue>* other_tasks)
+        -> void;
+
+    // Should be initiated in its own jthread
+    auto run(std::stop_token& st) -> void;
+
+  private:
+    // The further from room temperature an element is, the stronger
+    // the draw back to room temp will be.
+    auto ambient_temp_effect(Temperature temp, std::chrono::milliseconds delta)
+        -> double;
+    // Scale a gain constant based on the current time delta since the last
+    // reading
+    auto scaled_gain_effect(double gain, double power,
+                            std::chrono::milliseconds delta) -> double;
+    auto update_heat_pad() -> void;
+    auto update_peltiers() -> void;
+    auto run_motor() -> void;
+
+    Power _heat_pad_power;
+    PeltierPower _peltiers_power;
+    Temperature _lid_temp, _left_temp, _center_temp, _right_temp;
+    uint32_t _tick_peltiers;  // Last time a peltier message was sent
+    uint32_t _tick_heater;    // Last time a heater message was sent
+    uint32_t _current_tick;
+    PeriodicDataQueue _queue;
+    tasks::Tasks<SimulatorMessageQueue>* _task_registry;
+    bool _realtime;
+    // This really wants to be an std::latch, but that isn't available
+    // in gcc10. Bummer :(
+    std::atomic_bool _init_latch;
+};
+
+auto build(bool realtime)
+    -> tasks::Task<std::unique_ptr<std::jthread>, PeriodicDataThread>;
+
+};  // namespace periodic_data_thread

--- a/stm32-modules/include/thermocycler-refresh/simulator/thermal_plate_thread.hpp
+++ b/stm32-modules/include/thermocycler-refresh/simulator/thermal_plate_thread.hpp
@@ -11,6 +11,7 @@ namespace thermal_plate_thread {
 using SimThermalPlateTask =
     thermal_plate_task::ThermalPlateTask<SimulatorMessageQueue>;
 struct TaskControlBlock;
-auto build(periodic_data_thread::PeriodicDataThread *periodic_data)
+auto build(
+    std::shared_ptr<periodic_data_thread::PeriodicDataThread> periodic_data)
     -> tasks::Task<std::unique_ptr<std::jthread>, SimThermalPlateTask>;
 };  // namespace thermal_plate_thread

--- a/stm32-modules/include/thermocycler-refresh/simulator/thermal_plate_thread.hpp
+++ b/stm32-modules/include/thermocycler-refresh/simulator/thermal_plate_thread.hpp
@@ -2,6 +2,7 @@
 #include <memory>
 #include <thread>
 
+#include "simulator/periodic_data_thread.hpp"
 #include "simulator/simulator_queue.hpp"
 #include "thermocycler-refresh/tasks.hpp"
 #include "thermocycler-refresh/thermal_plate_task.hpp"
@@ -10,5 +11,6 @@ namespace thermal_plate_thread {
 using SimThermalPlateTask =
     thermal_plate_task::ThermalPlateTask<SimulatorMessageQueue>;
 struct TaskControlBlock;
-auto build() -> tasks::Task<std::unique_ptr<std::jthread>, SimThermalPlateTask>;
+auto build(periodic_data_thread::PeriodicDataThread *periodic_data)
+    -> tasks::Task<std::unique_ptr<std::jthread>, SimThermalPlateTask>;
 };  // namespace thermal_plate_thread

--- a/stm32-modules/thermocycler-refresh/simulator/CMakeLists.txt
+++ b/stm32-modules/thermocycler-refresh/simulator/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(
   thermal_plate_thread.cpp
   sim_board_revision_hardware.cpp
   motor_thread.cpp
+  periodic_data_thread.cpp
   main.cpp
 )
 

--- a/stm32-modules/thermocycler-refresh/simulator/lid_heater_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/lid_heater_thread.cpp
@@ -12,10 +12,11 @@ using namespace lid_heater_thread;
 class SimLidHeaterPolicy {
   private:
     double _power = 0.0F;
-    periodic_data_thread::PeriodicDataThread *_periodic_data;
+    std::shared_ptr<periodic_data_thread::PeriodicDataThread> _periodic_data;
 
   public:
-    SimLidHeaterPolicy(periodic_data_thread::PeriodicDataThread *periodic_data)
+    SimLidHeaterPolicy(
+        std::shared_ptr<periodic_data_thread::PeriodicDataThread> periodic_data)
         : _periodic_data(periodic_data) {}
 
     auto set_heater_power(double power) -> bool {
@@ -35,8 +36,10 @@ struct lid_heater_thread::TaskControlBlock {
     SimLidHeaterTask task;
 };
 
-auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb,
-         periodic_data_thread::PeriodicDataThread *periodic_data) -> void {
+auto run(
+    std::stop_token st, std::shared_ptr<TaskControlBlock> tcb,
+    std::shared_ptr<periodic_data_thread::PeriodicDataThread> periodic_data)
+    -> void {
     using namespace std::literals::chrono_literals;
     auto policy = SimLidHeaterPolicy(periodic_data);
     tcb->queue.set_stop_token(st);
@@ -50,7 +53,7 @@ auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb,
 }
 
 auto lid_heater_thread::build(
-    periodic_data_thread::PeriodicDataThread *periodic_data)
+    std::shared_ptr<periodic_data_thread::PeriodicDataThread> periodic_data)
     -> tasks::Task<std::unique_ptr<std::jthread>, SimLidHeaterTask> {
     auto tcb = std::make_shared<TaskControlBlock>();
     return tasks::Task(std::make_unique<std::jthread>(run, tcb, periodic_data),

--- a/stm32-modules/thermocycler-refresh/simulator/main.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/main.cpp
@@ -5,6 +5,7 @@
 #include "simulator/comm_thread.hpp"
 #include "simulator/lid_heater_thread.hpp"
 #include "simulator/motor_thread.hpp"
+#include "simulator/periodic_data_thread.hpp"
 #include "simulator/sim_driver.hpp"
 #include "simulator/simulator_queue.hpp"
 #include "simulator/system_thread.hpp"
@@ -14,15 +15,22 @@
 using namespace std;
 
 int main(int argc, char *argv[]) {
-    auto sim_driver = cli_parser::get_sim_driver(argc, argv);
+    auto cli_ret = cli_parser::get_sim_driver(argc, argv);
+    auto sim_driver = cli_ret.first;
+    auto realtime = cli_ret.second;
+
+    auto periodic_data = periodic_data_thread::build(realtime);
+
     auto system = system_thread::build();
-    auto thermal_plate = thermal_plate_thread::build();
-    auto lid_heater = lid_heater_thread::build();
+    auto thermal_plate = thermal_plate_thread::build(periodic_data.task);
+    auto lid_heater = lid_heater_thread::build(periodic_data.task);
     auto motor = motor_thread::build();
     auto comms = comm_thread::build(std::move(sim_driver));
     auto tasks = tasks::Tasks<SimulatorMessageQueue>(
         comms.task, system.task, thermal_plate.task, lid_heater.task,
         motor.task);
+
+    periodic_data.task->provide_tasks(&tasks);
 
     comm_thread::handle_input(std::move(sim_driver), tasks);
 
@@ -31,12 +39,14 @@ int main(int argc, char *argv[]) {
     thermal_plate.handle->request_stop();
     lid_heater.handle->request_stop();
     motor.handle->request_stop();
+    periodic_data.handle->request_stop();
 
     system.handle->join();
     comms.handle->join();
     thermal_plate.handle->join();
     lid_heater.handle->join();
     motor.handle->join();
+    periodic_data.handle->join();
 
     return 0;
 }

--- a/stm32-modules/thermocycler-refresh/simulator/main.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/main.cpp
@@ -22,15 +22,15 @@ int main(int argc, char *argv[]) {
     auto periodic_data = periodic_data_thread::build(realtime);
 
     auto system = system_thread::build();
-    auto thermal_plate = thermal_plate_thread::build(periodic_data.task);
-    auto lid_heater = lid_heater_thread::build(periodic_data.task);
+    auto thermal_plate = thermal_plate_thread::build(periodic_data.second);
+    auto lid_heater = lid_heater_thread::build(periodic_data.second);
     auto motor = motor_thread::build();
     auto comms = comm_thread::build(std::move(sim_driver));
     auto tasks = tasks::Tasks<SimulatorMessageQueue>(
         comms.task, system.task, thermal_plate.task, lid_heater.task,
         motor.task);
 
-    periodic_data.task->provide_tasks(&tasks);
+    periodic_data.second->provide_tasks(&tasks);
 
     comm_thread::handle_input(std::move(sim_driver), tasks);
 
@@ -39,14 +39,14 @@ int main(int argc, char *argv[]) {
     thermal_plate.handle->request_stop();
     lid_heater.handle->request_stop();
     motor.handle->request_stop();
-    periodic_data.handle->request_stop();
+    periodic_data.first->request_stop();
 
     system.handle->join();
     comms.handle->join();
     thermal_plate.handle->join();
     lid_heater.handle->join();
     motor.handle->join();
-    periodic_data.handle->join();
+    periodic_data.first->join();
 
     return 0;
 }

--- a/stm32-modules/thermocycler-refresh/simulator/periodic_data_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/periodic_data_thread.cpp
@@ -215,7 +215,8 @@ auto PeriodicDataThread::run_motor() -> void {
 }
 
 auto periodic_data_thread::build(bool realtime)
-    -> tasks::Task<std::unique_ptr<std::jthread>, PeriodicDataThread> {
+    -> std::pair<std::unique_ptr<std::jthread>,
+                 std::shared_ptr<PeriodicDataThread>> {
     auto thread = std::make_shared<PeriodicDataThread>(realtime);
 
     auto lambda = [](std::stop_token st,
@@ -223,6 +224,6 @@ auto periodic_data_thread::build(bool realtime)
         _thread->run(st);
     };
 
-    return tasks::Task(std::make_unique<std::jthread>(lambda, thread),
-                       thread.get());
+    return std::make_pair(std::make_unique<std::jthread>(lambda, thread),
+                          thread);
 }

--- a/stm32-modules/thermocycler-refresh/simulator/periodic_data_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/periodic_data_thread.cpp
@@ -1,0 +1,223 @@
+/**
+ * @file periodic_data_thread.cpp
+ * @brief Generates any periodic data (temperatures, motor ticks) during
+ * simulator operation.
+ * @details
+ * This module simulates any periodic data on the Thermocycler system.
+ * Specifically, it generates periodic thermistor data for all of the
+ * thermal elements and calls the Motor Step tick.
+ *
+ */
+
+#include "simulator/periodic_data_thread.hpp"
+
+#include <chrono>
+#include <stop_token>
+
+#include "simulator/lid_heater_thread.hpp"
+#include "simulator/thermal_plate_thread.hpp"
+#include "thermocycler-refresh/messages.hpp"
+#include "thermocycler-refresh/tasks.hpp"
+
+using namespace periodic_data_thread;
+
+/** Default starting temperature for all thermistors.*/
+static constexpr const double AMBIENT_TEMPERATURE = 23.0F;
+/** Gain term for peltier outputs, from experimental data.*/
+static constexpr const double PELTIER_GAIN = 3.2F;
+/** Gain term for lid heater output, from experimental data.*/
+static constexpr const double HEAT_PAD_GAIN = 0.72;
+/**
+ * Gain term for bringing temperature back down to ambient. Scaled against
+ * the difference between a temperature and its ambient condition. The
+ * constant is derived from rough modeling against the lid heater cooling
+ * from 100ºC to ambient temperature.
+ */
+static constexpr const double AMBIENT_TEMPERATURE_GAIN = 0.0015;
+
+static constexpr const auto PELTIER_PERIOD =
+    thermal_plate_thread::SimThermalPlateTask::CONTROL_PERIOD_TICKS;
+
+static constexpr const auto LID_PERIOD =
+    lid_heater_thread::SimLidHeaterTask::CONTROL_PERIOD_TICKS;
+
+PeriodicDataThread::PeriodicDataThread(bool realtime)
+    : _heat_pad_power(0),
+      _peltiers_power{.left = 0, .center = 0, .right = 0},
+      _lid_temp(AMBIENT_TEMPERATURE),
+      _left_temp(AMBIENT_TEMPERATURE),
+      _center_temp(AMBIENT_TEMPERATURE),
+      _right_temp(AMBIENT_TEMPERATURE),
+      _tick_peltiers(0),
+      _tick_heater(0),
+      _current_tick(0),
+      _queue(),
+      _task_registry(nullptr),
+      _realtime(realtime),
+      _init_latch(false) {}
+
+auto PeriodicDataThread::send_message(PeriodicDataMessage msg) -> bool {
+    return _queue.try_send(msg);
+}
+
+auto PeriodicDataThread::provide_tasks(
+    tasks::Tasks<SimulatorMessageQueue>* other_tasks) -> void {
+    _task_registry = other_tasks;
+    _init_latch.store(true);
+}
+
+auto PeriodicDataThread::run(std::stop_token& st) -> void {
+    // This doesn't use std::chrono to emulate the firmware 32bit counter
+    // overflow behavior
+    PeriodicDataMessage msg;
+    bool pending_lid_update = true, pending_peltier_update = true;
+
+    while (!_init_latch.load()) {
+        std::this_thread::yield();
+    }
+
+    auto actual_time = std::chrono::high_resolution_clock::now();
+
+    while (!st.stop_requested()) {
+        if (_realtime) {
+            // Use the high resolution clock to get an idea of the time
+            // difference
+            auto actual_time_new = std::chrono::high_resolution_clock::now();
+            auto tick_diff =
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    actual_time_new - actual_time);
+            _current_tick += tick_diff.count();
+            actual_time = actual_time_new;
+        } else {
+            // For simulated time, increment tick by the smallest
+            // increment that should matter
+            _current_tick += std::min(PELTIER_PERIOD, LID_PERIOD);
+        }
+
+        while (_queue.try_recv(&msg)) {
+            if (std::holds_alternative<HeatPadPower>(msg)) {
+                // Update heat pad powers
+                _heat_pad_power = std::get<HeatPadPower>(msg).power;
+                pending_lid_update = true;
+            } else if (std::holds_alternative<PeltierPower>(msg)) {
+                // Update peltier temperatures
+                _peltiers_power = std::get<PeltierPower>(msg);
+                pending_peltier_update = true;
+            } else if (std::holds_alternative<StartMotorMovement>(msg)) {
+                // TODO
+            }
+        }
+        if (pending_lid_update &&
+            ((_current_tick - _tick_heater) > LID_PERIOD)) {
+            pending_lid_update = false;
+            update_heat_pad();
+        }
+        if (pending_peltier_update &&
+            ((_current_tick - _tick_peltiers) > PELTIER_PERIOD)) {
+            pending_peltier_update = false;
+            update_peltiers();
+        }
+
+        // Yield at the end of each loop to let other processes run
+        if (_realtime) {
+            // Sleep for 1 millisecond
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+}
+
+auto PeriodicDataThread::ambient_temp_effect(Temperature temp,
+                                             std::chrono::milliseconds delta)
+    -> Temperature {
+    using Seconds = std::chrono::duration<double, std::chrono::seconds::period>;
+    auto seconds = std::chrono::duration_cast<Seconds>(delta);
+    return (AMBIENT_TEMPERATURE - temp) * AMBIENT_TEMPERATURE_GAIN *
+           seconds.count();
+}
+
+auto PeriodicDataThread::scaled_gain_effect(double gain, double power,
+                                            std::chrono::milliseconds delta)
+    -> Temperature {
+    using Seconds = std::chrono::duration<double, std::chrono::seconds::period>;
+    auto seconds = std::chrono::duration_cast<Seconds>(delta);
+
+    return seconds.count() * gain * power;
+}
+
+auto PeriodicDataThread::update_heat_pad() -> void {
+    auto converter = thermistor_conversion::Conversion<lookups::KS103J2G>(
+        lid_heater_thread::SimLidHeaterTask::
+            THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM,
+        lid_heater_thread::SimLidHeaterTask::ADC_BIT_MAX, false);
+
+    auto timedelta = std::chrono::milliseconds(_current_tick - _tick_heater);
+
+    _lid_temp += scaled_gain_effect(HEAT_PAD_GAIN, _heat_pad_power, timedelta) +
+                 ambient_temp_effect(_lid_temp, timedelta);
+    auto message = messages::LidTempReadComplete{
+        .lid_temp = converter.backconvert(_lid_temp),
+        .timestamp_ms = _current_tick};
+    _tick_heater = _current_tick;
+
+    if (_task_registry) {
+        static_cast<void>(
+            _task_registry->lid_heater->get_message_queue().try_send(message));
+    }
+}
+
+auto PeriodicDataThread::update_peltiers() -> void {
+    auto converter = thermistor_conversion::Conversion<lookups::KS103J2G>(
+        thermal_plate_thread::SimThermalPlateTask::
+            THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM,
+        thermal_plate_thread::SimThermalPlateTask::ADC_BIT_MAX, false);
+
+    auto timedelta = std::chrono::milliseconds(_current_tick - _tick_peltiers);
+
+    _left_temp +=
+        scaled_gain_effect(PELTIER_GAIN, _peltiers_power.left, timedelta) +
+        ambient_temp_effect(_left_temp, timedelta);
+    _center_temp +=
+        scaled_gain_effect(PELTIER_GAIN, _peltiers_power.center, timedelta) +
+        ambient_temp_effect(_center_temp, timedelta);
+    _right_temp +=
+        scaled_gain_effect(PELTIER_GAIN, _peltiers_power.right, timedelta) +
+        ambient_temp_effect(_right_temp, timedelta);
+
+    auto message = messages::ThermalPlateTempReadComplete{
+        .heat_sink = converter.backconvert(AMBIENT_TEMPERATURE),
+        .front_right = converter.backconvert(_right_temp),
+        .front_center = converter.backconvert(_center_temp),
+        .front_left = converter.backconvert(_left_temp),
+        .back_right = converter.backconvert(_right_temp),
+        .back_center = converter.backconvert(_center_temp),
+        .back_left = converter.backconvert(_left_temp),
+        .timestamp_ms = _current_tick};
+
+    _tick_peltiers = _current_tick;
+
+    if (_task_registry) {
+        static_cast<void>(
+            _task_registry->thermal_plate->get_message_queue().try_send(
+                message));
+    }
+}
+
+auto PeriodicDataThread::run_motor() -> void {
+    // Todo!!!
+}
+
+auto run_task(std::stop_token st, std::unique_ptr<PeriodicDataThread>& thread) {
+    return 0;
+}
+
+auto periodic_data_thread::build(bool realtime)
+    -> tasks::Task<std::unique_ptr<std::jthread>, PeriodicDataThread> {
+    auto thread = std::make_shared<PeriodicDataThread>(realtime);
+    return tasks::Task(std::make_unique<std::jthread>(
+                           [](std::stop_token st,
+                              std::shared_ptr<PeriodicDataThread> _thread) {
+                               _thread->run(st);
+                           },
+                           thread),
+                       thread.get());
+}

--- a/stm32-modules/thermocycler-refresh/simulator/periodic_data_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/periodic_data_thread.cpp
@@ -206,18 +206,15 @@ auto PeriodicDataThread::run_motor() -> void {
     // Todo!!!
 }
 
-auto run_task(std::stop_token st, std::unique_ptr<PeriodicDataThread>& thread) {
-    return 0;
-}
-
 auto periodic_data_thread::build(bool realtime)
     -> tasks::Task<std::unique_ptr<std::jthread>, PeriodicDataThread> {
     auto thread = std::make_shared<PeriodicDataThread>(realtime);
-    return tasks::Task(std::make_unique<std::jthread>(
-                           [](std::stop_token st,
-                              std::shared_ptr<PeriodicDataThread> _thread) {
-                               _thread->run(st);
-                           },
-                           thread),
+
+    auto lambda = [](std::stop_token st,
+                     std::shared_ptr<PeriodicDataThread> _thread) {
+        _thread->run(st);
+    };
+
+    return tasks::Task(std::make_unique<std::jthread>(lambda, thread),
                        thread.get());
 }


### PR DESCRIPTION
### Summary

Adds a new thread to the simulator target that acts as the time base for the simulator. Any data or behavior that depends on timing will be generated by this thread in order to keep the timebase consistent across the simulation.

This PR only adds periodic temperature data. There is a _really_ simplistic simulation of the temperature response from the peltiers and lid heater with two basic parts:
- Simple integrator with initial conditions at 23ºC and a gain constant derived from the PID tuning in #256 
- Small pull back to ambient temperature that scales with the difference from ambient temperature - i.e. `(ambient temp - current temp) * gain`. The gain constant is scaled to try to approximate the heat loss of the lid heater when it's turned off at 100ºC.

This also adds a command line option for the simulator, `--realtime`. If specified, the timing of everything will be based on the system clock to try to approximate the time it takes on a real thermocycler. If this flag is not specified, the periodic data will be generated much faster than real time.

The ticks for the motor drivers aren't simulated yet, so motor commands will still never return in the simulator.