### PR TITLE
chore(thermocycler-refresh): add environment variable for simulation speed

### DIFF
--- a/stm32-modules/include/thermocycler-refresh/simulator/cli_parser.hpp
+++ b/stm32-modules/include/thermocycler-refresh/simulator/cli_parser.hpp
@@ -16,4 +16,7 @@ using RT = std::pair<std::shared_ptr<sim_driver::SimDriver>, bool>;
  * used 2) whether the simulation should be realtime or accelerated
  */
 RT get_sim_driver(int, char**);
+
+bool check_realtime_environment_variable();
+
 }  // namespace cli_parser

--- a/stm32-modules/thermocycler-refresh/README.md
+++ b/stm32-modules/thermocycler-refresh/README.md
@@ -36,7 +36,7 @@ When compiling the firmware using your local compiler (using the `stm32-host` cm
 - Build and Test: `cmake --build ./build-stm32-host --target thermocycler-refresh-build-and-test` 
 
 ### Simulator
-There's a simulator! It host-compiles the core lib with boost for interaction. Right now it just talks over stdin and stdout but it should really learn about arbitrary sockets and whatnot. You can build it with `cmake --build ./build-stm32-host --target thermocycler-refresh-simulator` and then run it with `./build-stm32-host/stm32-modules/thermocycler-refresh/simulator/thermocycler-refresh-simulator`. You can type some gcodes in to stdin. To quit, either interrupt or kill or send EOF (ctrl-d on unixlikes).
+There's a simulator! It host-compiles the core lib with boost for interaction. It can run with input from either `stdin` or a socket. You can build it with `cmake --build ./build-stm32-host --target thermocycler-refresh-simulator` and then run it with `./build-stm32-host/stm32-modules/thermocycler-refresh/simulator/thermocycler-refresh-simulator --stdin`. You can type some gcodes in to stdin. To quit, either interrupt or kill or send EOF (ctrl-d on unixlikes). See `./simulator` for more detail.
 
 ## File Structure
 - `./tests/` contains the test-specific entrypoints and actual test code

--- a/stm32-modules/thermocycler-refresh/simulator/README.md
+++ b/stm32-modules/thermocycler-refresh/simulator/README.md
@@ -1,0 +1,25 @@
+# Thermocycler Refresh Simulator
+
+This directory has code specific to the TCR simulator
+
+## Running the simulator
+
+### Selecting an input
+
+The simulator can receive input from either stdin or a socket.
+
+- To use stdin, simply pass the flag `--stdin` when starting the simulator.
+- To use a socket, pass the flag `--socket` with a socket address to use.
+
+### Setting the serial number
+
+The simulator can be initialized with a custom serial identifier with an environment variable. If an environment variable called `SERIAL_NUMBER` is found, its value will be set as the device's serial number on initialization.
+
+### Setting the emulation speed
+
+The simulator has two options for emulating thermal & motor data, either __simulated time__ or __real time__.
+
+- In __simulated time__, all behaviors on the system occur _much_ faster than on a real Thermocycler. The response for the thermal & motor systems will still be emulated with simple models, but the rate at which this emulation happens will be nearly instantaneous.
+- In __real time__, all behaviors on the system should occur at the same rate they would on a real Thermocycler. This means that thermal ramp rates will be somewhat close to a realistic ramp, and motor movements will take approximately the same time as a real motor movement.
+
+The default mode is __simulated time__. To select __real time__, you can either 1) pass the flag `--realtime` when starting the simulator, or 2) set an environment variable `USE_REALTIME_SIM=True` (case insensitive) before starting the simulator.

--- a/stm32-modules/thermocycler-refresh/simulator/README.md
+++ b/stm32-modules/thermocycler-refresh/simulator/README.md
@@ -22,4 +22,4 @@ The simulator has two options for emulating thermal & motor data, either __simul
 - In __simulated time__, all behaviors on the system occur _much_ faster than on a real Thermocycler. The response for the thermal & motor systems will still be emulated with simple models, but the rate at which this emulation happens will be nearly instantaneous.
 - In __real time__, all behaviors on the system should occur at the same rate they would on a real Thermocycler. This means that thermal ramp rates will be somewhat close to a realistic ramp, and motor movements will take approximately the same time as a real motor movement.
 
-The default mode is __simulated time__. To select __real time__, you can either 1) pass the flag `--realtime` when starting the simulator, or 2) set an environment variable `USE_REALTIME_SIM=True` (case insensitive) before starting the simulator.
+The default mode is __simulated time__. To select __real time__, you can either 1) pass the flag `--realtime` when starting the simulator, or 2) set an environment variable `USE_REALTIME_SIM=True` before starting the simulator.

--- a/stm32-modules/thermocycler-refresh/simulator/cli_parser.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/cli_parser.cpp
@@ -1,8 +1,11 @@
 #include "simulator/cli_parser.hpp"
 
+#include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
+#include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <string>
 
 #include "simulator/sim_driver.hpp"
 #include "simulator/socket_sim_driver.hpp"
@@ -94,4 +97,20 @@ RT cli_parser::get_sim_driver(int num_args, char* args[]) {
     } else {
         neither_driver_error(desc);
     }
+}
+
+bool cli_parser::check_realtime_environment_variable() {
+    constexpr const char realtime_var_name[] = "USE_REALTIME_SIM";
+    constexpr const char string_true[] = "true";
+    const auto* var_value = getenv(realtime_var_name);
+
+    if (!var_value || strlen(var_value) == 0) {
+        return false;
+    }
+
+    // Convert to lowercase
+    auto var_string = std::string(var_value);
+    boost::algorithm::to_lower(var_string);
+
+    return var_string.starts_with(string_true);
 }

--- a/stm32-modules/thermocycler-refresh/simulator/main.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/main.cpp
@@ -17,7 +17,8 @@ using namespace std;
 int main(int argc, char *argv[]) {
     auto cli_ret = cli_parser::get_sim_driver(argc, argv);
     auto sim_driver = cli_ret.first;
-    auto realtime = cli_ret.second;
+    auto realtime =
+        cli_ret.second || cli_parser::check_realtime_environment_variable();
 
     auto periodic_data = periodic_data_thread::build(realtime);
 

--- a/stm32-modules/thermocycler-refresh/simulator/periodic_data_thread.cpp
+++ b/stm32-modules/thermocycler-refresh/simulator/periodic_data_thread.cpp
@@ -67,8 +67,6 @@ auto PeriodicDataThread::provide_tasks(
 }
 
 auto PeriodicDataThread::run(std::stop_token& st) -> void {
-    // This doesn't use std::chrono to emulate the firmware 32bit counter
-    // overflow behavior
     PeriodicDataMessage msg;
 
     while (!_init_latch.load()) {


### PR DESCRIPTION
Per @DerekMaggio request, adds the ability to set the runtime speed an environment variable. If the variable is set to `true` _or_ the flag is passed in, simulation is in real-time.