### PR TITLE
fix(heater-shaker): eliminate bad message acknowledgements

### DIFF
--- a/stm32-modules/heater-shaker/tests/test_heater_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_heater_task.cpp
@@ -98,21 +98,21 @@ SCENARIO("heater task message passing") {
         }
         WHEN("sending a set-temperature message as if from host comms") {
             auto message = messages::SetTemperatureMessage{
-                .id = 1231, .target_temperature = 45};
+                .id = 1231, .target_temperature = 55};
             tasks->get_heater_queue().backing_deque.push_back(
                 messages::HeaterMessage(message));
             tasks->run_heater_task();
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_heater_queue().backing_deque.empty());
                 AND_THEN(
-                    "the task should respond to the message to host comms") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
+                    "the task should set red LED and respond to host comms") {
                     auto system_response =
                         tasks->get_system_queue().backing_deque.front();
                     tasks->get_system_queue().backing_deque.pop_front();
                     REQUIRE(std::holds_alternative<messages::SetLEDMessage>(
                         system_response));
+                    REQUIRE(
+                        !tasks->get_host_comms_queue().backing_deque.empty());
                     auto response =
                         tasks->get_host_comms_queue().backing_deque.front();
                     tasks->get_host_comms_queue().backing_deque.pop_front();
@@ -143,23 +143,18 @@ SCENARIO("heater task message passing") {
         }
         WHEN("sending a set-temperature message as if from system") {
             auto message = messages::SetTemperatureMessage{
-                .id = 1231, .target_temperature = 45, .from_system = true};
+                .id = 1234, .target_temperature = 55, .from_system = true};
             tasks->get_heater_queue().backing_deque.push_back(
                 messages::HeaterMessage(message));
             tasks->run_heater_task();
-            tasks->get_system_task().run_once(
-                tasks->get_system_policy());  // handles SetLEDMessage
-            auto host_comms_response =
-                tasks->get_host_comms_queue().backing_deque.front();
-            tasks->get_host_comms_queue().backing_deque.pop_front();
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_heater_queue().backing_deque.empty());
-                AND_THEN("the task should respond to the message to system") {
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            host_comms_response));
-                    REQUIRE(
-                        tasks->get_host_comms_queue().backing_deque.empty());
+                AND_THEN("the task should set red LED and respond to system") {
+                    auto system_response =
+                        tasks->get_system_queue().backing_deque.front();
+                    tasks->get_system_queue().backing_deque.pop_front();
+                    REQUIRE(std::holds_alternative<messages::SetLEDMessage>(
+                        system_response));
                     REQUIRE(!tasks->get_system_queue().backing_deque.empty());
                     auto response =
                         tasks->get_system_queue().backing_deque.front();

--- a/stm32-modules/heater-shaker/tests/test_system_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_system_task.cpp
@@ -153,7 +153,8 @@ SCENARIO("system task message passing") {
         }
 
         WHEN("receiving a set-LED message as if from the host task") {
-            auto message = messages::SetLEDMessage{.id = 123};
+            auto message =
+                messages::SetLEDMessage{.id = 123, .from_host = true};
             tasks->get_system_queue().backing_deque.push_back(
                 messages::SystemMessage(message));
             tasks->get_system_task().run_once(tasks->get_system_policy());

--- a/stm32-modules/include/heater-shaker/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/host_comms_task.hpp
@@ -514,7 +514,8 @@ class HostCommsTask {
                 false, errors::write_into(tx_into, tx_limit,
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
-        auto message = messages::SetLEDMessage{.id = id, .mode = gcode.mode};
+        auto message = messages::SetLEDMessage{
+            .id = id, .mode = gcode.mode, .from_host = true};
         if (!task_registry->system->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/heater-shaker/heater-shaker/messages.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/messages.hpp
@@ -104,6 +104,7 @@ struct SetSerialNumberMessage {
 struct SetLEDMessage {
     uint32_t id;
     LED_MODE mode;
+    bool from_host = false;
 };
 
 struct IdentifyModuleStartLEDMessage {

--- a/stm32-modules/include/heater-shaker/heater-shaker/system_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/system_task.hpp
@@ -196,7 +196,7 @@ class SystemTask {
         if (!policy.check_I2C_ready()) {
             error = errors::ErrorCode::SYSTEM_LED_I2C_NOT_READY;
         } else {
-            error = policy.start_set_led(msg.mode);
+            error = policy.start_set_led(msg.mode); 
         }
         if (msg.from_host) {
             auto response = messages::AcknowledgePrevious{

--- a/stm32-modules/include/heater-shaker/heater-shaker/system_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/system_task.hpp
@@ -196,7 +196,7 @@ class SystemTask {
         if (!policy.check_I2C_ready()) {
             error = errors::ErrorCode::SYSTEM_LED_I2C_NOT_READY;
         } else {
-            error = policy.start_set_led(msg.mode); 
+            error = policy.start_set_led(msg.mode);
         }
         if (msg.from_host) {
             auto response = messages::AcknowledgePrevious{


### PR DESCRIPTION
Fixes for bad message acknowledgement error that's been popping up during testing. Error seems to be caused by hot-to-touch SetLEDMessage responding unnecessarily and without an originating id to the host comms task. The fix responds to host comms task with ErrorMessage only when necessary. Needs to be tested on latest built module.