### PR TITLE
chore(thermocycler-gen2): remove space from HW model

### DIFF
--- a/stm32-modules/thermocycler-gen2/src/version.cpp.in
+++ b/stm32-modules/thermocycler-gen2/src/version.cpp.in
@@ -1,7 +1,7 @@
 #include "core/version.hpp"
 
 static constexpr const char* _FW_VERSION_GENERATED = "${${TARGET_MODULE_NAME}_VERSION}";
-static constexpr const char* _HW_VERSION_GENERATED = "Opentrons ${TARGET_MODULE_NAME}";
+static constexpr const char* _HW_VERSION_GENERATED = "Opentrons-${TARGET_MODULE_NAME}";
 
 const char* version::fw_version() {
     return _FW_VERSION_GENERATED;


### PR DESCRIPTION
### Summary

Simply removes the space from the Hardware Model returned by M115. The space was causing trouble with the way the Python API generates dicts from messages, and the path of least resistance is just to get rid of the space in the model name. It now returns `Opentrons-thermocycler-gen2` instead of `Opentrons thermocycler-gen2`.

Tested with the simulator.