### PR TITLE
fix(heater-shaker): flip photointerrupter logic

### DIFF
--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
@@ -357,7 +357,7 @@ static void PlateLockTIM_Init(TIM_HandleTypeDef* tim3) {
   tim3->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
   HAL_TIM_PWM_Init(tim3);
 
-  motor_hardware_plate_lock_off(tim3); 
+  motor_hardware_plate_lock_off(tim3);
 }
 
 /**

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
@@ -374,7 +374,7 @@ static void EXTI0_Config(void)
   
   /* Configure plate lock engaged optical switch*/
   GPIO_InitStructure.Pin = PLATE_LOCK_ENGAGED_Pin;
-  GPIO_InitStructure.Mode = GPIO_MODE_IT_RISING;
+  GPIO_InitStructure.Mode = GPIO_MODE_IT_FALLING;
   GPIO_InitStructure.Pull = GPIO_PULLUP;
   GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_HIGH;
   HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStructure);
@@ -398,7 +398,7 @@ static void EXTI4_Config(void)
   
   /* Configure plate lock released optical switch*/
   GPIO_InitStructure.Pin = PLATE_LOCK_RELEASED_Pin;
-  GPIO_InitStructure.Mode = GPIO_MODE_IT_RISING;
+  GPIO_InitStructure.Mode = GPIO_MODE_IT_FALLING;
   GPIO_InitStructure.Pull = GPIO_PULLUP;
   GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_HIGH;
   HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStructure);
@@ -937,7 +937,7 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
 
 bool motor_hardware_plate_lock_sensor_read(uint16_t GPIO_Pin)
 {
-  if (GPIO_PIN_SET == HAL_GPIO_ReadPin(PLATE_LOCK_Port, GPIO_Pin)) {
+  if (GPIO_PIN_RESET == HAL_GPIO_ReadPin(PLATE_LOCK_Port, GPIO_Pin)) {
     return true;
   } else {
     return false;

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
@@ -357,7 +357,7 @@ static void PlateLockTIM_Init(TIM_HandleTypeDef* tim3) {
   tim3->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
   HAL_TIM_PWM_Init(tim3);
 
-  motor_hardware_plate_lock_off(tim3);
+  motor_hardware_plate_lock_off(tim3); 
 }
 
 /**


### PR DESCRIPTION
Photointerrupter output logic for plate latch end stop detection is now flipped, with a low output corresponding to an end stop flag detection.