### PR TITLE
feat(heater-shaker): add deactivate heater gcode

### DIFF
--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(heater-shaker
   test_m104d.cpp
   test_m105.cpp
   test_m105d.cpp
+  test_m106.cpp
   test_m123.cpp
   test_m124.cpp
   test_m3.cpp

--- a/stm32-modules/heater-shaker/tests/test_basic_gcodes.cpp
+++ b/stm32-modules/heater-shaker/tests/test_basic_gcodes.cpp
@@ -20,8 +20,8 @@ TEMPLATE_TEST_CASE("gcode basic parsing", "[gcode][parse]", gcode::SetRPM,
                    gcode::OpenPlateLock, gcode::ClosePlateLock,
                    gcode::GetPlateLockState, gcode::GetPlateLockStateDebug,
                    gcode::SetSerialNumber, gcode::SetLEDDebug,
-                   gcode::IdentifyModuleStartLED,
-                   gcode::IdentifyModuleStopLED) {
+                   gcode::IdentifyModuleStartLED, gcode::IdentifyModuleStopLED,
+                   gcode::DeactivateHeater) {
     SECTION("attempting to parse an empty string fails") {
         std::string to_parse = "";
         auto output = TestType::parse(to_parse.cbegin(), to_parse.cend());
@@ -53,7 +53,7 @@ TEMPLATE_TEST_CASE("gcodes without parameters parse", "[gcode][parse]",
                    gcode::GetSystemInfo, gcode::Home, gcode::OpenPlateLock,
                    gcode::ClosePlateLock, gcode::GetPlateLockState,
                    gcode::GetPlateLockStateDebug, gcode::IdentifyModuleStartLED,
-                   gcode::IdentifyModuleStopLED) {
+                   gcode::IdentifyModuleStopLED, gcode::DeactivateHeater) {
     SECTION("parsing the full prefix succeeds") {
         auto output =
             TestType::parse(TestType::prefix.cbegin(), TestType::prefix.cend());
@@ -78,8 +78,8 @@ TEMPLATE_TEST_CASE("gcode responses without parameters generate",
                    gcode::ActuateSolenoid, gcode::DebugControlPlateLockMotor,
                    gcode::SetSerialNumber, gcode::OpenPlateLock,
                    gcode::ClosePlateLock, gcode::SetLEDDebug,
-                   gcode::IdentifyModuleStartLED,
-                   gcode::IdentifyModuleStopLED) {
+                   gcode::IdentifyModuleStartLED, gcode::IdentifyModuleStopLED,
+                   gcode::DeactivateHeater) {
     SECTION("responses won't write into zero-size buffers") {
         std::string buffer(10, 'c');
         auto res =

--- a/stm32-modules/heater-shaker/tests/test_heater_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_heater_task.cpp
@@ -185,6 +185,28 @@ SCENARIO("heater task message passing") {
                             }
                         }
                     }
+                    AND_WHEN("sending a deactivate-heater command") {
+                        auto message = messages::DeactivateHeaterMessage{.id = 1234};
+                        tasks->get_heater_queue().backing_deque.push_back(
+                            messages::HeaterMessage(message));
+                        tasks->run_heater_task();
+                        THEN("the task should get the message") {
+                            REQUIRE(tasks->get_heater_queue().backing_deque.empty());
+                            AND_THEN("the task should change state and respond to host") {
+                                REQUIRE(tasks->get_heater_policy().last_enable_setting() == false);
+                                REQUIRE(!tasks->get_host_comms_queue().backing_deque.empty());
+                                auto response =
+                                    tasks->get_host_comms_queue().backing_deque.front();
+                                tasks->get_host_comms_queue().backing_deque.pop_front();
+                                REQUIRE(
+                                    std::holds_alternative<messages::AcknowledgePrevious>(
+                                        response));
+                                auto ack =
+                                    std::get<messages::AcknowledgePrevious>(response);
+                                REQUIRE(ack.responding_to_id == message.id);
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/stm32-modules/heater-shaker/tests/test_heater_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_heater_task.cpp
@@ -186,23 +186,31 @@ SCENARIO("heater task message passing") {
                         }
                     }
                     AND_WHEN("sending a deactivate-heater command") {
-                        auto message = messages::DeactivateHeaterMessage{.id = 1234};
+                        auto message =
+                            messages::DeactivateHeaterMessage{.id = 1234};
                         tasks->get_heater_queue().backing_deque.push_back(
                             messages::HeaterMessage(message));
                         tasks->run_heater_task();
                         THEN("the task should get the message") {
-                            REQUIRE(tasks->get_heater_queue().backing_deque.empty());
-                            AND_THEN("the task should change state and respond to host") {
-                                REQUIRE(tasks->get_heater_policy().last_enable_setting() == false);
-                                REQUIRE(!tasks->get_host_comms_queue().backing_deque.empty());
-                                auto response =
-                                    tasks->get_host_comms_queue().backing_deque.front();
-                                tasks->get_host_comms_queue().backing_deque.pop_front();
-                                REQUIRE(
-                                    std::holds_alternative<messages::AcknowledgePrevious>(
-                                        response));
+                            REQUIRE(tasks->get_heater_queue()
+                                        .backing_deque.empty());
+                            AND_THEN(
+                                "the task should change state and respond to "
+                                "host") {
+                                REQUIRE(tasks->get_heater_policy()
+                                            .last_enable_setting() == false);
+                                REQUIRE(!tasks->get_host_comms_queue()
+                                             .backing_deque.empty());
+                                auto response = tasks->get_host_comms_queue()
+                                                    .backing_deque.front();
+                                tasks->get_host_comms_queue()
+                                    .backing_deque.pop_front();
+                                REQUIRE(std::holds_alternative<
+                                        messages::AcknowledgePrevious>(
+                                    response));
                                 auto ack =
-                                    std::get<messages::AcknowledgePrevious>(response);
+                                    std::get<messages::AcknowledgePrevious>(
+                                        response);
                                 REQUIRE(ack.responding_to_id == message.id);
                             }
                         }

--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -774,6 +774,84 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                 }
             }
         }
+
+        WHEN("sending a deactivate heater") {
+            auto message_text = std::string("M106\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the heater and not "
+                "immediately ack") {
+                REQUIRE(tasks->get_heater_queue().backing_deque.size() != 0);
+                auto heater_message =
+                    tasks->get_heater_queue().backing_deque.front();
+                auto deactivate_heater_message =
+                    std::get<messages::DeactivateHeaterMessage>(heater_message);
+                tasks->get_heater_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = deactivate_heater_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("M106 OK\n"));
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending a bad response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = deactivate_heater_message.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+
+                AND_WHEN("sending an ack with error back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = deactivate_heater_message.id,
+                            .with_error = errors::ErrorCode::HEATER_HARDWARE_ERROR_LATCH});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should print the error rather than ack") {
+                        REQUIRE_THAT(
+                            tx_buf,
+                            Catch::Matchers::StartsWith(
+                                "ERR211:heater:heatpad thermistor overtemp or disconnected\n"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -814,7 +814,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                 AND_WHEN("sending a bad response back to the comms task") {
                     auto response = messages::HostCommsMessage(
                         messages::AcknowledgePrevious{
-                            .responding_to_id = deactivate_heater_message.id + 1});
+                            .responding_to_id =
+                                deactivate_heater_message.id + 1});
                     tasks->get_host_comms_queue().backing_deque.push_back(
                         response);
                     auto written_secondpass =
@@ -834,17 +835,18 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     auto response = messages::HostCommsMessage(
                         messages::AcknowledgePrevious{
                             .responding_to_id = deactivate_heater_message.id,
-                            .with_error = errors::ErrorCode::HEATER_HARDWARE_ERROR_LATCH});
+                            .with_error = errors::ErrorCode::
+                                HEATER_HARDWARE_ERROR_LATCH});
                     tasks->get_host_comms_queue().backing_deque.push_back(
                         response);
                     auto written_secondpass =
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should print the error rather than ack") {
-                        REQUIRE_THAT(
-                            tx_buf,
-                            Catch::Matchers::StartsWith(
-                                "ERR211:heater:heatpad thermistor overtemp or disconnected\n"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith(
+                                         "ERR211:heater:heatpad thermistor "
+                                         "overtemp or disconnected\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                         REQUIRE(written_secondpass != tx_buf.begin());

--- a/stm32-modules/heater-shaker/tests/test_m106.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m106.cpp
@@ -1,0 +1,37 @@
+#include <array>
+
+#include "catch2/catch.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "heater-shaker/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("DeactivateHeater (M106) response works", "[gcode][parse][M106]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(64, 'c');
+        WHEN("filling response") {
+            auto written = gcode::DeactivateHeater::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                std::string ok = "M106 OK\n";
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(ok));
+                REQUIRE(written == buffer.begin() + ok.size());
+                std::string suffix(buffer.size() - ok.size(), 'c');
+                REQUIRE_THAT(buffer, Catch::Matchers::EndsWith(suffix));
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::DeactivateHeater::write_response_into(
+                buffer.begin(), buffer.begin() + 6);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M106 Occcccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written == buffer.begin() + 6);
+            }
+        }
+    }
+}

--- a/stm32-modules/include/heater-shaker/heater-shaker/gcodes.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/gcodes.hpp
@@ -1129,4 +1129,35 @@ struct GetOffsetConstants {
     }
 };
 
+struct DeactivateHeater {
+    /**
+     * DeactivateHeater is M106 based on existing convention
+     *
+     * Acknowledged immediately upon receipt
+     * */
+    using ParseResult = std::optional<DeactivateHeater>;
+    static constexpr auto prefix = std::array{'M', '1', '0', '6'};
+    static constexpr const char* response = "M106 OK\n";
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt write_to_buf,
+                                    InLimit write_to_limit) {
+        return write_string_to_iterpair(write_to_buf, write_to_limit, response);
+    }
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(DeactivateHeater()), working);
+    }
+};
+
 }  // namespace gcode

--- a/stm32-modules/include/heater-shaker/heater-shaker/heater_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/heater_task.hpp
@@ -289,9 +289,8 @@ class HeaterTask {
         } else {
             state.system_status = State::IDLE;
         }
-        static_cast<void>(
-            task_registry->comms->get_message_queue().try_send(
-                messages::HostCommsMessage(response)));
+        static_cast<void>(task_registry->comms->get_message_queue().try_send(
+            messages::HostCommsMessage(response)));
     }
 
     template <typename Policy>

--- a/stm32-modules/include/heater-shaker/heater-shaker/heater_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/heater_task.hpp
@@ -279,6 +279,23 @@ class HeaterTask {
 
     template <typename Policy>
     requires HeaterExecutionPolicy<Policy>
+    auto visit_message(const messages::DeactivateHeaterMessage& msg,
+                       Policy& policy) -> void {
+        policy.disable_power_output();
+        auto response =
+            messages::AcknowledgePrevious{.responding_to_id = msg.id};
+        if (state.system_status == State::ERROR) {
+            response.with_error = most_relevant_error();
+        } else {
+            state.system_status = State::IDLE;
+        }
+        static_cast<void>(
+            task_registry->comms->get_message_queue().try_send(
+                messages::HostCommsMessage(response)));
+    }
+
+    template <typename Policy>
+    requires HeaterExecutionPolicy<Policy>
     auto visit_message(const messages::GetTemperatureMessage& msg,
                        Policy& policy) -> void {
         static_cast<void>(policy);

--- a/stm32-modules/include/heater-shaker/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/host_comms_task.hpp
@@ -47,7 +47,7 @@ class HostCommsTask {
         gcode::ClosePlateLock, gcode::GetPlateLockState,
         gcode::GetPlateLockStateDebug, gcode::SetLEDDebug,
         gcode::IdentifyModuleStartLED, gcode::IdentifyModuleStopLED,
-        gcode::SetOffsetConstants, gcode::GetOffsetConstants>;
+        gcode::SetOffsetConstants, gcode::GetOffsetConstants, gcode::DeactivateHeater>;
     using AckOnlyCache =
         AckCache<8, gcode::SetRPM, gcode::SetTemperature,
                  gcode::SetAcceleration, gcode::SetPIDConstants,
@@ -56,7 +56,7 @@ class HostCommsTask {
                  gcode::OpenPlateLock, gcode::ClosePlateLock,
                  gcode::SetSerialNumber, gcode::SetLEDDebug,
                  gcode::IdentifyModuleStartLED, gcode::IdentifyModuleStopLED,
-                 gcode::SetOffsetConstants>;
+                 gcode::SetOffsetConstants, gcode::DeactivateHeater>;
     using GetTempCache = AckCache<8, gcode::GetTemperature>;
     using GetTempDebugCache = AckCache<8, gcode::GetTemperatureDebug>;
     using GetRPMCache = AckCache<8, gcode::GetRPM>;
@@ -1006,6 +1006,28 @@ class HostCommsTask {
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
         auto message = messages::GetOffsetConstantsMessage{.id = id};
+        if (!task_registry->heater->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::DeactivateHeater& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::DeactivateHeaterMessage{.id = id};
         if (!task_registry->heater->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/heater-shaker/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/host_comms_task.hpp
@@ -47,7 +47,8 @@ class HostCommsTask {
         gcode::ClosePlateLock, gcode::GetPlateLockState,
         gcode::GetPlateLockStateDebug, gcode::SetLEDDebug,
         gcode::IdentifyModuleStartLED, gcode::IdentifyModuleStopLED,
-        gcode::SetOffsetConstants, gcode::GetOffsetConstants, gcode::DeactivateHeater>;
+        gcode::SetOffsetConstants, gcode::GetOffsetConstants,
+        gcode::DeactivateHeater>;
     using AckOnlyCache =
         AckCache<8, gcode::SetRPM, gcode::SetTemperature,
                  gcode::SetAcceleration, gcode::SetPIDConstants,

--- a/stm32-modules/include/heater-shaker/heater-shaker/messages.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/messages.hpp
@@ -259,6 +259,10 @@ struct GetOffsetConstantsResponse {
     double const_b, const_c;
 };
 
+struct DeactivateHeaterMessage {
+    uint32_t id;
+};
+
 struct AcknowledgePrevious {
     uint32_t responding_to_id;
     errors::ErrorCode with_error = errors::ErrorCode::NO_ERROR;
@@ -274,7 +278,7 @@ using HeaterMessage =
                    TemperatureConversionComplete, GetTemperatureDebugMessage,
                    SetPIDConstantsMessage, SetPowerTestMessage,
                    HandleNTCSetupError, SetOffsetConstantsMessage,
-                   GetOffsetConstantsMessage>;
+                   GetOffsetConstantsMessage, DeactivateHeaterMessage>;
 using MotorMessage = ::std::variant<
     std::monostate, MotorSystemErrorMessage, SetRPMMessage, GetRPMMessage,
     SetAccelerationMessage, CheckHomingStatusMessage, BeginHomingMessage,


### PR DESCRIPTION
Currently, the hardware controller class `deactivate module` command issues a `set_temperature(0)` gcode, which sets setpoint to 0. This gcode will now be used, which disables heatpad power output. This tested successfully on my at-home frankenstein module. An associated hardware controller class PR is in the works.