### PR TITLE
fix(heater-shaker): update setpoint with deactivate_heater

### DIFF
--- a/stm32-modules/heater-shaker/tests/test_heater_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_heater_task.cpp
@@ -199,6 +199,9 @@ SCENARIO("heater task message passing") {
                                 "host") {
                                 REQUIRE(tasks->get_heater_policy()
                                             .last_enable_setting() == false);
+                                REQUIRE(
+                                    tasks->get_heater_task().get_setpoint() ==
+                                    0.0);
                                 REQUIRE(!tasks->get_host_comms_queue()
                                              .backing_deque.empty());
                                 auto response = tasks->get_host_comms_queue()
@@ -232,6 +235,9 @@ SCENARIO("heater task message passing") {
                                         REQUIRE(tasks->get_heater_policy()
                                                     .last_enable_setting() ==
                                                 true);
+                                        REQUIRE(tasks->get_heater_task()
+                                                    .get_setpoint() ==
+                                                _valid_temp);
                                     }
                                 }
                             }

--- a/stm32-modules/include/heater-shaker/heater-shaker/gcodes.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/gcodes.hpp
@@ -123,10 +123,16 @@ struct GetTemperature {
         std::sized_sentinel_for<InputIt, InLimit>
     static auto write_response_into(InputIt buf, InLimit limit,
                                     double current_temperature,
-                                    double setpoint_temperature) -> InputIt {
-        auto res = snprintf(&*buf, (limit - buf), "M105 C:%0.2f T:%0.2f OK\n",
-                            static_cast<float>(current_temperature),
-                            static_cast<float>(setpoint_temperature));
+                                    std::optional<double> setpoint_temperature)
+        -> InputIt {
+        int res = 0;
+        if (setpoint_temperature) {
+            res = snprintf(&*buf, (limit - buf), "M105 C:%0.2f T:%0.2f OK\n",
+                           current_temperature, setpoint_temperature.value());
+        } else {
+            res = snprintf(&*buf, (limit - buf), "M105 C:%0.2f T:None OK\n",
+                           current_temperature);
+        }
         if (res <= 0) {
             return buf;
         }

--- a/stm32-modules/include/heater-shaker/heater-shaker/heater_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/heater_task.hpp
@@ -282,6 +282,7 @@ class HeaterTask {
     auto visit_message(const messages::DeactivateHeaterMessage& msg,
                        Policy& policy) -> void {
         policy.disable_power_output();
+        setpoint = 0;
         auto response =
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
         if (state.system_status == State::ERROR) {

--- a/stm32-modules/include/heater-shaker/heater-shaker/messages.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/messages.hpp
@@ -198,7 +198,7 @@ struct CheckPlateLockStatusMessage {
 struct GetTemperatureResponse {
     uint32_t responding_to_id;
     double current_temperature;
-    double setpoint_temperature;
+    std::optional<double> setpoint_temperature;
     errors::ErrorCode with_error = errors::ErrorCode::NO_ERROR;
 };
 


### PR DESCRIPTION
Need to set setpoint to 0 so hardware control class can properly utilize the setpoint to identify heater state.