### PR TITLE
feat(thermocycler-gen2): split Plate Lift into its own command

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/errors.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/errors.hpp
@@ -58,6 +58,7 @@ enum class ErrorCode {
     SEAL_MOTOR_BUSY = 504,
     SEAL_MOTOR_FAULT = 505,
     SEAL_MOTOR_STALL = 506,
+    LID_CLOSED = 507,
 };
 
 auto errorstring(ErrorCode code) -> const char*;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -1488,6 +1488,39 @@ struct CloseLid {
     }
 };
 
+/**
+ * @brief Uses M128. Commands the thermocycler to lift the plate.
+ *
+ * This command is only intended to be sent when the lid is already
+ * in the open position. The lid will open further to lift the plate,
+ * and then return to the open position.
+ *
+ */
+struct LiftPlate {
+    using ParseResult = std::optional<LiftPlate>;
+    static constexpr auto prefix = std::array{'M', '1', '2', '8'};
+    static constexpr const char* response = "M128 OK\n";
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(LiftPlate()), working);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+};
+
 struct DeactivateAll {
     using ParseResult = std::optional<DeactivateAll>;
     static constexpr auto prefix = std::array{'M', '1', '8'};

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -50,8 +50,8 @@ class HostCommsTask {
         gcode::GetSealDriveStatus, gcode::SetSealParameter, gcode::GetLidStatus,
         gcode::GetThermalPowerDebug, gcode::SetOffsetConstants,
         gcode::GetOffsetConstants, gcode::OpenLid, gcode::CloseLid,
-        gcode::DeactivateAll, gcode::GetBoardRevision, gcode::GetLidSwitches,
-        gcode::GetFrontButton>;
+        gcode::LiftPlate, gcode::DeactivateAll, gcode::GetBoardRevision,
+        gcode::GetLidSwitches, gcode::GetFrontButton>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::ActuateSolenoid, gcode::ActuateLidStepperDebug,
@@ -60,7 +60,8 @@ class HostCommsTask {
                  gcode::DeactivateLidHeating, gcode::SetPIDConstants,
                  gcode::SetPlateTemperature, gcode::DeactivatePlate,
                  gcode::SetFanAutomatic, gcode::SetSealParameter,
-                 gcode::SetOffsetConstants, gcode::OpenLid, gcode::CloseLid>;
+                 gcode::SetOffsetConstants, gcode::OpenLid, gcode::CloseLid,
+                 gcode::LiftPlate>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetLidTempDebugCache = AckCache<8, gcode::GetLidTemperatureDebug>;
     using GetPlateTempDebugCache = AckCache<8, gcode::GetPlateTemperatureDebug>;
@@ -1329,6 +1330,28 @@ class HostCommsTask {
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
         auto message = messages::OpenLidMessage{.id = id};
+        if (!task_registry->motor->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::LiftPlate& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::PlateLiftMessage{.id = id};
         if (!task_registry->motor->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -345,6 +345,10 @@ struct CloseLidMessage {
     uint32_t id;
 };
 
+struct PlateLiftMessage {
+    uint32_t id;
+};
+
 struct FrontButtonPressMessage {};
 
 // This is a two-stage message that is first sent to the Plate task,
@@ -402,11 +406,10 @@ using LidHeaterMessage =
                    GetLidTempMessage, SetLidTemperatureMessage,
                    DeactivateLidHeatingMessage, SetPIDConstantsMessage,
                    GetThermalPowerMessage, DeactivateAllMessage>;
-using MotorMessage =
-    ::std::variant<std::monostate, ActuateSolenoidMessage,
-                   LidStepperDebugMessage, LidStepperComplete,
-                   SealStepperDebugMessage, SealStepperComplete,
-                   GetSealDriveStatusMessage, SetSealParameterMessage,
-                   GetLidStatusMessage, OpenLidMessage, CloseLidMessage,
-                   FrontButtonPressMessage, GetLidSwitchesMessage>;
+using MotorMessage = ::std::variant<
+    std::monostate, ActuateSolenoidMessage, LidStepperDebugMessage,
+    LidStepperComplete, SealStepperDebugMessage, SealStepperComplete,
+    GetSealDriveStatusMessage, SetSealParameterMessage, GetLidStatusMessage,
+    OpenLidMessage, CloseLidMessage, PlateLiftMessage, FrontButtonPressMessage,
+    GetLidSwitchesMessage>;
 };  // namespace messages

--- a/stm32-modules/thermocycler-gen2/firmware/motor_task/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/motor_task/README.md
@@ -15,6 +15,9 @@ graph TD
     H(Open hinge motor)
     I(Close hinge motor)
 
+    LiftCheck{Lid is open?}
+    LiftFail[Return error]
+    LiftRun(Run Plate Lift action)
 
     A -->|Open Lid command| C
     A -->|Close Lid command| D
@@ -27,6 +30,9 @@ graph TD
     I --> G 
     G --> E
     H ---> E
+    A -->|Plate Lift command| LiftCheck
+    LiftCheck -->|No| LiftFail
+    LiftCheck -->|Yes| LiftRun --> E
 ```
 
 ### Seal motor sub-state machine
@@ -60,12 +66,16 @@ graph TD
 graph TD
     StartO[Open hinge]
     OpenToSwitch(Open to limit switch)
-    BackTo90(Close from switch to reach 90º)
+    OpenOverdrive(Overdrive into limit switch)
     DoneO[Done]
     StartC[Close hinge]
     CloseToSwitch(Close to limit switch)
     CloseOverdrive(Overdrive into limit switch)
     DoneC[Done]
+    LiftStart[Plate Lift]
+    LiftOpen(Open past 90º)
+    LiftReturn(Close past limit switch)
+    RunOpenHinge[Start Open Hinge action]
 
     LatchO1(Open latch)
     LatchO2(Close latch)
@@ -74,9 +84,11 @@ graph TD
 
     StartO -->|Hinge at open position| DoneO
     StartO -->|Hinge close or unknown| LatchO1 --> OpenToSwitch
-    OpenToSwitch --> LatchO2 --> BackTo90 --> DoneO
+    OpenToSwitch --> LatchO2 --> OpenOverdrive --> DoneO
 
     StartC -->|Closed switch engaged| DoneC
     StartC -->|Closed switch not engaged| LatchC1 --> CloseToSwitch
     CloseToSwitch --> CloseOverdrive --> LatchC2 --> DoneC
+
+    LiftStart --> LiftOpen --> LiftReturn --> RunOpenHinge
 ```

--- a/stm32-modules/thermocycler-gen2/firmware/motor_task/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/motor_task/README.md
@@ -21,7 +21,7 @@ graph TD
 
     A -->|Open Lid command| C
     A -->|Close Lid command| D
-    C ---->|Lid open| H
+    C ---->|Lid open| E
     D ---->|Lid closed| E
     C -->|Lid closed or unknown| F
     D -->|Lid Open or unknown| Falt

--- a/stm32-modules/thermocycler-gen2/src/errors.cpp
+++ b/stm32-modules/thermocycler-gen2/src/errors.cpp
@@ -79,6 +79,7 @@ const char* const SEAL_MOTOR_SPI_ERROR = "ERR503:seal:SPI error\n";
 const char* const SEAL_MOTOR_BUSY = "EERR504:seal:Seal motor busy\n";
 const char* const SEAL_MOTOR_FAULT = "ERR505:seal:Seal motor fault\n";
 const char* const SEAL_MOTOR_STALL = "ERR5006:seal:Seal motor stall event\n";
+const char* const LID_CLOSED = "ERR507:lid:Lid must be opened\n";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
@@ -135,6 +136,7 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(SEAL_MOTOR_BUSY);
         HANDLE_CASE(SEAL_MOTOR_FAULT);
         HANDLE_CASE(SEAL_MOTOR_STALL);
+        HANDLE_CASE(LID_CLOSED);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_m119.cpp
     test_m126.cpp 
     test_m127.cpp
+    test_m128.cpp
     test_m140.cpp
     test_m140d.cpp
     test_m141.cpp

--- a/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
@@ -2208,7 +2208,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                 auto motor_message =
                     tasks->get_motor_queue().backing_deque.front();
                 auto lid_motor_message =
-                    std::get<messages::LiftPlateMessage>(motor_message);
+                    std::get<messages::PlateLiftMessage>(motor_message);
                 tasks->get_motor_queue().backing_deque.pop_front();
                 REQUIRE(written_firstpass == tx_buf.begin());
                 REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());

--- a/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
@@ -2193,6 +2193,80 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                 }
             }
         }
+        WHEN("sending a LiftPlate message") {
+            std::string message_text = std::string("M128\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the motor task "
+                "and not immediately ack") {
+                REQUIRE(tasks->get_motor_queue().backing_deque.size() != 0);
+                auto motor_message =
+                    tasks->get_motor_queue().backing_deque.front();
+                auto lid_motor_message =
+                    std::get<messages::LiftPlateMessage>(motor_message);
+                tasks->get_motor_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = lid_motor_message.id});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("M128 OK\n"));
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending a bad response back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = lid_motor_message.id + 1});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending an ack with error back to the comms task") {
+                    auto response = messages::HostCommsMessage(
+                        messages::AcknowledgePrevious{
+                            .responding_to_id = lid_motor_message.id,
+                            .with_error = errors::ErrorCode::LID_CLOSED});
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should print the error rather than ack") {
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR507:"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                    }
+                }
+            }
+        }
         GIVEN("a board revision of Rev1") {
             std::array<TrinaryInput_t, BOARD_REV_PIN_COUNT> inputs = {
                 INPUT_FLOATING, INPUT_FLOATING, INPUT_FLOATING};

--- a/stm32-modules/thermocycler-gen2/tests/test_m128.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m128.cpp
@@ -1,0 +1,56 @@
+#include "catch2/catch.hpp"
+
+// Push this diagnostic to avoid a compiler error about printing to too
+// small of a buffer... which we're doing on purpose!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-gen2/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("LiftPlate (M128) parser works", "[gcode][parse][m128]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::LiftPlate::write_response_into(buffer.begin(),
+                                                                 buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M128 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::LiftPlate::write_response_into(
+                buffer.begin(), buffer.begin() + 5);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M128 ccccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a valid input") {
+        std::string buffer = "M128\n";
+        WHEN("parsing") {
+            auto res = gcode::LiftPlate::parse(buffer.begin(), buffer.end());
+            THEN("a valid gcode should be produced") {
+                REQUIRE(res.first.has_value());
+                REQUIRE(res.second != buffer.begin());
+            }
+        }
+    }
+    GIVEN("an invalid input") {
+        std::string buffer = "M 128\n";
+        WHEN("parsing") {
+            auto res = gcode::LiftPlate::parse(buffer.begin(), buffer.end());
+            THEN("an error should be produced") {
+                REQUIRE(!res.first.has_value());
+                REQUIRE(res.second == buffer.begin());
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Adds M128, a gcode dedicated to activating the plate lift mechanism on the Thermocycler Gen2. Also removes the plate lift portion from the lid open command, and switches the lid opening logic for the EVT placement of the Lid Open switch (it is now at 90º instead of the plate-lift position).

Tested on a Gen1 unit by manually blocking/unblocking a limit switch. The actual numeric distances will be tuned in a later PR once an EVT unit is available for testing.