### PR TITLE
feat(thermocycler-gen2): Seal motor limit switches

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/firmware/motor_hardware.h
+++ b/stm32-modules/include/thermocycler-gen2/firmware/motor_hardware.h
@@ -32,6 +32,7 @@ typedef struct {
     motor_step_callback_t lid_stepper_complete;
     motor_step_callback_t seal_stepper_tick;
     motor_error_callback_t seal_stepper_error;
+    motor_step_callback_t seal_stepper_limit_switch;
 } motor_hardware_callbacks;
 
 // ----------------------------------------------------------------------------
@@ -137,6 +138,33 @@ void motor_hardware_solenoid_engage();
  *
  */
 void motor_hardware_solenoid_release();
+
+/**
+ * @brief Check if the seal switch is currently triggered
+ *
+ * @return True if the switch is pressed, false otherwise
+ */
+bool motor_hardware_seal_switch_triggered();
+
+/**
+ * @brief Arm the seal switch interrupt for triggering. The switch must
+ * be armed before it will invoke its callback, and it will only invoke
+ * the callback one time per arming.
+ */
+void motor_hardware_seal_switch_set_armed();
+
+/**
+ * @brief Disarm the seal switch if it is armed.
+ * @see #motor_hardware_seal_switch_arm
+ */
+void motor_hardware_seal_switch_set_disarmed();
+
+/**
+ * @brief Should be invoked whenever the Seal Limit Switch line
+ * triggers an interrupt
+ *
+ */
+void motor_hardware_seal_switch_interrupt();
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/stm32-modules/include/thermocycler-gen2/firmware/motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/firmware/motor_policy.hpp
@@ -119,6 +119,18 @@ class MotorPolicy {
     auto tmc2130_step_pulse() -> bool;
 
     /**
+     * @brief Arm the limit switch for the seal motor.
+     *
+     */
+    auto seal_switch_set_armed() -> void;
+
+    /**
+     * @brief Disarm the limit switch for the seal motor.
+     *
+     */
+    auto seal_switch_set_disarmed() -> void;
+
+    /**
      * @brief Call the seal callback function
      *
      */

--- a/stm32-modules/include/thermocycler-gen2/test/test_motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/test/test_motor_policy.hpp
@@ -54,14 +54,9 @@ class TestMotorPolicy : public TestTMC2130Policy {
 
     auto seal_stepper_stop() -> void { _seal_moving = false; }
 
-    auto seal_switch_set_armed() -> void {
-        _seal_switch_armed = true;
-    }
+    auto seal_switch_set_armed() -> void { _seal_switch_armed = true; }
 
-    auto seal_switch_set_disarmed() -> void {
-        _seal_switch_armed = false;
-    }
-
+    auto seal_switch_set_disarmed() -> void { _seal_switch_armed = false; }
 
     // Test-specific functions
 

--- a/stm32-modules/include/thermocycler-gen2/test/test_motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/test/test_motor_policy.hpp
@@ -54,6 +54,15 @@ class TestMotorPolicy : public TestTMC2130Policy {
 
     auto seal_stepper_stop() -> void { _seal_moving = false; }
 
+    auto seal_switch_set_armed() -> void {
+        _seal_switch_armed = true;
+    }
+
+    auto seal_switch_set_disarmed() -> void {
+        _seal_switch_armed = false;
+    }
+
+
     // Test-specific functions
 
     auto tick() -> void {
@@ -74,6 +83,8 @@ class TestMotorPolicy : public TestTMC2130Policy {
 
     auto get_lid_overdrive() -> bool { return _lid_overdrive; }
 
+    auto seal_switch_is_armed() -> bool { return _seal_switch_armed; }
+
   private:
     // Solenoid is engaged when unpowered
     bool _solenoid_engaged = true;
@@ -85,5 +96,6 @@ class TestMotorPolicy : public TestTMC2130Policy {
     bool _lid_open_switch = false;
     bool _lid_closed_switch = false;
     bool _lid_overdrive = false;
+    bool _seal_switch_armed = false;
     Callback _callback;
 };

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/errors.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/errors.hpp
@@ -59,6 +59,7 @@ enum class ErrorCode {
     SEAL_MOTOR_FAULT = 505,
     SEAL_MOTOR_STALL = 506,
     LID_CLOSED = 507,
+    SEAL_MOTOR_SWITCH = 508,
 };
 
 auto errorstring(ErrorCode code) -> const char*;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -170,6 +170,7 @@ struct SealStepperComplete {
     enum class CompletionReason {
         ERROR,  // There was an error flag
         STALL,  // There was a stall
+        LIMIT,  // Limit switch was triggered
         DONE,   // No error
     };
     // Defaults to no-error

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -184,18 +184,18 @@ struct LidState {
     enum class Status {
         IDLE,                         /**< No lid action.*/
         OPENING_RETRACT_SEAL,         /**< Retracting seal before opening lid.*/
-        OPENING_RETRACT_SEAL_BACKOFF, /**< Extend seal to ease off of the 
+        OPENING_RETRACT_SEAL_BACKOFF, /**< Extend seal to ease off of the
                                            limit switch.*/
         OPENING_OPEN_HINGE,           /**< Opening lid hinge.*/
         CLOSING_RETRACT_SEAL,         /**< Retracting seal before closing lid.*/
-        CLOSING_RETRACT_SEAL_BACKOFF, /**< Extend seal to ease off of the 
+        CLOSING_RETRACT_SEAL_BACKOFF, /**< Extend seal to ease off of the
                                            limit switch.*/
         CLOSING_CLOSE_HINGE,          /**< Closing lid hinge.*/
-        CLOSING_EXTEND_SEAL,          /**< Extending seal after closing 
+        CLOSING_EXTEND_SEAL,          /**< Extending seal after closing
                                            lid hinge.*/
-        CLOSING_EXTEND_SEAL_BACKOFF,  /**< Retract seal to ease off of the 
+        CLOSING_EXTEND_SEAL_BACKOFF,  /**< Retract seal to ease off of the
                                            limit switch.*/
-        PLATE_LIFTING,       /**< Lid is walking through its state machine.*/
+        PLATE_LIFTING, /**< Lid is walking through its state machine.*/
     };
     // Current status of the lid. Declared atomic because
     // this flag is set & cleared by both the actual task context
@@ -725,6 +725,10 @@ class MotorTask {
         auto closed_switch = policy.lid_read_closed_switch();
         auto open_switch = policy.lid_read_open_switch();
 
+        if (_state.status != LidState::Status::IDLE) {
+            // ALWAYS return Between during a movement
+            return motor_util::LidStepper::Position::BETWEEN;
+        }
         if (closed_switch && open_switch) {
             return motor_util::LidStepper::Position::UNKNOWN;
         }
@@ -769,7 +773,6 @@ class MotorTask {
     template <MotorExecutionPolicy Policy>
     auto start_lid_open(uint32_t response_id, Policy& policy)
         -> errors::ErrorCode {
-        using Position = motor_util::SealStepper::Status;
         if (is_any_motor_moving()) {
             return errors::ErrorCode::LID_MOTOR_BUSY;
         }
@@ -784,33 +787,9 @@ class MotorTask {
                     messages::HostCommsMessage(response)));
             return error;
         }
-        switch (get_seal_position()) {
-            case Position::BETWEEN:
-                [[fallthrough]];
-            case Position::UNKNOWN:
-                // Need to extend a small amount, but only if the lid is open.
-                // Opening further with a closed lid might result in damage,
-                // so we skip to the Retract stage in that case.
-                if (get_lid_position(policy) ==
-                    motor_util::LidStepper::Position::CLOSED) {
-                    error = handle_lid_state_enter(
-                        LidState::Status::OPENING_RETRACT_SEAL, policy);
-                } else {
-                    error = handle_lid_state_enter(
-                        LidState::Status::OPENING_PARTIAL_EXTEND_SEAL, policy);
-                }
-                break;
-            case Position::ENGAGED:
-                // Need to retract
-                error = handle_lid_state_enter(
-                    LidState::Status::OPENING_RETRACT_SEAL, policy);
-                break;
-            case Position::RETRACTED:
-                // Can skip moving the seal and just open the lid
-                error = handle_lid_state_enter(
-                    LidState::Status::OPENING_OPEN_HINGE, policy);
-                break;
-        }
+        // Always retract the seal before opening
+        error = handle_lid_state_enter(LidState::Status::OPENING_RETRACT_SEAL,
+                                       policy);
 
         if (error == errors::ErrorCode::NO_ERROR) {
             _state.response_id = response_id;
@@ -834,7 +813,6 @@ class MotorTask {
     template <MotorExecutionPolicy Policy>
     auto start_lid_close(uint32_t response_id, Policy& policy)
         -> errors::ErrorCode {
-        using Position = motor_util::SealStepper::Status;
         if (is_any_motor_moving()) {
             return errors::ErrorCode::LID_MOTOR_BUSY;
         }
@@ -849,25 +827,10 @@ class MotorTask {
                     messages::HostCommsMessage(response)));
             return error;
         }
-        switch (_seal_position) {
-            case Position::BETWEEN:
-                [[fallthrough]];
-            case Position::UNKNOWN:
-                // Need to extend a small amount
-                error = handle_lid_state_enter(
-                    LidState::Status::CLOSING_PARTIAL_EXTEND_SEAL, policy);
-                break;
-            case Position::ENGAGED:
-                // Need to retract
-                error = handle_lid_state_enter(
-                    LidState::Status::CLOSING_RETRACT_SEAL, policy);
-                break;
-            case Position::RETRACTED:
-                // Can skip moving the seal and just close the lid
-                error = handle_lid_state_enter(
-                    LidState::Status::CLOSING_CLOSE_HINGE, policy);
-                break;
-        }
+
+        // Always retract seal before closing
+        error = handle_lid_state_enter(LidState::Status::CLOSING_RETRACT_SEAL,
+                                       policy);
 
         if (error == errors::ErrorCode::NO_ERROR) {
             _state.response_id = response_id;
@@ -999,7 +962,8 @@ class MotorTask {
             case LidState::Status::OPENING_RETRACT_SEAL_BACKOFF:
                 // The seal stepper is extended to back off the limit switch
                 error = start_seal_movement(
-                    SealStepperState::SWITCH_BACKOFF_MICROSTEPS_EXTEND, false, policy);
+                    SealStepperState::SWITCH_BACKOFF_MICROSTEPS_EXTEND, false,
+                    policy);
                 break;
             case LidState::Status::OPENING_OPEN_HINGE:
                 if (!start_lid_hinge_open(INVALID_ID, policy)) {
@@ -1014,7 +978,8 @@ class MotorTask {
             case LidState::Status::CLOSING_RETRACT_SEAL_BACKOFF:
                 // The seal stepper is extended to back off the limit switch
                 error = start_seal_movement(
-                    SealStepperState::SWITCH_BACKOFF_MICROSTEPS_EXTEND, false, policy);
+                    SealStepperState::SWITCH_BACKOFF_MICROSTEPS_EXTEND, false,
+                    policy);
                 break;
             case LidState::Status::CLOSING_CLOSE_HINGE:
                 if (!start_lid_hinge_close(INVALID_ID, policy)) {
@@ -1029,7 +994,8 @@ class MotorTask {
             case LidState::Status::CLOSING_EXTEND_SEAL_BACKOFF:
                 // The seal stepper is extended to back off the limit switch
                 error = start_seal_movement(
-                    SealStepperState::SWITCH_BACKOFF_MICROSTEPS_RETRACT, false, policy);
+                    SealStepperState::SWITCH_BACKOFF_MICROSTEPS_RETRACT, false,
+                    policy);
                 break;
             case LidState::Status::PLATE_LIFTING:
                 // The lid state machine handles everything
@@ -1064,41 +1030,54 @@ class MotorTask {
             case LidState::Status::IDLE:
                 // Do nothing
                 break;
-            case LidState::Status::OPENING_PARTIAL_EXTEND_SEAL:
-                _seal_position = motor_util::SealStepper::Status::BETWEEN;
-                handle_lid_state_enter(LidState::Status::OPENING_RETRACT_SEAL,
-                                       policy);
-                break;
             case LidState::Status::OPENING_RETRACT_SEAL:
+                _seal_position = motor_util::SealStepper::Status::BETWEEN;
+                // Start lid motor movement
+                error = handle_lid_state_enter(
+                    LidState::Status::OPENING_RETRACT_SEAL_BACKOFF, policy);
+                break;
+            case LidState::Status::OPENING_RETRACT_SEAL_BACKOFF:
                 _seal_position = motor_util::SealStepper::Status::RETRACTED;
                 // Start lid motor movement
-                handle_lid_state_enter(LidState::Status::OPENING_OPEN_HINGE,
-                                       policy);
+                error = handle_lid_state_enter(
+                    LidState::Status::OPENING_OPEN_HINGE, policy);
                 break;
             case LidState::Status::OPENING_OPEN_HINGE:
-                handle_lid_state_enter(LidState::Status::IDLE, policy);
-                break;
-            case LidState::Status::CLOSING_PARTIAL_EXTEND_SEAL:
-                _seal_position = motor_util::SealStepper::Status::BETWEEN;
-                handle_lid_state_enter(LidState::Status::CLOSING_RETRACT_SEAL,
-                                       policy);
+                error = handle_lid_state_enter(LidState::Status::IDLE, policy);
                 break;
             case LidState::Status::CLOSING_RETRACT_SEAL:
+                _seal_position = motor_util::SealStepper::Status::BETWEEN;
+                error = handle_lid_state_enter(
+                    LidState::Status::CLOSING_RETRACT_SEAL_BACKOFF, policy);
+                break;
+            case LidState::Status::CLOSING_RETRACT_SEAL_BACKOFF:
                 _seal_position = motor_util::SealStepper::Status::RETRACTED;
-                handle_lid_state_enter(LidState::Status::CLOSING_CLOSE_HINGE,
-                                       policy);
+                // Start lid motor movement
+                error = handle_lid_state_enter(
+                    LidState::Status::CLOSING_CLOSE_HINGE, policy);
                 break;
             case LidState::Status::CLOSING_CLOSE_HINGE:
-                handle_lid_state_enter(LidState::Status::CLOSING_EXTEND_SEAL,
-                                       policy);
+                error = handle_lid_state_enter(
+                    LidState::Status::CLOSING_EXTEND_SEAL, policy);
                 break;
             case LidState::Status::CLOSING_EXTEND_SEAL:
+                _seal_position = motor_util::SealStepper::Status::BETWEEN;
+                error = handle_lid_state_enter(
+                    LidState::Status::CLOSING_EXTEND_SEAL_BACKOFF, policy);
+                break;
+            case LidState::Status::CLOSING_EXTEND_SEAL_BACKOFF:
                 _seal_position = motor_util::SealStepper::Status::ENGAGED;
-                handle_lid_state_enter(LidState::Status::IDLE, policy);
+                // Start lid motor movement
+                error = handle_lid_state_enter(LidState::Status::IDLE, policy);
                 break;
             case LidState::Status::PLATE_LIFTING:
-                handle_lid_state_enter(LidState::Status::IDLE, policy);
+                error = handle_lid_state_enter(LidState::Status::IDLE, policy);
                 break;
+        }
+        if (error != errors::ErrorCode::NO_ERROR) {
+            // Clear the lid status no matter what
+            lid_response_send_and_clear(error);
+            handle_lid_state_enter(LidState::Status::IDLE, policy);
         }
         return error;
     }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_utils.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_utils.hpp
@@ -162,11 +162,13 @@ class SealStepper {
         return clock / static_cast<double>(tstep);
     }
 
-    [[nodiscard]] constexpr static auto inline mm_to_steps(double mm) -> signed long {
+    [[nodiscard]] constexpr static auto inline mm_to_steps(double mm)
+        -> signed long {
         return static_cast<signed long>(microsteps_per_mm * mm);
     }
 
-    [[nodiscard]] constexpr static auto inline steps_to_mm(signed int steps) -> double {
+    [[nodiscard]] constexpr static auto inline steps_to_mm(signed int steps)
+        -> double {
         return static_cast<double>(steps) * mm_per_microstep;
     }
 };

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_utils.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_utils.hpp
@@ -109,6 +109,10 @@ class SealStepper {
 
     // 16MHz external oscillator
     static constexpr const double tmc_external_clock = 16000000;
+    // Ratio of millimeters to microsteps
+    static constexpr const double microsteps_per_mm = 1750000 / 9.043375651;
+    // Ratio of microsteps to millimeters
+    static constexpr const double mm_per_microstep = 9.043375651 / 1750000;
 
     [[nodiscard]] static auto status_to_string(Status status) -> const char* {
         switch (status) {
@@ -156,6 +160,14 @@ class SealStepper {
         // Avoid divide-by-zero issues, bound tstep to at least 1
         tstep = std::max(tstep, static_cast<uint32_t>(1));
         return clock / static_cast<double>(tstep);
+    }
+
+    [[nodiscard]] constexpr static auto inline mm_to_steps(double mm) -> signed long {
+        return static_cast<signed long>(microsteps_per_mm * mm);
+    }
+
+    [[nodiscard]] constexpr static auto inline steps_to_mm(signed int steps) -> double {
+        return static_cast<double>(steps) * mm_per_microstep;
     }
 };
 

--- a/stm32-modules/thermocycler-gen2/firmware/motor_task/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/motor_task/README.md
@@ -1,8 +1,11 @@
 # Motor Task
 
-## Lid state machines
+## Lid Control
 
 ### Overall state machine
+
+The entire lid assembly (seal motor + lid hinge motor) is controlled through a central state machine, which then initiates actions through sub-state machines specific to each motor.
+
 ```mermaid
 graph TD
     A(Idle)
@@ -35,30 +38,29 @@ graph TD
     LiftCheck -->|Yes| LiftRun --> E
 ```
 
-### Seal motor sub-state machine
+### Seal motor
+
+Seal motor position is determined based off of two limit switches, one at the top of retraction and one at the bottom of extension.
+
+On the current PCB revision (Rev 2), there is only one line enabled for the seal motor limit switch. Therefore, the seal motor state machine must make assumptions about which limit switch is being triggered. Additionally, whenever a limit switch is triggered, the seal must then back off of the limit switch so that it is not resting in a triggered position.
+
+Limit switch detection is accomplished with a falling edge interrupt. Before a seal stepper motor movement, the limit switch may be "armed" by the motor task to mark that the next falling edge interrupt should result in a Seal Stepper Complete message. The interrupt is disarmed once it has been triggered once, and must be armed again before the next movement that needs to trigger a limit switch.
+
 ```mermaid
 graph TD
-    Start1[Extend seal]
-    OpenFull1(Open full distance)
-    RetractFull1(Retract until stall)
-    Done1[Done]
-    
-    Start1 ----->|Seal is extended| Done1
-    Start1 ---->|Seal is homed| OpenFull1
-    Start1 -->|Seal position unknown| RetractFull1
-    RetractFull1 ---> OpenFull1
-    OpenFull1 --> Done1
+    EStart[Extend Seal Action]
+    EArm(Arm limit switch)
+    EExtend(Extend to limit switch)
+    ERetract(Retract off of limit switch)
+    Done[Done]
+    RStart[Retract Seal Action]
+    RArm(Arm limit switch)
+    RRetract(Retract to limit switch)
+    RExtend(Extend off of limit switch)
 
-    Start2[Retract Seal]
-    RetractFull2(Retract until stall)
-    OpenSome2(Open a few mm)
-    Done2[Done]
+    EStart --> EArm --> EExtend -->ERetract --> Done
+    RStart --> RArm --> RRetract --> RExtend --> Done
 
-    Start2 -->|Seal position unknown| OpenSome2
-    Start2 ---->|Seal is extended| RetractFull2
-    Start2 -->|Seal is homed| Done2
-    OpenSome2 --> RetractFull2
-    RetractFull2 --> Done2
 ```
 
 ### Hinge motor sub-state machine

--- a/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_hardware.c
@@ -4,6 +4,7 @@
  */
 #include "firmware/motor_hardware.h"
 
+#include <stdatomic.h>
 #include <string.h>  // for memset
 #include <stdlib.h> // for abs
 
@@ -119,7 +120,7 @@ typedef struct seal_hardware_struct {
     bool direction;
     // Bool check for whether the next switch interrupt
     // should trigger a callback
-    bool limit_switch_armed;
+    atomic_bool limit_switch_armed;
     // Timer handle for the seal stepper
     TIM_HandleTypeDef timer;
 } seal_hardware_t;
@@ -158,7 +159,7 @@ static motor_hardware_t _motor_hardware = {
         .enabled = false,
         .moving = false,
         .direction = false,
-        .limit_switch_armed = false,
+        .limit_switch_armed = ATOMIC_VAR_INIT(false),
         .timer = {0}
     }
 };

--- a/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_policy.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_policy.cpp
@@ -89,3 +89,13 @@ auto MotorPolicy::tmc2130_step_pulse() -> bool {
     motor_hardware_seal_step_pulse();
     return true;
 }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto MotorPolicy::seal_switch_set_armed() -> void {
+    motor_hardware_seal_switch_set_armed();
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto MotorPolicy::seal_switch_set_disarmed() -> void {
+    motor_hardware_seal_switch_set_disarmed();
+}

--- a/stm32-modules/thermocycler-gen2/firmware/system/stm32g4xx_it.c
+++ b/stm32-modules/thermocycler-gen2/firmware/system/stm32g4xx_it.c
@@ -134,6 +134,7 @@ void TIM7_IRQHandler(void)
 void EXTI9_5_IRQHandler(void)
 {
     thermal_adc_ready_callback(ADC1_ITR);
+    motor_hardware_seal_switch_interrupt();
 }
 
 /**

--- a/stm32-modules/thermocycler-gen2/simulator/motor_thread.cpp
+++ b/stm32-modules/thermocycler-gen2/simulator/motor_thread.cpp
@@ -58,6 +58,10 @@ class SimMotorPolicy : public SimTMC2130Policy {
 
     auto seal_stepper_stop() -> void { _seal_moving = false; }
 
+    auto seal_switch_set_armed() -> void { _seal_switch_armed = true; }
+
+    auto seal_switch_set_disarmed() -> void { _seal_switch_armed = false; }
+
     // For simulation
     auto tick() -> void {
         if (_seal_moving) {
@@ -76,6 +80,7 @@ class SimMotorPolicy : public SimTMC2130Policy {
     bool _lid_closed_switch = false;
     bool _seal_moving = false;
     bool _lid_overdrive = false;
+    bool _seal_switch_armed = false;
     Callback _callback;
 };
 

--- a/stm32-modules/thermocycler-gen2/src/errors.cpp
+++ b/stm32-modules/thermocycler-gen2/src/errors.cpp
@@ -80,6 +80,8 @@ const char* const SEAL_MOTOR_BUSY = "EERR504:seal:Seal motor busy\n";
 const char* const SEAL_MOTOR_FAULT = "ERR505:seal:Seal motor fault\n";
 const char* const SEAL_MOTOR_STALL = "ERR5006:seal:Seal motor stall event\n";
 const char* const LID_CLOSED = "ERR507:lid:Lid must be opened\n";
+const char* const SEAL_MOTOR_SWITCH =
+    "ERR508:seal:Seal switch should not be engaged\n";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
@@ -137,6 +139,7 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(SEAL_MOTOR_FAULT);
         HANDLE_CASE(SEAL_MOTOR_STALL);
         HANDLE_CASE(LID_CLOSED);
+        HANDLE_CASE(SEAL_MOTOR_SWITCH);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
@@ -413,9 +413,8 @@ SCENARIO("motor task message passing") {
                 messages::OpenLidMessage{.id = 123});
             tasks->run_motor_task();
             THEN("the lid starts opening") {
-                REQUIRE(
-                    motor_task.get_lid_state() ==
-                    motor_task::LidState::Status::OPENING_PARTIAL_EXTEND_SEAL);
+                REQUIRE(motor_task.get_lid_state() ==
+                        motor_task::LidState::Status::OPENING_RETRACT_SEAL);
             }
             AND_WHEN("sending another OpenLid command immediately") {
                 tasks->get_motor_queue().backing_deque.push_back(
@@ -438,9 +437,8 @@ SCENARIO("motor task message passing") {
                 messages::CloseLidMessage{.id = 123});
             tasks->run_motor_task();
             THEN("the lid starts moving to the endstop") {
-                REQUIRE(
-                    motor_task.get_lid_state() ==
-                    motor_task::LidState::Status::CLOSING_PARTIAL_EXTEND_SEAL);
+                REQUIRE(motor_task.get_lid_state() ==
+                        motor_task::LidState::Status::CLOSING_RETRACT_SEAL);
             }
             AND_WHEN("sending another CloseLid command immediately") {
                 tasks->get_motor_queue().backing_deque.push_back(
@@ -463,9 +461,8 @@ SCENARIO("motor task message passing") {
                 messages::FrontButtonPressMessage());
             tasks->run_motor_task();
             THEN("the lid starts to open") {
-                REQUIRE(
-                    motor_task.get_lid_state() ==
-                    motor_task::LidState::Status::OPENING_PARTIAL_EXTEND_SEAL);
+                REQUIRE(motor_task.get_lid_state() ==
+                        motor_task::LidState::Status::OPENING_RETRACT_SEAL);
             }
         }
         GIVEN("lid closed sensor triggered") {
@@ -509,8 +506,7 @@ SCENARIO("motor task message passing") {
                 tasks->run_motor_task();
                 THEN("the lid starts to close") {
                     REQUIRE(motor_task.get_lid_state() ==
-                            motor_task::LidState::Status::
-                                CLOSING_PARTIAL_EXTEND_SEAL);
+                            motor_task::LidState::Status::CLOSING_RETRACT_SEAL);
                 }
             }
             WHEN("sending a GetLidSwitches message") {
@@ -536,363 +532,340 @@ SCENARIO("motor task message passing") {
     }
 }
 
-SCENARIO("motor task open and close lid behavior") {
-    auto tasks = TaskBuilder::build();
+struct MotorStep {
+    // Message to send on this step
+    messages::MotorMessage msg;
+    // If true, expect that the lid angle increased after this message
+    bool lid_angle_increased = false;
+    // If true, expect that the lid angle decreased after this message
+    bool lid_angle_decreased = false;
+    // If the lid moved (increase or decrease), check that the limit switches
+    // are either ignored or checked
+    bool lid_overdrive = false;
+    // Expected seal motor state
+    bool seal_on = false;
+    // Retraction is true, extension is false
+    bool seal_direction = false;
+    // If true, seal switch should be armed. If nullopt, doesn't matter.
+    std::optional<bool> seal_switch_armed = std::nullopt;
+
+    using SealPos = motor_util::SealStepper::Status;
+    // If this variable is set, expect seal in a specific position
+    std::optional<SealPos> seal_pos = std::nullopt;
+    // If true, expect an ack in the host comms task
+    std::optional<messages::AcknowledgePrevious> ack = std::nullopt;
+};
+
+/**
+ * @brief Executes a set of steps to exercise the lid motor state machine.
+ *
+ * @pre The state of any switches should be set \e before invoking this
+ */
+void test_motor_state_machine(std::shared_ptr<TaskBuilder> tasks,
+                              std::vector<MotorStep> &steps) {
     auto &motor_task = tasks->get_motor_task();
     auto &motor_policy = tasks->get_motor_policy();
     auto &motor_queue = tasks->get_motor_queue();
-    GIVEN("lid closed on startup") {
+    for (size_t i = 0; i < steps.size(); ++i) {
+        auto &step = steps[i];
+
+        auto lid_angle_before = motor_policy.get_angle();
+        motor_queue.backing_deque.push_back(step.msg);
+        tasks->run_motor_task();
+
+        DYNAMIC_SECTION("Step " << i) {
+            if (step.lid_angle_increased) {
+                THEN("the lid motor opened") {
+                    REQUIRE(motor_policy.get_angle() > lid_angle_before);
+                }
+            }
+            if (step.lid_angle_decreased) {
+                THEN("the lid motor closed") {
+                    REQUIRE(motor_policy.get_angle() < lid_angle_before);
+                }
+            }
+            THEN("the seal is controlled correctly") {
+                REQUIRE(motor_policy.seal_moving() == step.seal_on);
+                if (step.seal_on) {
+                    REQUIRE(motor_policy.get_tmc2130_direction() ==
+                            step.seal_direction);
+                }
+            }
+            if (step.seal_pos.has_value()) {
+                THEN("the seal position is set correctly") {
+                    REQUIRE(motor_task.get_seal_position() ==
+                            step.seal_pos.value());
+                }
+            }
+            if (step.ack.has_value()) {
+                THEN("an ack is sent to host comms") {
+                    auto ack = step.ack.value();
+                    REQUIRE(tasks->get_host_comms_queue().has_message());
+                    auto msg =
+                        tasks->get_host_comms_queue().backing_deque.front();
+                    REQUIRE(
+                        std::holds_alternative<messages::AcknowledgePrevious>(
+                            msg));
+                    auto response =
+                        std::get<messages::AcknowledgePrevious>(msg);
+                    REQUIRE(response.responding_to_id == ack.responding_to_id);
+                    REQUIRE(response.with_error == ack.with_error);
+                }
+            }
+        }
+    }
+}
+
+SCENARIO("motor task lid state machine") {
+    auto tasks = TaskBuilder::build();
+    auto &motor_policy = tasks->get_motor_policy();
+    GIVEN("lid is closed on startup") {
         motor_policy.set_lid_closed_switch(true);
         motor_policy.set_lid_open_switch(false);
         WHEN("sending open lid command") {
-            motor_queue.backing_deque.push_back(
-                messages::OpenLidMessage{.id = 123});
-            tasks->run_motor_task();
-            THEN("the seal starts retracting") {
-                REQUIRE(motor_policy.seal_moving());
-                REQUIRE(
-                    motor_policy
-                        .get_tmc2130_direction());  // Retracting is positive
-            }
-            auto lid_position = motor_policy.get_angle();
-            WHEN("seal movement ends with a stall") {
-                motor_queue.backing_deque.push_back(
-                    messages::SealStepperComplete{
-                        .reason = messages::SealStepperComplete::
-                            CompletionReason::STALL});
-                tasks->run_motor_task();
-                THEN("the seal stops moving") {
-                    REQUIRE(!motor_policy.seal_moving());
-                }
-                THEN("the seal is in the Retracted position") {
-                    REQUIRE(motor_task.get_seal_position() ==
-                            motor_util::SealStepper::Status::RETRACTED);
-                }
-                THEN("the lid starts opening") {
-                    REQUIRE(motor_policy.get_angle() > lid_position);
-                }
-                WHEN("lid movement completes") {
-                    motor_queue.backing_deque.push_back(
-                        messages::LidStepperComplete());
-                    lid_position = motor_policy.get_angle();
-                    tasks->run_motor_task();
-                    THEN("the lid overdrives into the switch a bit") {
-                        REQUIRE(motor_policy.get_angle() > lid_position);
-                        REQUIRE(motor_policy.get_lid_overdrive());
-                    }
-                    WHEN("the lid movement completes") {
-                        motor_queue.backing_deque.push_back(
-                            messages::LidStepperComplete());
-                        tasks->run_motor_task();
-                        THEN("the command is acknowledged") {
-                            REQUIRE(
-                                tasks->get_host_comms_queue().has_message());
-                            auto msg = tasks->get_host_comms_queue()
-                                           .backing_deque.front();
-                            REQUIRE(std::holds_alternative<
-                                    messages::AcknowledgePrevious>(msg));
-                            auto response =
-                                std::get<messages::AcknowledgePrevious>(msg);
-                            REQUIRE(response.responding_to_id == 123);
-                            REQUIRE(response.with_error ==
-                                    errors::ErrorCode::NO_ERROR);
-                        }
-                    }
-                }
-            }
+            std::vector<MotorStep> steps = {
+                // First step retracts seal switch
+                {.msg = messages::OpenLidMessage{.id = 123},
+                 .seal_on = true,
+                 .seal_direction = true,
+                 .seal_switch_armed = true},
+                // Second step extends seeal switch
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::LIMIT},
+                 .seal_on = true,
+                 .seal_direction = false,
+                 .seal_switch_armed = false},
+                // Third step opens hinge
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::DONE},
+                 .lid_angle_increased = true,
+                 .lid_overdrive = false},
+                // Fourth step overdrives hinge
+                {.msg = messages::LidStepperComplete(),
+                 .lid_angle_increased = true,
+                 .lid_overdrive = true},
+                // Should send ACK now
+                {.msg = messages::LidStepperComplete(),
+                 .ack =
+                     messages::AcknowledgePrevious{
+                         .responding_to_id = 123,
+                         .with_error = errors::ErrorCode::NO_ERROR}},
+            };
+            test_motor_state_machine(tasks, steps);
         }
-        WHEN("sending a lid close command") {
-            motor_queue.backing_deque.push_back(
-                messages::CloseLidMessage{.id = 456});
-            tasks->run_motor_task();
-            THEN("the message is immediately acked") {
-                REQUIRE(tasks->get_host_comms_queue().has_message());
-                auto msg = tasks->get_host_comms_queue().backing_deque.front();
-                REQUIRE(
-                    std::holds_alternative<messages::AcknowledgePrevious>(msg));
-                auto response = std::get<messages::AcknowledgePrevious>(msg);
-                REQUIRE(response.responding_to_id == 456);
-                REQUIRE(response.with_error == errors::ErrorCode::NO_ERROR);
-            }
+        WHEN("sending close lid command") {
+            std::vector<MotorStep> steps = {
+                // Command should end immediately
+                {.msg = messages::CloseLidMessage{.id = 123},
+                 .ack = messages::AcknowledgePrevious{
+                     .responding_to_id = 123,
+                     .with_error = errors::ErrorCode::NO_ERROR}}};
+            test_motor_state_machine(tasks, steps);
         }
-    }
-    GIVEN("lid unknown at startup") {
-        motor_policy.set_lid_closed_switch(false);
-        motor_policy.set_lid_open_switch(false);
-        REQUIRE(motor_task.get_seal_position() ==
-                motor_util::SealStepper::Status::UNKNOWN);
         WHEN("sending plate lift command") {
-            motor_queue.backing_deque.push_back(
-                messages::PlateLiftMessage{.id = 123});
-            tasks->run_motor_task();
-            THEN("an error is returned") {
-                REQUIRE(tasks->get_host_comms_queue().has_message());
-                auto msg = tasks->get_host_comms_queue().backing_deque.front();
-                REQUIRE(
-                    std::holds_alternative<messages::AcknowledgePrevious>(msg));
-                auto response = std::get<messages::AcknowledgePrevious>(msg);
-                REQUIRE(response.responding_to_id == 123);
-                REQUIRE(response.with_error == errors::ErrorCode::LID_CLOSED);
-            }
-            THEN("no movement occurs") {
-                REQUIRE(motor_task.get_lid_state() ==
-                        motor_task::LidState::Status::IDLE);
-            }
-        }
-        WHEN("sending open lid command") {
-            motor_queue.backing_deque.push_back(
-                messages::OpenLidMessage{.id = 123});
-            tasks->run_motor_task();
-            THEN("the seal starts to extend") {
-                REQUIRE(motor_policy.seal_moving());
-                REQUIRE(
-                    !motor_policy
-                         .get_tmc2130_direction());  // Retracting is positive
-            }
-            WHEN("seal movement ends without a stall") {
-                motor_queue.backing_deque.push_back(
-                    messages::SealStepperComplete());
-                tasks->run_motor_task();
-                THEN("the seal starts retracting") {
-                    REQUIRE(motor_policy.seal_moving());
-                    REQUIRE(
-                        motor_policy.get_tmc2130_direction());  // Retracting is
-                                                                // positive
-                }
-                auto lid_position = motor_policy.get_angle();
-                WHEN("seal movement ends with a stall") {
-                    motor_queue.backing_deque.push_back(
-                        messages::SealStepperComplete{
-                            .reason = messages::SealStepperComplete::
-                                CompletionReason::STALL});
-                    tasks->run_motor_task();
-                    THEN("the seal stops moving") {
-                        REQUIRE(!motor_policy.seal_moving());
-                    }
-                    THEN("the seal is in the Retracted position") {
-                        REQUIRE(motor_task.get_seal_position() ==
-                                motor_util::SealStepper::Status::RETRACTED);
-                    }
-                    THEN("the lid starts opening") {
-                        REQUIRE(motor_policy.get_angle() > lid_position);
-                    }
-                    WHEN("lid movement completes") {
-                        motor_queue.backing_deque.push_back(
-                            messages::LidStepperComplete());
-                        lid_position = motor_policy.get_angle();
-                        tasks->run_motor_task();
-                        THEN("the lid overdrives into the switch a bit") {
-                            REQUIRE(motor_policy.get_angle() > lid_position);
-                            REQUIRE(motor_policy.get_lid_overdrive());
-                        }
-                        WHEN("the lid movement completes") {
-                            motor_queue.backing_deque.push_back(
-                                messages::LidStepperComplete());
-                            tasks->run_motor_task();
-                            THEN("the command is acknowledged") {
-                                REQUIRE(tasks->get_host_comms_queue()
-                                            .has_message());
-                                auto msg = tasks->get_host_comms_queue()
-                                               .backing_deque.front();
-                                REQUIRE(std::holds_alternative<
-                                        messages::AcknowledgePrevious>(msg));
-                                auto response =
-                                    std::get<messages::AcknowledgePrevious>(
-                                        msg);
-                                REQUIRE(response.responding_to_id == 123);
-                                REQUIRE(response.with_error ==
-                                        errors::ErrorCode::NO_ERROR);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        WHEN("sending a lid close command") {
-            motor_queue.backing_deque.push_back(
-                messages::CloseLidMessage{.id = 456});
-            tasks->run_motor_task();
-
-            THEN("the seal starts to extend") {
-                REQUIRE(motor_policy.seal_moving());
-                REQUIRE(
-                    !motor_policy
-                         .get_tmc2130_direction());  // Retracting is positive
-            }
-            WHEN("seal movement ends without a stall") {
-                motor_queue.backing_deque.push_back(
-                    messages::SealStepperComplete());
-                tasks->run_motor_task();
-                THEN("the seal starts retracting") {
-                    REQUIRE(motor_policy.seal_moving());
-                    REQUIRE(
-                        motor_policy.get_tmc2130_direction());  // Retracting is
-                                                                // positive
-                }
-                auto lid_position = motor_policy.get_angle();
-                WHEN("seal movement ends with a stall") {
-                    motor_queue.backing_deque.push_back(
-                        messages::SealStepperComplete{
-                            .reason = messages::SealStepperComplete::
-                                CompletionReason::STALL});
-                    tasks->run_motor_task();
-                    THEN("the seal stops moving") {
-                        REQUIRE(!motor_policy.seal_moving());
-                    }
-                    THEN("the seal is in the Retracted position") {
-                        REQUIRE(motor_task.get_seal_position() ==
-                                motor_util::SealStepper::Status::RETRACTED);
-                    }
-                    THEN("the lid starts closing") {
-                        REQUIRE(motor_policy.get_angle() < lid_position);
-                    }
-                    WHEN("lid movement completes") {
-                        motor_queue.backing_deque.push_back(
-                            messages::LidStepperComplete());
-                        lid_position = motor_policy.get_angle();
-                        tasks->run_motor_task();
-                        THEN("the lid overdrives into the switch") {
-                            REQUIRE(motor_policy.get_angle() < lid_position);
-                            REQUIRE(motor_policy.get_lid_overdrive());
-                        }
-                        WHEN("the lid movement completes") {
-                            motor_queue.backing_deque.push_back(
-                                messages::LidStepperComplete());
-                            tasks->run_motor_task();
-                            THEN("the seal is engaged") {
-                                REQUIRE(motor_policy.seal_moving());
-                                REQUIRE(
-                                    !motor_policy
-                                         .get_tmc2130_direction());  // Retracting
-                                                                     // is
-                                                                     // positive
-                            }
-                            AND_WHEN("the seal movement ends") {
-                                motor_queue.backing_deque.push_back(
-                                    messages::SealStepperComplete());
-                                tasks->run_motor_task();
-                                REQUIRE(
-                                    motor_task.get_seal_position() ==
-                                    motor_util::SealStepper::Status::ENGAGED);
-                                THEN("the command is acknowledged") {
-                                    REQUIRE(tasks->get_host_comms_queue()
-                                                .has_message());
-                                    auto msg = tasks->get_host_comms_queue()
-                                                   .backing_deque.front();
-                                    REQUIRE(std::holds_alternative<
-                                            messages::AcknowledgePrevious>(
-                                        msg));
-                                    auto response =
-                                        std::get<messages::AcknowledgePrevious>(
-                                            msg);
-                                    REQUIRE(response.responding_to_id == 456);
-                                    REQUIRE(response.with_error ==
-                                            errors::ErrorCode::NO_ERROR);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            std::vector<MotorStep> steps = {
+                // Command should end with error
+                {.msg = messages::PlateLiftMessage{.id = 123},
+                 .ack = messages::AcknowledgePrevious{
+                     .responding_to_id = 123,
+                     .with_error = errors::ErrorCode::LID_CLOSED}}};
+            test_motor_state_machine(tasks, steps);
         }
     }
-    GIVEN("lid open on startup") {
+    GIVEN("lid is open on startup") {
         motor_policy.set_lid_closed_switch(false);
         motor_policy.set_lid_open_switch(true);
         WHEN("sending open lid command") {
-            motor_queue.backing_deque.push_back(
-                messages::OpenLidMessage{.id = 123});
-            tasks->run_motor_task();
-            THEN("an ACK is returned") {
-                REQUIRE(tasks->get_host_comms_queue().has_message());
-                auto msg = tasks->get_host_comms_queue().backing_deque.front();
-                REQUIRE(
-                    std::holds_alternative<messages::AcknowledgePrevious>(msg));
-                auto response = std::get<messages::AcknowledgePrevious>(msg);
-                REQUIRE(response.responding_to_id == 123);
-                REQUIRE(response.with_error == errors::ErrorCode::NO_ERROR);
-            }
-            THEN("no movement occurs") {
-                REQUIRE(motor_task.get_lid_state() ==
-                        motor_task::LidState::Status::IDLE);
-            }
+            std::vector<MotorStep> steps = {
+                // No action
+                {.msg = messages::OpenLidMessage{.id = 123},
+                 .ack =
+                     messages::AcknowledgePrevious{
+                         .responding_to_id = 123,
+                         .with_error = errors::ErrorCode::NO_ERROR}},
+            };
+            test_motor_state_machine(tasks, steps);
+        }
+        WHEN("sending close lid command") {
+            std::vector<MotorStep> steps = {
+                // First step retracts seal to switch
+                {.msg = messages::CloseLidMessage{.id = 123},
+                 .seal_on = true,
+                 .seal_direction = true,
+                 .seal_switch_armed = true},
+                // Second step extends seal from switch
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::LIMIT},
+                 .seal_on = true,
+                 .seal_direction = false,
+                 .seal_switch_armed = false},
+                // Third step closes hinge
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::DONE},
+                 .lid_angle_decreased = true,
+                 .lid_overdrive = false},
+                // Fourth step overdrives hinge
+                {.msg = messages::LidStepperComplete(),
+                 .lid_angle_decreased = true,
+                 .lid_overdrive = true},
+                // Now extend seal to switch
+                {.msg = messages::LidStepperComplete(),
+                 .seal_on = true,
+                 .seal_direction = false,
+                 .seal_switch_armed = true},
+                // Retract seal from switch
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::LIMIT},
+                 .seal_on = true,
+                 .seal_direction = true,
+                 .seal_switch_armed = false},
+                // Should send ACK now
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::DONE},
+                 .ack =
+                     messages::AcknowledgePrevious{
+                         .responding_to_id = 123,
+                         .with_error = errors::ErrorCode::NO_ERROR}},
+            };
+            test_motor_state_machine(tasks, steps);
         }
         WHEN("sending plate lift command") {
-            motor_queue.backing_deque.push_back(
-                messages::PlateLiftMessage{.id = 123});
-            auto lid_angle = motor_policy.get_angle();
-            tasks->run_motor_task();
-            THEN("the lid opens further") {
-                REQUIRE(motor_policy.get_angle() > lid_angle);
-                REQUIRE(motor_policy.get_lid_overdrive());
-                REQUIRE(motor_task.get_lid_state() ==
-                        motor_task::LidState::Status::PLATE_LIFTING);
-                AND_WHEN("the lid movement ends") {
-                    motor_queue.backing_deque.push_back(
-                        messages::LidStepperComplete());
-                    tasks->run_motor_task();
-                    THEN("the lid moves back down past the switch") {
-                        // Compare to the ORIGINAL angle
-                        REQUIRE(motor_policy.get_angle() < lid_angle);
-                        REQUIRE(motor_policy.get_lid_overdrive());
-                        AND_WHEN("the lid movement ends") {
-                            motor_queue.backing_deque.push_back(
-                                messages::LidStepperComplete());
-                            tasks->run_motor_task();
-                            THEN("the lid moves back to the switch") {
-                                // Compare to the ORIGINAL angle
-                                REQUIRE(motor_policy.get_angle() > lid_angle);
-                                REQUIRE(!motor_policy.get_lid_overdrive());
-                                lid_angle = motor_policy.get_angle();
-                                AND_WHEN("the lid movement ends") {
-                                    motor_queue.backing_deque.push_back(
-                                        messages::LidStepperComplete());
-                                    tasks->run_motor_task();
-                                    THEN("the lid overdrives into the switch") {
-                                        REQUIRE(motor_policy.get_angle() >
-                                                lid_angle);
-                                        REQUIRE(
-                                            motor_policy.get_lid_overdrive());
-                                        AND_WHEN("the final lid motion ends") {
-                                            motor_queue.backing_deque.push_back(
-                                                messages::LidStepperComplete());
-                                            tasks->run_motor_task();
-                                            THEN("an ACK is sent") {
-                                                REQUIRE(motor_task
-                                                            .get_lid_state() ==
-                                                        motor_task::LidState::
-                                                            Status::IDLE);
-                                                REQUIRE(
-                                                    tasks
-                                                        ->get_host_comms_queue()
-                                                        .has_message());
-                                                auto msg =
-                                                    tasks
-                                                        ->get_host_comms_queue()
-                                                        .backing_deque.front();
-                                                REQUIRE(std::holds_alternative<
-                                                        messages::
-                                                            AcknowledgePrevious>(
-                                                    msg));
-                                                auto response = std::get<
-                                                    messages::
-                                                        AcknowledgePrevious>(
-                                                    msg);
-                                                REQUIRE(
-                                                    response.responding_to_id ==
-                                                    123);
-                                                REQUIRE(response.with_error ==
-                                                        errors::ErrorCode::
-                                                            NO_ERROR);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            std::vector<MotorStep> steps = {
+                // First open past the switch
+                {.msg = messages::PlateLiftMessage{.id = 123},
+                 .lid_angle_increased = true,
+                 .lid_overdrive = true},
+                // Now close back below the switch
+                {.msg = messages::LidStepperComplete(),
+                 .lid_angle_decreased = true,
+                 .lid_overdrive = true},
+                // Now open back to the switch
+                {.msg = messages::LidStepperComplete(),
+                 .lid_angle_increased = true,
+                 .lid_overdrive = false},
+                // Now overdrive into the switch
+                {.msg = messages::LidStepperComplete(),
+                 .lid_angle_increased = true,
+                 .lid_overdrive = true},
+                // Should send ACK now
+                {.msg = messages::LidStepperComplete(),
+                 .ack =
+                     messages::AcknowledgePrevious{
+                         .responding_to_id = 123,
+                         .with_error = errors::ErrorCode::NO_ERROR}},
+            };
+            test_motor_state_machine(tasks, steps);
+        }
+    }
+    GIVEN("lid is unknown at startup") {
+        motor_policy.set_lid_closed_switch(false);
+        motor_policy.set_lid_open_switch(false);
+        WHEN("sending open lid command") {
+            std::vector<MotorStep> steps = {
+                // First step retracts seal switch
+                {.msg = messages::OpenLidMessage{.id = 123},
+                 .seal_on = true,
+                 .seal_direction = true,
+                 .seal_switch_armed = true},
+                // Second step extends seeal switch
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::LIMIT},
+                 .seal_on = true,
+                 .seal_direction = false,
+                 .seal_switch_armed = false},
+                // Third step opens hinge
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::DONE},
+                 .lid_angle_increased = true,
+                 .lid_overdrive = false},
+                // Fourth step overdrives hinge
+                {.msg = messages::LidStepperComplete(),
+                 .lid_angle_increased = true,
+                 .lid_overdrive = true},
+                // Should send ACK now
+                {.msg = messages::LidStepperComplete(),
+                 .ack =
+                     messages::AcknowledgePrevious{
+                         .responding_to_id = 123,
+                         .with_error = errors::ErrorCode::NO_ERROR}},
+            };
+            test_motor_state_machine(tasks, steps);
+        }
+        WHEN("sending close lid command") {
+            std::vector<MotorStep> steps = {
+                // First step retracts seal to switch
+                {.msg = messages::CloseLidMessage{.id = 123},
+                 .seal_on = true,
+                 .seal_direction = true,
+                 .seal_switch_armed = true},
+                // Second step extends seal from switch
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::LIMIT},
+                 .seal_on = true,
+                 .seal_direction = false,
+                 .seal_switch_armed = false},
+                // Third step closes hinge
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::DONE},
+                 .lid_angle_decreased = true,
+                 .lid_overdrive = false},
+                // Fourth step overdrives hinge
+                {.msg = messages::LidStepperComplete(),
+                 .lid_angle_decreased = true,
+                 .lid_overdrive = true},
+                // Now extend seal to switch
+                {.msg = messages::LidStepperComplete(),
+                 .seal_on = true,
+                 .seal_direction = false,
+                 .seal_switch_armed = true},
+                // Retract seal from switch
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::LIMIT},
+                 .seal_on = true,
+                 .seal_direction = true,
+                 .seal_switch_armed = false},
+                // Should send ACK now
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::DONE},
+                 .ack =
+                     messages::AcknowledgePrevious{
+                         .responding_to_id = 123,
+                         .with_error = errors::ErrorCode::NO_ERROR}},
+            };
+            test_motor_state_machine(tasks, steps);
+        }
+        WHEN("sending plate lift command") {
+            std::vector<MotorStep> steps = {
+                // Command should end with error
+                {.msg = messages::PlateLiftMessage{.id = 123},
+                 .ack = messages::AcknowledgePrevious{
+                     .responding_to_id = 123,
+                     .with_error = errors::ErrorCode::LID_CLOSED}}};
+            test_motor_state_machine(tasks, steps);
         }
     }
 }

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_utils.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_utils.cpp
@@ -111,6 +111,25 @@ SCENARIO("seal status stringification works") {
     }
 }
 
+SCENARIO("seal stepper microstep conversion works") {
+    GIVEN("a distance in mm") {
+        double mm = 9.043375651;
+        WHEN("converting to steps") {
+            auto result = SealStepper::mm_to_steps(steps);
+            THEN("the result is as expected") {
+                signed int expected = 1750000;
+                REQUIRE(result == expected);
+            }
+            AND_WHEN("backconverting") {
+                auto backconvert = SealStepper::steps_to_mm(result);
+                THEN("the conversion matches") {
+                    REQUIRE_THAT(backconvert, Catch::Matchers::WithinAbs(mm, 0.0001));
+                }
+            }
+        }
+    }
+}
+
 SCENARIO("MovementProfile functionality with flat acceleration") {
     GIVEN("a movement profile with a 1Hz interrupt") {
         constexpr int frequency = 1;

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_utils.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_utils.cpp
@@ -115,15 +115,16 @@ SCENARIO("seal stepper microstep conversion works") {
     GIVEN("a distance in mm") {
         double mm = 9.043375651;
         WHEN("converting to steps") {
-            auto result = SealStepper::mm_to_steps(steps);
+            auto steps = SealStepper::mm_to_steps(mm);
             THEN("the result is as expected") {
                 signed int expected = 1750000;
-                REQUIRE(result == expected);
+                REQUIRE(steps == expected);
             }
             AND_WHEN("backconverting") {
-                auto backconvert = SealStepper::steps_to_mm(result);
+                auto backconvert = SealStepper::steps_to_mm(steps);
                 THEN("the conversion matches") {
-                    REQUIRE_THAT(backconvert, Catch::Matchers::WithinAbs(mm, 0.0001));
+                    REQUIRE_THAT(backconvert,
+                                 Catch::Matchers::WithinAbs(mm, 0.0001));
                 }
             }
         }


### PR DESCRIPTION
### Summary

Adds support for limit switches for the seal motor. The two limit switches share a single falling edge interrupt due to PCB design. See `stm32-modules/thermocycler-gen2/firmware/motor_task/README.md` for more information on the scheme used.

- Added code to activate the correct input line as a falling interrupt and send a message to the motor task when the switch is triggered
- Modified the lid state machine to base movements off of the limit switches. When retracting or extending, the seal moves until one of the switches triggers, and then backs off by 0.5mm to leave the switch open while idle.
- Updated motor task tests to use a vector of conditions for each step in the lid state machine in order to simplify the tests

Tested that the seal switch interrupt works correctly and terminates seal movements, but without the correct switches I had to short the line to ground manually to test this. Was able to dry run the lid state machine stuff this way, but I am waiting on a unit to arrive in order to test with the actual mechanical assembly. A later PR will adjust the distances if necessary.