### PR TITLE
chore(thermocycler-gen2): use gen1 PID and VID for EVT

### DIFF
--- a/stm32-modules/thermocycler-gen2/firmware/host_comms_task/usbd_desc.c
+++ b/stm32-modules/thermocycler-gen2/firmware/host_comms_task/usbd_desc.c
@@ -27,7 +27,7 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 // TODO(frank 05-06-2022): Uncomment these VID/PID definitions and replace
-// the temporary values that replicate the Gen1 thermocycler
+// the temporary values that replicate the Gen1 thermocycler.
 //#define USBD_VID                      0x04D8
 //#define USBD_PID                      0xed8c
 #define USBD_VID                      0x04D8  /* same as Gen1 TC */

--- a/stm32-modules/thermocycler-gen2/firmware/host_comms_task/usbd_desc.c
+++ b/stm32-modules/thermocycler-gen2/firmware/host_comms_task/usbd_desc.c
@@ -26,8 +26,12 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-#define USBD_VID                      0x04D8
-#define USBD_PID                      0xed8c
+// TODO(frank 05-06-2022): Uncomment these VID/PID definitions and replace
+// the temporary values that replicate the Gen1 thermocycler
+//#define USBD_VID                      0x04D8
+//#define USBD_PID                      0xed8c
+#define USBD_VID                      0x04D8  /* same as Gen1 TC */
+#define USBD_PID                      0xED8C  /* same as Gen1 TC */
 #define USBD_LANGID_STRING            0x0409  /* Replace '0xbbb' with your device language ID */
 #define USBD_MANUFACTURER_STRING      "Opentrons" /* Add your manufacturer string */
 #define USBD_PRODUCT_HS_STRING        "Thermocycler HS" /* Add your product High Speed string */


### PR DESCRIPTION
Updating the robot to recognize the Gen2 USB PID/VID will include a buildroot update. For now we will use the the values from the Gen1 board so a buildroot update won't be required for EVT testing. Once the buildroot changes are applied + tested + rolled out, the values can revert to the Gen2 ones.

Verified that the PID/VID is updated as expected in firmware and seen by the host computer.