### PR TITLE
chore(thermocycler-gen2): Fixed cmake lint settings

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -58,6 +58,9 @@ class PlateControl {
     static constexpr double HEATSINK_SAFETY_THRESHOLD_WARM = 70.0F;
     /** Fan power when under safety threshold in warm/hot zone.*/
     static constexpr double FAN_POWER_UNDER_WARM_THRESHOLD = 0.15F;
+    /** When controlling to a warm temperature, scale fans to try to keep the
+     *  heatsink at (setpoint - 2º).*/
+    static constexpr double FAN_TARGET_DIFF_WARM = -2.0F;
     /** Min & max power settings when holding at a warm temp.*/
     static constexpr std::pair<double, double> FAN_POWER_LIMITS_WARM{0.35,
                                                                      0.55};

--- a/stm32-modules/thermocycler-gen2/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/firmware/CMakeLists.txt
@@ -75,6 +75,7 @@ target_compile_options(${TARGET_MODULE_NAME}
   PUBLIC
   -Wall
   -Werror
+  -Wimplicit-fallthrough
   $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
   $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
   $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
@@ -155,15 +156,17 @@ add_custom_target(${TARGET_MODULE_NAME}-bin ALL
 # include directories. So we can use the actually fairly cool transform command to turn them all into
 # extra-arg invocations and it'll figure it out.
 set(CLANG_EXTRA_ARGS ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+get_target_property(SRC_INCLUDE_DIRS ${TARGET_MODULE_NAME} INCLUDE_DIRECTORIES)
+list(APPEND CLANG_EXTRA_ARGS ${SRC_INCLUDE_DIRS})
 list(TRANSFORM CLANG_EXTRA_ARGS PREPEND --extra-arg=-I)
 # This helps with clang accepting what GCC accepts around the implementations of the message queue
 list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-frelaxed-template-template-args")
 list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-Werror=implicit-fallthrough")
 add_custom_target(${TARGET_MODULE_NAME}-lint
-  COMMENT "Linting"
   ALL
+  COMMENT "Linting"
   COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS} ${CORE_LINTABLE_SOURCES}
-  DEPENDS thermocycler-gen2-core # Required to include the thermistor_lookups file, and possibly generate it if not present
+  DEPENDS ${TARGET_MODULE_NAME}-core # Required to include the thermistor_lookups file, and possibly generate it if not present
 )
 
 # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an

--- a/stm32-modules/thermocycler-gen2/src/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/src/CMakeLists.txt
@@ -60,8 +60,10 @@ set(CORE_LINTABLE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/plate_control.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/board_revision.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/colors.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/motor_utils.cpp
-    )
+    ${CMAKE_CURRENT_SOURCE_DIR}/motor_utils.cpp)
+set(CORE_LINTABLE_SOURCES
+    ${CORE_LINTABLE_SOURCES}
+    PARENT_SCOPE)
 set(CORE_NONLINTABLE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/putchar.c
     ${CMAKE_CURRENT_BINARY_DIR}/thermistor_lookups.cpp
@@ -91,6 +93,7 @@ target_compile_options(${TARGET_MODULE_NAME}-core
   PRIVATE
   -Wall
   -Werror
+  -Wimplicit-fallthrough
   $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
   $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
   $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>

--- a/stm32-modules/thermocycler-gen2/src/board_revision.cpp
+++ b/stm32-modules/thermocycler-gen2/src/board_revision.cpp
@@ -7,7 +7,7 @@
 #include <array>
 #include <optional>
 
-using namespace board_revision;
+namespace board_revision {
 
 // Holds the expected inputs for a board rev
 struct BoardRevSetting {
@@ -22,6 +22,7 @@ constexpr static std::array<BoardRevSetting, BOARD_REV_INVALID> _revisions{
      {.pins = {INPUT_PULLDOWN, INPUT_PULLDOWN, INPUT_PULLDOWN},
       .revision = BOARD_REV_2}}};
 // The actual revision
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _revision = BoardRevision::BOARD_REV_INVALID;
 
 auto BoardRevisionIface::get() -> BoardRevision {
@@ -45,3 +46,5 @@ auto BoardRevisionIface::read() -> BoardRevision {
     _revision = BoardRevision::BOARD_REV_INVALID;
     return _revision;
 }
+
+};  // namespace board_revision

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -19,6 +19,7 @@ auto PlateControl::update_control(Seconds time) -> UpdateRet {
     PlateControlVals values = {0.0F};
     switch (_status) {
         case PlateStatus::INITIAL_HEAT:
+            [[fallthrough]];
         case PlateStatus::INITIAL_COOL:
             if (temp_within_setpoint()) {
                 _status = PlateStatus::OVERSHOOT;
@@ -97,6 +98,9 @@ auto PlateControl::set_new_target(double setpoint, double hold_time,
     return temp * IDLE_FAN_POWER_SLOPE;
 }
 
+// This function *could* be made const, but that obfuscates the intention,
+// which is to update the ramp target of a *member* of the class.
+// NOLINTNEXTLINE(readability-make-member-function-const)
 auto PlateControl::update_ramp(thermal_general::Peltier &peltier, Seconds time)
     -> void {
     if (_ramp_rate == RAMP_INFINITE) {
@@ -111,6 +115,9 @@ auto PlateControl::update_ramp(thermal_general::Peltier &peltier, Seconds time)
     }
 }
 
+// This function *could* be made static, but that obfuscates the intention,
+// which is to update the PID of a *member* of the class.
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto PlateControl::update_pid(thermal_general::Peltier &peltier, Seconds time)
     -> double {
     return peltier.pid.compute(peltier.temp_target - peltier.current_temp(),
@@ -131,19 +138,18 @@ auto PlateControl::update_fan(Seconds time) -> double {
         if (_status == PlateStatus::INITIAL_COOL) {
             // Ramping down to a cold temp is always 70% drive
             return FAN_POWER_RAMP_COLD;
-        } else {
-            // Holding at a cold temp is PID controlling the heatsink to 60ºC
-            if (_fan.temp_target != FAN_TARGET_TEMP_COLD) {
-                _fan.temp_target = FAN_TARGET_TEMP_COLD;
-                _fan.pid.arm_integrator_reset(_fan.current_temp() -
-                                              FAN_TARGET_TEMP_COLD);
-            }
-            // Power is clamped in range [0.35,0.7]
-            auto power =
-                _fan.pid.compute(_fan.current_temp() - _fan.temp_target, time);
-            return std::clamp(power, FAN_POWER_LIMITS_COLD.first,
-                              FAN_POWER_LIMITS_COLD.second);
         }
+        // Holding at a cold temp is PID controlling the heatsink to 60ºC
+        if (_fan.temp_target != FAN_TARGET_TEMP_COLD) {
+            _fan.temp_target = FAN_TARGET_TEMP_COLD;
+            _fan.pid.arm_integrator_reset(_fan.current_temp() -
+                                          FAN_TARGET_TEMP_COLD);
+        }
+        // Power is clamped in range [0.35,0.7]
+        auto power =
+            _fan.pid.compute(_fan.current_temp() - _fan.temp_target, time);
+        return std::clamp(power, FAN_POWER_LIMITS_COLD.first,
+                          FAN_POWER_LIMITS_COLD.second);
     }
     if (_status == PlateStatus::INITIAL_COOL) {
         // Ramping down to a non-cold temp is always just 55% drive
@@ -152,8 +158,8 @@ auto PlateControl::update_fan(Seconds time) -> double {
     // Ramping up OR holding at a warm/hot temperature means we want to
     // regulate the heatsink to stay under (setpoint - 2)º.
     // There is also a safety threshold of 70º.
-    auto threshold =
-        std::min(HEATSINK_SAFETY_THRESHOLD_WARM, setpoint() - 2.0F);
+    auto threshold = std::min(HEATSINK_SAFETY_THRESHOLD_WARM,
+                              setpoint() + FAN_TARGET_DIFF_WARM);
     if (_fan.current_temp() < threshold) {
         return FAN_POWER_UNDER_WARM_THRESHOLD;
     }
@@ -170,6 +176,9 @@ auto PlateControl::update_fan(Seconds time) -> double {
                       FAN_POWER_LIMITS_WARM.second);
 }
 
+// This function *could* be made const, but that obfuscates the intention,
+// which is to reset a *member* of the class.
+// NOLINTNEXTLINE(readability-make-member-function-const)
 auto PlateControl::reset_control(thermal_general::Peltier &peltier) -> void {
     if (_ramp_rate == RAMP_INFINITE) {
         peltier.temp_target = setpoint();
@@ -180,6 +189,9 @@ auto PlateControl::reset_control(thermal_general::Peltier &peltier) -> void {
                                      peltier.current_temp());
 }
 
+// This function *could* be made const, but that obfuscates the intention,
+// which is to reset a *member* of the class.
+// NOLINTNEXTLINE(readability-make-member-function-const)
 auto PlateControl::reset_control(thermal_general::HeatsinkFan &fan) -> void {
     // The fan always just targets the target temperature w/ an offset
     fan.temp_target = _setpoint + FAN_SETPOINT_OFFSET;
@@ -192,6 +204,7 @@ auto PlateControl::reset_control(thermal_general::HeatsinkFan &fan) -> void {
            PELTIER_COUNT;
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 [[nodiscard]] auto PlateControl::temperature_zone(double temp) const
     -> TemperatureZone {
     if (temp < (double)TemperatureZone::COLD) {


### PR DESCRIPTION
`clang-tidy` wasn't actually linting the `thermocycler-gen2-core` target. This PR fixes that, and also adds fallthrough checking to `gcc` because clang-tidy doesn't support it as a direct check and the workaround we were using doesn't seem to work correctly.

- Adjusted cmake linter settings to properly lint `core` sources
- Added -Wimplicit-fallthrough to gcc options because clang-tidy was not picking it up.
- Fixed some linting errors that were not being detected before