### PR TITLE
feat(thermocycler-gen2): seal switch safety checks

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/firmware/motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/firmware/motor_policy.hpp
@@ -131,6 +131,13 @@ class MotorPolicy {
     auto seal_switch_set_disarmed() -> void;
 
     /**
+     * @brief Read the seal limit switch
+     *
+     * @return true if the switch is triggered, false otherwise
+     */
+    auto seal_read_limit_switch() -> bool;
+
+    /**
      * @brief Call the seal callback function
      *
      */

--- a/stm32-modules/include/thermocycler-gen2/test/test_motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/test/test_motor_policy.hpp
@@ -58,6 +58,8 @@ class TestMotorPolicy : public TestTMC2130Policy {
 
     auto seal_switch_set_disarmed() -> void { _seal_switch_armed = false; }
 
+    auto seal_read_limit_switch() -> bool { return _seal_switch_triggered; }
+
     // Test-specific functions
 
     auto tick() -> void {
@@ -80,6 +82,10 @@ class TestMotorPolicy : public TestTMC2130Policy {
 
     auto seal_switch_is_armed() -> bool { return _seal_switch_armed; }
 
+    auto set_seal_switch_triggered(bool val) -> void {
+        _seal_switch_triggered = val;
+    }
+
   private:
     // Solenoid is engaged when unpowered
     bool _solenoid_engaged = true;
@@ -91,6 +97,7 @@ class TestMotorPolicy : public TestTMC2130Policy {
     bool _lid_open_switch = false;
     bool _lid_closed_switch = false;
     bool _lid_overdrive = false;
+    bool _seal_switch_triggered = false;
     bool _seal_switch_armed = false;
     Callback _callback;
 };

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -1596,10 +1596,10 @@ struct GetLidSwitches {
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputIt, InLimit>
     static auto write_response_into(InputIt buf, InLimit limit, int closed,
-                                    int open) -> InputIt {
+                                    int open, int seal) -> InputIt {
         int res = 0;
-        res = snprintf(&*buf, (limit - buf), "M901.D C:%i O:%i OK\n", closed,
-                       open);
+        res = snprintf(&*buf, (limit - buf), "M901.D C:%i O:%i S:%i OK\n",
+                       closed, open, seal);
         if (res <= 0) {
             return buf;
         }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -634,7 +634,8 @@ class HostCommsTask {
                 } else {
                     return cache_element.write_response_into(
                         tx_into, tx_limit, response.close_switch_pressed,
-                        response.open_switch_pressed);
+                        response.open_switch_pressed,
+                        response.seal_switch_pressed);
                 }
             },
             cache_entry);

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -368,7 +368,9 @@ struct GetLidSwitchesMessage {
 
 struct GetLidSwitchesResponse {
     uint32_t responding_to_id;
-    bool close_switch_pressed, open_switch_pressed;
+    bool close_switch_pressed;
+    bool open_switch_pressed;
+    bool seal_switch_pressed;
 };
 
 struct GetFrontButtonMessage {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -89,10 +89,10 @@ struct LidStepperState {
     // distance is 120 degrees which is far wider than the actual travel angle.
     constexpr static double FULL_OPEN_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(120);
-    // After opening to the open switch, the lid must open a few extra
-    // degrees to be fully seated in the open switch.
+    // After opening to the open switch, the lid must re-close a few
+    // degrees to be at exactly 90º
     constexpr static double OPEN_OVERDRIVE_DEGREES =
-        motor_util::LidStepper::angle_to_microsteps(3);
+        motor_util::LidStepper::angle_to_microsteps(-5);
     // Full open/close movements run until they hit an endstop switch, so the
     // distance is 120 degrees which is far wider than the actual travel angle.
     constexpr static double FULL_CLOSE_DEGREES =
@@ -103,9 +103,9 @@ struct LidStepperState {
     constexpr static double CLOSE_OVERDRIVE_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(-5);
     constexpr static double PLATE_LIFT_RAISE_DEGREES =
-        motor_util::LidStepper::angle_to_microsteps(5);
+        motor_util::LidStepper::angle_to_microsteps(20);
     constexpr static double PLATE_LIFT_LOWER_DEGREES =
-        motor_util::LidStepper::angle_to_microsteps(-30);
+        motor_util::LidStepper::angle_to_microsteps(-40);
     // Default run current is 1200 milliamperes
     constexpr static double DEFAULT_RUN_CURRENT =
         motor_util::LidStepper::current_to_dac(1200);

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -75,6 +75,8 @@ concept MotorExecutionPolicy = requires(Policy& p,
     {p.seal_switch_set_armed()};
     // A function to disarm the seal stepper limit switch
     {p.seal_switch_set_disarmed()};
+    // A function to read the seal limit switches
+    { p.seal_read_limit_switch() } -> std::same_as<bool>;
     // Policy defines a number that provides the number of seal motor ticks
     // in a second
     {std::is_integral_v<decltype(Policy::MotorTickFrequency)>};
@@ -351,6 +353,7 @@ class MotorTask {
             static_cast<void>(
                 _task_registry->comms->get_message_queue().try_send(
                     messages::HostCommsMessage(response)));
+            _lid_stepper_state.response_id = INVALID_ID;
         }
     }
 
@@ -370,8 +373,10 @@ class MotorTask {
 
         // Check for error after starting movement
         if (error != errors::ErrorCode::NO_ERROR) {
-            auto response = messages::AcknowledgePrevious{
-                .responding_to_id = msg.id, .with_error = error};
+            auto response =
+                messages::SealStepperDebugResponse{.responding_to_id = msg.id,
+                                                   .steps_taken = 0,
+                                                   .with_error = error};
             static_cast<void>(
                 _task_registry->comms->get_message_queue().try_send(
                     messages::HostCommsMessage(response)));
@@ -423,6 +428,7 @@ class MotorTask {
                 static_cast<void>(
                     _task_registry->comms->get_message_queue().try_send(
                         messages::HostCommsMessage(response)));
+                _seal_stepper_state.response_id = INVALID_ID;
             }
         }
     }
@@ -611,7 +617,8 @@ class MotorTask {
         auto response = messages::GetLidSwitchesResponse{
             .responding_to_id = msg.id,
             .close_switch_pressed = policy.lid_read_closed_switch(),
-            .open_switch_pressed = policy.lid_read_open_switch()};
+            .open_switch_pressed = policy.lid_read_open_switch(),
+            .seal_switch_pressed = policy.seal_read_limit_switch()};
 
         static_cast<void>(
             _task_registry->comms->get_message_queue().try_send(response));
@@ -655,6 +662,17 @@ class MotorTask {
 
         _seal_stepper_state.direction = steps > 0;
 
+        if (arm_limit_switch) {
+            // If we are moving until a seal limit switch event, it is
+            // important that the switch is NOT already triggered.
+            if (policy.seal_read_limit_switch()) {
+                return errors::ErrorCode::SEAL_MOTOR_SWITCH;
+            }
+            policy.seal_switch_set_armed();
+        } else {
+            policy.seal_switch_set_disarmed();
+        }
+
         // Steps is signed, so set direction accordingly
         auto ret = policy.tmc2130_set_direction(steps > 0);
         if (!ret) {
@@ -678,12 +696,6 @@ class MotorTask {
 
         _seal_stepper_state.status = SealStepperState::Status::MOVING;
         _seal_position = motor_util::SealStepper::Status::UNKNOWN;
-
-        if (arm_limit_switch) {
-            policy.seal_switch_set_armed();
-        } else {
-            policy.seal_switch_set_disarmed();
-        }
 
         ret = policy.seal_stepper_start(
             [&] { this->seal_step_callback(policy); });

--- a/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_policy.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_policy.cpp
@@ -99,3 +99,8 @@ auto MotorPolicy::seal_switch_set_armed() -> void {
 auto MotorPolicy::seal_switch_set_disarmed() -> void {
     motor_hardware_seal_switch_set_disarmed();
 }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto MotorPolicy::seal_read_limit_switch() -> bool {
+    return motor_hardware_seal_switch_triggered();
+}

--- a/stm32-modules/thermocycler-gen2/simulator/motor_thread.cpp
+++ b/stm32-modules/thermocycler-gen2/simulator/motor_thread.cpp
@@ -62,6 +62,8 @@ class SimMotorPolicy : public SimTMC2130Policy {
 
     auto seal_switch_set_disarmed() -> void { _seal_switch_armed = false; }
 
+    auto seal_read_limit_switch() -> bool { return false; }
+
     // For simulation
     auto tick() -> void {
         if (_seal_moving) {

--- a/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
@@ -2339,7 +2339,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                         messages::GetLidSwitchesResponse{
                             .responding_to_id = switch_status_messsage.id,
                             .close_switch_pressed = false,
-                            .open_switch_pressed = true});
+                            .open_switch_pressed = true,
+                            .seal_switch_pressed = false});
                     tasks->get_host_comms_queue().backing_deque.push_back(
                         response);
                     auto written_secondpass =
@@ -2347,7 +2348,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                                                               tx_buf.end());
                     THEN("the task should ack the previous message") {
                         REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "M901.D C:0 O:1 OK\n"));
+                                                 "M901.D C:0 O:1 S:0 OK\n"));
                         REQUIRE(written_secondpass != tx_buf.begin());
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());

--- a/stm32-modules/thermocycler-gen2/tests/test_m901d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m901d.cpp
@@ -12,10 +12,10 @@ SCENARIO("GetLidSwitches (M901.D) parser works", "[gcode][parse][m901d]") {
         std::string buffer(256, 'c');
         WHEN("filling response") {
             auto written = gcode::GetLidSwitches::write_response_into(
-                buffer.begin(), buffer.end(), true, true);
+                buffer.begin(), buffer.end(), true, true, true);
             THEN("the response should be written in full") {
-                REQUIRE_THAT(
-                    buffer, Catch::Matchers::StartsWith("M901.D C:1 O:1 OK\n"));
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "M901.D C:1 O:1 S:1 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }
@@ -25,7 +25,7 @@ SCENARIO("GetLidSwitches (M901.D) parser works", "[gcode][parse][m901d]") {
         std::string buffer(16, 'c');
         WHEN("filling response") {
             auto written = gcode::GetLidSwitches::write_response_into(
-                buffer.begin(), buffer.begin() + 7, true, true);
+                buffer.begin(), buffer.begin() + 7, true, true, true);
             THEN("the response should write only up to the available space") {
                 std::string response = "M901.Dcccccccccc";
                 response[6] = '\0';

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
@@ -159,11 +159,12 @@ SCENARIO("motor task message passing") {
                         !tasks->get_host_comms_queue().backing_deque.empty());
                     auto ack =
                         tasks->get_host_comms_queue().backing_deque.front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            ack));
-                    auto ack_msg = std::get<messages::AcknowledgePrevious>(ack);
+                    REQUIRE(std::holds_alternative<
+                            messages::SealStepperDebugResponse>(ack));
+                    auto ack_msg =
+                        std::get<messages::SealStepperDebugResponse>(ack);
                     REQUIRE(ack_msg.responding_to_id == 999);
+                    REQUIRE(ack_msg.steps_taken == 0);
                     REQUIRE(ack_msg.with_error ==
                             errors::ErrorCode::SEAL_MOTOR_BUSY);
                 }

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
@@ -659,7 +659,7 @@ SCENARIO("motor task lid state machine") {
                  .seal_on = true,
                  .seal_direction = true,
                  .seal_switch_armed = true},
-                // Second step extends seeal switch
+                // Second step extends seal switch
                 {.msg =
                      messages::SealStepperComplete{
                          .reason = messages::SealStepperComplete::
@@ -676,7 +676,7 @@ SCENARIO("motor task lid state machine") {
                  .lid_overdrive = false},
                 // Fourth step overdrives hinge
                 {.msg = messages::LidStepperComplete(),
-                 .lid_angle_increased = true,
+                 .lid_angle_decreased = true,
                  .lid_overdrive = true},
                 // Should send ACK now
                 {.msg = messages::LidStepperComplete(),
@@ -798,7 +798,7 @@ SCENARIO("motor task lid state machine") {
                  .lid_overdrive = false},
                 // Now overdrive into the switch
                 {.msg = messages::LidStepperComplete(),
-                 .lid_angle_increased = true,
+                 .lid_angle_decreased = true,
                  .lid_overdrive = true},
                 // Should send ACK now
                 {.msg = messages::LidStepperComplete(),
@@ -837,7 +837,7 @@ SCENARIO("motor task lid state machine") {
                  .lid_overdrive = false},
                 // Fourth step overdrives hinge
                 {.msg = messages::LidStepperComplete(),
-                 .lid_angle_increased = true,
+                 .lid_angle_decreased = true,
                  .lid_overdrive = true},
                 // Should send ACK now
                 {.msg = messages::LidStepperComplete(),


### PR DESCRIPTION
Adds some safety checks for the seal motors. Attempting to open or close the lid while the seal is already triggering one of the two (indistinguishable) endstop switches will result in an error. Future versions of the PCB will be able to account for this, but on Rev2 it is important to not risk damaging the switches since we can't distinguish whether a movement will result in driving the switch into a hardstop.

- Addressed a bug where the response ID isn't cleared after Debug Seal/Lid commands
- Added the seal switch status to the M901.D response for debugging purposes
- Adjusted distances for lid hinge based on testing with EVT unit

Tested on an EVT unit