### PR TITLE
fix(heater-shaker): fix message passing for bootloader

### DIFF
--- a/stm32-modules/heater-shaker/firmware/system/system_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/system/system_hardware.c
@@ -86,6 +86,13 @@ void system_hardware_enter_bootloader(void) {
   SysTick->LOAD = 0;
   SysTick->VAL = 0;
 
+  /* Clear Interrupt Enable Register & Interrupt Pending Register */
+  for (int i=0;i<8;i++)
+  {
+      NVIC->ICER[i]=0xFFFFFFFF;
+      NVIC->ICPR[i]=0xFFFFFFFF;
+  }
+
   // We have to make sure that the processor is mapping the system memory region to address 0,
   // which the bootloader expects
   __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH();

--- a/stm32-modules/include/heater-shaker/heater-shaker/system_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/system_task.hpp
@@ -110,7 +110,7 @@ class SystemTask {
         }
 
         auto cool_message = messages::SetTemperatureMessage{
-            .id = 1, .target_temperature = 0, .from_system = true};
+            .id = 0, .target_temperature = 0, .from_system = true};
         auto cool_id = prep_cache.add(cool_message);
         cool_message.id = cool_id;
         if (!task_registry->heater->get_message_queue().try_send(cool_message,
@@ -118,7 +118,7 @@ class SystemTask {
             prep_cache.remove_if_present(cool_id);
         }
 
-        auto disconnect_message = messages::ForceUSBDisconnectMessage{.id = 2};
+        auto disconnect_message = messages::ForceUSBDisconnectMessage{.id = 0};
         auto disconnect_id = prep_cache.add(disconnect_message);
         disconnect_message.id = disconnect_id;
         if (!task_registry->comms->get_message_queue().try_send(

--- a/stm32-modules/include/heater-shaker/heater-shaker/system_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/system_task.hpp
@@ -110,7 +110,7 @@ class SystemTask {
         }
 
         auto cool_message = messages::SetTemperatureMessage{
-            .id = 0, .target_temperature = 0, .from_system = true};
+            .id = 1, .target_temperature = 0, .from_system = true};
         auto cool_id = prep_cache.add(cool_message);
         cool_message.id = cool_id;
         if (!task_registry->heater->get_message_queue().try_send(cool_message,
@@ -118,7 +118,7 @@ class SystemTask {
             prep_cache.remove_if_present(cool_id);
         }
 
-        auto disconnect_message = messages::ForceUSBDisconnectMessage{.id = 0};
+        auto disconnect_message = messages::ForceUSBDisconnectMessage{.id = 2};
         auto disconnect_id = prep_cache.add(disconnect_message);
         disconnect_message.id = disconnect_id;
         if (!task_registry->comms->get_message_queue().try_send(


### PR DESCRIPTION
No plate-latch-closed detection was preventing H-S from running the enter-bootloader process. This fix also adds clearing the NVIC prior to entering the bootloader.