### PR TITLE
feat(thermocycler-gen2): add volumetric overshoot

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -1106,8 +1106,9 @@ struct SetPlateTemperature {
 
     // 0 seconds means infinite hold time
     constexpr static double infinite_hold = 0.0F;
-    // If no volume is specified, set to 0
-    constexpr static double default_volume = 0.0F;
+    // If no volume is specified, set to a negative number and let
+    // the rest of the firmware decide a default value
+    constexpr static double default_volume = -1.0F;
 
     double setpoint;
     double hold_time;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -1094,8 +1094,11 @@ class HostCommsTask {
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
 
-        auto message = messages::SetPlateTemperatureMessage{
-            .id = id, .setpoint = gcode.setpoint, .hold_time = gcode.hold_time, .volume = gcode.volume};
+        auto message =
+            messages::SetPlateTemperatureMessage{.id = id,
+                                                 .setpoint = gcode.setpoint,
+                                                 .hold_time = gcode.hold_time,
+                                                 .volume = gcode.volume};
         if (!task_registry->thermal_plate->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -1094,7 +1094,7 @@ class HostCommsTask {
         }
 
         auto message = messages::SetPlateTemperatureMessage{
-            .id = id, .setpoint = gcode.setpoint, .hold_time = gcode.hold_time};
+            .id = id, .setpoint = gcode.setpoint, .hold_time = gcode.hold_time, .volume = gcode.volume};
         if (!task_registry->thermal_plate->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -255,6 +255,7 @@ struct SetPlateTemperatureMessage {
     uint32_t id;
     double setpoint;
     double hold_time;
+    double volume;
 };
 
 struct SetFanAutomaticMessage {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -256,7 +256,7 @@ struct SetPlateTemperatureMessage {
     uint32_t id;
     double setpoint;
     double hold_time;
-    double volume;
+    double volume = 0.0F;
 };
 
 struct SetFanAutomaticMessage {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -63,6 +63,14 @@ class PlateControl {
                                                                      0.55};
     /** Min & max power settings when holding at a hot temp.*/
     static constexpr std::pair<double, double> FAN_POWER_LIMITS_HOT{0.30, 0.55};
+    /** Overshoot M constant */
+    static constexpr double OVERSHOOT_M_CONST = 0.0105;
+    /** Overshoot B constant in ºC*/
+    static constexpr double OVERSHOOT_B_CONST = 1.0869;
+    /** Undershoot M constant */
+    static constexpr double UNDERSHOOT_M_CONST = -0.0133;
+    /** Undershoot B constant in ºC*/
+    static constexpr double UNDERSHOOT_B_CONST = -0.4302;
 
     PlateControl() = delete;
     /**
@@ -143,6 +151,30 @@ class PlateControl {
      */
     [[nodiscard]] auto temp_within_setpoint() const -> bool;
 
+    /**
+     * @brief Calculate the overshoot target temperature based off of a
+     * setpoint temperature and a liquid volume
+     *
+     * @param setpoint  The temperature setpoint in ºC
+     * @param volume_ul The max volume in the plate, in microliters
+     * @return The overshoot setpoint that the thermocycler should target,
+     *         in ºC
+     */
+    [[nodiscard]] auto calculate_overshoot(double setpoint, double volume_ul)
+        -> double;
+
+    /**
+     * @brief Calculate the undershoot target temperature based off of a
+     * setpoint temperature and a liquid volume
+     *
+     * @param setpoint  The temperature setpoint in ºC
+     * @param volume_ul The max volume in the plate, in microliters
+     * @return The undershoot setpoint that the thermocycler should target,
+     *         in ºC
+     */
+    [[nodiscard]] auto calculate_undershoot(double setpoint, double volume_ul)
+        -> double;
+
   private:
     /**
      * @brief Apply a ramp to the target temperature of an element.
@@ -185,7 +217,9 @@ class PlateControl {
     thermal_general::Peltier &_center;
     thermal_general::HeatsinkFan &_fan;
 
-    double _setpoint = 0.0F;
+    // Adjusted setpoint based on overshoot status
+    double _current_setpoint = 0.0F;
+    double _setpoint = 0.0F;  // User-provided setpoint
     double _ramp_rate = 0.0F;
     Seconds _hold_time = 0.0F;            // Total hold time
     Seconds _remaining_hold_time = 0.0F;  // Hold time left, out of _hold_time

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -74,6 +74,10 @@ class PlateControl {
     static constexpr double UNDERSHOOT_M_CONST = -0.0133;
     /** Undershoot B constant in ºC*/
     static constexpr double UNDERSHOOT_B_CONST = -0.4302;
+    /** Minimum temperature difference to trigger overshoot, in ºC.*/
+    static constexpr double UNDERSHOOT_MIN_DIFFERENCE = 0.5;
+    /** Amount of time to stay in overshoot, in seconds.*/
+    static constexpr Seconds OVERSHOOT_TIME = 10.0F;
 
     PlateControl() = delete;
     /**
@@ -114,7 +118,8 @@ class PlateControl {
      * celsius per second.
      * @return True if the temperature target could be updated
      */
-    auto set_new_target(double setpoint, double hold_time = HOLD_INFINITE,
+    auto set_new_target(double setpoint, double volume_ul,
+                        double hold_time = HOLD_INFINITE,
                         double ramp_rate = RAMP_INFINITE) -> bool;
 
     /**
@@ -163,8 +168,8 @@ class PlateControl {
      * @return The overshoot setpoint that the thermocycler should target,
      *         in ºC
      */
-    [[nodiscard]] auto calculate_overshoot(double setpoint, double volume_ul)
-        -> double;
+    [[nodiscard]] static auto calculate_overshoot(double setpoint,
+                                                  double volume_ul) -> double;
 
     /**
      * @brief Calculate the undershoot target temperature based off of a
@@ -175,8 +180,8 @@ class PlateControl {
      * @return The undershoot setpoint that the thermocycler should target,
      *         in ºC
      */
-    [[nodiscard]] auto calculate_undershoot(double setpoint, double volume_ul)
-        -> double;
+    [[nodiscard]] static auto calculate_undershoot(double setpoint,
+                                                   double volume_ul) -> double;
 
   private:
     /**
@@ -224,6 +229,7 @@ class PlateControl {
     double _current_setpoint = 0.0F;
     double _setpoint = 0.0F;  // User-provided setpoint
     double _ramp_rate = 0.0F;
+    Seconds _remaining_overshoot_time = 0.0F;
     Seconds _hold_time = 0.0F;            // Total hold time
     Seconds _remaining_hold_time = 0.0F;  // Hold time left, out of _hold_time
 };

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -169,7 +169,9 @@ class PlateControl {
      *         in ºC
      */
     [[nodiscard]] static auto calculate_overshoot(double setpoint,
-                                                  double volume_ul) -> double;
+                                                  double volume_ul) -> double {
+        return setpoint + (OVERSHOOT_M_CONST * volume_ul) + OVERSHOOT_B_CONST;
+    }
 
     /**
      * @brief Calculate the undershoot target temperature based off of a
@@ -181,7 +183,9 @@ class PlateControl {
      *         in ºC
      */
     [[nodiscard]] static auto calculate_undershoot(double setpoint,
-                                                   double volume_ul) -> double;
+                                                   double volume_ul) -> double {
+        return setpoint + (UNDERSHOOT_M_CONST * volume_ul) + UNDERSHOOT_B_CONST;
+    }
 
   private:
     /**

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -505,7 +505,7 @@ class ThermalPlateTask {
             }
         }
 
-        double volume_ul = (msg.volume < 0.0F) ? DEFAULT_VOLUME_UL : msg.volume ;
+        double volume_ul = (msg.volume < 0.0F) ? DEFAULT_VOLUME_UL : msg.volume;
 
         if (msg.setpoint <= 0.0F) {
             _state.system_status = State::IDLE;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -107,6 +107,8 @@ class ThermalPlateTask {
     static constexpr double KD_MIN = -200;
     static constexpr double KD_MAX = 200;
     static constexpr double OVERTEMP_LIMIT_C = 115;
+    // If no volume is specified, this is the default
+    static constexpr double DEFAULT_VOLUME_UL = 25.0F;
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     static constexpr const double CONTROL_PERIOD_SECONDS =
         CONTROL_PERIOD_TICKS * 0.001;
@@ -503,11 +505,14 @@ class ThermalPlateTask {
             }
         }
 
+        double volume_ul = (msg.volume > 0.0F) ? msg.volume : DEFAULT_VOLUME_UL;
+
         if (msg.setpoint <= 0.0F) {
             _state.system_status = State::IDLE;
             policy.set_enabled(false);
         } else {
-            if (_plate_control.set_new_target(msg.setpoint, msg.hold_time)) {
+            if (_plate_control.set_new_target(msg.setpoint, volume_ul,
+                                              msg.hold_time)) {
                 _state.system_status = State::CONTROLLING;
             } else {
                 response.with_error = errors::ErrorCode::THERMAL_TARGET_BAD;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -505,7 +505,7 @@ class ThermalPlateTask {
             }
         }
 
-        double volume_ul = (msg.volume > 0.0F) ? msg.volume : DEFAULT_VOLUME_UL;
+        double volume_ul = (msg.volume < 0.0F) ? DEFAULT_VOLUME_UL : msg.volume ;
 
         if (msg.setpoint <= 0.0F) {
             _state.system_status = State::IDLE;

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
@@ -1,0 +1,44 @@
+# Thermal Subsystem
+
+The Thermocycler contains two primary thermal subassemblies, the _peltier plate_ and the _lid heater_.
+
+## Peltier Plate
+
+The plate consists of a 3 column array of peltier modules, where each column is individually controllable (referred to as the __left__, __right__, and __center__ regions). A total of six thermistors (one per peltier region) are mounted on the plate for thermal feedback.
+
+### Plate Offset
+
+The temperature measured by the thermistors is not necessarily equal to the temperature of the plate. In order to compensate for this temperature differential, a set of calibration coefficients can be programmed to set a function in the form of `y = mx + b`, wherein `x` is the temperature measured by a thermistor and `y` is the approximate temperature on the actual plate.
+
+### Ramp Control & Volumetric Overshoot
+
+When a new target temperature is set, the `plate_control` module enters a simple state machine. In order to ensure that the temperature of liquids in the plate is appropriate, the state machine includes __volumetric overshoot__ based on the maximum volume of liquid in a well (configured by the command to set the plate temperature).
+
+```mermaid
+graph TD
+    Start[New command]
+    Overshoot{Target temperature > 0.5ºC away?}
+    OvershootYes(Set target based on overshoot calculation)
+    OvershootNo(Set target to the user-specified temperature)
+    HotOrCold{Target > current temperature?}
+    InitialHeat(Initial Heat)
+    InitialCool(Initial Cool)
+    OvershootPhase(Stay in overshoot temperature)
+    HoldingPhase(Stay at user-specified temperature indefinitely)
+    Off(Off)
+
+    Start -->|Set temp command| Overshoot
+    Overshoot -->|Yes| OvershootYes --> HotOrCold
+    Overshoot -->|No| OvershootNo --> HotOrCold
+    HotOrCold -->|Yes| InitialHeat
+    HotOrCold -->|No| InitialCool
+    InitialHeat -->|Target temperature reached| OvershootPhase
+    InitialCool -->|Target temperature reached| OvershootPhase
+    OvershootPhase -->|10 seconds pass| HoldingPhase
+
+    Start -->|Disable command| Off
+```
+
+## Lid Heater
+
+The lid heater consists of a single resistive heating pad and a single thermistor for temperature feedback. The lid's primary purpose is to prevent condensation in the wells by providing a temperature above that of the peltier plate.

--- a/stm32-modules/thermocycler-gen2/scripts/test_pcr_cycle.py
+++ b/stm32-modules/thermocycler-gen2/scripts/test_pcr_cycle.py
@@ -15,8 +15,8 @@ def cycle(ser : serial.Serial):
         (5.0, 50.0),
         (20.0, 20.0) ]
     targets = [
-        (35.0, 5.0),
-        (50.0, 5.0),
+        (35.0, 10.0),
+        (20.0, 40.0),
         (65.0, 5.0),
         (80.0, 5.0),
         (95.0, 5.0),
@@ -52,13 +52,14 @@ def cycle(ser : serial.Serial):
                         test_utils.deactivate_lid(ser)
                     else:
                         new_temp = targets[target_idx][0]
-                        print(f'Moving to {new_temp}')
-                        test_utils.set_plate_temperature(new_temp, ser)
+                        new_hold = targets[target_idx][1]
+                        print(f'Moving to {new_temp} for {new_hold} seconds')
+                        test_utils.set_plate_temperature(new_temp, ser, hold_time=new_hold)
         sys.stdout.flush()
         return
     
-    print(f'Moving to {targets[0][0]}')
-    test_utils.set_plate_temperature(targets[0][0], ser)
+    print(f'Moving to {targets[0][0]} for {targets[0][1]} seconds')
+    test_utils.set_plate_temperature(targets[0][0], ser, targets[0][1])
     plot_temp.graphTemperatures(ser, update_callback)
 
 if __name__ == '__main__':

--- a/stm32-modules/thermocycler-gen2/scripts/test_pcr_cycle.py
+++ b/stm32-modules/thermocycler-gen2/scripts/test_pcr_cycle.py
@@ -7,7 +7,7 @@ import time
 import sys
 import argparse
 
-def cycle(ser : serial.Serial):
+def cycle(ser : serial.Serial, volume: float):
     # Cycle to 95 then 5 and finally back
     # Format is target temp, then hold time
     targets_pcr = [
@@ -15,8 +15,8 @@ def cycle(ser : serial.Serial):
         (5.0, 50.0),
         (20.0, 20.0) ]
     targets = [
-        (35.0, 10.0),
-        (20.0, 40.0),
+        (25.0, 30.0),
+        (20.0, 30.0),
         (65.0, 5.0),
         (80.0, 5.0),
         (95.0, 5.0),
@@ -54,12 +54,12 @@ def cycle(ser : serial.Serial):
                         new_temp = targets[target_idx][0]
                         new_hold = targets[target_idx][1]
                         print(f'Moving to {new_temp} for {new_hold} seconds')
-                        test_utils.set_plate_temperature(new_temp, ser, hold_time=new_hold)
+                        test_utils.set_plate_temperature(new_temp, ser, hold_time=new_hold, volume=volume)
         sys.stdout.flush()
         return
     
     print(f'Moving to {targets[0][0]} for {targets[0][1]} seconds')
-    test_utils.set_plate_temperature(targets[0][0], ser, targets[0][1])
+    test_utils.set_plate_temperature(targets[0][0], ser, targets[0][1], volume=volume)
     plot_temp.graphTemperatures(ser, update_callback)
 
 if __name__ == '__main__':
@@ -82,6 +82,6 @@ if __name__ == '__main__':
         test_utils.set_peltier_pid(args.constants[0], args.constants[1], args.constants[2], ser)
 
     test_utils.set_lid_temperature(105, ser)
-    cycle(ser)
+    cycle(ser, 400.0)
     test_utils.deactivate_lid(ser)
     test_utils.deactivate_plate(ser)

--- a/stm32-modules/thermocycler-gen2/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-gen2/scripts/test_utils.py
@@ -197,9 +197,13 @@ def set_heater_pid(p: float, i: float, d: float, ser: serial.Serial):
     print(res)
 
 # Sets the plate target as a temperature in celsius
-def set_plate_temperature(temperature: float, ser: serial.Serial, hold_time: float = 0):
+def set_plate_temperature(temperature: float, ser: serial.Serial, hold_time: float = 0, volume: float = None):
     print(f'Setting plate temperature target to {temperature}C and hold time to {hold_time} sec')
-    ser.write(f'M104 S{temperature} H{hold_time}\n'.encode())
+    toWrite = f'M104 S{temperature} H{hold_time}'
+    if(volume):
+        toWrite = toWrite + f' V{volume}'
+    toWrite = toWrite + '\n'
+    ser.write(toWrite.encode())
     res = ser.readline()
     guard_error(res, b'M104 OK')
     print(res)

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -20,7 +20,7 @@ auto PlateControl::update_control(Seconds time) -> UpdateRet {
     switch (_status) {
         case PlateStatus::INITIAL_HEAT:
             // Check if we crossed the TRUE threshold temp
-            if (plate_temp() > _setpoint) {
+            if (plate_temp() >= _setpoint) {
                 _status = PlateStatus::OVERSHOOT;
                 _remaining_overshoot_time = OVERSHOOT_TIME;
                 _left.temp_target = _current_setpoint;
@@ -34,7 +34,7 @@ auto PlateControl::update_control(Seconds time) -> UpdateRet {
             break;
         case PlateStatus::INITIAL_COOL:
             // Check if we crossed the TRUE threshold temp
-            if (plate_temp() < _setpoint) {
+            if (plate_temp() <= _setpoint) {
                 _status = PlateStatus::OVERSHOOT;
                 _remaining_overshoot_time = OVERSHOOT_TIME;
                 _left.temp_target = _current_setpoint;

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -97,6 +97,18 @@ auto PlateControl::set_new_target(double setpoint, double hold_time,
     return temp * IDLE_FAN_POWER_SLOPE;
 }
 
+[[nodiscard]] auto PlateControl::calculate_overshoot(double setpoint,
+                                                     double volume_ul)
+    -> double {
+    return setpoint + (OVERSHOOT_M_CONST * volume_ul) + OVERSHOOT_B_CONST;
+}
+
+[[nodiscard]] auto PlateControl::calculate_undershoot(double setpoint,
+                                                      double volume_ul)
+    -> double {
+    return setpoint + (UNDERSHOOT_M_CONST * volume_ul) + UNDERSHOOT_B_CONST;
+}
+
 auto PlateControl::update_ramp(thermal_general::Peltier &peltier, Seconds time)
     -> void {
     if (_ramp_rate == RAMP_INFINITE) {

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -19,10 +19,27 @@ auto PlateControl::update_control(Seconds time) -> UpdateRet {
     PlateControlVals values = {0.0F};
     switch (_status) {
         case PlateStatus::INITIAL_HEAT:
-            [[fallthrough]];
-        case PlateStatus::INITIAL_COOL:
-            if (temp_within_setpoint()) {
+            // Check if we crossed the TRUE threshold temp
+            if (plate_temp() > _setpoint) {
                 _status = PlateStatus::OVERSHOOT;
+                _remaining_overshoot_time = OVERSHOOT_TIME;
+                _left.temp_target = _current_setpoint;
+                _right.temp_target = _current_setpoint;
+                _center.temp_target = _current_setpoint;
+            } else {
+                update_ramp(_left, time);
+                update_ramp(_right, time);
+                update_ramp(_center, time);
+            }
+            break;
+        case PlateStatus::INITIAL_COOL:
+            // Check if we crossed the TRUE threshold temp
+            if (plate_temp() < _setpoint) {
+                _status = PlateStatus::OVERSHOOT;
+                _remaining_overshoot_time = OVERSHOOT_TIME;
+                _left.temp_target = _current_setpoint;
+                _right.temp_target = _current_setpoint;
+                _center.temp_target = _current_setpoint;
             } else {
                 update_ramp(_left, time);
                 update_ramp(_right, time);
@@ -30,26 +47,25 @@ auto PlateControl::update_control(Seconds time) -> UpdateRet {
             }
             break;
         case PlateStatus::OVERSHOOT:
-            // TODO overshoot control...  update target, track time
-            _status = PlateStatus::STEADY_STATE;
+            _remaining_overshoot_time -= time;
+            if (_remaining_overshoot_time <= 0.0F) {
+                _current_setpoint = _setpoint;
+                _left.temp_target = _setpoint;
+                _right.temp_target = _setpoint;
+                _center.temp_target = _setpoint;
+                _status = PlateStatus::STEADY_STATE;
+            }
             break;
         case PlateStatus::STEADY_STATE:
-            if (plate_temp() > _setpoint) {
-                _status = PlateStatus::OVERSHOOT;
-            }
+            // Hold time is ONLY updated in steady state!
+            _remaining_hold_time = std::max(_remaining_hold_time - time,
+                                            static_cast<double>(0.0F));
             break;
     }
 
     values.left_power = update_pid(_left, time);
     values.right_power = update_pid(_right, time);
     values.center_power = update_pid(_center, time);
-
-    // Hold time decreases whenever temp has reached the target
-    if (_status == PlateStatus::OVERSHOOT ||
-        _status == PlateStatus::STEADY_STATE) {
-        _remaining_hold_time =
-            std::max(_remaining_hold_time - time, static_cast<double>(0.0F));
-    }
 
     // Caller should check whether fan is manual after this function runs
     if (_fan.manual_control) {
@@ -66,8 +82,8 @@ auto PlateControl::update_control(Seconds time) -> UpdateRet {
     return UpdateRet(values);
 }
 
-auto PlateControl::set_new_target(double setpoint, double hold_time,
-                                  double ramp_rate) -> bool {
+auto PlateControl::set_new_target(double setpoint, double volume_ul,
+                                  double hold_time, double ramp_rate) -> bool {
     _ramp_rate = ramp_rate;
     _hold_time = hold_time;
     _remaining_hold_time = hold_time;
@@ -82,6 +98,19 @@ auto PlateControl::set_new_target(double setpoint, double hold_time,
     // have to reconsider this, see how it works for small changes.
     _status = (setpoint > plate_temp()) ? PlateStatus::INITIAL_HEAT
                                         : PlateStatus::INITIAL_COOL;
+
+    auto distance_to_target = std::abs(setpoint - plate_temp());
+    if (distance_to_target > UNDERSHOOT_MIN_DIFFERENCE) {
+        if (_status == PlateStatus::INITIAL_HEAT) {
+            _current_setpoint = calculate_overshoot(_setpoint, volume_ul);
+        } else {
+            _current_setpoint = calculate_undershoot(_setpoint, volume_ul);
+        }
+    } else {
+        // If we aren't changing by at least UNDERSHOOT_MIN_DIFFERENCE, just
+        // go directly to the setpoint
+        _current_setpoint = setpoint;
+    }
     return true;
 }
 
@@ -116,14 +145,14 @@ auto PlateControl::set_new_target(double setpoint, double hold_time,
 auto PlateControl::update_ramp(thermal_general::Peltier &peltier, Seconds time)
     -> void {
     if (_ramp_rate == RAMP_INFINITE) {
-        peltier.temp_target = _setpoint;
+        peltier.temp_target = _current_setpoint;
     }
-    if (peltier.temp_target < _setpoint) {
-        peltier.temp_target =
-            std::min(peltier.temp_target + (_ramp_rate * time), _setpoint);
-    } else if (peltier.temp_target > _setpoint) {
-        peltier.temp_target =
-            std::max(peltier.temp_target - (_ramp_rate * time), _setpoint);
+    if (peltier.temp_target < _current_setpoint) {
+        peltier.temp_target = std::min(
+            peltier.temp_target + (_ramp_rate * time), _current_setpoint);
+    } else if (peltier.temp_target > _current_setpoint) {
+        peltier.temp_target = std::max(
+            peltier.temp_target - (_ramp_rate * time), _current_setpoint);
     }
 }
 
@@ -206,7 +235,7 @@ auto PlateControl::reset_control(thermal_general::Peltier &peltier) -> void {
 // NOLINTNEXTLINE(readability-make-member-function-const)
 auto PlateControl::reset_control(thermal_general::HeatsinkFan &fan) -> void {
     // The fan always just targets the target temperature w/ an offset
-    fan.temp_target = _setpoint + FAN_SETPOINT_OFFSET;
+    fan.temp_target = _current_setpoint + FAN_SETPOINT_OFFSET;
     fan.pid.arm_integrator_reset(fan.current_temp() - fan.temp_target);
 }
 
@@ -234,5 +263,5 @@ auto PlateControl::reset_control(thermal_general::HeatsinkFan &fan) -> void {
 }
 
 [[nodiscard]] auto PlateControl::temp_within_setpoint() const -> bool {
-    return std::abs(_setpoint - plate_temp()) < SETPOINT_THRESHOLD;
+    return std::abs(_current_setpoint - plate_temp()) < SETPOINT_THRESHOLD;
 }

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -127,18 +127,6 @@ auto PlateControl::set_new_target(double setpoint, double volume_ul,
     return temp * IDLE_FAN_POWER_SLOPE;
 }
 
-[[nodiscard]] auto PlateControl::calculate_overshoot(double setpoint,
-                                                     double volume_ul)
-    -> double {
-    return setpoint + (OVERSHOOT_M_CONST * volume_ul) + OVERSHOOT_B_CONST;
-}
-
-[[nodiscard]] auto PlateControl::calculate_undershoot(double setpoint,
-                                                      double volume_ul)
-    -> double {
-    return setpoint + (UNDERSHOOT_M_CONST * volume_ul) + UNDERSHOOT_B_CONST;
-}
-
 // This function *could* be made const, but that obfuscates the intention,
 // which is to update the ramp target of a *member* of the class.
 // NOLINTNEXTLINE(readability-make-member-function-const)


### PR DESCRIPTION
Adds support for volumetric overshoot to the Thermocycler Gen2. This copies the behavior from the TC Gen1, including the coefficients for calculating the offset.

- Added a readme for the thermal subsystem to explain some of the less straightforward parts of the plate control
- Added overshoot to the `Platecontrol` class. The full state machine of it is shown in the readme.
- Added tests for the overshoot/undershoot calculations, and updated tests for the `PlateControl` class

Tested in the simulator, as well as on an EVT unit by setting the volume very high (400 uL) and moving to a few temperatures. The software targets the overshoot/undershoot temperature for 10 seconds as intended, and then moves to the real target.