### PR TITLE
fix(thermocycler-gen2): fixed LED power issues

### DIFF
--- a/stm32-modules/thermocycler-gen2/firmware/system/system_led_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/system/system_led_hardware.c
@@ -21,14 +21,17 @@
 // ----------------------------------------------------------------------------
 // LOCAL DEFINITIONS
 
-
-#define PULSE_WIDTH_FREQ (800000)
 #define TIMER_CLOCK_FREQ (170000000)
-// These two together give a 400kHz total period
+// These two together give an 800kHz total period
 #define TIM17_PRESCALER (0)
-#define TIM17_RELOAD (424)
+#define TIM17_RELOAD (212)
 // PWM should be scaled from 0 to MAX_PWM, inclusive
 #define MAX_PWM (TIM17_RELOAD + 1)
+
+// Port to enable the LED power return
+#define LED_ENABLE_PORT (GPIOC)
+// Pin to enable the LED power return
+#define LED_ENABLE_PIN (GPIO_PIN_11)
 
 struct led_hardware {
     TIM_HandleTypeDef tim; // Timer handle
@@ -103,6 +106,14 @@ void system_led_initialize(void) {
     sBreakDeadTimeConfig.AutomaticOutput = TIM_AUTOMATICOUTPUT_DISABLE;
     hal_ret = HAL_TIMEx_ConfigBreakDeadTime(&_leds.tim, &sBreakDeadTimeConfig);
     configASSERT(hal_ret == HAL_OK);
+
+    // Enable the LED Power Enable output
+    GPIO_InitStruct.Pin = LED_ENABLE_PIN;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_LOW;
+    HAL_GPIO_Init(LED_ENABLE_PORT, &GPIO_InitStruct);
+    HAL_GPIO_WritePin(LED_ENABLE_PORT, LED_ENABLE_PIN, GPIO_PIN_SET);
 
     // This is generated as the "post-init" function from STM32Cube
     __HAL_RCC_GPIOB_CLK_ENABLE();


### PR DESCRIPTION
Erroneous LED behavior was noticed on EVT units, most notably blinking lights while the seal motor was being driven. This issue was not seen in units being run in the NY office. Reviewing the code + schematic revealed that the LED Enable Pin was never being set. In theory the LED's never should have worked without this pin being set, but in practice they just worked at a reduced capacity.

After enabling this pin, the LED performance is more in-line with what is expected. Even on units that did not show erratic blinking, the colors are more representative of what's expected (in particular, the orange had been very red-ish and is now clearly orange).

This PR also increases the PWM frequency from 400kHz to approximately 800kHz. The latter showed erratic performance in the past, but testing with the power pin enabled indicates that this frequency works exactly as expected now.