### PR TITLE
fix(thermocycler-gen2): fix logic for `at_temp` response

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -33,7 +33,7 @@ class PlateControl {
     /** Number of peltiers on system.*/
     static constexpr double PELTIER_COUNT = 3.0F;
     /** Max ∆T to be considered "at" the setpoint.*/
-    static constexpr double SETPOINT_THRESHOLD = 0.5F;
+    static constexpr double SETPOINT_THRESHOLD = 1.5F;
 
     /** Degrees C *under* the threshold to set the fan.*/
     static constexpr double FAN_SETPOINT_OFFSET = (-2.0F);

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -251,5 +251,6 @@ auto PlateControl::reset_control(thermal_general::HeatsinkFan &fan) -> void {
 }
 
 [[nodiscard]] auto PlateControl::temp_within_setpoint() const -> bool {
-    return std::abs(_current_setpoint - plate_temp()) < SETPOINT_THRESHOLD;
+    return (_status == PlateStatus::STEADY_STATE) &&
+           (std::abs(_current_setpoint - plate_temp()) < SETPOINT_THRESHOLD);
 }

--- a/stm32-modules/thermocycler-gen2/tests/test_plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_plate_control.cpp
@@ -139,6 +139,18 @@ SCENARIO("PlateControl peltier control works") {
                             plate_control::PlateStatus::OVERSHOOT);
                     REQUIRE(!plateControl.temp_within_setpoint());
                 }
+                AND_WHEN("the temperature is at the overshoot temperature") {
+                    const auto real_target =
+                        HOT_TEMP +
+                        plate_control::PlateControl::calculate_overshoot(
+                            HOT_TEMP, input_volume);
+                    set_temp(thermistors, real_target);
+                    static_cast<void>(
+                        plateControl.update_control(UPDATE_RATE_SEC));
+                    THEN("temp_within_setpoint still returns false") {
+                        REQUIRE(!plateControl.temp_within_setpoint());
+                    }
+                }
                 AND_WHEN("holding at temperature for >10 seconds") {
                     static_cast<void>(plateControl.update_control(
                         plateControl.OVERSHOOT_TIME));


### PR DESCRIPTION
Small fix for the logic of the `at_target?` field in the GetPlateTemperature command, in order to more closely match the Gen1 thermocycler. During the 10 second overshoot phase, the firmware should never report that the peltiers are at their target.

Sanity tested on an EVT unit.