### PR TITLE
chore(thermocycler-gen2): set up channel testing script

### DIFF
--- a/stm32-modules/thermocycler-gen2/scripts/channel_test.py
+++ b/stm32-modules/thermocycler-gen2/scripts/channel_test.py
@@ -1,0 +1,170 @@
+#! python3
+
+import serial
+import time
+import re
+import argparse
+import datetime
+
+from serial.tools.list_ports import grep
+from typing import  Dict, Tuple, List
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run a simple PCR cycle")
+    parser.add_argument('-p', '--port', type=str, required=False, default=None,
+                        help='The USB port that the thermocycler is connected to')
+    parser.add_argument('-f', '--file', type=argparse.FileType('w'), required=False, default=None,
+                        help='File to write data to. If not specified, data is printed to the command line.')
+    parser.add_argument('-t', '--time', type=float, required=False, default=180,
+                        help='Number of seconds to measure data for each temperature')
+    return parser.parse_args()
+
+def build_serial(port: str = None) -> serial.Serial:
+    if not port:
+        avail = list(grep('.*hermocycler*'))
+        if not avail:
+            raise RuntimeError("could not find thermocycler")
+        return serial.Serial(avail[0].device, 115200)
+    return serial.Serial(port, 115200)
+
+
+class Thermocycler():
+    def __init__(self, port: str = None, debug: bool = False):
+        '''
+        Constructs a new Thermocycler. Leave `port` empty to connect to
+        the first Thermocycler connected over USB.
+        '''
+        self.ser = build_serial(port)
+        self.debug = debug
+    
+    
+    _POLL_FREQ = 2.0 
+    '''Poll frequency in Hz'''
+
+    class Thermistors():
+        def __init__(self, hs, fr, fc, fl, br, bc, bl):
+            self.hs = hs # heat sink
+            self.fr = fr # front right
+            self.fc = fc # front center
+            self.fl = fl # front left
+            self.br = br # back right
+            self.bc = bc # back center
+            self.bl = bl # back left
+        
+        def __str__(self):
+            return f'{self.hs},{self.fr},{self.fc},{self.fl},{self.br},{self.bc},{self.bl}'
+        
+    class Power():
+        def __init__(self, left, center, right):
+            self.left = left 
+            self.center = center 
+            self.right = right 
+        
+        def __str__(self):
+            return f'{self.left},{self.center},{self.right}'
+
+    def _send_and_recv(self, msg: str, guard_ret: str = None) -> str:
+        '''Internal utility to send a command and receive the response'''
+        self.ser.write(msg.encode())
+        ret = self.ser.readline()
+        if guard_ret:
+            if not ret.startswith(guard_ret.encode()):
+                raise RuntimeError(f'Incorrect Response: {ret}')
+        if ret.startswith('ERR'.encode()):
+            raise RuntimeError(ret)
+        return ret.decode()
+
+    _TEMP_DEBUG_RE = re.compile('^M105.D HST:(?P<HST>.+) FRT:(?P<FRT>.+) FLT:(?P<FLT>.+) FCT:(?P<FCT>.+) BRT:(?P<BRT>.+) BLT:(?P<BLT>.+) BCT:(?P<BCT>.+) HSA.* OK\n')
+    def get_plate_thermistors(self) -> Thermistors:
+        '''
+        Gets each thermistor on the plate.
+        '''
+        res = self._send_and_recv('M105.D\n', 'M105.D HST:')
+        match = re.match(self._TEMP_DEBUG_RE, res)
+        fr = float(match.group('FRT'))
+        br = float(match.group('BRT'))
+        fc = float(match.group('FCT')) 
+        bc = float(match.group('BCT'))
+        fl = float(match.group('FLT')) 
+        bl = float(match.group('BLT'))
+        hs = float(match.group('HST'))
+        return Thermocycler.Thermistors(hs, fr, fc, fl, br, bc, bl)
+    
+    _POWER_RE = re.compile('^M103.D L:(?P<left>.+) C:(?P<center>.+) R:(?P<right>.+) H:(?P<heater>.+) F:(?P<fans>.+) OK\n')
+    def get_peltier_power(self) -> Power:
+        '''
+        Get the power of all peltiers.
+        '''
+        res = self._send_and_recv('M103.D\n', 'M103.D L:')
+        match = re.match(self._POWER_RE, res)
+        left = float(match.group('left'))
+        center = float(match.group('center'))
+        right = float(match.group('right'))
+        return Thermocycler.Power(left, center, right)
+    
+    def set_plate_target(self, temperature: float, hold_time: float = 0, volume: float = None):
+        '''
+        Sets the target temperature of the thermal plate. The temperature is required,
+        but the hold_time and volume parameters may be left as defaults.
+        '''
+        send = f'M104 S{temperature} H{hold_time}'
+        if(volume):
+            send = send + f' V{volume}'
+        send = send + '\n'
+        self._send_and_recv(send, 'M104')
+    
+    def deactivate_all(self):
+        '''Turn off the lid heater and the peltiers'''
+        self._send_and_recv('M18\n', 'M18 OK')
+    
+    def open_lid(self):
+        '''Opens the lid and blocks'''
+        self._send_and_recv('M126\n', 'M126 OK')
+
+    def close_lid(self):
+        '''Closes the lid and blocks'''
+        self._send_and_recv('M127\n', 'M127 OK')
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    thermocycler = Thermocycler(port=args.port)
+
+    file = args.file
+    if not file:
+        timestamp = datetime.datetime.now()
+        file = open(f'./channel-test-{timestamp}.csv', 'w', newline='\n')
+
+    print('Writing to file ' + file.name)
+    
+    try:
+        temperatures = [94.0, 70.0, 50.0, 4.0]
+        start_time = time.time()
+        file.write('time,target,heatsink,front right,front center,front left,back right,back center,back left,left power,center power,right power')
+        file.write('\n')
+        for temp in temperatures:
+            thermocycler.set_plate_target(temp)
+            temp_start_time = time.time()
+            while time.time() < (temp_start_time + args.time):
+                thermistors = thermocycler.get_plate_thermistors()
+                power = thermocycler.get_peltier_power()
+                measurement_time = time.time()
+                seconds = measurement_time - start_time
+                toprint = f'{seconds},{temp},' + str(thermistors) + ',' + str(power)
+                file.write(toprint)
+                file.write('\n')
+                time.sleep(0.5)
+        thermocycler.deactivate_all()
+        
+    except KeyboardInterrupt:
+        # If the script is ended early, turn the thermocycler off
+        # for safety. When the script ends normally, it is okay for
+        # the plate to be kept at 4ºC indefinitely.
+        print(f'Ending early')
+        print('Turning off Thermocycler')
+        thermocycler.deactivate_all()
+    except RuntimeError:
+        # Same error handling if the thermocycler throws an error
+        print(f'Ending early due to error')
+        print('Turning off Thermocycler')
+        thermocycler.deactivate_all()

--- a/stm32-modules/thermocycler-gen2/scripts/channel_test.py
+++ b/stm32-modules/thermocycler-gen2/scripts/channel_test.py
@@ -14,7 +14,7 @@ def parse_args():
     parser.add_argument('-p', '--port', type=str, required=False, default=None,
                         help='The USB port that the thermocycler is connected to')
     parser.add_argument('-f', '--file', type=argparse.FileType('w'), required=False, default=None,
-                        help='File to write data to. If not specified, data is printed to the command line.')
+                        help='File to write data to. If not specified, a new file will be generated.')
     parser.add_argument('-t', '--time', type=float, required=False, default=180,
                         help='Number of seconds to measure data for each temperature')
     return parser.parse_args()

--- a/stm32-modules/thermocycler-gen2/scripts/plot_temp.py
+++ b/stm32-modules/thermocycler-gen2/scripts/plot_temp.py
@@ -18,19 +18,23 @@ def graphTemperatures(ser_in : serial.Serial = None, _callback = None):
     SAMPLE_LIMIT = 500
     SAMPLE_INTERVAL = 100
     x_time, y_lid , y_left, y_center, y_right, y_sink= [], [], [], [], [], []
+    lp, cp, rp = [], [], []
     if not ser_in:
         print('Building new serial')
         ser = test_utils.build_serial()
     else:
         ser = ser_in
 
-    fig = pp.figure()
-    lid_line, = pp.plot_date(x_time, y_lid, '-b', label='Lid (C)')
+    fig, axs = pp.subplots(2)
+    lid_line, = axs[0].plot_date(x_time, y_lid, '-b', label='Lid (C)')
     #plate_line, = pp.plot_date(x_time, y_plate, '-r', label='Plate (C)')
-    left_line, = pp.plot_date(x_time, y_left, '-r', label='Left (C)')
-    right_line, = pp.plot_date(x_time, y_right, '-c', label='Right (C)')
-    center_line, = pp.plot_date(x_time, y_center, '-y', label='Center (C)')
-    sink_line, = pp.plot_date(x_time, y_sink, '-g', label='Heatsink (C)')
+    left_line, = axs[0].plot_date(x_time, y_left, '-r', label='Left (C)')
+    right_line, = axs[0].plot_date(x_time, y_right, '-c', label='Right (C)')
+    center_line, = axs[0].plot_date(x_time, y_center, '-y', label='Center (C)')
+    sink_line, = axs[0].plot_date(x_time, y_sink, '-g', label='Heatsink (C)')
+    lp_line, = axs[1].plot_date(x_time, lp, '-r', label='left power')
+    cp_line, = axs[1].plot_date(x_time, cp, '-c', label='center power')
+    rp_line, = axs[1].plot_date(x_time, rp, '-y', label='right power')
     fig.legend()
 
     # Sub function for the updating
@@ -44,6 +48,10 @@ def graphTemperatures(ser_in : serial.Serial = None, _callback = None):
         y_left.append(left)
         y_right.append(right)
         y_center.append(center)
+        l, c, r = test_utils.get_thermal_power(ser)
+        lp.append(l)
+        cp.append(c)
+        rp.append(r)
 
         if _callback:
             _callback(lid, hs, right, left, center)
@@ -56,6 +64,9 @@ def graphTemperatures(ser_in : serial.Serial = None, _callback = None):
             y_left.pop(0)
             y_right.pop(0)
             y_center.pop(0)
+            lp.pop(0)
+            cp.pop(0)
+            rp.pop(0)
             
         lid_line.set_data(x_time, y_lid)
         #plate_line.set_data(x_time, y_plate)
@@ -63,12 +74,19 @@ def graphTemperatures(ser_in : serial.Serial = None, _callback = None):
         right_line.set_data(x_time, y_right)
         center_line.set_data(x_time, y_center)
         sink_line.set_data(x_time, y_sink)
+        lp_line.set_data(x_time, lp)
+        cp_line.set_data(x_time, cp)
+        rp_line.set_data(x_time, rp)
         if(len(x_time) == SAMPLE_LIMIT):
-            fig.gca().set_xlim(left=x_time[0], right = x_time[-1])
+            axs[0].set_xlim(left=x_time[0], right = x_time[-1])
+            axs[1].set_xlim(left=x_time[0], right = x_time[-1])
     
     max_x = datetime.now() + timedelta(milliseconds=SAMPLE_INTERVAL * SAMPLE_LIMIT)
-    fig.gca().set_xlim(left=datetime.now(), right = max_x)
-    fig.gca().set_ylim(bottom=0, top=100)
+    axs[0].set_xlim(left=datetime.now(), right = max_x)
+    axs[1].set_xlim(left=datetime.now(), right = max_x)
+    
+    axs[0].set_ylim(bottom=0, top=100)
+    axs[1].set_ylim(bottom=-1.2, top=1.2)
     animation = FuncAnimation(fig, update, interval=SAMPLE_INTERVAL)
     pp.show()
 

--- a/stm32-modules/thermocycler-gen2/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-gen2/scripts/test_utils.py
@@ -224,6 +224,16 @@ def set_peltier_pid(p: float, i: float, d: float, ser: serial.Serial):
     guard_error(res, b'M301 OK')
     print(res)
 
+_POWER_RE = re.compile('^M103.D L:(?P<left>.+) C:(?P<center>.+) R:(?P<right>.+) H:(?P<heater>.+) F:(?P<fans>.+) OK\n')
+
+def get_thermal_power(ser: serial.Serial):
+    ser.write(b'M103.D\n')
+    res = ser.readline()
+    guard_error(res, b'M103.D')
+    res_s = res.decode()
+    match = re.match(_POWER_RE, res_s)
+    return float(match.group('left')), float(match.group('center')), float(match.group('right'))
+
 # Debug command to move the hinge motor
 def move_lid_angle(angle: float, overdrive: bool, ser: serial.Serial):
     print(f'Moving lid by {angle}º overdrive = {overdrive}')


### PR DESCRIPTION
This adds a self contained python testing script intended to test the performance of each individual channel on a Thermocycler.

Other misc changes:
- Added a command in `test_utils` to get the power for each peltier
- Added power data in a separate plot to the `plot_data` tool

Tested by performing a run on an EVT unit