### PR TITLE
feat(thermocycler-gen2): thermal calibration and tuning

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/eeprom.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/eeprom.hpp
@@ -23,7 +23,7 @@ namespace eeprom {
  * readings. Using two constants, B and C (for legacy purposes), the
  * resulting temperature relationship can be summarized as follows:
  *
- * > Plate Temp = ((B + 1) * Measured Temp) + C
+ * > Plate Temp = A * (heatsink temp) + ((B + 1) * Measured Temp) + C
  *
  * One of the EEPROM pages is reserved for a flag to indicate whether
  * the values have been written. The \ref EEPROMFlag enum captures the
@@ -33,7 +33,7 @@ namespace eeprom {
  */
 struct OffsetConstants {
     // The value of the constants B and C
-    double b, c;
+    double a, b, c;
 };
 
 /**
@@ -54,15 +54,18 @@ class Eeprom {
      * default values if the EEPROM doesn't have programmed values.
      */
     template <at24c0xc::AT24C0xC_Policy Policy>
-    [[nodiscard]] auto get_offset_constants(Policy& policy) -> OffsetConstants {
-        OffsetConstants ret = {.b = OFFSET_DEFAULT_CONST,
-                               .c = OFFSET_DEFAULT_CONST};
+    [[nodiscard]] auto get_offset_constants(const OffsetConstants& defaults,
+                                            Policy& policy) -> OffsetConstants {
+        OffsetConstants ret = defaults;
         // Read the constantsss
         auto flag = read_const_flag(policy);
 
-        if (flag == EEPROMFlag::WRITTEN_NO_CHECKSUM) {
+        if (flag != EEPROMFlag::INVALID) {
             ret.b = read_const(EEPROMPageMap::CONST_B, policy);
             ret.c = read_const(EEPROMPageMap::CONST_C, policy);
+        }
+        if (flag == EEPROMFlag::WRITTEN_WITH_A) {
+            ret.a = read_const(EEPROMPageMap::CONST_A, policy);
         }
         _initialized = true;
         return ret;
@@ -81,6 +84,15 @@ class Eeprom {
     auto write_offset_constants(OffsetConstants constants, Policy& policy)
         -> bool {
         // Write the constants
+        if (!_eeprom.template write_value(
+                static_cast<uint8_t>(EEPROMPageMap::CONST_A), constants.a,
+                policy)) {
+            // Attempt to flag that the constants are not valid
+            static_cast<void>(_eeprom.template write_value(
+                static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG),
+                static_cast<uint32_t>(EEPROMFlag::INVALID), policy));
+            return false;
+        }
         if (!_eeprom.template write_value(
                 static_cast<uint8_t>(EEPROMPageMap::CONST_B), constants.b,
                 policy)) {
@@ -102,7 +114,7 @@ class Eeprom {
         // Flag that the constants are good
         return _eeprom.template write_value(
             static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG),
-            static_cast<uint32_t>(EEPROMFlag::WRITTEN_NO_CHECKSUM), policy);
+            static_cast<uint32_t>(EEPROMFlag::WRITTEN_WITH_A), policy);
     }
 
     /**
@@ -118,12 +130,17 @@ class Eeprom {
         CONST_B = 0,  // Value of the B constant
         CONST_C = 1,  // Value of the C constant
         // Flag indicating whether constants have been written.
-        // Set to 1 to mark that constants are written with no checksum
-        CONST_FLAG = 2
+        // See \ref EEPROMFlag
+        CONST_FLAG = 2,
+        CONST_A = 3,  // Value of the A constant
     };
 
     // Enumeration of the EEPROM_CONST_FLAG values
-    enum class EEPROMFlag { WRITTEN_NO_CHECKSUM = 1, INVALID = 0xFF };
+    enum class EEPROMFlag {
+        WRITTEN_NO_A = 1,    // Values of B and C are written
+        WRITTEN_WITH_A = 2,  // Values of all constants are written
+        INVALID = 0xFF       // No values are written
+    };
 
     static_assert(sizeof(EEPROMPageMap) == sizeof(uint8_t),
                   "EEPROM API requires uint8_t page address");
@@ -135,7 +152,7 @@ class Eeprom {
      * @brief Read one of the constants on the device
      *
      * @tparam Policy class for reading from the eeprom
-     * @param page Which page to read. Must be CONST_B or CONST_C
+     * @param page Which page to read. Must be a valid page
      * @param policy Instance of Policy for reading
      * @return double containing the constant
      */
@@ -166,9 +183,11 @@ class Eeprom {
             static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG), policy);
         if (val.has_value()) {
             auto flag = val.value();
-            if (flag ==
-                static_cast<uint32_t>(EEPROMFlag::WRITTEN_NO_CHECKSUM)) {
-                return EEPROMFlag::WRITTEN_NO_CHECKSUM;
+            if (flag == static_cast<uint32_t>(EEPROMFlag::WRITTEN_NO_A)) {
+                return EEPROMFlag::WRITTEN_NO_A;
+            }
+            if (flag == static_cast<uint32_t>(EEPROMFlag::WRITTEN_WITH_A)) {
+                return EEPROMFlag::WRITTEN_WITH_A;
             }
         }
         // Default

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -476,7 +476,8 @@ class HostCommsTask {
                         errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
                 } else {
                     return cache_element.write_response_into(
-                        tx_into, tx_limit, response.const_b, response.const_c);
+                        tx_into, tx_limit, response.const_a, response.const_b,
+                        response.const_c);
                 }
             },
             cache_entry);
@@ -1263,6 +1264,8 @@ class HostCommsTask {
         }
         auto message =
             messages::SetOffsetConstantsMessage{.id = id,
+                                                .a_set = gcode.const_a.defined,
+                                                .const_a = gcode.const_a.value,
                                                 .b_set = gcode.const_b.defined,
                                                 .const_b = gcode.const_b.value,
                                                 .c_set = gcode.const_c.defined,

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -277,6 +277,8 @@ struct SetPIDConstantsMessage {
 
 struct SetOffsetConstantsMessage {
     uint32_t id;
+    bool a_set;
+    double const_a;
     bool b_set;
     double const_b;
     bool c_set;
@@ -289,7 +291,7 @@ struct GetOffsetConstantsMessage {
 
 struct GetOffsetConstantsResponse {
     uint32_t responding_to_id;
-    double const_b, const_c;
+    double const_a, const_b, const_c;
 };
 
 struct UpdateUIMessage {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -673,8 +673,7 @@ class ThermalPlateTask {
     auto handle_temperature_conversion(uint16_t conversion_result,
                                        Thermistor& thermistor,
                                        bool apply_offset,
-                                       const double heatsink_temp = 0.0F)
-        -> void {
+                                       double heatsink_temp = 0.0F) -> void {
         auto visitor = [this, &thermistor](const auto value) -> void {
             this->visit_conversion(thermistor, value);
         };

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -116,9 +116,9 @@ class ThermalPlateTask {
         CONTROL_PERIOD_TICKS * 0.001;
     static constexpr size_t EEPROM_PAGES = 32;
     static constexpr uint8_t EEPROM_ADDRESS = 0b1010010;
-    static constexpr const double OFFSET_DEFAULT_CONST_A = 0.0F;
-    static constexpr const double OFFSET_DEFAULT_CONST_B = 0.0F;
-    static constexpr const double OFFSET_DEFAULT_CONST_C = 0.0F;
+    static constexpr const double OFFSET_DEFAULT_CONST_A = -0.02F;
+    static constexpr const double OFFSET_DEFAULT_CONST_B = 0.022F;
+    static constexpr const double OFFSET_DEFAULT_CONST_C = -0.154F;
 
     explicit ThermalPlateTask(Queue& q)
         : _message_queue(q),

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -93,10 +93,12 @@ class ThermalPlateTask {
     static constexpr double THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM = 10.0;
     static constexpr uint16_t ADC_BIT_MAX = 0x5DC0;
     static constexpr uint8_t PLATE_THERM_COUNT = 7;
-    // TODO most of these defaults will have to change
-    static constexpr double DEFAULT_KI = 0.05356;
-    static constexpr double DEFAULT_KP = 0.26225;
-    static constexpr double DEFAULT_KD = 0.00812;
+    // Peltier KI
+    static constexpr double DEFAULT_KI = 0.03;
+    // Peltier KP
+    static constexpr double DEFAULT_KP = 0.1;
+    // Peltier KD
+    static constexpr double DEFAULT_KD = 0.0;
     static constexpr double DEFAULT_FAN_KI = 0.01;
     static constexpr double DEFAULT_FAN_KP = 0.2;
     static constexpr double DEFAULT_FAN_KD = 0.05;
@@ -114,6 +116,7 @@ class ThermalPlateTask {
         CONTROL_PERIOD_TICKS * 0.001;
     static constexpr size_t EEPROM_PAGES = 32;
     static constexpr uint8_t EEPROM_ADDRESS = 0b1010010;
+    static constexpr const double OFFSET_DEFAULT_CONST_A = 0.0F;
     static constexpr const double OFFSET_DEFAULT_CONST_B = 0.0F;
     static constexpr const double OFFSET_DEFAULT_CONST_C = 0.0F;
 
@@ -197,7 +200,8 @@ class ThermalPlateTask {
           _plate_control(_peltier_left, _peltier_right, _peltier_center, _fans),
           // NOLINTNEXTLINE(readability-redundant-member-init)
           _eeprom(),
-          _offset_constants{.b = OFFSET_DEFAULT_CONST_B,
+          _offset_constants{.a = OFFSET_DEFAULT_CONST_A,
+                            .b = OFFSET_DEFAULT_CONST_B,
                             .c = OFFSET_DEFAULT_CONST_C},
           _last_update(0) {}
     ThermalPlateTask(const ThermalPlateTask& other) = delete;
@@ -232,7 +236,8 @@ class ThermalPlateTask {
         // If the EEPROM data hasn't been read, read it before doing
         // anything else.
         if (!_eeprom.initialized()) {
-            _offset_constants = _eeprom.get_offset_constants(policy);
+            _offset_constants =
+                _eeprom.get_offset_constants(_offset_constants, policy);
         }
 
         // This is the call down to the provided queue. It will block for
@@ -264,20 +269,21 @@ class ThermalPlateTask {
 
         // Peltier temperatures are implicitly updated by updating the values
         // in the thermistors
-        handle_temperature_conversion(msg.front_right,
-                                      _thermistors[THERM_FRONT_RIGHT], true);
-        handle_temperature_conversion(msg.front_left,
-                                      _thermistors[THERM_FRONT_LEFT], true);
-        handle_temperature_conversion(msg.front_center,
-                                      _thermistors[THERM_FRONT_CENTER], true);
-        handle_temperature_conversion(msg.back_right,
-                                      _thermistors[THERM_BACK_RIGHT], true);
-        handle_temperature_conversion(msg.back_left,
-                                      _thermistors[THERM_BACK_LEFT], true);
-        handle_temperature_conversion(msg.back_center,
-                                      _thermistors[THERM_BACK_CENTER], true);
         handle_temperature_conversion(msg.heat_sink,
                                       _thermistors[THERM_HEATSINK], false);
+        auto heatsink = _thermistors[THERM_HEATSINK].temp_c;
+        handle_temperature_conversion(
+            msg.front_right, _thermistors[THERM_FRONT_RIGHT], true, heatsink);
+        handle_temperature_conversion(
+            msg.front_left, _thermistors[THERM_FRONT_LEFT], true, heatsink);
+        handle_temperature_conversion(
+            msg.front_center, _thermistors[THERM_FRONT_CENTER], true, heatsink);
+        handle_temperature_conversion(
+            msg.back_right, _thermistors[THERM_BACK_RIGHT], true, heatsink);
+        handle_temperature_conversion(
+            msg.back_left, _thermistors[THERM_BACK_LEFT], true, heatsink);
+        handle_temperature_conversion(
+            msg.back_center, _thermistors[THERM_BACK_CENTER], true, heatsink);
 
         if (old_error_bitmap != _state.error_bitmap) {
             if (_state.error_bitmap != 0) {
@@ -629,6 +635,9 @@ class ThermalPlateTask {
         auto response =
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
 
+        if (msg.a_set) {
+            _offset_constants.a = msg.const_a;
+        }
         if (msg.b_set) {
             _offset_constants.b = msg.const_b;
         }
@@ -649,9 +658,11 @@ class ThermalPlateTask {
     template <ThermalPlateExecutionPolicy Policy>
     auto visit_message(const messages::GetOffsetConstantsMessage& msg,
                        Policy& policy) -> void {
-        _offset_constants = _eeprom.get_offset_constants(policy);
+        _offset_constants =
+            _eeprom.get_offset_constants(_offset_constants, policy);
         auto response = messages::GetOffsetConstantsResponse{
             .responding_to_id = msg.id,
+            .const_a = _offset_constants.a,
             .const_b = _offset_constants.b,
             .const_c = _offset_constants.c};
 
@@ -661,7 +672,9 @@ class ThermalPlateTask {
 
     auto handle_temperature_conversion(uint16_t conversion_result,
                                        Thermistor& thermistor,
-                                       bool apply_offset) -> void {
+                                       bool apply_offset,
+                                       const double heatsink_temp = 0.0F)
+        -> void {
         auto visitor = [this, &thermistor](const auto value) -> void {
             this->visit_conversion(thermistor, value);
         };
@@ -671,7 +684,8 @@ class ThermalPlateTask {
         std::visit(visitor, _converter.convert(conversion_result));
         // If there was an error, don't apply the offset
         if (apply_offset && (thermistor.error == errors::ErrorCode::NO_ERROR)) {
-            thermistor.temp_c = calculate_thermistor_offset(thermistor.temp_c);
+            thermistor.temp_c =
+                calculate_thermistor_offset(thermistor.temp_c, heatsink_temp);
         }
         if (old_error != thermistor.error) {
             if (thermistor.error != errors::ErrorCode::NO_ERROR) {
@@ -868,14 +882,17 @@ class ThermalPlateTask {
      *
      * @param temp The measured temperature of the thermistor with no offset
      * applied.
-     * @return double containing the
+     * @param heatsink_temp the current measured temperature of the heatsink
+     * @return double containing the adjusted thermistor temperature
      */
-    [[nodiscard]] auto calculate_thermistor_offset(double temp) const
+    [[nodiscard]] auto calculate_thermistor_offset(double temp,
+                                                   double heatsink_temp) const
         -> double {
         if (!_eeprom.initialized()) {
             return temp;
         }
-        return ((1.0F + _offset_constants.b) * temp) + _offset_constants.c;
+        return (_offset_constants.a * heatsink_temp) +
+               ((1.0F + _offset_constants.b) * temp) + _offset_constants.c;
     }
 
     Queue& _message_queue;

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
@@ -8,7 +8,15 @@ The plate consists of a 3 column array of peltier modules, where each column is 
 
 ### Plate Offset
 
-The temperature measured by the thermistors is not necessarily equal to the temperature of the plate. In order to compensate for this temperature differential, a set of calibration coefficients can be programmed to set a function in the form of `y = mx + b`, wherein `x` is the temperature measured by a thermistor and `y` is the approximate temperature on the actual plate.
+The temperature measured by the thermistors is not necessarily equal to the temperature of the plate. In order to compensate for this temperature differential, a set of calibration coefficients are provided to make a more accurate estimate of the temperature in the wells.
+
+- There are three offset coefficents, `A`, `B`, and `C`.
+- There are two inputs to the calibration function: The current uncalibrated temperature of the thermistor (`T`), and the current temperature measured on the heat sink (`H`).
+- The output is the Calibrated Temperature, `C`
+
+The offset compensation is as follows:
+
+> C = (A * H) + ((B + 1) * T) + C
 
 ### Ramp Control & Volumetric Overshoot
 

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
@@ -12,11 +12,9 @@ The temperature measured by the thermistors is not necessarily equal to the temp
 
 - There are three offset coefficents, `A`, `B`, and `C`.
 - There are two inputs to the calibration function: The current uncalibrated temperature of the thermistor (`T`), and the current temperature measured on the heat sink (`H`).
-- The output is the Calibrated Temperature, `C`
+- The output is the Calibrated Temperature, `Tc`
 
-The offset compensation is as follows:
-
-> C = (A * H) + ((B + 1) * T) + C
+The offset compensation is as follows: `Tc = (A * H) + ((B + 1) * T) + C`
 
 ### Ramp Control & Volumetric Overshoot
 

--- a/stm32-modules/thermocycler-gen2/scripts/test_utils.py
+++ b/stm32-modules/thermocycler-gen2/scripts/test_utils.py
@@ -314,15 +314,18 @@ def get_lid_status(ser: serial.Serial) -> Tuple[PositionStatus, PositionStatus]:
     return ret
 
 # Function to set offset constants
-def set_offset_constants(ser: serial.Serial, const_b = None, const_c = None):
+def set_offset_constants(ser: serial.Serial, const_a = None, const_b = None, const_c = None):
+    a_str = ''
+    if const_a != None:
+        a_str = f' A{const_a}'
     b_str = ''
     if const_b != None:
         b_str = f' B{const_b}'
     c_str = ''
     if const_c != None:
         c_str = f' C{const_c}'
-    print(f'Setting constants{b_str}{c_str}\n')
-    ser.write(f'M116{b_str}{c_str}\n'.encode())
+    print(f'Setting constants{a_str}{b_str}{c_str}\n')
+    ser.write(f'M116{a_str}{b_str}{c_str}\n'.encode())
     res = ser.readline()
     guard_error(res, b'M116 OK\n')
     print(res)
@@ -330,7 +333,7 @@ def set_offset_constants(ser: serial.Serial, const_b = None, const_c = None):
 def get_offset_constants(ser: serial.Serial):
     ser.write('M117\n'.encode())
     res = ser.readline()
-    guard_error(res, b'M117 B:')
+    guard_error(res, b'M117 A:')
     print(res)
 
 # Function to fully open the lid

--- a/stm32-modules/thermocycler-gen2/tests/test_eeprom.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_eeprom.cpp
@@ -11,7 +11,8 @@ TEST_CASE("eeprom class initialization tracking") {
         auto eeprom = Eeprom<32, 0x10>();
         THEN("it starts as noninitialized") { REQUIRE(!eeprom.initialized()); }
         WHEN("reading from the EEPROM") {
-            static_cast<void>(eeprom.get_offset_constants(policy));
+            auto defaults = OffsetConstants{.a = 0, .b = 0, .c = 0};
+            static_cast<void>(eeprom.get_offset_constants(defaults, policy));
             THEN("the EEPROM now shows as initialized") {
                 REQUIRE(eeprom.initialized());
             }
@@ -24,25 +25,34 @@ TEST_CASE("blank eeprom reading") {
         auto policy = TestAT24C0XCPolicy<32>();
         auto eeprom = Eeprom<32, 0x10>();
         WHEN("reading before writing anything") {
-            auto readback = eeprom.get_offset_constants(policy);
-            THEN("the resulting constants are 0") {
-                REQUIRE_THAT(readback.b, Catch::Matchers::WithinAbs(0, 0.01));
-                REQUIRE_THAT(readback.c, Catch::Matchers::WithinAbs(0, 0.01));
+            auto defaults = OffsetConstants{.a = 68, .b = -5, .c = 50};
+            auto readback = eeprom.get_offset_constants(defaults, policy);
+            THEN("the resulting constants are the defaults") {
+                REQUIRE_THAT(readback.a,
+                             Catch::Matchers::WithinAbs(defaults.a, 0.01));
+                REQUIRE_THAT(readback.b,
+                             Catch::Matchers::WithinAbs(defaults.b, 0.01));
+                REQUIRE_THAT(readback.c,
+                             Catch::Matchers::WithinAbs(defaults.c, 0.01));
             }
         }
     }
 }
 
 TEST_CASE("eeprom reading and writing") {
-    GIVEN("an EEPROM and constants B = 10 and C = -12") {
+    GIVEN("an EEPROM and constants A= -3.5, B = 10 and C = -12") {
         auto policy = TestAT24C0XCPolicy<32>();
         auto eeprom = Eeprom<32, 0x10>();
-        OffsetConstants constants = {.b = 10.0F, .c = -12.0F};
+        OffsetConstants constants = {.a = -3.5F, .b = 10.0F, .c = -12.0F};
         WHEN("writing the constants") {
             REQUIRE(eeprom.write_offset_constants(constants, policy));
             AND_THEN("reading back the constants") {
-                auto readback = eeprom.get_offset_constants(policy);
+                auto defaults =
+                    OffsetConstants{.a = -100, .b = -100, .c = -100};
+                auto readback = eeprom.get_offset_constants(defaults, policy);
                 THEN("the constants match") {
+                    REQUIRE_THAT(readback.a,
+                                 Catch::Matchers::WithinAbs(constants.a, 0.01));
                     REQUIRE_THAT(readback.b,
                                  Catch::Matchers::WithinAbs(constants.b, 0.01));
                     REQUIRE_THAT(readback.c,

--- a/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
@@ -1941,6 +1941,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     std::get<messages::SetOffsetConstantsMessage>(plate_msg);
                 REQUIRE(!tasks->get_host_comms_queue().has_message());
                 REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(!message.a_set);
                 REQUIRE(!message.b_set);
                 REQUIRE(!message.c_set);
                 AND_WHEN("sending good response back") {
@@ -2006,6 +2007,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     auto response = messages::HostCommsMessage(
                         messages::GetOffsetConstantsResponse{
                             .responding_to_id = message.id,
+                            .const_a = 2.0,
                             .const_b = 10.0,
                             .const_c = 15.0});
                     tasks->get_host_comms_queue().backing_deque.push_back(
@@ -2014,7 +2016,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should ack the previous message") {
-                        auto response = "M117 B:10.00 C:15.00 OK\n";
+                        auto response = "M117 A:2.000 B:10.000 C:15.000 OK\n";
                         REQUIRE_THAT(tx_buf,
                                      Catch::Matchers::StartsWith(response));
                         REQUIRE(written_secondpass ==
@@ -2027,6 +2029,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     auto response = messages::HostCommsMessage(
                         messages::GetOffsetConstantsResponse{
                             .responding_to_id = message.id + 1,
+                            .const_a = 2.0,
                             .const_b = 10.0,
                             .const_c = 15.0});
                     tasks->get_host_comms_queue().backing_deque.push_back(

--- a/stm32-modules/thermocycler-gen2/tests/test_m116.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m116.cpp
@@ -35,6 +35,7 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
                 REQUIRE(parsed.second != input.begin());
                 REQUIRE(parsed.first.has_value());
                 auto &val = parsed.first.value();
+                REQUIRE(!val.const_a.defined);
                 REQUIRE(!val.const_b.defined);
                 REQUIRE(!val.const_c.defined);
             }
@@ -49,6 +50,7 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
                 REQUIRE(parsed.second != input.begin());
                 REQUIRE(parsed.first.has_value());
                 auto &val = parsed.first.value();
+                REQUIRE(!val.const_a.defined);
                 REQUIRE(val.const_b.defined);
                 REQUIRE_THAT(val.const_b.value,
                              Catch::Matchers::WithinAbs(-0.543, 0.01));
@@ -65,6 +67,7 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
                 REQUIRE(parsed.second != input.begin());
                 REQUIRE(parsed.first.has_value());
                 auto &val = parsed.first.value();
+                REQUIRE(!val.const_a.defined);
                 REQUIRE(!val.const_b.defined);
                 REQUIRE(val.const_c.defined);
                 REQUIRE_THAT(val.const_c.value,
@@ -72,7 +75,24 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
             }
         }
     }
-    GIVEN("input to set both constants") {
+    GIVEN("input to set A constant") {
+        std::string input = "M116 A123.5\n";
+        WHEN("parsing") {
+            auto parsed =
+                gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            THEN("parsing should be succesful") {
+                REQUIRE(parsed.second != input.begin());
+                REQUIRE(parsed.first.has_value());
+                auto &val = parsed.first.value();
+                REQUIRE(!val.const_b.defined);
+                REQUIRE(!val.const_c.defined);
+                REQUIRE(val.const_a.defined);
+                REQUIRE_THAT(val.const_a.value,
+                             Catch::Matchers::WithinAbs(123.5, 0.01));
+            }
+        }
+    }
+    GIVEN("input to set B and C constants") {
         std::string input = "M116 B543 C123.5\n";
         WHEN("parsing") {
             auto parsed =
@@ -81,12 +101,34 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
                 REQUIRE(parsed.second != input.begin());
                 REQUIRE(parsed.first.has_value());
                 auto &val = parsed.first.value();
+                REQUIRE(!val.const_a.defined);
                 REQUIRE(val.const_b.defined);
                 REQUIRE_THAT(val.const_b.value,
                              Catch::Matchers::WithinAbs(543, 0.01));
                 REQUIRE(val.const_c.defined);
                 REQUIRE_THAT(val.const_c.value,
                              Catch::Matchers::WithinAbs(123.5, 0.01));
+            }
+        }
+    }
+    GIVEN("input to set A, B, and C constants") {
+        std::string input = "M116 A2.043 B543 C123.5\n";
+        WHEN("parsing") {
+            auto parsed =
+                gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            THEN("parsing should be succesful") {
+                REQUIRE(parsed.second != input.begin());
+                REQUIRE(parsed.first.has_value());
+                auto &val = parsed.first.value();
+                REQUIRE(val.const_a.defined);
+                REQUIRE_THAT(val.const_a.value,
+                             Catch::Matchers::WithinAbs(2.043, 0.001));
+                REQUIRE(val.const_b.defined);
+                REQUIRE_THAT(val.const_b.value,
+                             Catch::Matchers::WithinAbs(543, 0.001));
+                REQUIRE(val.const_c.defined);
+                REQUIRE_THAT(val.const_c.value,
+                             Catch::Matchers::WithinAbs(123.5, 0.001));
             }
         }
     }

--- a/stm32-modules/thermocycler-gen2/tests/test_m117.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m117.cpp
@@ -9,9 +9,9 @@ SCENARIO("GetOffsetConstants (M105.D) parser works", "[gcode][parse][m105.d]") {
         std::string buffer(256, 'c');
         WHEN("filling response") {
             auto written = gcode::GetOffsetConstants::write_response_into(
-                buffer.begin(), buffer.end(), 10.0, 15.0);
+                buffer.begin(), buffer.end(), 2.0, 10.0, 15.0);
             THEN("the response should be written in full") {
-                auto response_str = "M117 B:10.00 C:15.00 OK\n";
+                auto response_str = "M117 A:2.000 B:10.000 C:15.000 OK\n";
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(response_str));
                 REQUIRE(written == buffer.begin() + strlen(response_str));
             }
@@ -22,9 +22,9 @@ SCENARIO("GetOffsetConstants (M105.D) parser works", "[gcode][parse][m105.d]") {
         std::string buffer(16, 'c');
         WHEN("filling response") {
             auto written = gcode::GetOffsetConstants::write_response_into(
-                buffer.begin(), buffer.begin() + 7, 10.0, 15.0);
+                buffer.begin(), buffer.begin() + 7, 2.0, 10.0, 15.0);
             THEN("the response should write only up to the available space") {
-                std::string response = "M117 Bcccccccccc";
+                std::string response = "M117 Acccccccccc";
                 response.at(6) = '\0';
                 REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
                 REQUIRE(written != buffer.begin());


### PR DESCRIPTION
### Summary

- Added in a new calibration offset for the thermal system which takes the current heat sink temperature into account when calculating the offset from thermistor to plate, copied from the Thermocycler Gen1.
- Modified default PID values for peltiers to be less aggressive in order to reduce oscillation
- Added default thermal calibration values based off of initial population testing on EVT units

Tested on an EVT unit. The offset values were verified by testing the steady-state temperature in the well plates using a multiprobe tool.