### PR TITLE
feat(thermocycler-gen2): simulate motors

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_utils.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_utils.hpp
@@ -34,6 +34,9 @@ class LidStepper {
     constexpr static double DEGREES_TO_MICROSTEPS =
         STEPS_PER_REV * MICROSTEPPING * GEAR_RATIO_SCALAR;
     constexpr static double ROTATION_TO_STEPS = DEGREES_TO_MICROSTEPS * 360;
+    // Total factor to multiply from degrees to microsteps
+    constexpr static double MICROSTEPS_TO_DEGREES =
+        1.0F / DEGREES_TO_MICROSTEPS;
 
   public:
     /** Possible states of the lid stepper.*/
@@ -89,6 +92,11 @@ class LidStepper {
     [[nodiscard]] constexpr static auto angle_to_microsteps(double angle)
         -> int32_t {
         return static_cast<int32_t>(angle * DEGREES_TO_MICROSTEPS);
+    }
+
+    [[nodiscard]] constexpr static auto microsteps_to_angle(int32_t steps)
+        -> double {
+        return static_cast<double>(steps) * MICROSTEPS_TO_DEGREES;
     }
 };
 

--- a/stm32-modules/thermocycler-gen2/simulator/motor_thread.cpp
+++ b/stm32-modules/thermocycler-gen2/simulator/motor_thread.cpp
@@ -1,8 +1,11 @@
 #include "simulator/motor_thread.hpp"
 
+#include <algorithm>
+
 #include "simulator/sim_tmc2130_policy.hpp"
 #include "systemwide.h"
 #include "thermocycler-gen2/errors.hpp"
+#include "thermocycler-gen2/motor_utils.hpp"
 #include "thermocycler-gen2/tasks.hpp"
 
 using namespace motor_thread;
@@ -14,37 +17,73 @@ class SimMotorPolicy : public SimTMC2130Policy {
     /** Frequency of the seal motor interrupt in hertz.*/
     static constexpr const uint32_t MotorTickFrequency = 1000000;
 
-    SimMotorPolicy() : SimTMC2130Policy(), _callback() {}
+    SimMotorPolicy(SimMotorTask::Queue &queue)
+        : SimTMC2130Policy(), _callback(), _task_queue(queue) {}
 
     // Functionality to fulfill concept
 
     auto lid_stepper_set_dac(uint8_t dac_val) -> void { _dac_val = dac_val; }
-    auto lid_stepper_start(int32_t steps, bool overdrive) -> void {
-        _lid_overdrive = overdrive;
-        // Simulate jumping right to the end
-        if (_lid_fault) {
-            return;
-        }
-        _actual_angle += steps;
-        _moving = false;
-    }
-    auto lid_stepper_stop() -> void { _moving = false; }
 
-    auto lid_stepper_check_fault() -> bool { return _lid_fault; }
+    // Simulates the movement occuring immediately
+    auto lid_stepper_start(int32_t steps, bool overdrive) -> void {
+        auto current_position = current_lid_angle();
+
+        // First, check if a switch is already triggered
+        if (!overdrive) {
+            if (steps > 0 && open_switch_triggered(current_position)) {
+                send_lid_done();
+                return;
+            }
+            if (steps < 0 && close_switch_triggered(current_position)) {
+                send_lid_done();
+                return;
+            }
+        }
+
+        auto target_angle = current_position +
+                            motor_util::LidStepper::microsteps_to_angle(steps);
+        // Now, check if the movement will trigger a switch
+        if (!overdrive) {
+            if (steps > 0) {
+                if (current_position < open_switch_pos_angle &&
+                    target_angle > open_switch_pos_angle - switch_width_angle) {
+                    target_angle = open_switch_pos_angle;
+                }
+            } else {
+                if (current_position > close_switch_pos_angle &&
+                    target_angle <
+                        close_switch_pos_angle + switch_width_angle) {
+                    target_angle = close_switch_pos_angle;
+                }
+            }
+        }
+        // Change the angle and send the response
+        auto target_steps =
+            motor_util::LidStepper::angle_to_microsteps(target_angle);
+        _lid_step_position =
+            std::clamp<int32_t>(target_steps, min_lid_steps, max_lid_steps);
+        send_lid_done();
+    }
+    auto lid_stepper_stop() -> void { return; }
+
+    auto lid_stepper_check_fault() -> bool { return false; }
 
     auto lid_stepper_reset() -> bool {
-        _moving = false;
         _dac_val = 0;
-        _lid_fault = false;
         return true;
     }
 
     auto lid_solenoid_disengage() -> void { _solenoid_engaged = false; }
     auto lid_solenoid_engage() -> void { _solenoid_engaged = true; }
 
-    auto lid_read_closed_switch() -> bool { return _lid_closed_switch; }
+    // Check based on the current angle position
+    auto lid_read_closed_switch() -> bool {
+        return close_switch_triggered(current_lid_angle());
+    }
 
-    auto lid_read_open_switch() -> bool { return _lid_open_switch; }
+    auto lid_read_open_switch() -> bool {
+        return open_switch_triggered(current_lid_angle());
+    }
 
     auto seal_stepper_start(Callback cb) -> bool {
         if (_seal_moving) {
@@ -72,18 +111,46 @@ class SimMotorPolicy : public SimTMC2130Policy {
     }
 
   private:
+    // Lowest position the lid can move before stalling
+    static constexpr uint32_t min_lid_steps =
+        motor_util::LidStepper::angle_to_microsteps(-2.0);
+    // Max position for the lid before stalling
+    static constexpr uint32_t max_lid_steps =
+        motor_util::LidStepper::angle_to_microsteps(120.0);
+    // Position of center of closed switch
+    static constexpr double close_switch_pos_angle = 0.0F;
+    // Position of center of open switch
+    static constexpr double open_switch_pos_angle = 90.0F;
+    // Simulated width of each lid switch in degrees
+    static constexpr double switch_width_angle = 1.0F;
+
+    // Check if open switch is triggered
+    [[nodiscard]] static auto open_switch_triggered(double angle) -> bool {
+        return std::abs(angle - open_switch_pos_angle) <= switch_width_angle;
+    }
+
+    // Check if close switch is triggered
+    [[nodiscard]] static auto close_switch_triggered(double angle) -> bool {
+        return std::abs(angle - close_switch_pos_angle) <= switch_width_angle;
+    }
+
+    // Convert _lid_step_position from steps to angle
+    [[nodiscard]] auto current_lid_angle() const -> double {
+        return motor_util::LidStepper::microsteps_to_angle(_lid_step_position);
+    }
+
+    auto send_lid_done() -> void {
+        static_cast<void>(_task_queue.try_send(messages::LidStepperComplete()));
+    }
+
     // Solenoid is engaged when unpowered
     bool _solenoid_engaged = true;
     uint8_t _dac_val = 0;
-    int32_t _actual_angle = 0;
-    bool _moving = false;
-    bool _lid_fault = false;
-    bool _lid_open_switch = false;
-    bool _lid_closed_switch = false;
+    int32_t _lid_step_position = 0;
     bool _seal_moving = false;
-    bool _lid_overdrive = false;
     bool _seal_switch_armed = false;
     Callback _callback;
+    SimMotorTask::Queue &_task_queue;
 };
 
 struct motor_thread::TaskControlBlock {
@@ -95,7 +162,7 @@ struct motor_thread::TaskControlBlock {
 
 auto run(std::stop_token st, std::shared_ptr<TaskControlBlock> tcb) -> void {
     using namespace std::literals::chrono_literals;
-    auto policy = SimMotorPolicy();
+    auto policy = SimMotorPolicy(tcb->queue);
     tcb->queue.set_stop_token(st);
     while (!st.stop_requested()) {
         try {

--- a/stm32-modules/thermocycler-gen2/simulator/motor_thread.cpp
+++ b/stm32-modules/thermocycler-gen2/simulator/motor_thread.cpp
@@ -89,7 +89,7 @@ class SimMotorPolicy : public SimTMC2130Policy {
     auto seal_stepper_start(Callback cb) -> bool {
         _seal_active = true;
 
-        while(_seal_active) {
+        while (_seal_active) {
             cb();
         }
 

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_utils.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_utils.cpp
@@ -52,6 +52,13 @@ SCENARIO("Lid stepper microstep conversion works") {
         WHEN("converting") {
             auto result = LidStepper::angle_to_microsteps(angle);
             THEN("the result is 1768 steps") { REQUIRE(result == 1768); }
+            AND_WHEN("backconverting") {
+                auto backconvert = LidStepper::microsteps_to_angle(result);
+                THEN("results match") {
+                    REQUIRE_THAT(backconvert,
+                                 Catch::Matchers::WithinAbs(angle, 0.001));
+                }
+            }
         }
     }
     GIVEN("a target of -1 degree") {
@@ -59,6 +66,13 @@ SCENARIO("Lid stepper microstep conversion works") {
         WHEN("converting") {
             auto result = LidStepper::angle_to_microsteps(angle);
             THEN("the result is -1768 steps") { REQUIRE(result == -1768); }
+            AND_WHEN("backconverting") {
+                auto backconvert = LidStepper::microsteps_to_angle(result);
+                THEN("results match") {
+                    REQUIRE_THAT(backconvert,
+                                 Catch::Matchers::WithinAbs(angle, 0.001));
+                }
+            }
         }
     }
     GIVEN("a target of 360 degrees") {
@@ -66,13 +80,27 @@ SCENARIO("Lid stepper microstep conversion works") {
         WHEN("converting") {
             auto result = LidStepper::angle_to_microsteps(angle);
             THEN("the result is 636800 steps") { REQUIRE(result == 636800); }
+            AND_WHEN("backconverting") {
+                auto backconvert = LidStepper::microsteps_to_angle(result);
+                THEN("results match") {
+                    REQUIRE_THAT(backconvert,
+                                 Catch::Matchers::WithinAbs(angle, 0.001));
+                }
+            }
         }
     }
     GIVEN("a target of 0 degrees") {
         double angle = 0.0F;
         WHEN("converting") {
             auto result = LidStepper::angle_to_microsteps(angle);
-            THEN("the result is 0 steps") { REQUIRE(result == 0); }
+            THEN("the result is correct steps") { REQUIRE(result == 0); }
+            AND_WHEN("backconverting") {
+                auto backconvert = LidStepper::microsteps_to_angle(result);
+                THEN("results match") {
+                    REQUIRE_THAT(backconvert,
+                                 Catch::Matchers::WithinAbs(angle, 0.001));
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Adds simple simulation of the lid & seal motors on the thermocycler gen2. The lid is more involved just because most of the seal logic is already handled by the task itself.

Tested on the simulator by sending the commands to open/close the lid, and checking the lid & seal status via gcode after each action. Also tested sending the commands to move the lid by microsteps and confirmed the logic limits the lid appropriately.