### PR TITLE
feat(thermocycler-gen2): per-channel peltier tuning

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -1375,9 +1375,11 @@ struct SetOffsetConstants {
         auto ret = SetOffsetConstants();
         working = prefix_matches(old_working, limit, prefix_channel);
         if (working != old_working) {
+            if (working == limit) {
+                return std::make_pair(std::nullopt, input);
+            }
             // Next character must be the channel selection
-            auto chan = *working;
-            switch (chan) {
+            switch (static_cast<char>(*working)) {
                 case 'L':
                     ret.channel = PeltierSelection::LEFT;
                     break;
@@ -1392,6 +1394,7 @@ struct SetOffsetConstants {
                     return std::make_pair(std::nullopt, input);
             }
             std::advance(working, 1);
+            old_working = working;
         }
         working = prefix_matches(old_working, limit, prefix_a);
         if (working != old_working) {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -476,8 +476,8 @@ class HostCommsTask {
                         errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
                 } else {
                     return cache_element.write_response_into(
-                        tx_into, tx_limit, response.const_a, response.const_b,
-                        response.const_c);
+                        tx_into, tx_limit, response.a, response.bl, response.cl,
+                        response.bc, response.cc, response.br, response.cr);
                 }
             },
             cache_entry);

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -1264,6 +1264,7 @@ class HostCommsTask {
         }
         auto message =
             messages::SetOffsetConstantsMessage{.id = id,
+                                                .channel = gcode.channel,
                                                 .a_set = gcode.const_a.defined,
                                                 .const_a = gcode.const_a.value,
                                                 .b_set = gcode.const_b.defined,

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -291,7 +291,7 @@ struct GetOffsetConstantsMessage {
 
 struct GetOffsetConstantsResponse {
     uint32_t responding_to_id;
-    double const_a, const_b, const_c;
+    double a, bl, cl, bc, cc, br, cr;
 };
 
 struct UpdateUIMessage {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -277,6 +277,7 @@ struct SetPIDConstantsMessage {
 
 struct SetOffsetConstantsMessage {
     uint32_t id;
+    PeltierSelection channel;
     bool a_set;
     double const_a;
     bool b_set;

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
@@ -16,6 +16,8 @@ The temperature measured by the thermistors is not necessarily equal to the temp
 
 The offset compensation is as follows: `Tc = (A * H) + ((B + 1) * T) + C`
 
+Furthermore, there are separate B and C coefficients for each channel (L/C/R).
+
 ### Ramp Control & Volumetric Overshoot
 
 When a new target temperature is set, the `plate_control` module enters a simple state machine. In order to ensure that the temperature of liquids in the plate is appropriate, the state machine includes __volumetric overshoot__ based on the maximum volume of liquid in a well (configured by the command to set the plate temperature).

--- a/stm32-modules/thermocycler-gen2/tests/test_eeprom.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_eeprom.cpp
@@ -5,13 +5,16 @@
 using namespace at24c0xc_test_policy;
 using namespace eeprom;
 
+static auto _default = OffsetConstants{
+    .a = 68, .bl = -5, .cl = -4, .bc = -1.5, .cc = 0, .br = 2, .cr = 50.2};
+
 TEST_CASE("eeprom class initialization tracking") {
     GIVEN("an EEPROM") {
         auto policy = TestAT24C0XCPolicy<32>();
         auto eeprom = Eeprom<32, 0x10>();
         THEN("it starts as noninitialized") { REQUIRE(!eeprom.initialized()); }
         WHEN("reading from the EEPROM") {
-            auto defaults = OffsetConstants{.a = 0, .b = 0, .c = 0};
+            auto defaults = _default;
             static_cast<void>(eeprom.get_offset_constants(defaults, policy));
             THEN("the EEPROM now shows as initialized") {
                 REQUIRE(eeprom.initialized());
@@ -25,15 +28,23 @@ TEST_CASE("blank eeprom reading") {
         auto policy = TestAT24C0XCPolicy<32>();
         auto eeprom = Eeprom<32, 0x10>();
         WHEN("reading before writing anything") {
-            auto defaults = OffsetConstants{.a = 68, .b = -5, .c = 50};
+            auto defaults = _default;
             auto readback = eeprom.get_offset_constants(defaults, policy);
             THEN("the resulting constants are the defaults") {
                 REQUIRE_THAT(readback.a,
                              Catch::Matchers::WithinAbs(defaults.a, 0.01));
-                REQUIRE_THAT(readback.b,
-                             Catch::Matchers::WithinAbs(defaults.b, 0.01));
-                REQUIRE_THAT(readback.c,
-                             Catch::Matchers::WithinAbs(defaults.c, 0.01));
+                REQUIRE_THAT(readback.bl,
+                             Catch::Matchers::WithinAbs(defaults.bl, 0.01));
+                REQUIRE_THAT(readback.cl,
+                             Catch::Matchers::WithinAbs(defaults.cl, 0.01));
+                REQUIRE_THAT(readback.bc,
+                             Catch::Matchers::WithinAbs(defaults.bc, 0.01));
+                REQUIRE_THAT(readback.cc,
+                             Catch::Matchers::WithinAbs(defaults.cc, 0.01));
+                REQUIRE_THAT(readback.br,
+                             Catch::Matchers::WithinAbs(defaults.br, 0.01));
+                REQUIRE_THAT(readback.cr,
+                             Catch::Matchers::WithinAbs(defaults.cr, 0.01));
             }
         }
     }
@@ -43,20 +54,33 @@ TEST_CASE("eeprom reading and writing") {
     GIVEN("an EEPROM and constants A= -3.5, B = 10 and C = -12") {
         auto policy = TestAT24C0XCPolicy<32>();
         auto eeprom = Eeprom<32, 0x10>();
-        OffsetConstants constants = {.a = -3.5F, .b = 10.0F, .c = -12.0F};
+        OffsetConstants constants = {.a = 32,
+                                     .bl = -33,
+                                     .cl = -44,
+                                     .bc = -1.55,
+                                     .cc = 0.51,
+                                     .br = 1,
+                                     .cr = 99.99};
         WHEN("writing the constants") {
             REQUIRE(eeprom.write_offset_constants(constants, policy));
             AND_THEN("reading back the constants") {
-                auto defaults =
-                    OffsetConstants{.a = -100, .b = -100, .c = -100};
+                auto defaults = _default;
                 auto readback = eeprom.get_offset_constants(defaults, policy);
                 THEN("the constants match") {
                     REQUIRE_THAT(readback.a,
                                  Catch::Matchers::WithinAbs(constants.a, 0.01));
-                    REQUIRE_THAT(readback.b,
-                                 Catch::Matchers::WithinAbs(constants.b, 0.01));
-                    REQUIRE_THAT(readback.c,
-                                 Catch::Matchers::WithinAbs(constants.c, 0.01));
+                    REQUIRE_THAT(readback.bl, Catch::Matchers::WithinAbs(
+                                                  constants.bl, 0.01));
+                    REQUIRE_THAT(readback.cl, Catch::Matchers::WithinAbs(
+                                                  constants.cl, 0.01));
+                    REQUIRE_THAT(readback.bc, Catch::Matchers::WithinAbs(
+                                                  constants.bc, 0.01));
+                    REQUIRE_THAT(readback.cc, Catch::Matchers::WithinAbs(
+                                                  constants.cc, 0.01));
+                    REQUIRE_THAT(readback.br, Catch::Matchers::WithinAbs(
+                                                  constants.br, 0.01));
+                    REQUIRE_THAT(readback.cr, Catch::Matchers::WithinAbs(
+                                                  constants.cr, 0.01));
                 }
             }
         }

--- a/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
@@ -1944,7 +1944,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                 REQUIRE(!message.a_set);
                 REQUIRE(!message.b_set);
                 REQUIRE(!message.c_set);
-                // REQUIRE(message.channel == PeltierSelection::ALL);
+                REQUIRE(message.channel == PeltierSelection::ALL);
                 AND_WHEN("sending good response back") {
                     auto response = messages::HostCommsMessage(
                         messages::AcknowledgePrevious{.responding_to_id =

--- a/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
@@ -1944,6 +1944,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                 REQUIRE(!message.a_set);
                 REQUIRE(!message.b_set);
                 REQUIRE(!message.c_set);
+                // REQUIRE(message.channel == PeltierSelection::ALL);
                 AND_WHEN("sending good response back") {
                     auto response = messages::HostCommsMessage(
                         messages::AcknowledgePrevious{.responding_to_id =
@@ -2007,16 +2008,22 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     auto response = messages::HostCommsMessage(
                         messages::GetOffsetConstantsResponse{
                             .responding_to_id = message.id,
-                            .const_a = 2.0,
-                            .const_b = 10.0,
-                            .const_c = 15.0});
+                            .a = 2.0,
+                            .bl = 10.0,
+                            .cl = 15.0,
+                            .bc = 10.0,
+                            .cc = 15.0,
+                            .br = 10.0,
+                            .cr = 15.0});
                     tasks->get_host_comms_queue().backing_deque.push_back(
                         response);
                     auto written_secondpass =
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should ack the previous message") {
-                        auto response = "M117 A:2.000 B:10.000 C:15.000 OK\n";
+                        auto response =
+                            "M117 A:2.000 BL:10.000 CL:15.000 BC:10.000 "
+                            "CC:15.000 BR:10.000 CR:15.000 OK\n";
                         REQUIRE_THAT(tx_buf,
                                      Catch::Matchers::StartsWith(response));
                         REQUIRE(written_secondpass ==
@@ -2029,9 +2036,13 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     auto response = messages::HostCommsMessage(
                         messages::GetOffsetConstantsResponse{
                             .responding_to_id = message.id + 1,
-                            .const_a = 2.0,
-                            .const_b = 10.0,
-                            .const_c = 15.0});
+                            .a = 2.0,
+                            .bl = 10.0,
+                            .cl = 15.0,
+                            .bc = 10.0,
+                            .cc = 15.0,
+                            .br = 10.0,
+                            .cr = 15.0});
                     tasks->get_host_comms_queue().backing_deque.push_back(
                         response);
                     auto written_secondpass =

--- a/stm32-modules/thermocycler-gen2/tests/test_m116.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m116.cpp
@@ -54,7 +54,7 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
         }
     }
     GIVEN("input to set B constant") {
-        std::string input = "M116 B-0.543\n";
+        std::string input = "M116.L B-0.543\n";
         WHEN("parsing") {
             auto parsed =
                 gcode::SetOffsetConstants::parse(input.begin(), input.end());
@@ -62,6 +62,7 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
                 REQUIRE(parsed.second != input.begin());
                 REQUIRE(parsed.first.has_value());
                 auto &val = parsed.first.value();
+                REQUIRE(val.channel == PeltierSelection::LEFT);
                 REQUIRE(!val.const_a.defined);
                 REQUIRE(val.const_b.defined);
                 REQUIRE_THAT(val.const_b.value,
@@ -71,7 +72,7 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
         }
     }
     GIVEN("input to set C constant") {
-        std::string input = "M116 C123.5\n";
+        std::string input = "M116.C C123.5\n";
         WHEN("parsing") {
             auto parsed =
                 gcode::SetOffsetConstants::parse(input.begin(), input.end());
@@ -79,6 +80,7 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
                 REQUIRE(parsed.second != input.begin());
                 REQUIRE(parsed.first.has_value());
                 auto &val = parsed.first.value();
+                REQUIRE(val.channel == PeltierSelection::CENTER);
                 REQUIRE(!val.const_a.defined);
                 REQUIRE(!val.const_b.defined);
                 REQUIRE(val.const_c.defined);
@@ -96,6 +98,7 @@ SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
                 REQUIRE(parsed.second != input.begin());
                 REQUIRE(parsed.first.has_value());
                 auto &val = parsed.first.value();
+                REQUIRE(val.channel == PeltierSelection::ALL);
                 REQUIRE(!val.const_b.defined);
                 REQUIRE(!val.const_c.defined);
                 REQUIRE(val.const_a.defined);

--- a/stm32-modules/thermocycler-gen2/tests/test_m117.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m117.cpp
@@ -9,9 +9,12 @@ SCENARIO("GetOffsetConstants (M105.D) parser works", "[gcode][parse][m105.d]") {
         std::string buffer(256, 'c');
         WHEN("filling response") {
             auto written = gcode::GetOffsetConstants::write_response_into(
-                buffer.begin(), buffer.end(), 2.0, 10.0, 15.0);
+                buffer.begin(), buffer.end(), 2.0, 10.0, 15.0, 10.0, 15.0, 10.0,
+                15.0);
             THEN("the response should be written in full") {
-                auto response_str = "M117 A:2.000 B:10.000 C:15.000 OK\n";
+                auto response_str =
+                    "M117 A:2.000 BL:10.000 CL:15.000 BC:10.000 CC:15.000 "
+                    "BR:10.000 CR:15.000 OK\n";
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(response_str));
                 REQUIRE(written == buffer.begin() + strlen(response_str));
             }
@@ -22,7 +25,8 @@ SCENARIO("GetOffsetConstants (M105.D) parser works", "[gcode][parse][m105.d]") {
         std::string buffer(16, 'c');
         WHEN("filling response") {
             auto written = gcode::GetOffsetConstants::write_response_into(
-                buffer.begin(), buffer.begin() + 7, 2.0, 10.0, 15.0);
+                buffer.begin(), buffer.begin() + 7, 2.0, 10.0, 15.0, 11.0, 12.0,
+                13.0, 14.0);
             THEN("the response should write only up to the available space") {
                 std::string response = "M117 Acccccccccc";
                 response.at(6) = '\0';

--- a/stm32-modules/thermocycler-gen2/tests/test_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_thermal_plate_task.cpp
@@ -288,15 +288,15 @@ SCENARIO("thermal plate task message passing") {
                                 response);
                         REQUIRE(constants.responding_to_id == get_offsets.id);
                         REQUIRE_THAT(
-                            constants.const_a,
+                            constants.a,
                             Catch::Matchers::WithinAbs(
                                 plate_task.OFFSET_DEFAULT_CONST_A, 0.001F));
                         REQUIRE_THAT(
-                            constants.const_b,
+                            constants.bl,
                             Catch::Matchers::WithinAbs(
                                 plate_task.OFFSET_DEFAULT_CONST_B, 0.001F));
                         REQUIRE_THAT(
-                            constants.const_c,
+                            constants.cl,
                             Catch::Matchers::WithinAbs(
                                 plate_task.OFFSET_DEFAULT_CONST_C, 0.001F));
                     }


### PR DESCRIPTION
Initial thermal characterization testing on EVT units shows higher uniformity numbers than expected. Some estimated calculations based on early testing data suggest that tuning the devices with a different B & C coefficient for each channel will greatly improve the uniformity on outlier units. This PR adds the functionality to the firmware for having these separate coefficients.

- The thermal plate task has been modified to apply a different set of coefficients to the left/center/right channels, and the EEPROM driver is updated to store all 7 constants.
- The command to set the offset coefficients (M116) has been modified to accept a suffix with a channel to set, e.g. `M116.L` to set the left channel's values. The A value is always shared, however.

Tested on a simulator by _greatly_ changing the B and C constants per channel and verifying that the temperatures change on each side of the plate. Also tested on hardware that:
- The defaults are the same on each channel
- The updated values are kept over power cycles
- The updated values affect each channel independently

All while sitting at ambient temperature.