### PR TITLE
fix(thermocycler-gen2): system shutdown turns off thermal elements

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
@@ -290,7 +290,7 @@ class LidHeaterTask {
         auto response =
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
 
-        if (_state.system_status == State::ERROR) {
+        if (_state.system_status == State::ERROR && !msg.from_system) {
             response.with_error = most_relevant_error();
             static_cast<void>(
                 _task_registry->comms->get_message_queue().try_send(response));
@@ -306,8 +306,13 @@ class LidHeaterTask {
             _state.error_bitmap |= State::HEATER_POWER_ERROR;
         }
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        if (msg.from_system) {
+            static_cast<void>(
+                _task_registry->system->get_message_queue().try_send(response));
+        } else {
+            static_cast<void>(
+                _task_registry->comms->get_message_queue().try_send(response));
+        }
     }
 
     template <LidHeaterExecutionPolicy Policy>

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -250,6 +250,7 @@ struct SetLidTemperatureMessage {
 
 struct DeactivateLidHeatingMessage {
     uint32_t id;
+    bool from_system = false;
 };
 
 struct SetPlateTemperatureMessage {
@@ -265,6 +266,7 @@ struct SetFanAutomaticMessage {
 
 struct DeactivatePlateMessage {
     uint32_t id;
+    bool from_system = false;
 };
 
 struct SetPIDConstantsMessage {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -556,7 +556,7 @@ class ThermalPlateTask {
         auto response =
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
 
-        if (_state.system_status == State::ERROR) {
+        if (_state.system_status == State::ERROR && !msg.from_system) {
             response.with_error = most_relevant_error();
             static_cast<void>(
                 _task_registry->comms->get_message_queue().try_send(response));
@@ -566,8 +566,13 @@ class ThermalPlateTask {
         policy.set_enabled(false);
         _state.system_status = State::IDLE;
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        if (msg.from_system) {
+            static_cast<void>(
+                _task_registry->system->get_message_queue().try_send(response));
+        } else {
+            static_cast<void>(
+                _task_registry->comms->get_message_queue().try_send(response));
+        }
     }
 
     template <ThermalPlateExecutionPolicy Policy>

--- a/stm32-modules/thermocycler-gen2/tests/test_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_lid_heater_task.cpp
@@ -252,6 +252,21 @@ SCENARIO("lid heater task message passing") {
                     }
                 }
             }
+            AND_WHEN(
+                "sending a DeactivateLidHeating command from system task") {
+                tasks->get_host_comms_queue().backing_deque.pop_front();
+                auto tempMessage = messages::DeactivateLidHeatingMessage{
+                    .id = 321, .from_system = true};
+                tasks->get_lid_heater_queue().backing_deque.push_back(
+                    messages::LidHeaterMessage(tempMessage));
+                tasks->run_lid_heater_task();
+                THEN("the task should respond to the message") {
+                    REQUIRE(!tasks->get_system_queue().backing_deque.empty());
+                    REQUIRE(std::get<messages::AcknowledgePrevious>(
+                                tasks->get_system_queue().backing_deque.front())
+                                .responding_to_id == 321);
+                }
+            }
             AND_WHEN("sending a DeactivateAll command") {
                 tasks->get_host_comms_queue().backing_deque.pop_front();
                 auto tempMessage = messages::DeactivateAllMessage{.id = 321};

--- a/stm32-modules/thermocycler-gen2/tests/test_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_thermal_plate_task.cpp
@@ -627,6 +627,21 @@ SCENARIO("thermal plate task message passing") {
                     }
                 }
             }
+            AND_WHEN("sending a DeactivatePlate command from the system task") {
+                tasks->get_host_comms_queue().backing_deque.pop_front();
+                auto tempMessage = messages::DeactivatePlateMessage{
+                    .id = 321, .from_system = true};
+                plate_queue.backing_deque.push_back(
+                    messages::ThermalPlateMessage(tempMessage));
+                tasks->get_system_queue().backing_deque.clear();
+                tasks->run_thermal_plate_task();
+                THEN("the task should respond to the message") {
+                    REQUIRE(!tasks->get_system_queue().backing_deque.empty());
+                    REQUIRE(std::get<messages::AcknowledgePrevious>(
+                                tasks->get_system_queue().backing_deque.front())
+                                .responding_to_id == 321);
+                }
+            }
             AND_WHEN("sending a DeactivateAll command") {
                 tasks->get_host_comms_queue().backing_deque.pop_front();
                 auto tempMessage = messages::DeactivateAllMessage{.id = 321};


### PR DESCRIPTION
- deactivation messages have a new field to specify whether ack should be sent to system task instead of host task
- system task disables LED's before shutdown
- system task disables lid heater and thermistors before shutdown

Tested on simulator and on hardware.