### PR TITLE
chore(thermocycler-gen2): Fan PWM at 1kHz

### DIFF
--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_fan_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_fan_hardware.c
@@ -12,7 +12,7 @@
 #define SINK_FAN_PWM_Pin (GPIO_PIN_6)
 #define SINK_FAN_PWM_GPIO_Port (GPIOA)
 
-#define PULSE_WIDTH_FREQ (25000)
+#define PULSE_WIDTH_FREQ (1000)
 #define TIMER_CLOCK_FREQ (170000000)
 // These two together give a 25kHz pulse width, and the ARR value
 // of 99 gives us a nice scale of 0-100 for the pulse width.


### PR DESCRIPTION
The TC1 Arduino firmware uses `analogWrite` for fan PWM, which research shows should be around the magnitude of 1kHz. The TC2 has been  using the suggested 25kHz from the fan datasheet, but testing shows that reducing the PWM frequency to 1kHz will allow a lower slow-end fan velocity. A lower fan velocity is beneficial for uniformity at high target temperatures. 

Scope captures below show the fan velocity (captured from the tachometer pin) at 15% PWM driven at 25kHz and 1kHz respectively. 

![image](https://user-images.githubusercontent.com/27798632/171279415-9a043e92-c3f9-4dcf-85ea-e4c166716614.png)

![image](https://user-images.githubusercontent.com/27798632/171279436-c892b9e4-6679-4bf1-9874-914040621dd0.png)
