### PR TITLE
fix(heater-shaker): M241 return semantics

### DIFF
--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -1279,9 +1279,9 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN("the task should ack the previous message") {
                         REQUIRE_THAT(tx_buf,
                                      Catch::Matchers::StartsWith(
-                                         "M241.D STATE:IDLE_UNKNOWN "
+                                         "M241.D STATUS:IDLE_UNKNOWN "
                                          "OpenSensor:1 ClosedSensor:1 OK\n"));
-                        REQUIRE(written_secondpass == tx_buf.begin() + 57);
+                        REQUIRE(written_secondpass == tx_buf.begin() + 58);
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }

--- a/stm32-modules/heater-shaker/tests/test_m241.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m241.cpp
@@ -13,7 +13,7 @@ SCENARIO("GetPlateLockState (M241) response works", "[gcode][parse][M241]") {
             auto written = gcode::GetPlateLockState::write_response_into(
                 buffer.begin(), buffer.end(), std::array<char, 14>{"hello"});
             THEN("the response should be written in full") {
-                std::string ok = "M241 STATE:hello OK\n";
+                std::string ok = "M241 STATUS:hello OK\n";
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(ok));
                 REQUIRE(written == buffer.begin() + ok.size());
                 std::string suffix(buffer.size() - ok.size(), 'c');
@@ -26,12 +26,12 @@ SCENARIO("GetPlateLockState (M241) response works", "[gcode][parse][M241]") {
         std::string buffer(32, 'c');
         WHEN("filling response") {
             auto written = gcode::GetPlateLockState::write_response_into(
-                buffer.begin(), buffer.begin() + 16,
+                buffer.begin(), buffer.begin() + 17,
                 std::array<char, 14>{"hello"});
             THEN("the response should write only up to the available space") {
-                std::string response = "M241 STATE:hellocccccccccccccccc";
+                std::string response = "M241 STATUS:helloccccccccccccccc";
                 REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
-                REQUIRE(written == buffer.begin() + 16);
+                REQUIRE(written == buffer.begin() + 17);
             }
         }
     }

--- a/stm32-modules/heater-shaker/tests/test_m241d.cpp
+++ b/stm32-modules/heater-shaker/tests/test_m241d.cpp
@@ -16,7 +16,7 @@ SCENARIO("GetPlateLockStateDebug (M241.D) response works",
                 true, false);
             THEN("the response should be written in full") {
                 std::string ok =
-                    "M241.D STATE:hello OpenSensor:1 ClosedSensor:0 OK\n";
+                    "M241.D STATUS:hello OpenSensor:1 ClosedSensor:0 OK\n";
                 REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(ok));
                 REQUIRE(written == buffer.begin() + ok.size());
                 std::string suffix(buffer.size() - ok.size(), 'c');
@@ -29,12 +29,12 @@ SCENARIO("GetPlateLockStateDebug (M241.D) response works",
         std::string buffer(32, 'c');
         WHEN("filling response") {
             auto written = gcode::GetPlateLockStateDebug::write_response_into(
-                buffer.begin(), buffer.begin() + 16,
+                buffer.begin(), buffer.begin() + 17,
                 std::array<char, 14>{"hello"}, true, false);
             THEN("the response should write only up to the available space") {
-                std::string response = "M241.D STATE:helcccccccccccccccc";
+                std::string response = "M241.D STATUS:helccccccccccccccc";
                 REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
-                REQUIRE(written == buffer.begin() + 16);
+                REQUIRE(written == buffer.begin() + 17);
             }
         }
     }

--- a/stm32-modules/include/heater-shaker/heater-shaker/gcodes.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/gcodes.hpp
@@ -915,7 +915,7 @@ struct GetPlateLockState {
                                     const InLimit write_to_limit,
                                     std::array<char, 14> plate_lock_state)
         -> InputIt {
-        static constexpr const char* prefix = "M241 STATE:";
+        static constexpr const char* prefix = "M241 STATUS:";
         auto written =
             write_string_to_iterpair(write_to_buf, write_to_limit, prefix);
         if (written == write_to_limit) {

--- a/stm32-modules/include/heater-shaker/heater-shaker/gcodes.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/gcodes.hpp
@@ -964,7 +964,7 @@ struct GetPlateLockStateDebug {
                                     std::array<char, 14> plate_lock_state,
                                     bool plate_lock_open_state,
                                     bool plate_lock_closed_state) -> InputIt {
-        static constexpr const char* prefix = "M241.D STATE:";
+        static constexpr const char* prefix = "M241.D STATUS:";
         auto written =
             write_string_to_iterpair(write_to_buf, write_to_limit, prefix);
         if (written == write_to_limit) {


### PR DESCRIPTION
Previously returned `M241 STATE:xyz OK`. Changed to `M241 STATUS:xyz OK` to agree with module driver.

Opentrons/opentrons#10249