### PR TITLE
feat(thermocycler-gen2): read fan tachometers

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/firmware/thermal_fan_hardware.h
+++ b/stm32-modules/include/thermocycler-gen2/firmware/thermal_fan_hardware.h
@@ -28,6 +28,15 @@ bool thermal_fan_set_power(double power);
  */
 double thermal_fan_get_power(void);
 
+double thermal_fan_get_tach_1_rpm(void);
+
+double thermal_fan_get_tach_2_rpm(void);
+
+/**
+ * @brief Callback for MSP init of TIM4
+ */
+void thermal_fan_tim4_msp_init(void);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/stm32-modules/include/thermocycler-gen2/firmware/thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/firmware/thermal_plate_policy.hpp
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <utility> // std::pair
+#include <utility>  // std::pair
 
 #include "firmware/thermal_hardware.h"
 #include "thermocycler-gen2/thermal_general.hpp"

--- a/stm32-modules/include/thermocycler-gen2/firmware/thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/firmware/thermal_plate_policy.hpp
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <utility> // std::pair
+
 #include "firmware/thermal_hardware.h"
 #include "thermocycler-gen2/thermal_general.hpp"
 
@@ -30,6 +32,8 @@ class ThermalPlatePolicy {
     auto set_fan(double power) -> bool;
 
     auto get_fan() -> double;
+
+    auto get_fan_rpm() -> std::pair<double, double>;
 
     auto set_write_protect(bool write_protect) -> void;
 

--- a/stm32-modules/include/thermocycler-gen2/test/test_thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/test/test_thermal_plate_policy.hpp
@@ -61,7 +61,7 @@ class TestThermalPlatePolicy
     auto get_fan() -> double { return _fan_power; }
 
     auto get_fan_rpm() -> std::pair<double, double> {
-        double val = 5000.0F * _fan_power;
+        double val = 17500.0F * _fan_power;
         return std::make_pair(val, val);
     }
 

--- a/stm32-modules/include/thermocycler-gen2/test/test_thermal_plate_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/test/test_thermal_plate_policy.hpp
@@ -60,6 +60,11 @@ class TestThermalPlatePolicy
 
     auto get_fan() -> double { return _fan_power; }
 
+    auto get_fan_rpm() -> std::pair<double, double> {
+        double val = 5000.0F * _fan_power;
+        return std::make_pair(val, val);
+    }
+
     bool _enabled = false;
     TestPeltier _left = TestPeltier();
     TestPeltier _center = TestPeltier();

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -668,7 +668,7 @@ struct GetPlateTemperatureDebug {
  * @brief Uses M103.D to get the current power output for all thermal elements.
  *
  * Format: M103.D\n
- * Return: M103.D L:<left peltier> C:<center> R:<right> H:<heater> F:<fans>
+ * Return: M103.D L:<left peltier> C:<center> R:<right> H:<heater> F:<fans> T1:<tach1> T2:<tach2>
  *
  */
 struct GetThermalPowerDebug {
@@ -693,13 +693,14 @@ struct GetThermalPowerDebug {
     static auto write_response_into(InputIt buf, InLimit limit,
                                     double left_power, double center_power,
                                     double right_power, double heater_power,
-                                    double fan_power) -> InputIt {
+                                    double fan_power, double tach1, double tach2) -> InputIt {
         auto res = snprintf(
             &*buf, (limit - buf),
-            "M103.D L:%0.2f C:%0.2f R:%0.2f H:%0.2f F:%0.2f OK\n",
+            "M103.D L:%0.2f C:%0.2f R:%0.2f H:%0.2f F:%0.2f T1:%3.2f T2:%3.2f OK\n",
             static_cast<float>(left_power), static_cast<float>(center_power),
             static_cast<float>(right_power), static_cast<float>(heater_power),
-            static_cast<float>(fan_power));
+            static_cast<float>(fan_power), static_cast<float>(tach1),
+            static_cast<float>(tach2));
         if (res <= 0) {
             return buf;
         }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -668,7 +668,8 @@ struct GetPlateTemperatureDebug {
  * @brief Uses M103.D to get the current power output for all thermal elements.
  *
  * Format: M103.D\n
- * Return: M103.D L:<left peltier> C:<center> R:<right> H:<heater> F:<fans> T1:<tach1> T2:<tach2>
+ * Return: M103.D L:<left peltier> C:<center> R:<right> H:<heater> F:<fans>
+ * T1:<tach1> T2:<tach2>
  *
  */
 struct GetThermalPowerDebug {
@@ -693,10 +694,12 @@ struct GetThermalPowerDebug {
     static auto write_response_into(InputIt buf, InLimit limit,
                                     double left_power, double center_power,
                                     double right_power, double heater_power,
-                                    double fan_power, double tach1, double tach2) -> InputIt {
+                                    double fan_power, double tach1,
+                                    double tach2) -> InputIt {
         auto res = snprintf(
             &*buf, (limit - buf),
-            "M103.D L:%0.2f C:%0.2f R:%0.2f H:%0.2f F:%0.2f T1:%3.2f T2:%3.2f OK\n",
+            "M103.D L:%0.2f C:%0.2f R:%0.2f H:%0.2f F:%0.2f T1:%3.2f T2:%3.2f "
+            "OK\n",
             static_cast<float>(left_power), static_cast<float>(center_power),
             static_cast<float>(right_power), static_cast<float>(heater_power),
             static_cast<float>(fan_power), static_cast<float>(tach1),

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -540,7 +540,8 @@ class HostCommsTask {
                     return gcode::GetThermalPowerDebug::write_response_into(
                         tx_into, tx_limit, cache_element.left,
                         cache_element.center, cache_element.right,
-                        response.heater, cache_element.fans);
+                        response.heater, cache_element.fans,
+                        cache_element.tach1, cache_element.tach2);
                 }
             },
             cache_entry);

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -223,7 +223,7 @@ struct GetThermalPowerMessage {
 struct GetPlatePowerResponse {
     uint32_t responding_to_id;
 
-    double left, center, right, fans;
+    double left, center, right, fans, tach1, tach2;
 };
 
 // Lid Task response to GetThermalPowerMessage

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -53,7 +53,7 @@ concept ThermalPlateExecutionPolicy = requires(Policy& p, PeltierID id,
     // A function to get the current power of the heatsink fan.
     { p.get_fan() } -> std::same_as<double>;
     // A function to get the fan RPM from the tachometers
-    { p.get_fan_rpm() } -> std::same_as<std::pair<double,double>>;
+    { p.get_fan_rpm() } -> std::same_as<std::pair<double, double>>;
 }
 &&at24c0xc::AT24C0xC_Policy<Policy>;
 

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -8,6 +8,7 @@
 #include <concepts>
 #include <cstddef>
 #include <tuple>
+#include <utility>
 #include <variant>
 
 #include "core/pid.hpp"
@@ -51,6 +52,8 @@ concept ThermalPlateExecutionPolicy = requires(Policy& p, PeltierID id,
     { p.set_fan(1.0F) } -> std::same_as<bool>;
     // A function to get the current power of the heatsink fan.
     { p.get_fan() } -> std::same_as<double>;
+    // A function to get the fan RPM from the tachometers
+    { p.get_fan_rpm() } -> std::same_as<std::pair<double,double>>;
 }
 &&at24c0xc::AT24C0xC_Policy<Policy>;
 
@@ -630,11 +633,14 @@ class ThermalPlateTask {
                                             .left = 0.0F,
                                             .center = 0.0F,
                                             .right = 0.0F,
-                                            .fans = policy.get_fan()};
+                                            .fans = policy.get_fan(),
+                                            .tach1 = 0.0F,
+                                            .tach2 = 0.0F};
 
         auto left = policy.get_peltier(_peltier_left.id);
         auto center = policy.get_peltier(_peltier_center.id);
         auto right = policy.get_peltier(_peltier_right.id);
+        std::tie(response.tach1, response.tach2) = policy.get_fan_rpm();
 
         response.left =
             left.second *

--- a/stm32-modules/thermocycler-gen2/firmware/system/stm32g4xx_hal_msp.c
+++ b/stm32-modules/thermocycler-gen2/firmware/system/stm32g4xx_hal_msp.c
@@ -7,6 +7,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32g4xx_hal.h"
 #include "firmware/system_led_hardware.h"
+#include "firmware/thermal_fan_hardware.h"
 
 /**
   * Initializes the Global MSP.
@@ -131,6 +132,14 @@ void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef* htim_pwm)
     __HAL_RCC_TIM15_CLK_DISABLE();
   }
 
+}
+
+void HAL_TIM_IC_MspInit(TIM_HandleTypeDef* htim_ic) 
+{
+    if(htim_ic->Instance==TIM4)
+    {
+        thermal_fan_tim4_msp_init();
+    }
 }
 
 /**

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
@@ -50,3 +50,18 @@ graph TD
 ## Lid Heater
 
 The lid heater consists of a single resistive heating pad and a single thermistor for temperature feedback. The lid's primary purpose is to prevent condensation in the wells by providing a temperature above that of the peltier plate.
+
+## Fans
+
+### Control
+
+The fans are controlled by a PWM channel on Timer 16
+
+### Tachometer Feedback
+
+The tachometers for the fans are monitored by Channels 1 and 2 on Timer 4. The input channels are configured for Input Capture monitoring on rising edges. Testing shows that the approximate low range of the fan velocity is ~50 RPM
+
+- The timer is set to run at 10kHz and count to 2,000 (thus running for 0.2 seconds)
+- When the timer starts, a DMA transaction is configured for each channel to move the first two Input Capture readings into buffers
+- When the timer overflows, the difference between the two readings is saved into a variable for each channel. This gives the _period_ of the fan tachometer.
+- - The interrupt also clears the buffers, in order to be able to detect an idle fan.

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
@@ -59,9 +59,11 @@ The fans are controlled by a PWM channel on Timer 16
 
 ### Tachometer Feedback
 
-The tachometers for the fans are monitored by Channels 1 and 2 on Timer 4. The input channels are configured for Input Capture monitoring on rising edges. Testing shows that the approximate low range of the fan velocity is ~50 RPM
+The tachometers for the fans are monitored by Channels 1 and 2 on Timer 4. The input channels are configured for Input Capture monitoring on rising edges. Testing shows that the approximate low range of the fan velocity is ~40 RPM
 
-- The timer is set to run at 10kHz and count to 2,000 (thus running for 0.2 seconds)
-- When the timer starts, a DMA transaction is configured for each channel to move the first two Input Capture readings into buffers
+- The timer is set to run at 100kHz and run for a total period of 0.25 seconds
+- When the timer starts, a DMA transaction is configured for each channel to move the first three Input Capture readings into buffers. The first reading is effectively ignored.
 - When the timer overflows, the difference between the two readings is saved into a variable for each channel. This gives the _period_ of the fan tachometer.
 - - The interrupt also clears the buffers, in order to be able to detect an idle fan.
+
+The timer is configured in One Pulse Mode, so the interrupt is free to reenable the timer and it will start counting from 0.

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
@@ -59,7 +59,7 @@ The fans are controlled by a PWM channel on Timer 16
 
 ### Tachometer Feedback
 
-The tachometers for the fans are monitored by Channels 1 and 2 on Timer 4. The input channels are configured for Input Capture monitoring on rising edges. Testing shows that the approximate low range of the fan velocity is ~40 RPM
+The tachometers for the fans are monitored by Channels 1 and 2 on Timer 4. The input channels are configured for Input Capture monitoring on rising edges. Testing shows that the approximate low range of the fan tachometer is ~40 pulses per second
 
 - The timer is set to run at 100kHz and run for a total period of 0.25 seconds
 - When the timer starts, a DMA transaction is configured for each channel to move the first three Input Capture readings into buffers. The first reading is effectively ignored.

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_fan_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_fan_hardware.c
@@ -32,6 +32,7 @@
 #define TACH_TIMER_PRESCALE (1699)
 #define TACH_TIMER_PRESCALED_FREQ (TIMER_CLOCK_FREQ / (TACH_TIMER_PRESCALE + 1))
 #define SEC_PER_MIN (60)
+#define PULSES_PER_ROTATION (2)
 
 #define TACH_TIMER_RELOAD ((TIMER_CLOCK_FREQ / (TACH_TIMER_FREQ * (TACH_TIMER_PRESCALE + 1))) -1)
 
@@ -258,7 +259,7 @@ double thermal_fan_get_tach_1_rpm(void) {
         return 0;
     }
     return ((double)SEC_PER_MIN * (double)TACH_TIMER_PRESCALED_FREQ) 
-            / ((double)_fans.tach.tach_1_period);
+            / ((double)_fans.tach.tach_1_period * PULSES_PER_ROTATION);
 }
 
 double thermal_fan_get_tach_2_rpm(void) {
@@ -266,7 +267,7 @@ double thermal_fan_get_tach_2_rpm(void) {
         return 0;
     }
     return ((double)SEC_PER_MIN * (double)TACH_TIMER_PRESCALED_FREQ) 
-            / ((double)_fans.tach.tach_2_period);
+            / ((double)_fans.tach.tach_2_period * PULSES_PER_ROTATION);
 }
 
 // Local function implementations

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_fan_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_fan_hardware.c
@@ -1,5 +1,7 @@
 #include "firmware/thermal_fan_hardware.h"
 
+#include <stdatomic.h>
+#include <string.h>
 
 #include "FreeRTOS.h"
 #include "stm32g4xx_hal_def.h"
@@ -24,7 +26,26 @@
 // PWM should be scaled from 0 to MAX_PWM, inclusive
 #define MAX_PWM (TIM16_RELOAD + 1)
 
+#define TACH_NUM_READINGS (2)
+// Tachometer timer reload frequency
+#define TACH_TIMER_FREQ (1)
+#define TACH_TIMER_PRESCALE (16999)
+#define TACH_TIMER_PRESCALED_FREQ (TIMER_CLOCK_FREQ / (TACH_TIMER_PRESCALE + 1))
+#define SEC_PER_MIN (60)
+
+#define TACH_TIMER_RELOAD ((TIMER_CLOCK_FREQ / (TACH_TIMER_FREQ * (TACH_TIMER_PRESCALE + 1))) -1)
+
 // Private typedefs
+
+struct Tachometer {
+    TIM_HandleTypeDef timer;
+    DMA_HandleTypeDef tach_1_dma;
+    DMA_HandleTypeDef tach_2_dma;
+    atomic_uint_fast16_t buffer_1[TACH_NUM_READINGS];
+    atomic_uint_fast16_t buffer_2[TACH_NUM_READINGS];
+    atomic_uint_fast16_t tach_1_period;
+    atomic_uint_fast16_t tach_2_period;
+};
 
 struct Fans {
     // Configuration
@@ -35,6 +56,7 @@ struct Fans {
     bool initialized;
     double power;
     TIM_HandleTypeDef timer;
+    struct Tachometer tach;
 };
 
 // Local variables
@@ -45,10 +67,21 @@ static struct Fans _fans = {
     .pwm_channel = TIM_CHANNEL_1,
     .initialized = false,
     .power = 0.0F,
-    .timer = {}
+    .timer = {},
+    .tach = {
+        .timer = {},
+        .buffer_1 = {},
+        .buffer_2 = {},
+        .tach_1_period = 0,
+        .tach_2_period = 0
+    }
 };
 
 // Private function declarations
+
+static void thermal_fan_init_tach(struct Tachometer *tach);
+static void thermal_fan_restart_tach_dma();
+static void thermal_fan_start_tach_timer();
 
 /**
  * @brief Enable or disable the fans (12v power supply)
@@ -122,6 +155,12 @@ void thermal_fan_initialize(void) {
     GPIO_InitStruct.Alternate = GPIO_AF1_TIM16;
     HAL_GPIO_Init(SINK_FAN_PWM_GPIO_Port, &GPIO_InitStruct);
 
+    // Configure timer 4 for Input Capture mode to read the tachometers
+    thermal_fan_init_tach(&_fans.tach);
+
+    thermal_fan_restart_tach_dma();
+    thermal_fan_start_tach_timer();
+
     _fans.initialized = true;
 }
 
@@ -151,7 +190,6 @@ bool thermal_fan_set_power(double power) {
             return false;
         }
     }
-    
 
     return true;
 }
@@ -160,7 +198,130 @@ double thermal_fan_get_power(void) {
     return _fans.power;
 }
 
+void thermal_fan_tim4_msp_init(void) {
+    HAL_StatusTypeDef hal_ret = HAL_ERROR;
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    /* Peripheral clock enable */
+    __HAL_RCC_TIM4_CLK_ENABLE();
+
+    __HAL_RCC_GPIOD_CLK_ENABLE();
+    /**TIM4 GPIO Configuration
+    PD12     ------> TIM4_CH1
+    PD13     ------> TIM4_CH2
+    */
+    GPIO_InitStruct.Pin = GPIO_PIN_12|GPIO_PIN_13;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Alternate = GPIO_AF2_TIM4;
+    HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
+
+    /* TIM4 DMA Init */
+    /* TIM4_CH1 Init */
+    _fans.tach.tach_1_dma.Instance = DMA1_Channel2;
+    _fans.tach.tach_1_dma.Init.Request = DMA_REQUEST_TIM4_CH1;
+    _fans.tach.tach_1_dma.Init.Direction = DMA_PERIPH_TO_MEMORY;
+    _fans.tach.tach_1_dma.Init.PeriphInc = DMA_PINC_DISABLE;
+    _fans.tach.tach_1_dma.Init.MemInc = DMA_MINC_ENABLE;
+    _fans.tach.tach_1_dma.Init.PeriphDataAlignment = DMA_PDATAALIGN_HALFWORD;
+    _fans.tach.tach_1_dma.Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;
+    _fans.tach.tach_1_dma.Init.Mode = DMA_NORMAL;
+    _fans.tach.tach_1_dma.Init.Priority = DMA_PRIORITY_LOW;
+    hal_ret = HAL_DMA_Init(&_fans.tach.tach_1_dma);
+    configASSERT(hal_ret == HAL_OK);
+
+    __HAL_LINKDMA(&_fans.tach.timer,hdma[TIM_DMA_ID_CC1],_fans.tach.tach_1_dma);
+
+    /* TIM4_CH2 Init */
+    _fans.tach.tach_2_dma.Instance = DMA1_Channel3;
+    _fans.tach.tach_2_dma.Init.Request = DMA_REQUEST_TIM4_CH2;
+    _fans.tach.tach_2_dma.Init.Direction = DMA_PERIPH_TO_MEMORY;
+    _fans.tach.tach_2_dma.Init.PeriphInc = DMA_PINC_DISABLE;
+    _fans.tach.tach_2_dma.Init.MemInc = DMA_MINC_ENABLE;
+    _fans.tach.tach_2_dma.Init.PeriphDataAlignment = DMA_PDATAALIGN_HALFWORD;
+    _fans.tach.tach_2_dma.Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;
+    _fans.tach.tach_2_dma.Init.Mode = DMA_NORMAL;
+    _fans.tach.tach_2_dma.Init.Priority = DMA_PRIORITY_LOW;
+    hal_ret = HAL_DMA_Init(&_fans.tach.tach_2_dma);
+    configASSERT(hal_ret == HAL_OK);
+
+    __HAL_LINKDMA(&_fans.tach.timer,hdma[TIM_DMA_ID_CC2],_fans.tach.tach_2_dma);
+    
+    /* TIM4 interrupt Init */
+    HAL_NVIC_SetPriority(TIM4_IRQn, 5, 0);
+    HAL_NVIC_EnableIRQ(TIM4_IRQn);
+}
+
+
+double thermal_fan_get_tach_1_rpm(void) {
+    if(_fans.tach.tach_1_period == 0) {
+        return 0;
+    }
+    return (SEC_PER_MIN * TACH_TIMER_PRESCALED_FREQ) / ((double)_fans.tach.tach_1_period);
+}
+
+double thermal_fan_get_tach_2_rpm(void) {
+    if(_fans.tach.tach_2_period == 0) {
+        return 0;
+    }
+    return (SEC_PER_MIN * TACH_TIMER_PRESCALED_FREQ) / ((double)_fans.tach.tach_2_period);
+}
+
 // Local function implementations
+
+static void thermal_fan_init_tach(struct Tachometer *tach) {
+    HAL_StatusTypeDef hal_ret = HAL_ERROR;
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    TIM_IC_InitTypeDef sConfigIC = {0};
+
+    tach->timer.Instance = TIM4;
+    tach->timer.Init.Prescaler = TACH_TIMER_PRESCALE;
+    tach->timer.Init.CounterMode = TIM_COUNTERMODE_UP;
+    tach->timer.Init.Period = TACH_TIMER_RELOAD;
+    tach->timer.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    tach->timer.Init.RepetitionCounter = 0;
+    tach->timer.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    hal_ret = HAL_TIM_IC_Init(&tach->timer);
+    configASSERT(hal_ret == HAL_OK);
+
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_ENABLE;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    hal_ret = HAL_TIMEx_MasterConfigSynchronization(&tach->timer, &sMasterConfig);
+    configASSERT(hal_ret == HAL_OK);
+
+    sConfigIC.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
+    sConfigIC.ICSelection = TIM_ICSELECTION_DIRECTTI;
+    sConfigIC.ICPrescaler = TIM_ICPSC_DIV1;
+    sConfigIC.ICFilter = 4;
+    hal_ret = HAL_TIM_IC_ConfigChannel(&tach->timer, &sConfigIC, TIM_CHANNEL_1);
+    configASSERT(hal_ret == HAL_OK);
+    hal_ret = HAL_TIM_IC_ConfigChannel(&tach->timer, &sConfigIC, TIM_CHANNEL_2);
+    configASSERT(hal_ret == HAL_OK);
+
+}
+
+static void thermal_fan_restart_tach_dma() {
+    // The interrupt only checks the last entry in the array to decide whether
+    // the fan was moving, so it's ok to leave the rest
+    _fans.tach.buffer_1[TACH_NUM_READINGS - 1] = 0;
+    _fans.tach.buffer_2[TACH_NUM_READINGS - 1] = 0;
+    HAL_DMA_Abort_IT(&_fans.tach.tach_1_dma);
+    HAL_DMA_Start_IT(&_fans.tach.tach_1_dma, (uint32_t)&_fans.tach.timer.Instance->CCR1,
+                     (uint32_t)_fans.tach.buffer_1, TACH_NUM_READINGS);
+    HAL_DMA_Abort_IT(&_fans.tach.tach_2_dma);
+    HAL_DMA_Start_IT(&_fans.tach.tach_2_dma, (uint32_t)&_fans.tach.timer.Instance->CCR1,
+                     (uint32_t)_fans.tach.buffer_2, TACH_NUM_READINGS);
+}
+
+static void thermal_fan_start_tach_timer() {
+    __HAL_TIM_ENABLE_DMA(&_fans.tach.timer, TIM_DMA_CC1);
+    __HAL_TIM_ENABLE_DMA(&_fans.tach.timer, TIM_DMA_CC2);
+    TIM_CCxChannelCmd(_fans.tach.timer.Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+    TIM_CCxChannelCmd(_fans.tach.timer.Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+
+    __HAL_TIM_ENABLE_IT(&_fans.tach.timer, TIM_IT_UPDATE);
+    __HAL_TIM_ENABLE(&_fans.tach.timer);
+}
 
 static bool thermal_fan_set_enable(bool enabled) {
     if(!_fans.initialized) { return false; }
@@ -169,4 +330,22 @@ static bool thermal_fan_set_enable(bool enabled) {
     HAL_GPIO_WritePin(_fans.enable_port, _fans.enable_pin, state);
 
     return true;
+}
+
+// This interrupt does NOT go through the HAL system because it doesn't
+// work with the requirements for this timer application.
+void TIM4_IRQHandler(void) {
+    __HAL_TIM_CLEAR_IT(&_fans.tach.timer, TIM_IT_UPDATE);
+    if(_fans.tach.buffer_1[1] > 0) {
+        _fans.tach.tach_1_period = _fans.tach.buffer_1[1] - _fans.tach.buffer_1[0];
+    } else {
+        _fans.tach.tach_1_period = 0;
+    }
+    if(_fans.tach.buffer_2[1] > 0) {
+        _fans.tach.tach_2_period = _fans.tach.buffer_2[1] - _fans.tach.buffer_2[0];
+    } else {
+        _fans.tach.tach_2_period = 0;
+    }
+    
+    thermal_fan_restart_tach_dma();
 }

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_plate_policy.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_plate_policy.cpp
@@ -50,6 +50,13 @@ auto ThermalPlatePolicy::set_fan(double power) -> bool {
 auto ThermalPlatePolicy::get_fan() -> double { return thermal_fan_get_power(); }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto ThermalPlatePolicy::get_fan_rpm() -> std::pair<double, double> {
+    auto t1 = thermal_fan_get_tach_1_rpm();
+    auto t2 = thermal_fan_get_tach_2_rpm();
+    return std::make_pair(t1, t2);
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPlatePolicy::set_write_protect(bool write_protect) -> void {
     thermal_eeprom_set_write_protect(write_protect);
     if (!write_protect) {

--- a/stm32-modules/thermocycler-gen2/simulator/thermal_plate_thread.cpp
+++ b/stm32-modules/thermocycler-gen2/simulator/thermal_plate_thread.cpp
@@ -100,7 +100,7 @@ struct SimThermalPlatePolicy
     auto get_fan() -> double { return _fan_power; }
 
     auto get_fan_rpm() -> std::pair<double, double> {
-        double val = 5000.0F * _fan_power;
+        double val = 17500.0F * _fan_power;
         return std::make_pair(val, val);
     }
 

--- a/stm32-modules/thermocycler-gen2/simulator/thermal_plate_thread.cpp
+++ b/stm32-modules/thermocycler-gen2/simulator/thermal_plate_thread.cpp
@@ -99,6 +99,11 @@ struct SimThermalPlatePolicy
 
     auto get_fan() -> double { return _fan_power; }
 
+    auto get_fan_rpm() -> std::pair<double, double> {
+        double val = 5000.0F * _fan_power;
+        return std::make_pair(val, val);
+    }
+
     auto send_power() -> void {
         _periodic_data->send_message(periodic_data_thread::PeriodicDataMessage(
             periodic_data_thread::PeltierPower{

--- a/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
@@ -1834,7 +1834,9 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                             .left = 0.0,
                             .center = 0.1,
                             .right = 0.2,
-                            .fans = 0.5});
+                            .fans = 0.5,
+                            .tach1 = 123,
+                            .tach2 = 345});
                     tasks->get_host_comms_queue().backing_deque.push_back(
                         response);
                     auto written_secondpass =
@@ -1867,7 +1869,7 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                             THEN("the task should ack the previous message") {
                                 const char response_msg[] =
                                     "M103.D L:0.00 C:0.10 R:0.20 H:0.30 F:0.50 "
-                                    "OK\n";
+                                    "T1:123.00 T2:345.00 OK\n";
                                 REQUIRE_THAT(
                                     tx_buf,
                                     Catch::Matchers::StartsWith(response_msg));

--- a/stm32-modules/thermocycler-gen2/tests/test_m103d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m103d.cpp
@@ -10,12 +10,12 @@ SCENARIO("GetThermalPowerDebug (M103.D) parser works",
         std::string buffer(256, 'c');
         WHEN("writing response") {
             auto written = gcode::GetThermalPowerDebug::write_response_into(
-                buffer.begin(), buffer.end(), 0.0, 0.1, 0.2, 0.3, 0.4);
+                buffer.begin(), buffer.end(), 0.0, 0.1, 0.2, 0.3, 0.4, 0.5,
+                0.6);
             THEN("the response should be written in full") {
-                REQUIRE_THAT(
-                    buffer,
-                    Catch::Matchers::StartsWith(
-                        "M103.D L:0.00 C:0.10 R:0.20 H:0.30 F:0.40 OK\n"));
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "M103.D L:0.00 C:0.10 R:0.20 H:0.30 "
+                                         "F:0.40 T1:0.50 T2:0.60 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }
@@ -24,7 +24,8 @@ SCENARIO("GetThermalPowerDebug (M103.D) parser works",
         std::string buffer(16, 'c');
         WHEN("filling response") {
             auto written = gcode::GetThermalPowerDebug::write_response_into(
-                buffer.begin(), buffer.begin() + 7, 0.0, 0.1, 0.2, 0.3, 0.4);
+                buffer.begin(), buffer.begin() + 7, 0.0, 0.1, 0.2, 0.3, 0.4,
+                0.5, 0.6);
             THEN("the response should write only up to the available space") {
                 std::string response = "M103.Dcccccccccc";
                 response.at(6) = '\0';

--- a/stm32-modules/thermocycler-gen2/tests/test_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_thermal_plate_task.cpp
@@ -699,6 +699,7 @@ SCENARIO("thermal plate task message passing") {
             policy._center.direction = PeltierDirection::PELTIER_COOLING;
             policy._right.power = 0.3;
             policy._fan_power = 1.0;
+            auto expected_rpm = policy.get_fan_rpm().first;
             WHEN("sending GetThermalPowerMessage") {
                 auto message = messages::GetThermalPowerMessage{.id = 123};
                 plate_queue.backing_deque.push_back(message);
@@ -717,6 +718,10 @@ SCENARIO("thermal plate task message passing") {
                                  Catch::Matchers::WithinAbs(0.3, 0.01));
                     REQUIRE_THAT(response.fans,
                                  Catch::Matchers::WithinAbs(1.0, 0.01));
+                    REQUIRE_THAT(response.tach1, Catch::Matchers::WithinAbs(
+                                                     expected_rpm, 0.01));
+                    REQUIRE_THAT(response.tach2, Catch::Matchers::WithinAbs(
+                                                     expected_rpm, 0.01));
                 }
             }
         }


### PR DESCRIPTION
Adds support to read the fan tachometers.

The tachometers use TIM4 channels 1 and 2 configured as Input Capture lines. TIM4 is set to One Pulse Mode and counts at 100kHz for 0.25 seconds. _This period was chosen based on the low end of the pulse rate being ~40Hz_. Whenever the timer is reset, DMA for each line is configured to capture the first 3 input capture readings into a buffer. When TIM4 overflows (and disables itself), the period for each tachometer is calculated based off of the latter 2 readings in its respective buffer. If there are not enough valid readings, the tachometer period is set to 0 to indicate that it is not moving. The timer is then restarted to refresh the reading.

The fan datasheet cites a max speed around 17,500 RPM. Testing on hardware shows expected scaling based on power (power of 30% gives around 5500 RPM).

- Simulator and test policy just scale the power by 17,500 to match the datasheet
- M103.D now reports the two tachometer readings. Currently there's no actual integration of tachometer speed into control.