### PR TITLE
fix(thermocycler-gen2): increase seal backoff distance

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -141,7 +141,7 @@ struct SealStepperState {
     constexpr static signed long FULL_RETRACT_MICROSTEPS =
         (FULL_EXTEND_MICROSTEPS * -1);
     // Distance to back off after triggering a limit switch
-    constexpr static double SWITCH_BACKOFF_MM = 0.5F;
+    constexpr static double SWITCH_BACKOFF_MM = 1.0F;
     // Distance to RETRACT to back off a limit switch
     constexpr static signed long SWITCH_BACKOFF_MICROSTEPS_RETRACT =
         motor_util::SealStepper::mm_to_steps(SWITCH_BACKOFF_MM);


### PR DESCRIPTION
At the end of a seal movement to a limit switch, we have to back off of the limit switch because there is no way to distinguish which switch is pressed. Some EVT units were not backing off of the switch with the original distance of 0.5mm. Regardless of the mechanical reasons for this difference, a distance of 1.0mm seems to fix the issue.

The backoff requirement will not be present on DVT units and onwards (each switch will have its own line), so it is low risk to switch this for EVT.

Tested on an EVT unit that had been getting "stuck" every 3-4 open/close cycles. The unit can work for 10+ cycles now without problem.