### PR TITLE
fix(heater-shaker): initialize temperature setpoint to std::nullopt

### DIFF
--- a/stm32-modules/heater-shaker/tests/test_heater_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_heater_task.cpp
@@ -291,7 +291,7 @@ SCENARIO("heater task message passing") {
                     auto gettemp =
                         std::get<messages::GetTemperatureResponse>(response);
                     REQUIRE(gettemp.responding_to_id == message.id);
-                    REQUIRE(gettemp.setpoint_temperature == 0);
+                    REQUIRE(gettemp.setpoint_temperature == std::nullopt);
                     REQUIRE_THAT(gettemp.current_temperature,
                                  Catch::Matchers::WithinAbs(55.0, .01));
                 }

--- a/stm32-modules/heater-shaker/tests/test_message_passing.cpp
+++ b/stm32-modules/heater-shaker/tests/test_message_passing.cpp
@@ -86,7 +86,7 @@ SCENARIO("testing full message passing integration") {
                 written = tasks->get_host_comms_task().run_once(
                     response_buffer.begin(), response_buffer.end());
                 REQUIRE_THAT(response_buffer, Catch::Matchers::StartsWith(
-                                                  "M105 C:95.20 T:0.00 OK\n"));
+                                                  "M105 C:95.20 T:None OK\n"));
             }
         }
 

--- a/stm32-modules/include/heater-shaker/heater-shaker/heater_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/heater_task.hpp
@@ -155,7 +155,7 @@ class HeaterTask {
               .error_bit = State::BOARD_SENSE_ERROR},
           state{.system_status = State::IDLE, .error_bitmap = 0},
           pid(DEFAULT_KP, DEFAULT_KI, DEFAULT_KD, CONTROL_PERIOD_S, 1.0, -1.0),
-          setpoint(0),
+          setpoint(std::nullopt),
           _flash(),
           _offset_constants{.b = OFFSET_DEFAULT_CONST_B,
                             .c = OFFSET_DEFAULT_CONST_C} {}


### PR DESCRIPTION
For API compatibility

#318 