### PR TITLE
fix(thermocycler-gen2): disable stallguard by default

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -210,7 +210,7 @@ static constexpr tmc2130::TMC2130RegisterMap default_tmc_config = {
                    .run_current = SealStepperState::DEFAULT_RUN_CURRENT,
                    .hold_current_delay = 0b0111},
     .tpowerdown = {},
-    .tcoolthrs = {.threshold = SealStepperState::DEFAULT_SG_MIN_VELOCITY},
+    .tcoolthrs = {.threshold = SealStepperState::DISABLED_SG_MIN_VELOCITY},
     .thigh = {.threshold = 0xFFFFF},
     .chopconf = {.toff = 0b101, .hstrt = 0b101, .hend = 0b11, .tbl = 0b10},
     .coolconf = {.sgt = SealStepperState::DEFAULT_STALLGUARD_THRESHOLD}};


### PR DESCRIPTION
Now that the Thermocycler Gen2 uses limit switches for the seal motor, there's no reason for Stallguard to be enabled. No issues have been reported yet but theoretically it could cause the seal motor to stop early.