### PR TITLE
fix(thermocycler-gen2): I2C error mitigation

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/firmware/ads1115.hpp
+++ b/stm32-modules/include/thermocycler-gen2/firmware/ads1115.hpp
@@ -14,11 +14,11 @@
 namespace ADS1115 {
 
 enum class Error {
-    ADCTimeout, /**< Timed out waiting for ADC.*/
-    I2CTimeout, /**< Timed out waiting for I2C.*/
-    DoubleArm, /**< ADC already armed.*/
-    ADCPin,     /**< Pin is not allowed.*/
-    ADCInit     /**< ADC is not initialized.*/
+    ADCTimeout = 1, /**< Timed out waiting for ADC.*/
+    I2CTimeout = 2, /**< Timed out waiting for I2C.*/
+    DoubleArm = 3,  /**< ADC already armed.*/
+    ADCPin = 4,     /**< Pin is not allowed.*/
+    ADCInit = 5     /**< ADC is not initialized.*/
 };
 
 class ADC {

--- a/stm32-modules/include/thermocycler-gen2/firmware/ads1115.hpp
+++ b/stm32-modules/include/thermocycler-gen2/firmware/ads1115.hpp
@@ -15,6 +15,8 @@ namespace ADS1115 {
 
 enum class Error {
     ADCTimeout, /**< Timed out waiting for ADC.*/
+    I2CTimeout, /**< Timed out waiting for I2C.*/
+    DoubleArm, /**< ADC already armed.*/
     ADCPin,     /**< Pin is not allowed.*/
     ADCInit     /**< ADC is not initialized.*/
 };

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -93,7 +93,7 @@ class ThermalPlateTask {
     using Queue = QueueImpl<Message>;
     using Milliseconds = std::chrono::milliseconds;
     using Seconds = std::chrono::duration<double, std::chrono::seconds::period>;
-    static constexpr const uint32_t CONTROL_PERIOD_TICKS = 50;
+    static constexpr const uint32_t CONTROL_PERIOD_TICKS = 1;
     static constexpr double THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM = 10.0;
     static constexpr uint16_t ADC_BIT_MAX = 0x5DC0;
     static constexpr uint8_t PLATE_THERM_COUNT = 7;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -93,7 +93,7 @@ class ThermalPlateTask {
     using Queue = QueueImpl<Message>;
     using Milliseconds = std::chrono::milliseconds;
     using Seconds = std::chrono::duration<double, std::chrono::seconds::period>;
-    static constexpr const uint32_t CONTROL_PERIOD_TICKS = 1;
+    static constexpr const uint32_t CONTROL_PERIOD_TICKS = 50;
     static constexpr double THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM = 10.0;
     static constexpr uint16_t ADC_BIT_MAX = 0x5DC0;
     static constexpr uint8_t PLATE_THERM_COUNT = 7;

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/ads1115.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/ads1115.cpp
@@ -101,11 +101,12 @@ auto ADC::read(uint16_t pin) -> ADC::ReadVal {
     }
 
     static_cast<void>(release_lock());
-    if ((!i2c_ret) || (notification_val == 0)) {
-        auto err = (i2c_ret) ? Error::ADCTimeout : Error::I2CTimeout;
-        return ReadVal(err);
+    if (!i2c_ret) {
+        return ReadVal(Error::I2CTimeout);
     }
-
+    if (notification_val == 0) {
+        return ReadVal(Error::ADCTimeout);
+    }
     return ReadVal(_last_result);
 }
 

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/ads1115.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/ads1115.cpp
@@ -82,7 +82,7 @@ auto ADC::read(uint16_t pin) -> ADC::ReadVal {
     i2c_ret = thermal_arm_adc_for_read(_id);
     if (!i2c_ret) {
         static_cast<void>(release_lock());
-        return ReadVal(Error::ADCTimeout);
+        return ReadVal(Error::DoubleArm);
     }
     // This kicks off the conversion on the selected pin
     i2c_ret = thermal_i2c_write_16(
@@ -102,7 +102,8 @@ auto ADC::read(uint16_t pin) -> ADC::ReadVal {
 
     static_cast<void>(release_lock());
     if ((!i2c_ret) || (notification_val == 0)) {
-        return ReadVal(Error::ADCTimeout);
+        auto err = (i2c_ret) ? Error::ADCTimeout : Error::I2CTimeout;
+        return ReadVal(err);
     }
 
     return ReadVal(_last_result);

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -85,7 +85,7 @@ static auto read_thermistor(const ADCPinMap &pin) -> uint16_t {
         _adc.at(static_cast<uint8_t>(pin.adc_index)).read(pin.adc_pin);
     if (std::holds_alternative<ADS1115::Error>(result)) {
         done = true;
-        return 0xFFFF;
+        return 0xFFFF - (uint16_t)std::get<ADS1115::Error>(result);
     }
     if(std::get<uint16_t>(result) == 0) {
         done = true;

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -96,13 +96,10 @@ static auto read_thermistor(const ADCPinMap &pin) -> uint16_t {
                 _adc.at(static_cast<uint8_t>(pin.adc_index)).read(pin.adc_pin);
         } else {
             // Retries expired
-            done = true;
+            return static_cast<uint16_t>(std::get<ADS1115::Error>(result));
         }
     }
 
-    if (std::holds_alternative<ADS1115::Error>(result)) {
-        return static_cast<uint16_t>(std::get<ADS1115::Error>(result));
-    }
     return std::get<uint16_t>(result);
 }
 

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -15,6 +15,8 @@
 
 namespace thermal_plate_control_task {
 
+static constexpr uint8_t MAX_RETRIES = 3;
+
 enum class ADCAddress : uint8_t {
     ADC_FRONT = ((0x48) << 1),  // AKA ADC1
     ADC_REAR = ((0x49) << 1)    // AKA ADC2
@@ -79,8 +81,25 @@ static StaticTask_t
  * ADC cannot be read.
  */
 static auto read_thermistor(const ADCPinMap &pin) -> uint16_t {
+    uint8_t retries = 0;
+    bool done = false;
+    // Keep trying to read
     auto result =
         _adc.at(static_cast<uint8_t>(pin.adc_index)).read(pin.adc_pin);
+    while (!done) {
+        if (std::holds_alternative<uint16_t>(result)) {
+            done = true;
+        } else if (++retries < MAX_RETRIES) {
+            // Short delay for reliability
+            vTaskDelay(pdMS_TO_TICKS(5));
+            result =
+                _adc.at(static_cast<uint8_t>(pin.adc_index)).read(pin.adc_pin);
+        } else {
+            // Retries expired
+            done = true;
+        }
+    }
+
     if (std::holds_alternative<ADS1115::Error>(result)) {
         return static_cast<uint16_t>(std::get<ADS1115::Error>(result));
     }

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -15,7 +15,7 @@
 
 namespace thermal_plate_control_task {
 
-static constexpr uint8_t MAX_RETRIES = 3;
+static constexpr uint8_t MAX_RETRIES = 5;
 
 enum class ADCAddress : uint8_t {
     ADC_FRONT = ((0x48) << 1),  // AKA ADC1

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -82,7 +82,7 @@ static auto read_thermistor(const ADCPinMap &pin) -> uint16_t {
     auto result =
         _adc.at(static_cast<uint8_t>(pin.adc_index)).read(pin.adc_pin);
     if (std::holds_alternative<ADS1115::Error>(result)) {
-        return 0xFFFF - (uint16_t)std::get<ADS1115::Error>(result);
+        return static_cast<uint16_t>(std::get<ADS1115::Error>(result));
     }
     return std::get<uint16_t>(result);
 }

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/freertos_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/freertos_thermal_plate_task.cpp
@@ -68,8 +68,6 @@ static constexpr std::array<ADCPinMap, thermal_general::ThermistorID::THERM_LID>
         {ADC_FRONT, 0}   // Heat sink
     }};
 
-static bool done = false;
-
 // Internal FreeRTOS data structure for the task
 static StaticTask_t
     data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -84,11 +82,7 @@ static auto read_thermistor(const ADCPinMap &pin) -> uint16_t {
     auto result =
         _adc.at(static_cast<uint8_t>(pin.adc_index)).read(pin.adc_pin);
     if (std::holds_alternative<ADS1115::Error>(result)) {
-        done = true;
         return 0xFFFF - (uint16_t)std::get<ADS1115::Error>(result);
-    }
-    if(std::get<uint16_t>(result) == 0) {
-        done = true;
     }
     return std::get<uint16_t>(result);
 }
@@ -123,7 +117,6 @@ static void run_thermistor_task(void *param) {
             &last_wake_time,
             // NOLINTNEXTLINE(readability-static-accessed-through-instance)
             _main_task.CONTROL_PERIOD_TICKS);
-        if(!done) {
         readings.front_right = read_thermistor(
             _adc_map[thermal_general::ThermistorID::THERM_FRONT_RIGHT]);
         readings.front_left = read_thermistor(
@@ -143,7 +136,6 @@ static void run_thermistor_task(void *param) {
         auto send_ret = _main_task.get_message_queue().try_send(readings);
         static_cast<void>(
             send_ret);  // Not much we can do if messages won't send
-        }
     }
 }
 

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_hardware.c
@@ -46,8 +46,8 @@
 /** Private definitions */
 
 #define I2C_INSTANCE (I2C2)
-/* Driven by PCLK1 to 1MHz */
-#define I2C_TIMING   (0x00802172)
+/* Driven by PCLK1 to Fast Mode - just shy of 400kHz */
+#define I2C_TIMING   (0x80500D1D)
 /** Max buffer: 2 data bytes*/
 #define I2C_BUF_MAX (2)
 /** Size of register address: 1 byte.*/

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_hardware.c
@@ -52,9 +52,9 @@
 #define I2C_BUF_MAX (2)
 /** Size of register address: 1 byte.*/
 #define REGISTER_ADDR_LEN (1)
-/** NVIC priority of ADC interrupts.
- * On the higher end (low-priority) because timing
- * is not critical compared to other interrupts.
+/** 
+ * NVIC priority of ADC interrupts.
+ * Matches the priority of motor interrupts.
  */
 #define ADC_READY_ITR_PRIO (4)
 

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_hardware.c
@@ -65,7 +65,7 @@
 
 /** Local variables */
 
-static TaskHandle_t _i2c_task_to_notify = NULL;
+static _Atomic TaskHandle_t _i2c_task_to_notify = NULL;
 static atomic_flag _initialization_started = ATOMIC_FLAG_INIT;
 static bool _initialization_done = false;
 
@@ -187,10 +187,6 @@ bool thermal_i2c_write_16(uint16_t addr, uint8_t reg, uint16_t val) {
     }
 
     // Set up notification info
-    if(_i2c_task_to_notify != NULL) {
-        xSemaphoreGive(_i2c_semaphore);
-        return false;
-    }
     _i2c_task_to_notify = xTaskGetCurrentTaskHandle();
 
     // Prepare buffer & send it

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_hardware.c
@@ -56,7 +56,7 @@
  * On the higher end (low-priority) because timing
  * is not critical compared to other interrupts.
  */
-#define ADC_READY_ITR_PRIO (10)
+#define ADC_READY_ITR_PRIO (4)
 
 /** EEPROM write protect pin */
 #define EEPROM_WRITE_PROTECT_PIN  (GPIO_PIN_10)


### PR DESCRIPTION
Cycle testing with simultaneous thermal control & lid open/close control shows that the code for reading from the thermistor ADC's periodically fails. This results in an error state that ruins an active thermocycler run. The following changes appear to mitigate the effect:

- Increased I2C interrupt priority to match motor interrupts
- Added more detailed ADC error reporting through the raw ADC reading 
- Reduced the I2C bus speed from an excessive 1MHz to 400kHz
- Added a retry system, wherein a failed reading can be repeated

Tested with a 12 hour cycle test on EVT-06.