### PR TITLE
fix(thermocycler-gen2): changes to uniformity error check

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -246,8 +246,8 @@ class PlateControl {
     auto reset_control(thermal_general::HeatsinkFan &fan) -> void;
 
     /**
-     * @brief Based on the current temperature readings, check if every
-     * channel on the Thermocycler has crossed the current setpoint
+     * @brief Based on the current temperature readings, check if the average
+     * temperature of the plate has crossed the setpoint
      *
      * @param heating If true, check if the channels are above the target.
      *                Otherwise checks if they are below the target.

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
@@ -47,6 +47,13 @@ graph TD
     Start -->|Disable command| Off
 ```
 
+### Thermistor Drift Errors
+
+The firmware raises an error if the thermistors on the plate seem to have excessively drifted. If the following conditions are met, then the thermal plate task enters an error state until the device is reset:
+- There is an active temperature target
+- The plate control has finisehd the Overshoot Phase and 30 additional seconds have passed
+- The hottest thermistor and the coldest thermistor on the plate are more than 4ºC apart from one another
+
 ## Lid Heater
 
 The lid heater consists of a single resistive heating pad and a single thermistor for temperature feedback. The lid's primary purpose is to prevent condensation in the wells by providing a temperature above that of the peltier plate.

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -286,9 +286,10 @@ auto PlateControl::reset_control(thermal_general::HeatsinkFan &fan) -> void {
 }
 
 [[nodiscard]] auto PlateControl::crossed_setpoint(bool heating) const -> bool {
-    return crossed_setpoint(_left, heating) &&
-           crossed_setpoint(_center, heating) &&
-           crossed_setpoint(_right, heating);
+    if (heating) {
+        return plate_temp() > _setpoint;
+    }
+    return plate_temp() < _setpoint;
 }
 
 [[nodiscard]] auto PlateControl::crossed_setpoint(

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -287,9 +287,9 @@ auto PlateControl::reset_control(thermal_general::HeatsinkFan &fan) -> void {
 
 [[nodiscard]] auto PlateControl::crossed_setpoint(bool heating) const -> bool {
     if (heating) {
-        return plate_temp() > _setpoint;
+        return plate_temp() >= _setpoint;
     }
-    return plate_temp() < _setpoint;
+    return plate_temp() <= _setpoint;
 }
 
 [[nodiscard]] auto PlateControl::crossed_setpoint(

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -20,7 +20,7 @@ auto PlateControl::update_control(Seconds time) -> UpdateRet {
     switch (_status) {
         case PlateStatus::INITIAL_HEAT:
             // Check if we crossed the TRUE threshold temp
-            if (plate_temp() >= _setpoint) {
+            if (crossed_setpoint(true)) {
                 _status = PlateStatus::OVERSHOOT;
                 _remaining_overshoot_time = OVERSHOOT_TIME;
                 _left.temp_target = _current_setpoint;
@@ -34,7 +34,7 @@ auto PlateControl::update_control(Seconds time) -> UpdateRet {
             break;
         case PlateStatus::INITIAL_COOL:
             // Check if we crossed the TRUE threshold temp
-            if (plate_temp() <= _setpoint) {
+            if (crossed_setpoint(false)) {
                 _status = PlateStatus::OVERSHOOT;
                 _remaining_overshoot_time = OVERSHOOT_TIME;
                 _left.temp_target = _current_setpoint;
@@ -54,12 +54,15 @@ auto PlateControl::update_control(Seconds time) -> UpdateRet {
                 _right.temp_target = _setpoint;
                 _center.temp_target = _setpoint;
                 _status = PlateStatus::STEADY_STATE;
+                _uniformity_error_timer = UNIFORMITY_CHECK_DELAY;
             }
             break;
         case PlateStatus::STEADY_STATE:
             // Hold time is ONLY updated in steady state!
             _remaining_hold_time = std::max(_remaining_hold_time - time,
                                             static_cast<double>(0.0F));
+            _uniformity_error_timer = std::max(_uniformity_error_timer - time,
+                                               static_cast<double>(0.0F));
             break;
     }
 
@@ -256,6 +259,10 @@ auto PlateControl::reset_control(thermal_general::HeatsinkFan &fan) -> void {
 }
 
 [[nodiscard]] auto PlateControl::thermistor_drift_check() const -> bool {
+    if ((_status != PlateStatus::STEADY_STATE) ||
+        (_uniformity_error_timer > 0.0F)) {
+        return true;
+    }
     auto temperatures = get_peltier_temps();
     double min = temperatures.at(0);
     double max = temperatures.at(0);
@@ -276,4 +283,18 @@ auto PlateControl::reset_control(thermal_general::HeatsinkFan &fan) -> void {
         _right.thermistors.first.temp_c,
         _right.thermistors.second.temp_c,
     }};
+}
+
+[[nodiscard]] auto PlateControl::crossed_setpoint(bool heating) const -> bool {
+    return crossed_setpoint(_left, heating) &&
+           crossed_setpoint(_center, heating) &&
+           crossed_setpoint(_right, heating);
+}
+
+[[nodiscard]] auto PlateControl::crossed_setpoint(
+    const thermal_general::Peltier &channel, bool heating) const -> bool {
+    if (heating) {
+        return channel.current_temp() >= _setpoint;
+    }
+    return channel.current_temp() <= _setpoint;
 }


### PR DESCRIPTION
Per internal discussion, it seems that the uniformity error checking is excessively aggressive - the Thermocycler tends to flag a uniformity error while thermistors are still settling. This PR adjusts the behavior so that the Thermocycler gives an extra 30 seconds _after_ the end of the Overshoot phase until it starts checking for the error. 

Tested on hardware by setting target temperature and unplugging thermistors. Unplugging before the 30 seconds and then plugging the thermistor back in shows that no uniformity error is flagged. If a thermistor is unplugged _after_ the 30 seconds, the uniformity error is triggered and stays active.