### PR TITLE
fix(startup): exception handling is more resilient 

### DIFF
--- a/stm32-modules/common/module-startup/module-startup.S
+++ b/stm32-modules/common/module-startup/module-startup.S
@@ -88,6 +88,17 @@ Fault_Handler:
     ldr     r0, =Post_Fault_Handler
     str     r0, [sp,#0x18]
 
+    /* LR should hold an EXC_RETURN code, but there is a chance that it is
+     * either an invalid value, or simply marks exception behavior that we
+     * don't want. We always want to return to Handler mode so the Fault
+     * Handler can safely jump to the bootloader, so we ovewrite the LR
+     * register before returning from this exception. 
+     *
+     * The danger of *not* overwriting LR is that, if its value is invalid,
+     * the processor will end up getting stuck in a loop of excepting into
+     * this fault handler forever. */
+    ldr     lr,=0xFFFFFFF1
+
     /* In order to clear the hard fault flag, we overwrite LR and return
      * to the Post_Fault_Handler function */
     bx      lr


### PR DESCRIPTION
In the module-startup program, the processor has the opportunity to become locked in an endless loop of the `Fault_Handler` if the Link Register holds an invalid EXC_RETURN value, because the program uses this value to define the proper exception return behavior. Sometimes `LR` seems to be loaded with an invalid value when the built-in bootloader enters an exception. This handler _always_ wants to use Return to Handler Mode when jumping to the `Post_Fault_Handler`, so this PR makes sure it does that.

Tested with WIP TD3 DFU code. Without this change, the CPU cycles through the Fault Handler forever. With this change, it ends up entering DFU mode correctly.