### PR TITLE
fix(heater-shaker): store target rpm

### DIFF
--- a/stm32-modules/heater-shaker/tests/test_message_passing.cpp
+++ b/stm32-modules/heater-shaker/tests/test_message_passing.cpp
@@ -36,6 +36,13 @@ SCENARIO("testing full message passing integration") {
             }
         }
         WHEN("sending a get-rpm message by string to the host comms task") {
+            tasks->get_motor_policy().test_set_current_rpm(1050);
+            auto pre_message = messages::SetRPMMessage{
+                .id = 123, .target_rpm = 3500};  // needed to populate setpoint
+            tasks->get_motor_queue().backing_deque.push_back(
+                messages::MotorMessage(pre_message));
+            tasks->get_motor_task().run_once(tasks->get_motor_policy());
+            tasks->get_host_comms_queue().backing_deque.pop_front();
             std::string message_str = "M123\n";
             tasks->get_host_comms_queue().backing_deque.push_back(
                 messages::HostCommsMessage(messages::IncomingMessageFromHost(
@@ -45,8 +52,6 @@ SCENARIO("testing full message passing integration") {
                 auto written = tasks->get_host_comms_task().run_once(
                     response_buffer.begin(), response_buffer.end());
                 REQUIRE(written == response_buffer.begin());
-                tasks->get_motor_policy().test_set_current_rpm(1050);
-                tasks->get_motor_policy().set_rpm(3500);
                 tasks->get_motor_task().run_once(tasks->get_motor_policy());
                 written = tasks->get_host_comms_task().run_once(
                     response_buffer.begin(), response_buffer.end());

--- a/stm32-modules/heater-shaker/tests/test_motor_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_motor_task.cpp
@@ -168,11 +168,16 @@ SCENARIO("motor task core message handling", "[motor]") {
             }
         }
         WHEN("sending a get-rpm message") {
+            tasks->get_motor_policy().test_set_current_rpm(1050);
+            auto pre_message = messages::SetRPMMessage{
+                .id = 123, .target_rpm = 3500};  // needed to populate setpoint
+            tasks->get_motor_queue().backing_deque.push_back(
+                messages::MotorMessage(pre_message));
+            tasks->get_motor_task().run_once(tasks->get_motor_policy());
+            tasks->get_host_comms_queue().backing_deque.pop_front();
             auto message = messages::GetRPMMessage{.id = 123};
             tasks->get_motor_queue().backing_deque.push_back(
                 messages::MotorMessage(message));
-            tasks->get_motor_policy().test_set_current_rpm(1050);
-            tasks->get_motor_policy().set_rpm(3500);
             tasks->get_motor_task().run_once(tasks->get_motor_policy());
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_motor_queue().backing_deque.empty());

--- a/stm32-modules/include/heater-shaker/heater-shaker/motor_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/motor_task.hpp
@@ -113,7 +113,8 @@ class MotorTask {
         : state{.status = State::STOPPED_UNKNOWN},
           plate_lock_state{.status = PlateLockState::IDLE_UNKNOWN},
           message_queue(q),
-          task_registry(nullptr) {}
+          task_registry(nullptr),
+          setpoint(0) {}
     MotorTask(const MotorTask& other) = delete;
     auto operator=(const MotorTask& other) -> MotorTask& = delete;
     MotorTask(MotorTask&& other) noexcept = delete;
@@ -165,6 +166,7 @@ class MotorTask {
         } else {
             policy.homing_solenoid_disengage();
             error = policy.set_rpm(msg.target_rpm);
+            setpoint = msg.target_rpm;
             state.status = State::RUNNING;
             policy.delay_ticks(MOTOR_START_WAIT_TICKS);
             if ((msg.target_rpm != 0) &&
@@ -172,6 +174,7 @@ class MotorTask {
                 error = errors::ErrorCode::MOTOR_UNABLE_TO_MOVE;
                 policy.stop();
                 state.status = State::ERROR;
+                setpoint = 0;
             }
         }
         auto response = messages::AcknowledgePrevious{
@@ -211,7 +214,7 @@ class MotorTask {
         auto response =
             messages::GetRPMResponse{.responding_to_id = msg.id,
                                      .current_rpm = policy.get_current_rpm(),
-                                     .setpoint_rpm = policy.get_target_rpm()};
+                                     .setpoint_rpm = setpoint};
         static_cast<void>(task_registry->comms->get_message_queue().try_send(
             messages::HostCommsMessage(response)));
     }
@@ -231,6 +234,7 @@ class MotorTask {
             policy.homing_solenoid_engage(HOMING_SOLENOID_CURRENT_HOLD);
             policy.stop();
             state.status = State::STOPPED_HOMED;
+            setpoint = 0;
             static_cast<void>(
                 task_registry->comms->get_message_queue().try_send(
                     messages::AcknowledgePrevious{.responding_to_id =
@@ -244,7 +248,9 @@ class MotorTask {
                 auto code = errors::from_motor_error(
                     msg.errors, static_cast<errors::MotorErrorOffset>(offset));
                 if (code != errors::ErrorCode::NO_ERROR) {
+                    policy.stop();
                     state.status = State::ERROR;
+                    setpoint = 0;
                     static_cast<void>(
                         task_registry->comms->get_message_queue().try_send(
                             messages::HostCommsMessage(
@@ -306,6 +312,7 @@ class MotorTask {
                 policy.homing_solenoid_engage(HOMING_SOLENOID_CURRENT_HOLD);
                 policy.stop();
                 state.status = State::STOPPED_HOMED;
+                setpoint = 0;
                 if (!msg.from_startup) {
                     static_cast<void>(
                         task_registry->comms->get_message_queue().try_send(
@@ -343,6 +350,7 @@ class MotorTask {
                 auto error = errors::ErrorCode::MOTOR_UNABLE_TO_MOVE;
                 policy.stop();
                 state.status = State::ERROR;
+                setpoint = 0;
                 if (msg.from_startup) {
                     static_cast<void>(
                         task_registry->comms->get_message_queue().try_send(
@@ -572,6 +580,7 @@ class MotorTask {
     uint32_t cached_home_id = 0;
     uint32_t homing_cycles_coasting = 0;
     uint32_t polling_time = 0;
+    int16_t setpoint;
 };
 
 };  // namespace motor_task


### PR DESCRIPTION
Previously, target rpm was gleaned from the motor control library current mechanical rotor speed reference, and would change during ramping up/down. This caused hardware control class to classify speed state as HOLDING prematurely (and potentially never enter ACCELERATING/DECELERATING states).

This stores a fixed target rpm in the motor task via the SetRPM gcode and reports it back through the GetRPM gcode.

Closes Opentrons/opentrons#10815