### PR TITLE
feat(tempdeck-gen3): add ui task & heartbeat led

### DIFF
--- a/cpp-utils/include/ot_utils/freertos/freertos_timer.hpp
+++ b/cpp-utils/include/ot_utils/freertos/freertos_timer.hpp
@@ -18,7 +18,7 @@ class FreeRTOSTimer {
      */
     using Callback = std::function<void()>;
     FreeRTOSTimer(const char* name, Callback&& callback, uint32_t period_ms)
-        : FreeRTOSTimer(name, callback, true, period_ms) {}
+        : FreeRTOSTimer(name, std::forward<Callback>(callback), true, period_ms) {}
 
     FreeRTOSTimer(const char* name, Callback&& callback, bool autoreload,
                   uint32_t period_ms)
@@ -58,7 +58,7 @@ class FreeRTOSTimer {
 
     auto start_from_isr() -> bool {
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-        auto ret = xTimerStartFromISR(_timer, &xHigherPriorityTaskWoken);
+        auto ret = xTimerStartFromISR(timer, &xHigherPriorityTaskWoken);
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
         portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
         return ret == pdPASS;
@@ -66,7 +66,7 @@ class FreeRTOSTimer {
 
     auto stop_from_isr() -> bool {
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-        auto ret = xTimerStopFromISR(_timer, &xHigherPriorityTaskWoken);
+        auto ret = xTimerStopFromISR(timer, &xHigherPriorityTaskWoken);
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
         portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
         return ret == pdPASS;

--- a/stm32-modules/include/tempdeck-gen3/firmware/firmware_tasks.hpp
+++ b/stm32-modules/include/tempdeck-gen3/firmware/firmware_tasks.hpp
@@ -16,5 +16,7 @@ constexpr size_t HOST_STACK_SIZE = 2048;
 constexpr uint8_t HOST_TASK_PRIORITY = 1;
 constexpr size_t SYSTEM_STACK_SIZE = 256;
 constexpr uint8_t SYSTEM_TASK_PRIORITY = 1;
+constexpr size_t UI_STACK_SIZE = 256;
+constexpr uint8_t UI_TASK_PRIORITY = 1;
 
 };  // namespace tasks

--- a/stm32-modules/include/tempdeck-gen3/firmware/freertos_ui_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/firmware/freertos_ui_task.hpp
@@ -1,0 +1,14 @@
+/*
+ * Interface for the firmware-specifc parts of the system task
+ */
+#pragma once
+
+#include "FreeRTOS.h"
+#include "firmware/firmware_tasks.hpp"
+#include "task.h"
+
+namespace ui_control_task {
+
+// Actual function that runs in the task
+auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void;
+}  // namespace ui_control_task

--- a/stm32-modules/include/tempdeck-gen3/firmware/ui_hardware.h
+++ b/stm32-modules/include/tempdeck-gen3/firmware/ui_hardware.h
@@ -1,0 +1,19 @@
+#ifndef UI_HARDWARE_H__
+#define UI_HARDWARE_H__
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#include <stdbool.h>
+
+void ui_hardware_initialize();
+
+/**
+ * @brief Enter the bootloader. This function never returns.
+ */
+void ui_hardware_set_heartbeat_led(bool setting);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  // _UI_HARDWARE_H__

--- a/stm32-modules/include/tempdeck-gen3/firmware/ui_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/firmware/ui_policy.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+class UIPolicy {
+  public:
+    auto set_heartbeat_led(bool value) -> void;
+};

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
@@ -99,4 +99,5 @@ using HostCommsMessage =
 using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,
                    SetSerialNumberMessage, EnterBootloaderMessage>;
+using UIMessage = ::std::variant<std::monostate, UpdateUIMessage>;
 };  // namespace messages

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
@@ -60,6 +60,10 @@ struct IncomingMessageFromHost {
     const char* limit;
 };
 
+// This empty message is just used to signal that the UI task should update
+// its outputs
+struct UpdateUIMessage {};
+
 struct GetSystemInfoMessage {
     uint32_t id;
 };

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/tasks.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/tasks.hpp
@@ -15,16 +15,20 @@ struct Tasks {
     using HostCommsQueue = QueueImpl<messages::HostCommsMessage>;
     // Message queue for system task
     using SystemQueue = QueueImpl<messages::SystemMessage>;
+    // Message queue for UI task
+    using UIQueue = QueueImpl<messages::UIMessage>;
 
     // Central aggregator
     using QueueAggregator =
-        queue_aggregator::QueueAggregator<HostCommsQueue, SystemQueue>;
+        queue_aggregator::QueueAggregator<HostCommsQueue, SystemQueue, UIQueue>;
 
     // Addresses
     static constexpr size_t HostAddress =
         QueueAggregator::template get_queue_idx<HostCommsQueue>();
     static constexpr size_t SystemAddress =
         QueueAggregator::template get_queue_idx<SystemQueue>();
+    static constexpr size_t UIAddress =
+        QueueAggregator::template get_queue_idx<UIQueue>();
 };
 
 };  // namespace tasks

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/ui_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/ui_task.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "hal/message_queue.hpp"
+#include "tempdeck-gen3/messages.hpp"
+#include "tempdeck-gen3/tasks.hpp"
+
+namespace ui_task {
+
+template <typename Policy>
+concept UIPolicy = requires(Policy& p) {
+    // A function to set the heartbeat LED on or off
+    {p.set_heartbeat_led(true)};
+};
+
+// Structure to hold runtime info for the heartbeat LED.
+// The LED is run with a psuedo-pwm to confirm that the
+// firmware is running and tasks are being called at
+// regular intervals
+class Heartbeat {
+  private:  
+    const uint32_t _period;
+    uint8_t _pwm = 0;
+    uint8_t _count = 0;
+    int8_t  _direction = 1;
+
+  public:
+    
+    explicit Heartbeat(uint32_t period = 25) : _period(period) {}
+
+    /**
+     * @brief Increment heartbeat counter. This provides a pseudo-pwm
+     * setup where a "pwm" counter runs from 0 to a configurable period
+     * value, and the LED is turned on and off based on whether the repeating
+     * counter is below the PWM value.
+     * 
+     * @return true if the LED should be set to on, false if it should 
+     * be set to off.
+     */
+    auto tick() -> bool {
+        ++_count;
+        if(_count == _period) {
+            _count = 0;
+            _pwm += _direction;
+            if(_pwm == _period) {
+                _direction = -1;
+            } else if(_pwm == 0) {
+                _direction = 1;
+            }
+        }
+        return (_pwm > 2) && (_count < _pwm);
+    }
+};
+
+using Message = messages::UIMessage;
+
+template <template <class> class QueueImpl>
+requires MessageQueue<QueueImpl<Message>, Message>
+class UITask {
+  public:
+    using Queue = QueueImpl<Message>;
+    using Aggregator = typename tasks::Tasks<QueueImpl>::QueueAggregator;
+    using Queues = typename tasks::Tasks<QueueImpl>;
+
+    // The timer driving LED update frequency should run at this period
+    static constexpr uint32_t UPDATE_PERIOD_MS = 1;
+
+    explicit UITask(Queue& q, Aggregator* aggregator)
+        : _message_queue(q), _task_registry(aggregator), _heartbeat() {}
+    UITask(const UITask& other) = delete;
+    auto operator=(const UITask& other) -> UITask& = delete;
+    UITask(UITask&& other) noexcept = delete;
+    auto operator=(UITask&& other) noexcept -> UITask& = delete;
+    ~UITask() = default;
+
+    auto provide_aggregator(Aggregator* aggregator) {
+        _task_registry = aggregator;
+    }
+
+    // This should be called from the periodic update timer to drive the
+    // update frequency of the LED's on the system
+    auto update_callback() {
+        static_cast<void>(_message_queue.try_send(messages::UpdateUIMessage{}));
+    }
+
+    template <UIPolicy Policy>
+    auto run_once(Policy& policy) -> void {
+        auto message = Message(std::monostate());
+        _message_queue.recv(&message);
+        auto visit_helper = [this, &policy](auto& message) -> void {
+            this->visit_message(message, policy);
+        };
+        std::visit(visit_helper, message);
+    }
+
+  private:
+
+    template <UIPolicy Policy>
+    auto visit_message(const std::monostate& message, Policy& policy) -> void {
+        static_cast<void>(message);
+        static_cast<void>(policy);
+    }
+
+    template <UIPolicy Policy>
+    auto visit_message(const messages::UpdateUIMessage& message, Policy& policy) -> void {
+        static_cast<void>(message);
+        policy.set_heartbeat_led(_heartbeat.tick());
+    }
+
+    Queue& _message_queue;
+    Aggregator* _task_registry;
+    Heartbeat _heartbeat;
+};
+
+};  // namespace ui_task

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/ui_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/ui_task.hpp
@@ -50,6 +50,9 @@ class Heartbeat {
         }
         return (_pwm > 2) && (_count < _pwm);
     }
+
+    // Get the current pwm period
+    auto pwm() -> uint8_t { return _pwm; }
 };
 
 using Message = messages::UIMessage;

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/ui_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/ui_task.hpp
@@ -52,7 +52,7 @@ class Heartbeat {
     }
 
     // Get the current pwm period
-    auto pwm() -> uint8_t { return _pwm; }
+    [[nodiscard]] auto pwm() const -> uint8_t { return _pwm; }
 };
 
 using Message = messages::UIMessage;

--- a/stm32-modules/include/tempdeck-gen3/test/test_tasks.hpp
+++ b/stm32-modules/include/tempdeck-gen3/test/test_tasks.hpp
@@ -2,6 +2,7 @@
 
 #include "tempdeck-gen3/host_comms_task.hpp"
 #include "tempdeck-gen3/system_task.hpp"
+#include "tempdeck-gen3/ui_task.hpp"
 #include "tempdeck-gen3/tasks.hpp"
 #include "test/test_message_queue.hpp"
 
@@ -15,15 +16,19 @@ class TestTasks {
     explicit TestTasks()
         : _comms_queue("comms"),
           _system_queue("system"),
+          _ui_queue("ui"),
           _aggregator(_comms_queue, _system_queue),
           _comms_task(_comms_queue, &_aggregator),
-          _system_task(_system_queue, &_aggregator) {}
+          _system_task(_system_queue, &_aggregator),
+          _ui_task(_ui_queue, &_aggregator) {}
 
     Queues::HostCommsQueue _comms_queue;
     Queues::SystemQueue _system_queue;
+    Queues::UIQueue _ui_queue;
     Queues::QueueAggregator _aggregator;
     host_comms_task::HostCommsTask<TestMessageQueue> _comms_task;
     system_task::SystemTask<TestMessageQueue> _system_task;
+    ui_task::UITask<TestMessageQueue> _ui_task;
 };
 
 static auto BuildTasks() -> TestTasks* { return new TestTasks(); }

--- a/stm32-modules/include/tempdeck-gen3/test/test_tasks.hpp
+++ b/stm32-modules/include/tempdeck-gen3/test/test_tasks.hpp
@@ -2,8 +2,8 @@
 
 #include "tempdeck-gen3/host_comms_task.hpp"
 #include "tempdeck-gen3/system_task.hpp"
-#include "tempdeck-gen3/ui_task.hpp"
 #include "tempdeck-gen3/tasks.hpp"
+#include "tempdeck-gen3/ui_task.hpp"
 #include "test/test_message_queue.hpp"
 
 namespace tasks {
@@ -17,7 +17,7 @@ class TestTasks {
         : _comms_queue("comms"),
           _system_queue("system"),
           _ui_queue("ui"),
-          _aggregator(_comms_queue, _system_queue),
+          _aggregator(_comms_queue, _system_queue, _ui_queue),
           _comms_task(_comms_queue, &_aggregator),
           _system_task(_system_queue, &_aggregator),
           _ui_task(_ui_queue, &_aggregator) {}

--- a/stm32-modules/include/tempdeck-gen3/test/test_ui_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/test/test_ui_policy.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+struct TestUIPolicy {
+
+    void set_heartbeat_led(bool set) {
+        _heartbeat_set = set;
+        ++_heartbeat_set_count;
+    }
+
+    bool _heartbeat_set = false;
+    size_t _heartbeat_set_count = 0;
+};

--- a/stm32-modules/include/tempdeck-gen3/test/test_ui_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/test/test_ui_policy.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 struct TestUIPolicy {
-
     void set_heartbeat_led(bool set) {
         _heartbeat_set = set;
         ++_heartbeat_set_count;

--- a/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
@@ -8,6 +8,7 @@ add_STM32G4_usb(${TARGET_MODULE_NAME})
 
 set(SYSTEM_DIR "${CMAKE_CURRENT_SOURCE_DIR}/system")
 set(COMMS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/host_comms_task")
+set(UI_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ui")
 set(COMMON_MCU_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../common/STM32G491")
 set(COMMON_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../common/src")
 set(GDBINIT_PATH "${CMAKE_CURRENT_BINARY_DIR}/../../common/STM32G491/gdbinit")
@@ -20,7 +21,10 @@ set(${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS
   ${SYSTEM_DIR}/system_policy.cpp 
   ${COMMS_DIR}/freertos_comms_task.cpp
   ${COMMS_DIR}/usb_hardware.c
-  )
+  ${UI_DIR}/freertos_ui_task.cpp
+  ${UI_DIR}/ui_hardware.c
+  ${UI_DIR}/ui_policy.cpp
+)
 
 # Add source files that should NOT be checked by clang-tidy here
 set(${TARGET_MODULE_NAME}_FW_NONLINTABLE_SRCS

--- a/stm32-modules/tempdeck-gen3/firmware/main.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/main.cpp
@@ -3,6 +3,7 @@
 #include "firmware/firmware_tasks.hpp"
 #include "firmware/freertos_comms_task.hpp"
 #include "firmware/freertos_system_task.hpp"
+#include "firmware/freertos_ui_task.hpp"
 #include "firmware/system_stm32g4xx.h"
 #include "ot_utils/freertos/freertos_task.hpp"
 #include "task.h"
@@ -13,6 +14,8 @@ using EntryPoint = std::function<void(tasks::FirmwareTasks::QueueAggregator *)>;
 static auto host_task_entry = EntryPoint(host_comms_control_task::run);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto system_task_entry = EntryPoint(system_control_task::run);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto ui_task_entry = EntryPoint(ui_control_task::run);
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto aggregator = tasks::FirmwareTasks::QueueAggregator();
@@ -25,11 +28,16 @@ static auto host_task =
 static auto system_task =
     ot_utils::freertos_task::FreeRTOSTask<tasks::SYSTEM_STACK_SIZE, EntryPoint>(
         system_task_entry);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto ui_task =
+    ot_utils::freertos_task::FreeRTOSTask<tasks::UI_STACK_SIZE, EntryPoint>(
+        ui_task_entry);
 
 auto main() -> int {
     HardwareInit();
     host_task.start(tasks::HOST_TASK_PRIORITY, "HostComms", &aggregator);
     system_task.start(tasks::SYSTEM_TASK_PRIORITY, "System", &aggregator);
+    ui_task.start(tasks::UI_TASK_PRIORITY, "UI", &aggregator);
 
     vTaskStartScheduler();
     return 0;

--- a/stm32-modules/tempdeck-gen3/firmware/ui/freertos_ui_task.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/ui/freertos_ui_task.cpp
@@ -1,0 +1,47 @@
+#include "firmware/freertos_ui_task.hpp"
+
+#include "firmware/ui_policy.hpp"
+#include "tempdeck-gen3/ui_task.hpp"
+#include "ot_utils/freertos/freertos_timer.hpp"
+#include "firmware/ui_hardware.h"
+
+namespace ui_control_task {
+
+enum class Notifications : uint8_t {
+    INCOMING_MESSAGE = 1,
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static tasks::FirmwareTasks::UIQueue
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    _queue(static_cast<uint8_t>(Notifications::INCOMING_MESSAGE),
+           "UI Queue");
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto _top_task = ui_task::UITask(_queue, nullptr);
+
+static auto _timer_callback = [ObjectPtr = &_top_task] {ObjectPtr->update_callback();};
+
+// This timer provides the backing timing for the UI task
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto _ui_timer = ot_utils::freertos_timer::FreeRTOSTimer(
+    "UI Timer", 
+    _timer_callback,
+    _top_task.UPDATE_PERIOD_MS);
+
+auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
+    auto* handle = xTaskGetCurrentTaskHandle();
+    _queue.provide_handle(handle);
+    aggregator->register_queue(_queue);
+    _top_task.provide_aggregator(aggregator);
+
+    ui_hardware_initialize();
+
+    auto policy = UIPolicy();
+    _ui_timer.start();
+    while (true) {
+        _top_task.run_once(policy);
+    }
+}
+
+};  // namespace ui_control_task

--- a/stm32-modules/tempdeck-gen3/firmware/ui/freertos_ui_task.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/ui/freertos_ui_task.cpp
@@ -1,9 +1,9 @@
 #include "firmware/freertos_ui_task.hpp"
 
-#include "firmware/ui_policy.hpp"
-#include "tempdeck-gen3/ui_task.hpp"
-#include "ot_utils/freertos/freertos_timer.hpp"
 #include "firmware/ui_hardware.h"
+#include "firmware/ui_policy.hpp"
+#include "ot_utils/freertos/freertos_timer.hpp"
+#include "tempdeck-gen3/ui_task.hpp"
 
 namespace ui_control_task {
 
@@ -14,20 +14,20 @@ enum class Notifications : uint8_t {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static tasks::FirmwareTasks::UIQueue
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-    _queue(static_cast<uint8_t>(Notifications::INCOMING_MESSAGE),
-           "UI Queue");
+    _queue(static_cast<uint8_t>(Notifications::INCOMING_MESSAGE), "UI Queue");
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _top_task = ui_task::UITask(_queue, nullptr);
 
-static auto _timer_callback = [ObjectPtr = &_top_task] {ObjectPtr->update_callback();};
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto _timer_callback = [ObjectPtr = &_top_task] {
+    ObjectPtr->update_callback();
+};
 
 // This timer provides the backing timing for the UI task
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _ui_timer = ot_utils::freertos_timer::FreeRTOSTimer(
-    "UI Timer", 
-    _timer_callback,
-    _top_task.UPDATE_PERIOD_MS);
+    "UI Timer", _timer_callback, decltype(_top_task)::UPDATE_PERIOD_MS);
 
 auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
     auto* handle = xTaskGetCurrentTaskHandle();

--- a/stm32-modules/tempdeck-gen3/firmware/ui/ui_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/ui/ui_hardware.c
@@ -16,7 +16,8 @@ typedef struct {
     bool initialized;
 } UIHardware_t;
 
-static UIHardware_t _ui = {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static UIHardware_t ui_hardware = {
     .initialized = false
 };
 
@@ -28,19 +29,21 @@ void ui_hardware_initialize() {
         .Speed = GPIO_SPEED_LOW,
         .Alternate = 0
     };
+    //NOLINTNEXTLINE(performance-no-int-to-ptr)
     __HAL_RCC_GPIOB_CLK_ENABLE();
+    //NOLINTNEXTLINE(performance-no-int-to-ptr)
     HAL_GPIO_Init(HEARTBEAT_LED_PORT, &init);
-    _ui.initialized = true;
+    ui_hardware.initialized = true;
 }
 
 /**
  * @brief Set the heartbeat LED on or off
  */
 void ui_hardware_set_heartbeat_led(bool setting) {
-    if(!_ui.initialized) {
+    if(!ui_hardware.initialized) {
         ui_hardware_initialize();
     }
-    // Active high
+    //NOLINTNEXTLINE(performance-no-int-to-ptr)
     HAL_GPIO_WritePin(HEARTBEAT_LED_PORT, HEARTBEAT_LED_PIN,
         setting ? GPIO_PIN_SET : GPIO_PIN_RESET);
 }

--- a/stm32-modules/tempdeck-gen3/firmware/ui/ui_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/ui/ui_hardware.c
@@ -1,0 +1,46 @@
+#include "firmware/ui_hardware.h"
+
+#include <stdbool.h>
+
+#include "stm32g4xx_hal.h"
+#include "stm32g4xx_hal_gpio.h"
+
+/** Local defines */
+
+#define HEARTBEAT_LED_PORT (GPIOB)
+#define HEARTBEAT_LED_PIN  (GPIO_PIN_12)
+
+/** Hardware static data struct */
+
+typedef struct {
+    bool initialized;
+} UIHardware_t;
+
+static UIHardware_t _ui = {
+    .initialized = false
+};
+
+void ui_hardware_initialize() {
+    GPIO_InitTypeDef init = {
+        .Pin = HEARTBEAT_LED_PIN,
+        .Mode = GPIO_MODE_OUTPUT_PP,
+        .Pull = GPIO_NOPULL,
+        .Speed = GPIO_SPEED_LOW,
+        .Alternate = 0
+    };
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+    HAL_GPIO_Init(HEARTBEAT_LED_PORT, &init);
+    _ui.initialized = true;
+}
+
+/**
+ * @brief Set the heartbeat LED on or off
+ */
+void ui_hardware_set_heartbeat_led(bool setting) {
+    if(!_ui.initialized) {
+        ui_hardware_initialize();
+    }
+    // Active high
+    HAL_GPIO_WritePin(HEARTBEAT_LED_PORT, HEARTBEAT_LED_PIN,
+        setting ? GPIO_PIN_SET : GPIO_PIN_RESET);
+}

--- a/stm32-modules/tempdeck-gen3/firmware/ui/ui_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/ui/ui_policy.cpp
@@ -1,0 +1,7 @@
+#include "firmware/ui_policy.hpp"
+
+#include "firmware/ui_hardware.h"
+
+auto UIPolicy::set_heartbeat_led(bool value) -> void {
+    ui_hardware_set_heartbeat_led(value);
+}

--- a/stm32-modules/tempdeck-gen3/firmware/ui/ui_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/ui/ui_policy.cpp
@@ -2,6 +2,7 @@
 
 #include "firmware/ui_hardware.h"
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto UIPolicy::set_heartbeat_led(bool value) -> void {
     ui_hardware_set_heartbeat_led(value);
 }

--- a/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(${TARGET_MODULE_NAME}
     test_main.cpp
     test_host_comms_task.cpp
     test_system_task.cpp
+    test_ui_task.cpp
+    # gcode tests
     test_m115.cpp
     test_m996.cpp
     test_dfu_gcode.cpp

--- a/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ include(AddBuildAndTestTarget)
 
 add_executable(${TARGET_MODULE_NAME}
     test_main.cpp
+    test_heartbeat.cpp
     test_host_comms_task.cpp
     test_system_task.cpp
     test_ui_task.cpp

--- a/stm32-modules/tempdeck-gen3/tests/test_heartbeat.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_heartbeat.cpp
@@ -1,0 +1,47 @@
+#include <array>
+
+#include "catch2/catch.hpp"
+#include "tempdeck-gen3/ui_task.hpp"
+
+TEST_CASE("Heartbeat class functionality") {
+    GIVEN("a heartbeat with a period of 5") {
+        const uint32_t PERIOD = 5;
+        auto subject = ui_task::Heartbeat(PERIOD);
+        THEN("the pwm starts at 0") { REQUIRE(subject.pwm() == 0); }
+        THEN("the first two PERIOD worth of ticks are all off") {
+            for (size_t i = 0; i < PERIOD * 2; ++i) {
+                DYNAMIC_SECTION("tick " + i) {
+                    for (size_t j = 0; j < i; ++j) {
+                        subject.tick();
+                    }
+                    REQUIRE(!subject.tick());
+                }
+            }
+        }
+        THEN("the pwm changes every 5 ticks") {
+            auto values = std::array<uint8_t, 14>{
+                {0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3}};
+            for (size_t i = 0; i < values.size(); ++i) {
+                DYNAMIC_SECTION("pwm value: " + values[i]) {
+                    REQUIRE(subject.pwm() == 0);
+                    for (size_t j = 0; j < PERIOD * i; ++j) {
+                        subject.tick();
+                    }
+                    REQUIRE(subject.pwm() == values[i]);
+                }
+            }
+        }
+        AND_GIVEN("the heartbeat has been ticked to a PWM of 3") {
+            while (subject.pwm() < 3) {
+                subject.tick();
+            }
+            THEN("the next two ticks should turn on the LED") {
+                REQUIRE(subject.tick());
+                REQUIRE(subject.tick());
+                AND_THEN("the next tick should turn the LED off") {
+                    REQUIRE(!subject.tick());
+                }
+            }
+        }
+    }
+}

--- a/stm32-modules/tempdeck-gen3/tests/test_ui_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_ui_task.cpp
@@ -1,0 +1,12 @@
+#include "catch2/catch.hpp"
+#include "test/test_ui_policy.hpp"
+#include "test/test_tasks.hpp"
+
+TEST_CASE("ui periodic updates") {
+    auto *tasks = tasks::BuildTasks();
+    TestUIPolicy policy;
+    WHEN("sending an UpdateUIMessage") {
+        auto msg = messages::UpdateUIMessage;
+        REQUIRE(tasks->_ui_queue.try_send(msg));
+    }
+}

--- a/stm32-modules/tempdeck-gen3/tests/test_ui_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_ui_task.cpp
@@ -1,12 +1,19 @@
 #include "catch2/catch.hpp"
-#include "test/test_ui_policy.hpp"
 #include "test/test_tasks.hpp"
+#include "test/test_ui_policy.hpp"
 
 TEST_CASE("ui periodic updates") {
     auto *tasks = tasks::BuildTasks();
     TestUIPolicy policy;
     WHEN("sending an UpdateUIMessage") {
-        auto msg = messages::UpdateUIMessage;
+        auto msg = messages::UpdateUIMessage();
         REQUIRE(tasks->_ui_queue.try_send(msg));
+        tasks->_ui_task.run_once(policy);
+        THEN("the message is consumed") {
+            REQUIRE(!tasks->_ui_queue.has_message());
+        }
+        THEN("the heartbeat LED is updated") {
+            REQUIRE(policy._heartbeat_set_count == 1);
+        }
     }
 }


### PR DESCRIPTION
Adds a UI task driven by a FreeRTOS soft timer, and for now that task just sets a heartbeat LED. This task will be expanded in the future when an actual UI is relevant.

Tested on a TD3 board, the LED pulsing is consistent and pleasant.