### PR TITLE
feat(tempdeck-gen3): add thermal tasks

### DIFF
--- a/stm32-modules/include/tempdeck-gen3/firmware/firmware_tasks.hpp
+++ b/stm32-modules/include/tempdeck-gen3/firmware/firmware_tasks.hpp
@@ -14,9 +14,17 @@ using FirmwareTasks = Tasks<FreeRTOSMessageQueue>;
 
 constexpr size_t HOST_STACK_SIZE = 2048;
 constexpr uint8_t HOST_TASK_PRIORITY = 1;
+
 constexpr size_t SYSTEM_STACK_SIZE = 256;
 constexpr uint8_t SYSTEM_TASK_PRIORITY = 1;
+
 constexpr size_t UI_STACK_SIZE = 256;
 constexpr uint8_t UI_TASK_PRIORITY = 1;
+
+constexpr size_t THERMISTOR_STACK_SIZE = 256;
+constexpr uint8_t THERMISTOR_TASK_PRIORITY = 1;
+
+constexpr size_t THERMAL_STACK_SIZE = 512;
+constexpr uint8_t THERMAL_TASK_PRIORITY = 1;
 
 };  // namespace tasks

--- a/stm32-modules/include/tempdeck-gen3/firmware/freertos_thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/firmware/freertos_thermal_task.hpp
@@ -1,0 +1,14 @@
+/*
+ * Interface for the firmware-specifc parts of the thermal tasks
+ */
+#pragma once
+
+#include "FreeRTOS.h"
+#include "firmware/firmware_tasks.hpp"
+#include "task.h"
+
+namespace thermal_control_task {
+
+// Actual function that runs in the task
+auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void;
+}  // namespace thermal_control_task

--- a/stm32-modules/include/tempdeck-gen3/firmware/freertos_thermistor_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/firmware/freertos_thermistor_task.hpp
@@ -1,0 +1,14 @@
+/*
+ * Interface for the firmware-specifc parts of the thermal tasks
+ */
+#pragma once
+
+#include "FreeRTOS.h"
+#include "firmware/firmware_tasks.hpp"
+#include "task.h"
+
+namespace thermistor_control_task {
+
+// Actual function that runs in the task
+auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void;
+}  // namespace thermistor_control_task

--- a/stm32-modules/include/tempdeck-gen3/firmware/thermistor_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/firmware/thermistor_policy.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cstdint>
+
+class ThermistorPolicy {
+  public:
+    [[nodiscard]] auto get_time_ms() const -> uint32_t;
+};

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
@@ -94,6 +94,7 @@ struct ForceUSBDisconnect {
 };
 
 struct ThermistorReadings {
+    uint32_t timestamp;
     uint32_t plate;
     uint32_t heatsink;
 };
@@ -105,4 +106,5 @@ using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,
                    SetSerialNumberMessage, EnterBootloaderMessage>;
 using UIMessage = ::std::variant<std::monostate, UpdateUIMessage>;
+using ThermalMessage = ::std::variant<std::monostate, ThermistorReadings>;
 };  // namespace messages

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
@@ -89,6 +89,11 @@ struct ForceUSBDisconnect {
     size_t return_address;
 };
 
+struct ThermistorReadings {
+    uint32_t plate;
+    uint32_t heatsink;
+};
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse>;

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/tasks.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/tasks.hpp
@@ -17,10 +17,13 @@ struct Tasks {
     using SystemQueue = QueueImpl<messages::SystemMessage>;
     // Message queue for UI task
     using UIQueue = QueueImpl<messages::UIMessage>;
+    // Message queue for Thermal Control Task
+    using ThermalQueue = QueueImpl<messages::ThermalMessage>;
 
     // Central aggregator
     using QueueAggregator =
-        queue_aggregator::QueueAggregator<HostCommsQueue, SystemQueue, UIQueue>;
+        queue_aggregator::QueueAggregator<HostCommsQueue, SystemQueue, UIQueue,
+                                          ThermalQueue>;
 
     // Addresses
     static constexpr size_t HostAddress =
@@ -29,6 +32,8 @@ struct Tasks {
         QueueAggregator::template get_queue_idx<SystemQueue>();
     static constexpr size_t UIAddress =
         QueueAggregator::template get_queue_idx<UIQueue>();
+    static constexpr size_t ThermalAddress =
+        QueueAggregator::template get_queue_idx<ThermalQueue>();
 };
 
 };  // namespace tasks

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -53,6 +53,10 @@ class ThermalTask {
         std::visit(visit_helper, message);
     }
 
+    [[nodiscard]] auto get_readings() const -> ThermalReadings {
+        return _readings;
+    }
+
   private:
     template <ThermalPolicy Policy>
     auto visit_message(const std::monostate& message, Policy& policy) -> void {

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "hal/message_queue.hpp"
+#include "tempdeck-gen3/messages.hpp"
+#include "tempdeck-gen3/tasks.hpp"
+
+namespace thermal_task {
+
+template <typename Policy>
+concept ThermalPolicy = requires(Policy& p) {
+    {p()};
+};
+
+using Message = messages::ThermalMessage;
+
+struct ThermalReadings {
+    uint32_t plate_adc = 0;
+    uint32_t heatsink_adc = 0;
+    uint32_t last_tick = 0;
+};
+
+template <template <class> class QueueImpl>
+requires MessageQueue<QueueImpl<Message>, Message>
+class ThermalTask {
+  public:
+    using Queue = QueueImpl<Message>;
+    using Aggregator = typename tasks::Tasks<QueueImpl>::QueueAggregator;
+    using Queues = typename tasks::Tasks<QueueImpl>;
+
+    explicit ThermalTask(Queue& q, Aggregator* aggregator)
+        : _message_queue(q), _task_registry(aggregator), _readings() {}
+    ThermalTask(const ThermalTask& other) = delete;
+    auto operator=(const ThermalTask& other) -> ThermalTask& = delete;
+    ThermalTask(ThermalTask&& other) noexcept = delete;
+    auto operator=(ThermalTask&& other) noexcept -> ThermalTask& = delete;
+    ~ThermalTask() = default;
+
+    auto provide_aggregator(Aggregator* aggregator) {
+        _task_registry = aggregator;
+    }
+
+    template <ThermalPolicy Policy>
+    auto run_once(Policy& policy) -> void {
+        if (!_task_registry) {
+            return;
+        }
+
+        auto message = Message(std::monostate());
+        _message_queue.recv(&message);
+        auto visit_helper = [this, &policy](auto& message) -> void {
+            this->visit_message(message, policy);
+        };
+        std::visit(visit_helper, message);
+    }
+
+  private:
+    template <ThermalPolicy Policy>
+    auto visit_message(const std::monostate& message, Policy& policy) -> void {
+        static_cast<void>(message);
+        static_cast<void>(policy);
+    }
+
+    template <ThermalPolicy Policy>
+    auto visit_message(const messages::ThermistorReadings& message,
+                       Policy& policy) -> void {
+        static_cast<void>(policy);
+        _readings.heatsink_adc = message.heatsink;
+        _readings.plate_adc = message.plate;
+        _readings.last_tick = message.timestamp;
+    }
+
+    Queue& _message_queue;
+    Aggregator* _task_registry;
+    ThermalReadings _readings;
+};
+
+};  // namespace thermal_task

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -28,7 +28,10 @@ class ThermalTask {
     using Queues = typename tasks::Tasks<QueueImpl>;
 
     explicit ThermalTask(Queue& q, Aggregator* aggregator)
-        : _message_queue(q), _task_registry(aggregator), _readings() {}
+        : _message_queue(q),
+          _task_registry(aggregator),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
+          _readings() {}
     ThermalTask(const ThermalTask& other) = delete;
     auto operator=(const ThermalTask& other) -> ThermalTask& = delete;
     ThermalTask(ThermalTask&& other) noexcept = delete;

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermistor_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermistor_task.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "hal/message_queue.hpp"
+#include "tempdeck-gen3/messages.hpp"
+#include "tempdeck-gen3/tasks.hpp"
+
+namespace thermistor_task {
+
+template <typename Policy>
+concept ThermistorPolicy = requires(Policy& p) {
+    // A function to get the system time in ms. This may be relative to any
+    // time (startup, epoch, etc) so long as the return value measures
+    // millisecond increments.
+    { p.get_time_ms() } -> std::same_as<uint32_t>;
+};
+
+template <template <class> class QueueImpl>
+class ThermistorTask {
+  public:
+    using Aggregator = typename tasks::Tasks<QueueImpl>::QueueAggregator;
+    using Queues = typename tasks::Tasks<QueueImpl>;
+
+    // The task reading the thermistor data should run at this frequency
+    static constexpr uint32_t THERMISTOR_READ_FREQ_HZ = 10;
+    // Number of 1ms ticks for each thermistor read period
+    static constexpr uint32_t THERMISTOR_READ_PERIOD_MS =
+        (1000 / THERMISTOR_READ_FREQ_HZ);
+
+    explicit ThermistorTask(Aggregator* aggregator)
+        : _task_registry(aggregator) {}
+    ThermistorTask(const ThermistorTask& other) = delete;
+    auto operator=(const ThermistorTask& other) -> ThermistorTask& = delete;
+    ThermistorTask(ThermistorTask&& other) noexcept = delete;
+    auto operator=(ThermistorTask&& other) noexcept -> ThermistorTask& = delete;
+    ~ThermistorTask() = default;
+
+    auto provide_aggregator(Aggregator* aggregator) {
+        _task_registry = aggregator;
+    }
+
+    template <ThermistorPolicy Policy>
+    auto run_once(Policy& policy) -> void {
+        if (!_task_registry) {
+            return;
+        }
+        messages::ThermistorReadings msg = {
+            .timestamp = policy.get_time_ms(), .plate = 0, .heatsink = 0};
+        static_cast<void>(_task_registry->send(msg));
+    }
+
+  private:
+    Aggregator* _task_registry;
+};
+
+};  // namespace thermistor_task

--- a/stm32-modules/include/tempdeck-gen3/test/test_tasks.hpp
+++ b/stm32-modules/include/tempdeck-gen3/test/test_tasks.hpp
@@ -3,6 +3,8 @@
 #include "tempdeck-gen3/host_comms_task.hpp"
 #include "tempdeck-gen3/system_task.hpp"
 #include "tempdeck-gen3/tasks.hpp"
+#include "tempdeck-gen3/thermal_task.hpp"
+#include "tempdeck-gen3/thermistor_task.hpp"
 #include "tempdeck-gen3/ui_task.hpp"
 #include "test/test_message_queue.hpp"
 
@@ -17,18 +19,24 @@ class TestTasks {
         : _comms_queue("comms"),
           _system_queue("system"),
           _ui_queue("ui"),
-          _aggregator(_comms_queue, _system_queue, _ui_queue),
+          _thermal_queue("thermal"),
+          _aggregator(_comms_queue, _system_queue, _ui_queue, _thermal_queue),
           _comms_task(_comms_queue, &_aggregator),
           _system_task(_system_queue, &_aggregator),
-          _ui_task(_ui_queue, &_aggregator) {}
+          _ui_task(_ui_queue, &_aggregator),
+          _thermistor_task(&_aggregator),
+          _thermal_task(_thermal_queue, &_aggregator) {}
 
     Queues::HostCommsQueue _comms_queue;
     Queues::SystemQueue _system_queue;
     Queues::UIQueue _ui_queue;
+    Queues::ThermalQueue _thermal_queue;
     Queues::QueueAggregator _aggregator;
     host_comms_task::HostCommsTask<TestMessageQueue> _comms_task;
     system_task::SystemTask<TestMessageQueue> _system_task;
     ui_task::UITask<TestMessageQueue> _ui_task;
+    thermistor_task::ThermistorTask<TestMessageQueue> _thermistor_task;
+    thermal_task::ThermalTask<TestMessageQueue> _thermal_task;
 };
 
 static auto BuildTasks() -> TestTasks* { return new TestTasks(); }

--- a/stm32-modules/include/tempdeck-gen3/test/test_thermistor_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/test/test_thermistor_policy.hpp
@@ -1,14 +1,10 @@
 #pragma once
 
 struct TestThermistorPolicy {
-    [[nodiscard]] auto get_time_ms() const -> uint32_t {
-        return _time_ms;
-    }
+    [[nodiscard]] auto get_time_ms() const -> uint32_t { return _time_ms; }
 
     // For test integration to bump up time
-    auto advance_time(uint32_t time_ms) {
-        _time_ms += time_ms;
-    }
+    auto advance_time(uint32_t time_ms) { _time_ms += time_ms; }
 
     uint32_t _time_ms = 0;
 };

--- a/stm32-modules/include/tempdeck-gen3/test/test_thermistor_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/test/test_thermistor_policy.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+struct TestThermistorPolicy {
+    [[nodiscard]] auto get_time_ms() const -> uint32_t {
+        return _time_ms;
+    }
+
+    // For test integration to bump up time
+    auto advance_time(uint32_t time_ms) {
+        _time_ms += time_ms;
+    }
+
+    uint32_t _time_ms = 0;
+};

--- a/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
@@ -9,6 +9,7 @@ add_STM32G4_usb(${TARGET_MODULE_NAME})
 set(SYSTEM_DIR "${CMAKE_CURRENT_SOURCE_DIR}/system")
 set(COMMS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/host_comms_task")
 set(UI_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ui")
+set(THERMAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/thermal_control")
 set(COMMON_MCU_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../common/STM32G491")
 set(COMMON_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../common/src")
 set(GDBINIT_PATH "${CMAKE_CURRENT_BINARY_DIR}/../../common/STM32G491/gdbinit")
@@ -24,6 +25,9 @@ set(${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS
   ${UI_DIR}/freertos_ui_task.cpp
   ${UI_DIR}/ui_hardware.c
   ${UI_DIR}/ui_policy.cpp
+  ${THERMAL_DIR}/freertos_thermal_task.cpp
+  ${THERMAL_DIR}/freertos_thermistor_task.cpp
+  ${THERMAL_DIR}/thermistor_policy.cpp
 )
 
 # Add source files that should NOT be checked by clang-tidy here

--- a/stm32-modules/tempdeck-gen3/firmware/main.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/main.cpp
@@ -3,6 +3,8 @@
 #include "firmware/firmware_tasks.hpp"
 #include "firmware/freertos_comms_task.hpp"
 #include "firmware/freertos_system_task.hpp"
+#include "firmware/freertos_thermal_task.hpp"
+#include "firmware/freertos_thermistor_task.hpp"
 #include "firmware/freertos_ui_task.hpp"
 #include "firmware/system_stm32g4xx.h"
 #include "ot_utils/freertos/freertos_task.hpp"
@@ -16,6 +18,10 @@ static auto host_task_entry = EntryPoint(host_comms_control_task::run);
 static auto system_task_entry = EntryPoint(system_control_task::run);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto ui_task_entry = EntryPoint(ui_control_task::run);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto thermistor_task_entry = EntryPoint(thermistor_control_task::run);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto thermal_task_entry = EntryPoint(thermal_control_task::run);
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto aggregator = tasks::FirmwareTasks::QueueAggregator();
@@ -32,12 +38,23 @@ static auto system_task =
 static auto ui_task =
     ot_utils::freertos_task::FreeRTOSTask<tasks::UI_STACK_SIZE, EntryPoint>(
         ui_task_entry);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto thermistor_task =
+    ot_utils::freertos_task::FreeRTOSTask<tasks::THERMISTOR_STACK_SIZE,
+                                          EntryPoint>(thermistor_task_entry);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto thermal_task =
+    ot_utils::freertos_task::FreeRTOSTask<tasks::THERMAL_STACK_SIZE,
+                                          EntryPoint>(thermal_task_entry);
 
 auto main() -> int {
     HardwareInit();
     host_task.start(tasks::HOST_TASK_PRIORITY, "HostComms", &aggregator);
     system_task.start(tasks::SYSTEM_TASK_PRIORITY, "System", &aggregator);
     ui_task.start(tasks::UI_TASK_PRIORITY, "UI", &aggregator);
+    thermistor_task.start(tasks::THERMISTOR_TASK_PRIORITY, "Thermistor",
+                          &aggregator);
+    thermal_task.start(tasks::THERMAL_TASK_PRIORITY, "Thermal", &aggregator);
 
     vTaskStartScheduler();
     return 0;

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
@@ -1,0 +1,35 @@
+#include "firmware/freertos_thermal_task.hpp"
+
+#include "tempdeck-gen3/thermal_task.hpp"
+
+namespace thermal_control_task {
+
+enum class Notifications : uint8_t {
+    INCOMING_MESSAGE = 1,
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static tasks::FirmwareTasks::ThermalQueue
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    _queue(static_cast<uint8_t>(Notifications::INCOMING_MESSAGE),
+           "Thermal Queue");
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto _top_task = thermal_task::ThermalTask(_queue, nullptr);
+
+struct FakePolicy {
+    auto operator()() -> void {}
+};
+auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
+    auto* handle = xTaskGetCurrentTaskHandle();
+    _queue.provide_handle(handle);
+    aggregator->register_queue(_queue);
+    _top_task.provide_aggregator(aggregator);
+
+    auto policy = FakePolicy();
+    while (true) {
+        _top_task.run_once(policy);
+    }
+}
+
+};  // namespace thermal_control_task

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermistor_task.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermistor_task.cpp
@@ -1,0 +1,36 @@
+#include "firmware/freertos_thermistor_task.hpp"
+
+#include "FreeRTOS.h"
+#include "firmware/thermistor_policy.hpp"
+#include "task.h"
+#include "tempdeck-gen3/thermal_task.hpp"
+#include "tempdeck-gen3/thermistor_task.hpp"
+
+namespace thermistor_control_task {
+
+enum class Notifications : uint8_t {
+    INCOMING_MESSAGE = 1,
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto _top_task =
+    thermistor_task::ThermistorTask<FreeRTOSMessageQueue>(nullptr);
+
+auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    static_assert(configTICK_RATE_HZ == 1000,
+                  "FreeRTOS tickrate must be at 1000 Hz");
+
+    // Thermistor task has no queue, just need to provide aggregator handle
+    _top_task.provide_aggregator(aggregator);
+
+    auto policy = ThermistorPolicy();
+    auto last_wake_time = xTaskGetTickCount();
+    while (true) {
+        vTaskDelayUntil(&last_wake_time,
+                        decltype(_top_task)::THERMISTOR_READ_PERIOD_MS);
+        _top_task.run_once(policy);
+    }
+}
+
+};  // namespace thermistor_control_task

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermistor_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermistor_policy.cpp
@@ -1,0 +1,10 @@
+
+#include "firmware/thermistor_policy.hpp"
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+[[nodiscard]] auto ThermistorPolicy::get_time_ms() const -> uint32_t {
+    return xTaskGetTickCount();
+}

--- a/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
@@ -10,6 +10,8 @@ add_executable(${TARGET_MODULE_NAME}
     test_host_comms_task.cpp
     test_system_task.cpp
     test_ui_task.cpp
+    test_thermistor_task.cpp
+    test_thermal_task.cpp
     # gcode tests
     test_m115.cpp
     test_m996.cpp

--- a/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
@@ -1,0 +1,29 @@
+#include "catch2/catch.hpp"
+#include "test/test_tasks.hpp"
+
+struct FakePolicy {
+    auto operator()() -> void {}
+};
+
+TEST_CASE("thermal task message handling") {
+    auto *tasks = tasks::BuildTasks();
+    FakePolicy policy;
+    WHEN("new thermistor readings are received") {
+        auto thermistors_msg = messages::ThermistorReadings{
+            .timestamp = 1000,
+            .plate = 456,
+            .heatsink = 123,
+        };
+        tasks->_thermal_queue.backing_deque.push_back(thermistors_msg);
+        tasks->_thermal_task.run_once(policy);
+        THEN("the message is consumed") {
+            REQUIRE(!tasks->_thermal_queue.has_message());
+        }
+        THEN("the readings are updated properly") {
+            auto readings = tasks->_thermal_task.get_readings();
+            REQUIRE(readings.heatsink_adc == thermistors_msg.heatsink);
+            REQUIRE(readings.plate_adc == thermistors_msg.plate);
+            REQUIRE(readings.last_tick == thermistors_msg.timestamp);
+        }
+    }
+}

--- a/stm32-modules/tempdeck-gen3/tests/test_thermistor_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_thermistor_task.cpp
@@ -1,0 +1,19 @@
+#include "catch2/catch.hpp"
+#include "test/test_tasks.hpp"
+#include "test/test_thermistor_policy.hpp"
+
+TEST_CASE("thermistor task functionality") {
+    auto *tasks = tasks::BuildTasks();
+    TestThermistorPolicy policy;
+    policy.advance_time(123);
+    WHEN("thermistor task runs once") {
+        tasks->_thermistor_task.run_once(policy);
+        THEN("a Thermistor Message is sent to the thermal task") {
+            REQUIRE(tasks->_thermal_queue.has_message());
+            auto msg = tasks->_thermal_queue.backing_deque.front();
+            REQUIRE(std::holds_alternative<messages::ThermistorReadings>(msg));
+            auto therms = std::get<messages::ThermistorReadings>(msg);
+            REQUIRE(therms.timestamp == policy.get_time_ms());
+        }
+    }
+}


### PR DESCRIPTION
Adds the Thermal Task and Thermistor Task for the tempdeck-gen3, as per the architecture documentation.

The tasks don't really _do_ anything yet - the thermistor task sends messages with empty thermistor data and valid timestamps, while the thermal task doesn't do anything but hold the latest thermistor update data.

* Thermistor task policy just requires a way to get the current time (for attaching a timestamp to the message)
* Thermal task policy doesn't have _any_ real requirements, just has a placeholder expression to allow a placeholder policy for now
* Added some very basic tests for the tasks as placeholders

Tested on a board with a debugger that the Thermal Task keeps getting messages from the Thermistor Task, and that the timestamp keeps incrementing properly.