### PR TITLE
feat(tempdeck-gen3): add GetTemperatureDebug command

### DIFF
--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/host_comms_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/host_comms_task.hpp
@@ -33,11 +33,12 @@ class HostCommsTask {
   private:
     using GCodeParser =
         gcode::GroupParser<gcode::GetSystemInfo, gcode::EnterBootloader,
-                           gcode::SetSerialNumber>;
+                           gcode::SetSerialNumber, gcode::GetTemperatureDebug>;
     using AckOnlyCache =
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         AckCache<10, gcode::EnterBootloader, gcode::SetSerialNumber>;
     using GetSystemInfoCache = AckCache<4, gcode::GetSystemInfo>;
+    using GetTempDebugCache = AckCache<4, gcode::GetTemperatureDebug>;
 
   public:
     static constexpr size_t TICKS_TO_WAIT_ON_SEND = 10;
@@ -48,7 +49,9 @@ class HostCommsTask {
           // builds complain NOLINTNEXTLINE(readability-redundant-member-init)
           ack_only_cache(),
           // NOLINTNEXTLINE(readability-redundant-member-init)
-          get_system_info_cache() {}
+          get_system_info_cache(),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
+          get_temp_debug_cache() {}
     HostCommsTask(const HostCommsTask& other) = delete;
     auto operator=(const HostCommsTask& other) -> HostCommsTask& = delete;
     HostCommsTask(HostCommsTask&& other) noexcept = delete;
@@ -250,6 +253,30 @@ class HostCommsTask {
             cache_entry);
     }
 
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(const messages::GetTempDebugResponse& response,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto cache_entry =
+            get_temp_debug_cache.remove_if_present(response.responding_to_id);
+        return std::visit(
+            [tx_into, tx_limit, response](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (std::is_same_v<std::monostate, T>) {
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                } else {
+                    return cache_element.write_response_into(
+                        tx_into, tx_limit, response.plate_temp,
+                        response.heatsink_temp, response.plate_adc,
+                        response.heatsink_adc);
+                }
+            },
+            cache_entry);
+    }
+
     /**
      * visit_gcode() is a set of member function overloads, each of which is
      * called when we parse the appropriate gcode out of the receive buffer.
@@ -332,6 +359,27 @@ class HostCommsTask {
         return std::make_pair(true, tx_into);
     }
 
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::GetTemperatureDebug& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = get_temp_debug_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::GetTempDebugMessage{.id = id};
+        if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            get_temp_debug_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
     // Our error handler just writes an error and bails
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
@@ -348,6 +396,7 @@ class HostCommsTask {
     Aggregator* task_registry;
     AckOnlyCache ack_only_cache;
     GetSystemInfoCache get_system_info_cache;
+    GetTempDebugCache get_temp_debug_cache;
     bool may_connect_latch = true;
 };
 

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
@@ -99,12 +99,26 @@ struct ThermistorReadings {
     uint32_t heatsink;
 };
 
+struct GetTempDebugMessage {
+    uint32_t id;
+};
+
+struct GetTempDebugResponse {
+    uint32_t responding_to_id;
+    float plate_temp;
+    float heatsink_temp;
+    uint16_t plate_adc;
+    uint16_t heatsink_adc;
+};
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
-                   ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse>;
+                   ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
+                   GetTempDebugResponse>;
 using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,
                    SetSerialNumberMessage, EnterBootloaderMessage>;
 using UIMessage = ::std::variant<std::monostate, UpdateUIMessage>;
-using ThermalMessage = ::std::variant<std::monostate, ThermistorReadings>;
+using ThermalMessage =
+    ::std::variant<std::monostate, ThermistorReadings, GetTempDebugMessage>;
 };  // namespace messages

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -108,6 +108,20 @@ class ThermalTask {
         }
     }
 
+    template <ThermalPolicy Policy>
+    auto visit_message(const messages::GetTempDebugMessage& message,
+                       Policy& policy) -> void {
+        static_cast<void>(policy);
+
+        auto response = messages::GetTempDebugResponse{
+            .responding_to_id = message.id,
+            .plate_temp = static_cast<float>(_readings.plate_temp),
+            .heatsink_temp = static_cast<float>(_readings.heatsink_temp),
+            .plate_adc = static_cast<uint16_t>(_readings.plate_adc),
+            .heatsink_adc = static_cast<uint16_t>(_readings.heatsink_adc)};
+        static_cast<void>(_task_registry->send(response));
+    }
+
     Queue& _message_queue;
     Aggregator* _task_registry;
     ThermalReadings _readings;

--- a/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_thermistor_task.cpp
     test_thermal_task.cpp
     # gcode tests
+    test_m105d.cpp
     test_m115.cpp
     test_m996.cpp
     test_dfu_gcode.cpp

--- a/stm32-modules/tempdeck-gen3/tests/test_host_comms_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_host_comms_task.cpp
@@ -160,6 +160,64 @@ SCENARIO("host comms commands to system task") {
     }
 }
 
+SCENARIO("host comms commands to thermal task") {
+    auto *tasks = tasks::BuildTasks();
+    std::string tx_buf(128, 'c');
+    WHEN("sending gcode M105.D") {
+        auto message_text = std::string("M105.D\n");
+        auto message_obj =
+            messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                &*message_text.begin(), &*message_text.end()));
+        REQUIRE(tasks->_comms_queue.try_send(message_obj));
+        auto written =
+            tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+        THEN("the task does not immediately ack") {
+            REQUIRE(written == tx_buf.begin());
+        }
+        THEN("a message is sent to the thermal task") {
+            REQUIRE(tasks->_thermal_queue.has_message());
+            auto thermal_msg = tasks->_thermal_queue.backing_deque.front();
+            REQUIRE(std::holds_alternative<messages::GetTempDebugMessage>(
+                thermal_msg));
+            auto id = std::get<messages::GetTempDebugMessage>(thermal_msg).id;
+            AND_WHEN("sending response with wrong id") {
+                auto response =
+                    messages::GetTempDebugResponse{.responding_to_id = id + 1,
+                                                   .plate_temp = 1.0,
+                                                   .heatsink_temp = 2.0,
+                                                   .plate_adc = 123,
+                                                   .heatsink_adc = 456};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an error is printed") {
+                    auto expected = errorstring(
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+            AND_WHEN("sending a good response") {
+                auto response =
+                    messages::GetTempDebugResponse{.responding_to_id = id,
+                                                   .plate_temp = 1.0,
+                                                   .heatsink_temp = 2.0,
+                                                   .plate_adc = 123,
+                                                   .heatsink_adc = 456};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an error is printed") {
+                    auto expected =
+                        "M105.D PT:1.00 HST:2.00 PA:123 HSA:456 OK\n";
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+        }
+    }
+}
+
 SCENARIO("host comms usb disconnect") {
     auto *tasks = tasks::BuildTasks();
     std::string tx_buf(128, 'c');

--- a/stm32-modules/tempdeck-gen3/tests/test_m105d.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_m105d.cpp
@@ -1,0 +1,38 @@
+#include <array>
+
+#include "catch2/catch.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "tempdeck-gen3/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("GetTemperatureDebug (M105.D) parser works",
+         "[gcode][parse][m105.d]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetTemperatureDebug::write_response_into(
+                buffer.begin(), buffer.end(), 10.0, 15.0, 10, 15);
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(
+                    buffer, Catch::Matchers::StartsWith(
+                                "M105.D PT:10.00 HST:15.00 PA:10 HSA:15 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetTemperatureDebug::write_response_into(
+                buffer.begin(), buffer.begin() + 7, 10.0, 15.0, 10, 15);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M105.Dcccccccccc";
+                response.at(6) = '\0';
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds command M105.D to get the temperature of the system. This is a debug command that includes both the temperature readings for the thermistors _and_ the raw ADC counts.

Tested on hardware by sending the command through Python with 10k resistors in the NTC0 and NTC1 slots.