### PR TITLE
feat(tempdeck-gen3): peltier driver firmware

### DIFF
--- a/stm32-modules/include/tempdeck-gen3/firmware/thermal_hardware.h
+++ b/stm32-modules/include/tempdeck-gen3/firmware/thermal_hardware.h
@@ -1,0 +1,22 @@
+#ifndef THERMAL_HARDWARE_H_
+#define THERMAL_HARDWARE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#include <stdbool.h>
+#include <stdint.h>
+
+void thermal_hardware_init();
+
+void thermal_hardware_enable_peltiers();
+void thermal_hardware_disable_peltiers();
+
+bool thermal_hardware_set_peltier_heat(double power);
+bool thermal_hardware_set_peltier_cool(double power);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  /* THERMAL_HARDWARE_H_ */

--- a/stm32-modules/include/tempdeck-gen3/firmware/thermal_hardware.h
+++ b/stm32-modules/include/tempdeck-gen3/firmware/thermal_hardware.h
@@ -8,12 +8,43 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
+/**
+ * @brief Initializes the hardware involved in the peltier drive circuit.
+ * Includes:
+ * - 12v enable line
+ * - Peltier enable line
+ * - TIM1 Ch0 and Ch1 as PWM output for cooling and heating
+ *
+ */
 void thermal_hardware_init();
 
+/**
+ * @brief Enable the peltiers. If the peltiers are already enabled,
+ * this will have no real effect.
+ *
+ */
 void thermal_hardware_enable_peltiers();
+/**
+ * @brief Disable the peltiers. This will reset the PWM of each channel to
+ * 0 and disable the Peltier Enable line.
+ *
+ */
 void thermal_hardware_disable_peltiers();
 
+/**
+ * @brief Set the peltier to drive at a fixed PWM in the heating direction.
+ *
+ * @param power The percentage of power to apply to the peltier.
+ * @return true if the peltier could be set, false if there is an error.
+ */
 bool thermal_hardware_set_peltier_heat(double power);
+
+/**
+ * @brief Set the peltier to drive at a fixed PWM in the cooling direction.
+ *
+ * @param power The percentage of power to apply to the peltier.
+ * @return true if the peltier could be set, false if there is an error.
+ */
 bool thermal_hardware_set_peltier_cool(double power);
 
 #ifdef __cplusplus

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -139,7 +139,7 @@ class ThermalTask {
             if (message.power > 0.0F) {
                 ok = policy.set_peltier_heat_power(message.power);
             } else {
-                ok = policy.set_peltier_cool_power(message.power);
+                ok = policy.set_peltier_cool_power(std::abs(message.power));
             }
             if (!ok) {
                 response.with_error = errors::ErrorCode::THERMAL_PELTIER_ERROR;

--- a/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
@@ -40,6 +40,7 @@ set(${TARGET_MODULE_NAME}_FW_NONLINTABLE_SRCS
   ${SYSTEM_DIR}/system_serial_number.c
   ${SYSTEM_DIR}/stm32g4xx_it.c
   ${SYSTEM_DIR}/stm32g4xx_hal_msp.c
+  ${THERMAL_DIR}/thermal_hardware.c
   ${THERMISTOR_DIR}/thermistor_hardware.c
   ${COMMS_DIR}/usbd_conf.c
   ${COMMS_DIR}/usbd_desc.c

--- a/stm32-modules/tempdeck-gen3/firmware/system/stm32g4xx_hal_msp.c
+++ b/stm32-modules/tempdeck-gen3/firmware/system/stm32g4xx_hal_msp.c
@@ -26,7 +26,6 @@ void HAL_MspInit(void)
 
 void HAL_MspDeInit(void)
 {
-
     __HAL_RCC_SYSCFG_CLK_DISABLE();
     __HAL_RCC_PWR_CLK_DISABLE();
     
@@ -55,8 +54,22 @@ void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* htim_base)
     }
 }
 
-/* USER CODE BEGIN 1 */
 
-/* USER CODE END 1 */
+void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef* htim_pwm)
+{
+    if(htim_pwm->Instance==TIM1)
+    {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM1_CLK_ENABLE();
+    }
+}
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef* htim_pwm)
+{
+    if(htim_pwm->Instance==TIM1)
+    {
+        /* Peripheral clock disable */
+        __HAL_RCC_TIM1_CLK_DISABLE();
+    }
+
+}

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
@@ -1,8 +1,8 @@
 #include "firmware/freertos_thermal_task.hpp"
 
+#include "firmware/thermal_hardware.h"
 #include "firmware/thermal_policy.hpp"
 #include "tempdeck-gen3/thermal_task.hpp"
-#include "firmware/thermal_hardware.h"
 
 namespace thermal_control_task {
 

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
@@ -2,6 +2,7 @@
 
 #include "firmware/thermal_policy.hpp"
 #include "tempdeck-gen3/thermal_task.hpp"
+#include "firmware/thermal_hardware.h"
 
 namespace thermal_control_task {
 
@@ -23,6 +24,8 @@ auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
     _queue.provide_handle(handle);
     aggregator->register_queue(_queue);
     _top_task.provide_aggregator(aggregator);
+
+    thermal_hardware_init();
 
     auto policy = ThermalPolicy();
     while (true) {

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
@@ -1,0 +1,237 @@
+#include "firmware/thermal_hardware.h"
+
+// HAL includes
+#include "stm32g4xx_hal.h"
+#include "stm32g4xx_hal_gpio.h"
+#include "stm32g4xx_hal_tim.h"
+
+// RTOS includes
+#include "FreeRTOS.h"
+
+
+// ***************************************************************************
+// Local constants
+
+#define PULSE_WIDTH_FREQ (500000)
+#define TIMER_CLOCK_FREQ (170000000)
+// These two together give a 25kHz pulse width, and the ARR value
+// of 99 gives us a nice scale of 0-100 for the pulse width.
+// A finer scale is possible by reducing the prescale value and
+// adjusting the reload to match.
+#define TIM1_PRESCALER (0)
+#define TIM1_RELOAD ((TIMER_CLOCK_FREQ / (PULSE_WIDTH_FREQ * (TIM1_PRESCALER + 1))) - 1)
+// PWM should be scaled from 0 to MAX_PWM, inclusive
+#define MAX_PWM (TIM1_RELOAD + 1)
+
+#define COOLING_CHANNEL (TIM_CHANNEL_1)
+#define COOLING_PORT (GPIOC)
+#define COOLING_PIN (GPIO_PIN_0)
+
+#define HEATING_CHANNEL (TIM_CHANNEL_2)
+#define HEATING_PORT (GPIOC)
+#define HEATING_PIN (GPIO_PIN_1)
+
+#define PELTIER_ENABLE_PORT (GPIOA)
+#define PELTIER_ENABLE_PIN (GPIO_PIN_0)
+
+#define ENABLE_12V_PORT (GPIOA)
+#define ENABLE_12V_PIN (GPIO_PIN_3)
+
+// ***************************************************************************
+// Local typedefs
+
+struct thermal_hardware {
+    TIM_HandleTypeDef timer;
+    bool initialized;
+    bool enabled;
+    double cool_side_power;
+    double hot_side_power;
+};
+
+
+// ***************************************************************************
+// Local variables
+
+static struct thermal_hardware hardware = {
+    .timer = {},
+    .initialized = false,
+    .enabled = false,
+    .cool_side_power = 0.0F,
+    .hot_side_power = 0.0F,
+};
+
+// ***************************************************************************
+// Static function declaration
+
+/**
+ * @brief Initializes the Peltier's timer, TIM1
+ */
+static void init_peltier_timer();
+
+/**
+ * @brief Initializes the GPIO lines for the 12v Enable and Peltier Enable,
+ * and enables the 12v rail on the PCB.
+ */
+static void init_gpio();
+
+// ***************************************************************************
+// Public function implementation
+
+void thermal_hardware_init() {
+    if(!hardware.initialized) {
+        init_gpio();
+        init_peltier_timer();
+
+        hardware.initialized = true;
+    }
+}
+
+void thermal_hardware_enable_peltiers() {
+    if(!hardware.initialized) {
+        return;
+    }
+    hardware.enabled = true;
+    HAL_GPIO_WritePin(PELTIER_ENABLE_PORT, PELTIER_ENABLE_PIN, GPIO_PIN_SET);
+}
+
+void thermal_hardware_disable_peltiers() {
+    if(!hardware.initialized) {
+        return;
+    }
+    hardware.enabled = false;
+    HAL_GPIO_WritePin(PELTIER_ENABLE_PORT, PELTIER_ENABLE_PIN, GPIO_PIN_RESET);
+    
+}
+
+bool thermal_hardware_set_peltier_heat(double power) {
+    if((!hardware.initialized) || (!hardware.enabled)) {
+        return false;
+    }
+
+    if(power < 0.1F && power > 0.0F) {
+        power = 0.1F;
+    }
+    if(power < 0.0F) {
+        power = 0.0F;
+    }
+    if(power > 0.9F) {
+        power = 0.9F;
+    }
+
+    uint32_t pwm = power * (double)MAX_PWM;
+    __HAL_TIM_SET_COMPARE(&hardware.timer, COOLING_CHANNEL, 0);
+    __HAL_TIM_SET_COMPARE(&hardware.timer, HEATING_CHANNEL, pwm);
+    
+}
+
+bool thermal_hardware_set_peltier_cool(double power) {
+    if((!hardware.initialized) || (!hardware.enabled)) {
+        return false;
+    }
+    
+}
+
+
+// ***************************************************************************
+// Static function implementation
+
+static void init_peltier_timer() {
+    HAL_StatusTypeDef hal_ret = HAL_ERROR;
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    TIM_OC_InitTypeDef sConfigOC = {0};
+    TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+
+    hardware.timer.Instance = TIM1;
+    hardware.timer.Init.Prescaler = TIM1_PRESCALER;
+    hardware.timer.Init.CounterMode = TIM_COUNTERMODE_UP;
+    hardware.timer.Init.Period = TIM1_RELOAD;
+    hardware.timer.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    hardware.timer.Init.RepetitionCounter = 0;
+    hardware.timer.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    hal_ret = HAL_TIM_PWM_Init(&hardware.timer);
+    configASSERT(hal_ret == HAL_OK);
+
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+    sMasterConfig.MasterOutputTrigger2 = TIM_TRGO2_RESET;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    hal_ret = HAL_TIMEx_MasterConfigSynchronization(&hardware.timer, &sMasterConfig);
+    configASSERT(hal_ret == HAL_OK);
+
+    // PWM1 means the output is enabled if the current timer count is LESS THAN
+    // the pulse value. Therefore, a pulse of 0 keeps the PWM off all the time,
+    // and a pulse of the auto-reload-register + 1 will keep it on 100% of the
+    // time.
+    sConfigOC.OCMode = TIM_OCMODE_PWM1;
+    sConfigOC.Pulse = 0;
+    sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+    sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
+    sConfigOC.OCFastMode = TIM_OCFAST_ENABLE;
+    sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
+    sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
+
+    hal_ret = HAL_TIM_PWM_ConfigChannel(&hardware.timer,
+                                        &sConfigOC,
+                                        HEATING_CHANNEL);
+    configASSERT(hal_ret == HAL_OK);
+
+    hal_ret = HAL_TIM_PWM_ConfigChannel(&hardware.timer,
+                                        &sConfigOC,
+                                        COOLING_CHANNEL);
+    configASSERT(hal_ret == HAL_OK);
+
+    // Breaktime settings are all default
+    sBreakDeadTimeConfig.OffStateRunMode = TIM_OSSR_DISABLE;
+    sBreakDeadTimeConfig.OffStateIDLEMode = TIM_OSSI_DISABLE;
+    sBreakDeadTimeConfig.LockLevel = TIM_LOCKLEVEL_OFF;
+    sBreakDeadTimeConfig.DeadTime = 0;
+    sBreakDeadTimeConfig.BreakState = TIM_BREAK_DISABLE;
+    sBreakDeadTimeConfig.BreakPolarity = TIM_BREAKPOLARITY_HIGH;
+    sBreakDeadTimeConfig.BreakFilter = 0;
+    sBreakDeadTimeConfig.BreakAFMode = TIM_BREAK_AFMODE_INPUT;
+    sBreakDeadTimeConfig.Break2State = TIM_BREAK2_DISABLE;
+    sBreakDeadTimeConfig.Break2Polarity = TIM_BREAK2POLARITY_HIGH;
+    sBreakDeadTimeConfig.Break2Filter = 0;
+    sBreakDeadTimeConfig.Break2AFMode = TIM_BREAK_AFMODE_INPUT;
+    sBreakDeadTimeConfig.AutomaticOutput = TIM_AUTOMATICOUTPUT_DISABLE;
+    hal_ret = HAL_TIMEx_ConfigBreakDeadTime(&hardware.timer, &sBreakDeadTimeConfig);
+    configASSERT(hal_ret == HAL_OK);
+    
+    // Set up the PWM GPIO pins 
+
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    /**TIM1 GPIO Configuration
+    PC0     ------> TIM1_CH1
+    PC1     ------> TIM1_CH2
+    */
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_MEDIUM;
+    GPIO_InitStruct.Alternate = GPIO_AF2_TIM1;
+    GPIO_InitStruct.Pin = HEATING_PIN;
+    HAL_GPIO_Init(HEATING_PORT, &GPIO_InitStruct);
+    GPIO_InitStruct.Pin = COOLING_PIN;
+    HAL_GPIO_Init(COOLING_PORT, &GPIO_InitStruct);
+
+    // Activate both PWM channels with a compare val of 0
+    HAL_TIM_PWM_Start(&hardware.timer, HEATING_CHANNEL);
+    HAL_TIM_PWM_Start(&hardware.timer, COOLING_CHANNEL);
+}
+
+static void init_gpio() {
+    GPIO_InitTypeDef init = {0};
+
+    __GPIOA_CLK_ENABLE();
+
+    init.Pin = ENABLE_12V_PIN;
+    init.Mode = GPIO_MODE_OUTPUT_PP;
+    init.Pull = GPIO_NOPULL;
+    init.Speed = GPIO_SPEED_LOW;
+
+    HAL_GPIO_Init(&init, ENABLE_12V_PORT);
+
+    init.Pin = PELTIER_ENABLE_PIN;
+    HAL_GPIO_Init(&init, PELTIER_ENABLE_PORT);
+
+    HAL_GPIO_WritePin(ENABLE_12V_PORT, ENABLE_12V_PIN, GPIO_PIN_SET);
+}

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
@@ -17,6 +17,7 @@
 
 // Given a desired frequency of 500kHz, we do not need to prescale the timer
 #define TIM1_PRESCALER (0)
+// Calculates out to 339
 #define TIM1_RELOAD ((TIMER_CLOCK_FREQ / (PULSE_WIDTH_FREQ * (TIM1_PRESCALER + 1))) - 1)
 // PWM should be scaled from 0 to MAX_PWM, inclusive
 #define MAX_PWM (TIM1_RELOAD + 1)

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
@@ -14,10 +14,8 @@
 
 #define PULSE_WIDTH_FREQ (500000)
 #define TIMER_CLOCK_FREQ (170000000)
-// These two together give a 25kHz pulse width, and the ARR value
-// of 99 gives us a nice scale of 0-100 for the pulse width.
-// A finer scale is possible by reducing the prescale value and
-// adjusting the reload to match.
+
+// Given a desired frequency of 500kHz, we do not need to prescale the timer
 #define TIM1_PRESCALER (0)
 #define TIM1_RELOAD ((TIMER_CLOCK_FREQ / (PULSE_WIDTH_FREQ * (TIM1_PRESCALER + 1))) - 1)
 // PWM should be scaled from 0 to MAX_PWM, inclusive

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
@@ -9,7 +9,7 @@ auto ThermalPolicy::enable_peltier() -> void {
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPolicy::disable_peltier() -> void {
-    thermal_hardware_enable_peltiers();
+    thermal_hardware_disable_peltiers();
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
@@ -1,19 +1,23 @@
 #include "firmware/thermal_policy.hpp"
 
-// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-auto ThermalPolicy::enable_peltier() -> void {}
+#include "firmware/thermal_hardware.h"
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-auto ThermalPolicy::disable_peltier() -> void {}
+auto ThermalPolicy::enable_peltier() -> void {
+    thermal_hardware_enable_peltiers();
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto ThermalPolicy::disable_peltier() -> void {
+    thermal_hardware_enable_peltiers();
+}
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPolicy::set_peltier_heat_power(double power) -> bool {
-    static_cast<void>(power);
-    return true;
+    return thermal_hardware_set_peltier_heat(power);
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPolicy::set_peltier_cool_power(double power) -> bool {
-    static_cast<void>(power);
-    return true;
+    return thermal_hardware_set_peltier_cool(power);
 }


### PR DESCRIPTION
Adds the necessary code to control the peltier drive circuitry.

* Channels 0 and 1 are used for cooling and heating, respectively.
* A 12v Rail Enable line is set to  high on startup
* A Peltier Enable line is set high or low based off of the Thermal Task
* TIM1 runs with a period of ~500kHz, and PWM output is clamped in the range [0.1, 0.9] based off of the constraints of the constant current topology.

Checked with an oscilloscope that:
* The PWM runs at 500kHz
* The PWM is always between [0.1,0.9]
* The enable line is set/disabled properly
* The correct channel is set based off of positive/negative power settings with M104.D
* Sending `M104.D S0` disables the peltier entirely