### PR TITLE
feat(thermocycler-gen2): peltier fine tuning

### DIFF
--- a/stm32-modules/common/src/pid.cpp
+++ b/stm32-modules/common/src/pid.cpp
@@ -59,6 +59,7 @@ auto PID::compute(double error, double sampletime) -> double {
 auto PID::reset() -> void {
     _last_error = 0;
     _last_iterm = 0;
+    _reset_trigger = NONE;
 }
 
 auto PID::arm_integrator_reset(double error) -> void {

--- a/stm32-modules/common/src/pid.cpp
+++ b/stm32-modules/common/src/pid.cpp
@@ -16,7 +16,8 @@ PID::PID(double kp, double ki, double kd, double sampletime,
       _windup_limit_high(windup_limit_high),
       _windup_limit_low(windup_limit_low),
       _last_error(0),
-      _last_iterm(0) {}
+      _last_iterm(0),
+      _reset_threshold(0) {}
 
 auto PID::kp() const -> double { return _kp; }
 
@@ -35,8 +36,8 @@ auto PID::windup_limit_low() const -> double { return _windup_limit_low; }
 auto PID::last_error() const -> double { return _last_error; }
 
 auto PID::compute(double error) -> double {
-    if (((_reset_trigger == FALLING) && (error <= 0)) ||
-        ((_reset_trigger == RISING) && (error > 0))) {
+    if (((_reset_trigger == FALLING) && (error <= _reset_threshold)) ||
+        ((_reset_trigger == RISING) && (error > -_reset_threshold))) {
         _last_iterm = 0;
         _reset_trigger = NONE;
     }
@@ -62,10 +63,11 @@ auto PID::reset() -> void {
     _reset_trigger = NONE;
 }
 
-auto PID::arm_integrator_reset(double error) -> void {
+auto PID::arm_integrator_reset(double error, double threshold) -> void {
     if (error <= 0) {
         _reset_trigger = RISING;
     } else {
         _reset_trigger = FALLING;
     }
+    _reset_threshold = std::abs(threshold);
 }

--- a/stm32-modules/include/common/core/pid.hpp
+++ b/stm32-modules/include/common/core/pid.hpp
@@ -56,7 +56,7 @@ class PID {
     [[nodiscard]] auto windup_limit_low() const -> double;
     [[nodiscard]] auto last_error() const -> double;
     [[nodiscard]] auto last_iterm() const -> double;
-    auto arm_integrator_reset(double error) -> void;
+    auto arm_integrator_reset(double error, double threshold = 0.0F) -> void;
 
   private:
     enum IntegratorResetTrigger { RISING, FALLING, NONE };
@@ -69,4 +69,6 @@ class PID {
     double _last_error;
     double _last_iterm;
     IntegratorResetTrigger _reset_trigger = NONE;
+    // Degrees away from target where reset_trigger should be triggered
+    double _reset_threshold;
 };

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -87,6 +87,8 @@ class PlateControl {
     static constexpr Seconds UNIFORMITY_CHECK_DELAY = 30.0F;
     /** Approximation of ambient temperature */
     static constexpr double TEMPERATURE_AMBIENT = 23.0F;
+    /** How far from target temp to reset Integral Windup.*/
+    static constexpr double WINDUP_RESET_THRESHOLD = 3.0F;
 
     PlateControl() = delete;
     /**

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -278,9 +278,23 @@ class PlateControl {
      * @return The number of degrees to the target temperature where the
      * controller should use full PID rather than just maxing out the power.
      */
-    [[nodiscard]] auto proportional_band(PID &pid) const -> double;
+    [[nodiscard]] static auto proportional_band(PID &pid) -> double {
+        if (pid.kp() == 0.0F) {
+            return 0.0F;
+        }
+        return 1.0F / pid.kp();
+    }
 
-    [[nodiscard]] auto moving_away_from_ambient(double current, double target) const -> bool;
+    [[nodiscard]] static auto moving_away_from_ambient(double current,
+                                                       double target) -> bool {
+        auto target_from_ambient = target - TEMPERATURE_AMBIENT;
+        auto current_from_ambient = current - TEMPERATURE_AMBIENT;
+        // If the new target crosses ambient, we are moving away
+        if ((target_from_ambient * current_from_ambient) < 0) {
+            return true;
+        }
+        return std::abs(target_from_ambient) > std::abs(current_from_ambient);
+    }
 
     PlateStatus _status = PlateStatus::STEADY_STATE;  // State machine for plate
     thermal_general::Peltier &_left;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -85,6 +85,8 @@ class PlateControl {
     /** Minimum time that the system must be in steady state before
      *  checking for uniformity errors.*/
     static constexpr Seconds UNIFORMITY_CHECK_DELAY = 30.0F;
+    /** Approximation of ambient temperature */
+    static constexpr double TEMPERATURE_AMBIENT = 23.0F;
 
     PlateControl() = delete;
     /**
@@ -266,6 +268,19 @@ class PlateControl {
      */
     [[nodiscard]] auto crossed_setpoint(const thermal_general::Peltier &channel,
                                         bool heating) const -> bool;
+
+    /**
+     * @brief Returns the number of degrees difference from the target
+     * where the controller should use full PID rather than maxing out the
+     * power of the peltiers.
+     *
+     * @param pid The PID controller to calculate the band from
+     * @return The number of degrees to the target temperature where the
+     * controller should use full PID rather than just maxing out the power.
+     */
+    [[nodiscard]] auto proportional_band(PID &pid) const -> double;
+
+    [[nodiscard]] auto moving_away_from_ambient(double current, double target) const -> bool;
 
     PlateStatus _status = PlateStatus::STEADY_STATE;  // State machine for plate
     thermal_general::Peltier &_left;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -98,11 +98,11 @@ class ThermalPlateTask {
     static constexpr uint16_t ADC_BIT_MAX = 0x5DC0;
     static constexpr uint8_t PLATE_THERM_COUNT = 7;
     // Peltier KI
-    static constexpr double DEFAULT_KI = 0.03;
+    static constexpr double DEFAULT_KI = 0.02;
     // Peltier KP
-    static constexpr double DEFAULT_KP = 0.1;
+    static constexpr double DEFAULT_KP = 0.17609173039298845;
     // Peltier KD
-    static constexpr double DEFAULT_KD = 0.0;
+    static constexpr double DEFAULT_KD = 0.3;
     static constexpr double DEFAULT_FAN_KI = 0.01;
     static constexpr double DEFAULT_FAN_KP = 0.2;
     static constexpr double DEFAULT_FAN_KD = 0.05;

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
@@ -47,6 +47,16 @@ graph TD
     Start -->|Disable command| Off
 ```
 
+### Integral Windup Compensation
+
+A byproduct of PID control is integral windup, wherein the integral term grows so much while moving to a target that it causes a significant overshoot after reaching the target. The firmware deals with this in two ways:
+- When moving to a temperature that is _away_ from ambient temperature (relative to starting temperature), the firmware utilizes `conditional integration`. The peltiers are controlled open-loop until getting within the "proportional band" from the target, at which point the PID control begins.
+- When moving to a temperature that is _towards_ ambient temperature (relative to starting temperature), the firmware uses PID control for the entire ramp. However, the PID controller is armed to reset the integral term once the error from the target temperature is less than 3ºC. This prevents excessive overshoot that `contional integration` would cause in this scenario.
+
+### Heating to cold temperatures
+
+When __heating__ to a temperature that is less than the current heatsink temperature, special compensation must be made to reduce unwanted overshoot. The firmware sets the effective Overshoot Target to __2ºC__ less than the "actual" target; the peltiers will overshoot this target and end up very close to the original overshoot target.
+
 ### Thermistor Drift Errors
 
 The firmware raises an error if the thermistors on the plate seem to have excessively drifted. If the following conditions are met, then the thermal plate task enters an error state until the device is reset:

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/README.md
@@ -50,8 +50,8 @@ graph TD
 ### Integral Windup Compensation
 
 A byproduct of PID control is integral windup, wherein the integral term grows so much while moving to a target that it causes a significant overshoot after reaching the target. The firmware deals with this in two ways:
-- When moving to a temperature that is _away_ from ambient temperature (relative to starting temperature), the firmware utilizes `conditional integration`. The peltiers are controlled open-loop until getting within the "proportional band" from the target, at which point the PID control begins.
-- When moving to a temperature that is _towards_ ambient temperature (relative to starting temperature), the firmware uses PID control for the entire ramp. However, the PID controller is armed to reset the integral term once the error from the target temperature is less than 3ºC. This prevents excessive overshoot that `contional integration` would cause in this scenario.
+- When moving to a temperature that is _away_ from ambient temperature (relative to starting temperature), the firmware utilizes Conditional Integration. The peltiers are controlled open-loop until getting within the "proportional band" from the target, at which point the PID control begins.
+- When moving to a temperature that is _towards_ ambient temperature (relative to starting temperature), the firmware uses PID control for the entire ramp. However, the PID controller is armed to reset the integral term once the error from the target temperature is less than 3ºC. This prevents excessive overshoot that conditional integration would cause in this scenario.
 
 ### Heating to cold temperatures
 
@@ -61,7 +61,7 @@ When __heating__ to a temperature that is less than the current heatsink tempera
 
 The firmware raises an error if the thermistors on the plate seem to have excessively drifted. If the following conditions are met, then the thermal plate task enters an error state until the device is reset:
 - There is an active temperature target
-- The plate control has finisehd the Overshoot Phase and 30 additional seconds have passed
+- The plate control has finished the Overshoot Phase and 30 additional seconds have passed
 - The hottest thermistor and the coldest thermistor on the plate are more than 4ºC apart from one another
 
 ## Lid Heater

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -236,7 +236,8 @@ auto PlateControl::reset_control(thermal_general::Peltier &peltier) -> void {
         if (!moving_away_from_ambient(peltier.current_temp(),
                                       peltier.temp_target)) {
             peltier.pid.arm_integrator_reset(
-                peltier.temp_target - peltier.current_temp(), 3);
+                peltier.temp_target - peltier.current_temp(),
+                WINDUP_RESET_THRESHOLD);
         }
 
     } else {


### PR DESCRIPTION
This PR makes a number of changes to the Thermal Plate control firmware for better thermal performance.

- Added the ability to configure the integrator reset threshold in the PID driver.
- Made some significant changes to how the firmware deals with integral windup. Previously, it would always reset the integral term once a peltier reached its target temperature; this ended up causing very noticeable oscillations around target temperatures. There are now a few different methods of compensation described in the updated Thermal README file:
  - Conditional Integration when moving away from ambient. The proportional band is defined as 1.0/Kp
  - Integral term reset at 3º from target when moving towards ambient. Conditional Integration showed too much overshoot in this case, as did resetting the integral term _at_ the target
  - When **heating up** to a temperature that is below the heatsink temperature, the initial target temperature is shifted 2º down. Testing showed that there is a consistent over-overshoot of ~2º, and this brings the max plate temperature within reasonable bounds.
- Added new default PID constants to the peltiers. These were iteratively developed off of PID Tuner values.