### PR TITLE
feat(thermocycler-gen2): support Rev3 PCB

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/board_revision.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/board_revision.hpp
@@ -15,6 +15,7 @@ namespace board_revision {
 enum BoardRevision {
     BOARD_REV_1 = 1,
     BOARD_REV_2 = 2,
+    BOARD_REV_3 = 3,
     BOARD_REV_INVALID = 0xFF
 };
 

--- a/stm32-modules/thermocycler-gen2/src/board_revision.cpp
+++ b/stm32-modules/thermocycler-gen2/src/board_revision.cpp
@@ -20,7 +20,9 @@ constexpr static std::array<BoardRevSetting, BOARD_REV_INVALID> _revisions{
     {{.pins = {INPUT_FLOATING, INPUT_FLOATING, INPUT_FLOATING},
       .revision = BOARD_REV_1},
      {.pins = {INPUT_PULLDOWN, INPUT_PULLDOWN, INPUT_PULLDOWN},
-      .revision = BOARD_REV_2}}};
+      .revision = BOARD_REV_2},
+     {.pins = {INPUT_PULLUP, INPUT_PULLDOWN, INPUT_PULLDOWN},
+      .revision = BOARD_REV_3}}};
 // The actual revision
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _revision = BoardRevision::BOARD_REV_INVALID;

--- a/stm32-modules/thermocycler-gen2/tests/test_board_revision.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_board_revision.cpp
@@ -38,17 +38,29 @@ SCENARIO("board revision checking works") {
             }
         }
     }
+    GIVEN("all pins pulled down") {
+        inputs.at(0) = INPUT_PULLUP;
+        inputs.at(1) = INPUT_PULLDOWN;
+        inputs.at(2) = INPUT_PULLDOWN;
+        board_revision::set_pin_values(inputs);
+        WHEN("getting board revision without rereading") {
+            auto revision = board_revision::BoardRevisionIface::get();
+            THEN("the revision is still rev2") {
+                REQUIRE(revision == board_revision::BoardRevision::BOARD_REV_2);
+            }
+        }
+        WHEN("reading board revision") {
+            auto revision = board_revision::BoardRevisionIface::read();
+            THEN("the revision is rev3") {
+                REQUIRE(revision == board_revision::BoardRevision::BOARD_REV_3);
+            }
+        }
+    }
     GIVEN("one pin pulled down and two pulled up") {
         inputs.at(0) = INPUT_PULLDOWN;
         inputs.at(1) = INPUT_PULLUP;
         inputs.at(2) = INPUT_PULLUP;
         board_revision::set_pin_values(inputs);
-        WHEN("getting board revision without rereading") {
-            auto revision = board_revision::BoardRevisionIface::get();
-            THEN("the revision is rev1") {
-                REQUIRE(revision == board_revision::BoardRevision::BOARD_REV_2);
-            }
-        }
         WHEN("reading board revision") {
             auto revision = board_revision::BoardRevisionIface::read();
             THEN("the revision is invalid") {


### PR DESCRIPTION
This lets the firmware run on a Rev3 Thermocycler Gen2 PCB. Tested on hardware, firmware accepts the revision pullup resistors fine.