### PR TITLE
feat(tempdeck-gen3): add initial simulator

### DIFF
--- a/stm32-modules/include/common/simulator/simulator_queue.hpp
+++ b/stm32-modules/include/common/simulator/simulator_queue.hpp
@@ -6,14 +6,17 @@
 #include <limits>
 #include <thread>
 
-template <typename Message, size_t queue_size = 8>
+template <typename M, size_t queue_size = 8>
 class SimulatorMessageQueue {
   public:
     using clock = std::chrono::steady_clock;
+    using Message = M;
     using QueueType =
         boost::lockfree::queue<Message, boost::lockfree::capacity<queue_size>>;
     class StopDuringMsgWait : public std::exception {};
     SimulatorMessageQueue() : queue(queue_size), mythread_stop_token() {}
+
+    struct Tag {};
 
     auto get_backing_queue() -> QueueType& { return queue; }
     auto set_stop_token(std::stop_token st) { mythread_stop_token = st; }

--- a/stm32-modules/include/tempdeck-gen3/simulator/cli_parser.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/cli_parser.hpp
@@ -1,0 +1,22 @@
+#include <memory>
+#include <string>
+
+#include "simulator/sim_driver.hpp"
+
+namespace cli_parser {
+/**
+ * First value is the sim input driver, second input is a boolean
+ * set to true if the sim should run in realtime and false if it
+ * should run in simulated time
+ */
+using RT = std::pair<std::shared_ptr<sim_driver::SimDriver>, bool>;
+
+/**
+ * Parse the inputs and determine 1) what kind of input should be
+ * used 2) whether the simulation should be realtime or accelerated
+ */
+RT get_sim_driver(int, char**);
+
+bool check_realtime_environment_variable();
+
+}  // namespace cli_parser

--- a/stm32-modules/include/tempdeck-gen3/simulator/sim_driver.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/sim_driver.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <functional>
+
+#include "simulator/simulator_queue.hpp"
+#include "tempdeck-gen3/host_comms_task.hpp"
+#include "tempdeck-gen3/messages.hpp"
+
+namespace sim_driver {
+
+using SendToCommsFunc = std::function<void(messages::IncomingMessageFromHost&)>;
+
+class SimDriver {
+  public:
+    virtual const std::string& get_name() const = 0;
+    virtual void write(const std::string& message) = 0;
+    virtual void read(SendToCommsFunc&& send_to_comms) = 0;
+};
+}  // namespace sim_driver

--- a/stm32-modules/include/tempdeck-gen3/simulator/sim_system_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/sim_system_policy.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "systemwide.h"
+#include "tempdeck-gen3/errors.hpp"
+
+struct SimSystemPolicy {
+    using Serial = std::array<char, SYSTEM_WIDE_SERIAL_NUMBER_LENGTH>;
+    void enter_bootloader(void) { ++_bootloader_count; }
+
+    errors::ErrorCode set_serial_number(Serial ser) {
+        _serial = ser;
+        _serial_set = true;
+        return errors::ErrorCode::NO_ERROR;
+    }
+
+    Serial get_serial_number() {
+        if (_serial_set) {
+            return _serial;
+        }
+        Serial empty_serial = {"EMPTYSN"};
+        return empty_serial;
+    }
+
+    int _bootloader_count = 0;
+    Serial _serial = {'x'};
+    bool _serial_set = false;
+};

--- a/stm32-modules/include/tempdeck-gen3/simulator/sim_thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/sim_thermal_policy.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+struct SimThermalPolicy {
+    auto enable_peltier() -> void { _enabled = true; }
+
+    auto disable_peltier() -> void { _enabled = false; }
+
+    auto set_peltier_heat_power(double power) -> bool {
+        if (!_enabled) {
+            return false;
+        }
+        _power = std::min(1.0, std::abs(power));
+        return true;
+    }
+
+    auto set_peltier_cool_power(double power) -> bool {
+        if (!_enabled) {
+            return false;
+        }
+        _power = -std::min(1.0, std::abs(power));
+        return true;
+    }
+
+    // Test integration functions
+
+    auto is_cooling() -> bool { return _enabled && (_power < 0.0); }
+
+    auto is_heating() -> bool { return _enabled && (_power > 0.0); }
+
+    bool _enabled = false;
+    double _power = 0.0F;  // Positive for heat, negative for cool
+};

--- a/stm32-modules/include/tempdeck-gen3/simulator/sim_thermistor_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/sim_thermistor_policy.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "test/test_ads1115_policy.hpp"
+
+struct SimThermistorPolicy {
+    explicit SimThermistorPolicy(bool realtime = false)
+        : _realtime(realtime), _written() {}
+
+    [[nodiscard]] auto get_time_ms() const -> uint32_t { return _time_ms; }
+    auto sleep_ms(uint32_t time_ms) {
+        if (_realtime) {
+            using namespace std::chrono_literals;
+            auto time = 1ms * time_ms;
+            std::this_thread::sleep_for(time);
+        }
+        _time_ms += time_ms;
+    }
+
+    auto ads1115_mark_initialized() -> void { _initialized = true; }
+
+    auto ads1115_check_initialized() -> bool { return _initialized; }
+
+    auto ads1115_get_lock() -> void {
+        while (_locked) {
+            std::this_thread::yield();
+        }
+        _locked = true;
+    }
+
+    auto ads1115_release_lock() -> void { _locked = false; }
+
+    auto ads1115_arm_for_read() -> bool {
+        _read_armed = true;
+        return true;
+    }
+
+    auto ads1115_wait_for_pulse(uint32_t timeout_ms) -> bool {
+        if (_read_armed) {
+            _read_armed = false;
+            return true;
+        }
+        return false;
+    }
+
+    auto ads1115_i2c_write_16(uint8_t reg, uint16_t val) -> bool {
+        _written[reg] = val;
+        return true;
+    }
+
+    auto ads1115_i2c_read_16(uint8_t reg) -> std::optional<uint16_t> {
+        using Ret = std::optional<uint16_t>;
+        if (_written.find(reg) != _written.end()) {
+            return Ret(_written.at(reg));
+        }
+        return Ret(0);
+    }
+
+    uint32_t _time_ms = 0;
+
+  private:
+    bool _realtime;
+    std::atomic_bool _initialized = false;
+    std::atomic_bool _locked = false;
+    std::atomic_bool _read_armed = false;
+    // Written registers - addr : value
+    std::map<uint8_t, uint16_t> _written;
+};

--- a/stm32-modules/include/tempdeck-gen3/simulator/sim_ui_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/sim_ui_policy.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+struct SimUIPolicy {
+    void set_heartbeat_led(bool set) {
+        _heartbeat_set = set;
+        ++_heartbeat_set_count;
+    }
+
+    bool _heartbeat_set = false;
+    size_t _heartbeat_set_count = 0;
+};

--- a/stm32-modules/include/tempdeck-gen3/simulator/simulator_tasks.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/simulator_tasks.hpp
@@ -17,16 +17,24 @@ namespace tasks {
 using SimTasks = Tasks<SimulatorMessageQueue>;
 
 auto run_comms_task(std::stop_token st,
+                    std::shared_ptr<SimTasks::HostCommsQueue> queue_ptr,
                     std::shared_ptr<SimTasks::QueueAggregator> aggregator,
                     std::shared_ptr<sim_driver::SimDriver> driver) -> void;
+
 auto run_system_task(std::stop_token st,
+                     std::shared_ptr<SimTasks::SystemQueue> queue_ptr,
                      std::shared_ptr<SimTasks::QueueAggregator> aggregator)
     -> void;
+
 auto run_ui_task(std::stop_token st,
+                 std::shared_ptr<SimTasks::UIQueue> queue_ptr,
                  std::shared_ptr<SimTasks::QueueAggregator> aggregator) -> void;
+
 auto run_thermal_task(std::stop_token st,
+                      std::shared_ptr<SimTasks::ThermalQueue> queue_ptr,
                       std::shared_ptr<SimTasks::QueueAggregator> aggregator)
     -> void;
+
 auto run_thermistor_task(std::stop_token st,
                          std::shared_ptr<SimTasks::QueueAggregator> aggregator)
     -> void;

--- a/stm32-modules/include/tempdeck-gen3/simulator/simulator_tasks.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/simulator_tasks.hpp
@@ -1,0 +1,34 @@
+/**
+ * @file firmware_tasks.hpp
+ * @brief Expands on generic tasks.hpp to provide specific typedefs
+ * for the firmware build
+ */
+#pragma once
+
+#include <memory>
+#include <thread>
+
+#include "simulator/sim_driver.hpp"
+#include "simulator/simulator_queue.hpp"
+#include "tempdeck-gen3/tasks.hpp"
+
+namespace tasks {
+
+using SimTasks = Tasks<SimulatorMessageQueue>;
+
+auto run_comms_task(std::stop_token st,
+                    std::shared_ptr<SimTasks::QueueAggregator> aggregator,
+                    std::shared_ptr<sim_driver::SimDriver> driver) -> void;
+auto run_system_task(std::stop_token st,
+                     std::shared_ptr<SimTasks::QueueAggregator> aggregator)
+    -> void;
+auto run_ui_task(std::stop_token st,
+                 std::shared_ptr<SimTasks::QueueAggregator> aggregator) -> void;
+auto run_thermal_task(std::stop_token st,
+                      std::shared_ptr<SimTasks::QueueAggregator> aggregator)
+    -> void;
+auto run_thermistor_task(std::stop_token st,
+                         std::shared_ptr<SimTasks::QueueAggregator> aggregator)
+    -> void;
+
+};  // namespace tasks

--- a/stm32-modules/include/tempdeck-gen3/simulator/socket_sim_driver.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/socket_sim_driver.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include <boost/asio.hpp>
+
+#include "simulator/sim_driver.hpp"
+#include "simulator/simulator_queue.hpp"
+#include "simulator/simulator_tasks.hpp"
+#include "tempdeck-gen3/host_comms_task.hpp"
+#include "tempdeck-gen3/messages.hpp"
+
+namespace socket_sim_driver {
+
+struct AddressInfo {
+    std::string host;
+    int port;
+};
+
+class SocketSimDriver : public sim_driver::SimDriver {
+    static const std::string name;
+    AddressInfo address_info;
+    std::unique_ptr<boost::asio::ip::tcp::socket> s;
+
+  public:
+    SocketSimDriver(std::string);
+    const std::string& get_host() const;
+    int get_port() const;
+    const std::string& get_name() const;
+
+    void write(const std::string& message);
+    void read(sim_driver::SendToCommsFunc&& send_to_comms);
+};
+}  // namespace socket_sim_driver

--- a/stm32-modules/include/tempdeck-gen3/simulator/stdin_sim_driver.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/stdin_sim_driver.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "simulator/sim_driver.hpp"
+#include "simulator/simulator_queue.hpp"
+#include "simulator/simulator_tasks.hpp"
+#include "tempdeck-gen3/host_comms_task.hpp"
+#include "tempdeck-gen3/messages.hpp"
+
+namespace stdin_sim_driver {
+class StdinSimDriver : public sim_driver::SimDriver {
+    static const std::string name;
+
+  public:
+    StdinSimDriver();
+    const std::string& get_name() const;
+    void write(const std::string& message);
+    void read(sim_driver::SendToCommsFunc&& send_to_comms);
+};
+}  // namespace stdin_sim_driver

--- a/stm32-modules/tempdeck-gen3/simulator/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/simulator/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_executable(
   ${TARGET_MODULE_NAME}-simulator
   main.cpp
+  cli_parser.cpp
+  simulator_tasks.cpp
+  socket_sim_driver.cpp 
+  stdin_sim_driver.cpp
 )
 
 target_link_libraries(

--- a/stm32-modules/tempdeck-gen3/simulator/cli_parser.cpp
+++ b/stm32-modules/tempdeck-gen3/simulator/cli_parser.cpp
@@ -1,0 +1,116 @@
+#include "simulator/cli_parser.hpp"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/program_options.hpp>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "simulator/sim_driver.hpp"
+#include "simulator/socket_sim_driver.hpp"
+#include "simulator/stdin_sim_driver.hpp"
+
+using namespace cli_parser;
+
+[[noreturn]] void no_options_specified_error(
+    boost::program_options::options_description desc) {
+    std::cerr
+        << std::endl
+        << "ERROR: You must provide either the --stdin OR the --socket option."
+        << std::endl
+        << std::endl;
+    std::cerr << desc << std::endl;
+    exit(1);
+}
+
+[[noreturn]] void both_drivers_specified_error(
+    boost::program_options::options_description desc) {
+    std::cerr << std::endl
+              << "ERROR: You may only provide either the --stdin OR the "
+                 "--socket option, not both."
+              << std::endl
+              << std::endl;
+    std::cerr << desc << std::endl;
+    exit(1);
+}
+
+[[noreturn]] void neither_driver_error(
+    boost::program_options::options_description desc) {
+    std::cerr << std::endl
+              << "ERROR: Neither --socket or --stdin was specified";
+    std::cerr << desc << std::endl;
+    exit(1);
+}
+
+RT cli_parser::get_sim_driver(int num_args, char* args[]) {
+    bool use_stdin = false;
+    bool use_socket = false;
+    bool realtime = false;
+    bool options_specified = num_args > 1;
+
+    boost::program_options::options_description desc("Allowed options");
+    desc.add_options()("help", "Show this help message")(
+        "stdin", boost::program_options::bool_switch(&use_stdin),
+        "Use stdin to provide G-Codes")("socket",
+                                        boost::program_options::value<
+                                            std::string>(),
+                                        "Use socket to provide G-Codes")
+        ("realtime", boost::program_options::bool_switch(&realtime),
+         "Thermal and motor data should run in real time");
+
+    boost::program_options::variables_map vm;
+    /*
+     * Have to do this long crazy parser creation to make sure that partial
+     * options are not accepted. For instance, `--std` was being accepted as
+     * --stdin, and that's super confusing
+     */
+    auto parser =
+        boost::program_options::command_line_parser(num_args, args)
+            .options(desc)
+            .style(boost::program_options::command_line_style::default_style &
+                   ~boost::program_options::command_line_style::allow_guessing)
+            .run();
+    boost::program_options::store(parser, vm);
+    boost::program_options::notify(vm);
+
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+    }
+    if (vm.count("socket")) {
+        use_socket = true;
+    }
+    if (num_args <= 1) {
+        no_options_specified_error(desc);
+    }
+    if (use_stdin && use_socket) {
+        both_drivers_specified_error(desc);
+    }
+
+    if (use_stdin) {
+        return RT(std::make_shared<stdin_sim_driver::StdinSimDriver>(),
+                  realtime);
+    } else if (use_socket) {
+        return RT(std::make_shared<socket_sim_driver::SocketSimDriver>(
+                      vm["socket"].as<std::string>()),
+                  realtime);
+    } else {
+        neither_driver_error(desc);
+    }
+}
+
+bool cli_parser::check_realtime_environment_variable() {
+    constexpr const char realtime_var_name[] = "USE_REALTIME_SIM";
+    constexpr const char string_true[] = "true";
+    const auto* var_value = getenv(realtime_var_name);
+
+    if (!var_value || strlen(var_value) == 0) {
+        return false;
+    }
+
+    // Convert to lowercase
+    auto var_string = std::string(var_value);
+    boost::algorithm::to_lower(var_string);
+
+    return var_string.starts_with(string_true);
+}

--- a/stm32-modules/tempdeck-gen3/simulator/main.cpp
+++ b/stm32-modules/tempdeck-gen3/simulator/main.cpp
@@ -6,15 +6,22 @@ auto main(int argc, char* argv[]) -> int {
     auto cli_ret = cli_parser::get_sim_driver(argc, argv);
     auto sim_driver = cli_ret.first;
 
-    auto aggregator = std::make_shared<tasks::SimTasks::QueueAggregator>();
+    auto comms_queue = std::make_shared<tasks::SimTasks::HostCommsQueue>();
+    auto system_queue = std::make_shared<tasks::SimTasks::SystemQueue>();
+    auto ui_queue = std::make_shared<tasks::SimTasks::UIQueue>();
+    auto thermal_queue = std::make_shared<tasks::SimTasks::ThermalQueue>();
 
-    auto comms = std::make_unique<std::jthread>(tasks::run_comms_task,
-                                                aggregator, sim_driver);
-    auto system =
-        std::make_unique<std::jthread>(tasks::run_system_task, aggregator);
-    auto ui = std::make_unique<std::jthread>(tasks::run_ui_task, aggregator);
-    auto thermal =
-        std::make_unique<std::jthread>(tasks::run_thermal_task, aggregator);
+    auto aggregator = std::make_shared<tasks::SimTasks::QueueAggregator>(
+        *comms_queue, *system_queue, *ui_queue, *thermal_queue);
+
+    auto comms = std::make_unique<std::jthread>(
+        tasks::run_comms_task, comms_queue, aggregator, sim_driver);
+    auto system = std::make_unique<std::jthread>(tasks::run_system_task,
+                                                 system_queue, aggregator);
+    auto ui = std::make_unique<std::jthread>(tasks::run_ui_task, ui_queue,
+                                             aggregator);
+    auto thermal = std::make_unique<std::jthread>(tasks::run_thermal_task,
+                                                  thermal_queue, aggregator);
     auto thermistor =
         std::make_unique<std::jthread>(tasks::run_thermistor_task, aggregator);
 

--- a/stm32-modules/tempdeck-gen3/simulator/main.cpp
+++ b/stm32-modules/tempdeck-gen3/simulator/main.cpp
@@ -1,2 +1,40 @@
+#include "simulator/cli_parser.hpp"
+#include "simulator/sim_driver.hpp"
+#include "simulator/simulator_tasks.hpp"
 
-auto main() -> int { return 0; }
+auto main(int argc, char* argv[]) -> int {
+    auto cli_ret = cli_parser::get_sim_driver(argc, argv);
+    auto sim_driver = cli_ret.first;
+
+    auto aggregator = std::make_shared<tasks::SimTasks::QueueAggregator>();
+
+    auto comms = std::make_unique<std::jthread>(tasks::run_comms_task,
+                                                aggregator, sim_driver);
+    auto system =
+        std::make_unique<std::jthread>(tasks::run_system_task, aggregator);
+    auto ui = std::make_unique<std::jthread>(tasks::run_ui_task, aggregator);
+    auto thermal =
+        std::make_unique<std::jthread>(tasks::run_thermal_task, aggregator);
+    auto thermistor =
+        std::make_unique<std::jthread>(tasks::run_thermistor_task, aggregator);
+
+    auto send_to_comms = [&aggregator](messages::IncomingMessageFromHost& msg) {
+        aggregator->send(msg);
+    };
+    sim_driver->read(std::move(send_to_comms));
+
+    // Previous line returns when connection is closed
+    comms->request_stop();
+    system->request_stop();
+    ui->request_stop();
+    thermal->request_stop();
+    thermistor->request_stop();
+
+    comms->join();
+    system->join();
+    ui->join();
+    thermal->join();
+    thermistor->join();
+
+    return 0;
+}

--- a/stm32-modules/tempdeck-gen3/simulator/simulator_tasks.cpp
+++ b/stm32-modules/tempdeck-gen3/simulator/simulator_tasks.cpp
@@ -1,0 +1,56 @@
+#include "simulator/simulator_tasks.hpp"
+
+#include "tempdeck-gen3/host_comms_task.hpp"
+#include "tempdeck-gen3/system_task.hpp"
+#include "tempdeck-gen3/thermal_task.hpp"
+#include "tempdeck-gen3/thermistor_task.hpp"
+#include "tempdeck-gen3/ui_task.hpp"
+
+using namespace tasks;
+
+auto tasks::run_comms_task(
+    std::stop_token st, std::shared_ptr<SimTasks::QueueAggregator> aggregator,
+    std::shared_ptr<sim_driver::SimDriver> driver) -> void {
+    auto queue = SimTasks::HostCommsQueue();
+    aggregator->register_queue(queue);
+    auto task = host_comms_task::HostCommsTask(queue, aggregator.get());
+    std::string buffer(1024, 'c');
+
+    queue.set_stop_token(st);
+    while (!st.stop_requested()) {
+        try {
+            auto wrote_to = task.run_once(buffer.begin(), buffer.end());
+            driver->write(std::string(buffer.begin(), wrote_to));
+        } catch (const SimTasks::HostCommsQueue::StopDuringMsgWait sdmw) {
+            return;
+        }
+    }
+}
+
+auto tasks::run_system_task(
+    std::stop_token st, std::shared_ptr<SimTasks::QueueAggregator> aggregator)
+    -> void {
+    while (!st.stop_requested()) {
+    }
+}
+
+auto tasks::run_ui_task(std::stop_token st,
+                        std::shared_ptr<SimTasks::QueueAggregator> aggregator)
+    -> void {
+    while (!st.stop_requested()) {
+    }
+}
+
+auto tasks::run_thermal_task(
+    std::stop_token st, std::shared_ptr<SimTasks::QueueAggregator> aggregator)
+    -> void {
+    while (!st.stop_requested()) {
+    }
+}
+
+auto tasks::run_thermistor_task(
+    std::stop_token st, std::shared_ptr<SimTasks::QueueAggregator> aggregator)
+    -> void {
+    while (!st.stop_requested()) {
+    }
+}

--- a/stm32-modules/tempdeck-gen3/simulator/simulator_tasks.cpp
+++ b/stm32-modules/tempdeck-gen3/simulator/simulator_tasks.cpp
@@ -1,5 +1,9 @@
 #include "simulator/simulator_tasks.hpp"
 
+#include "simulator/sim_system_policy.hpp"
+#include "simulator/sim_thermal_policy.hpp"
+#include "simulator/sim_thermistor_policy.hpp"
+#include "simulator/sim_ui_policy.hpp"
 #include "tempdeck-gen3/host_comms_task.hpp"
 #include "tempdeck-gen3/system_task.hpp"
 #include "tempdeck-gen3/thermal_task.hpp"
@@ -9,10 +13,10 @@
 using namespace tasks;
 
 auto tasks::run_comms_task(
-    std::stop_token st, std::shared_ptr<SimTasks::QueueAggregator> aggregator,
+    std::stop_token st, std::shared_ptr<SimTasks::HostCommsQueue> queue_ptr,
+    std::shared_ptr<SimTasks::QueueAggregator> aggregator,
     std::shared_ptr<sim_driver::SimDriver> driver) -> void {
-    auto queue = SimTasks::HostCommsQueue();
-    aggregator->register_queue(queue);
+    auto &queue = *queue_ptr;
     auto task = host_comms_task::HostCommsTask(queue, aggregator.get());
     std::string buffer(1024, 'c');
 
@@ -28,29 +32,66 @@ auto tasks::run_comms_task(
 }
 
 auto tasks::run_system_task(
-    std::stop_token st, std::shared_ptr<SimTasks::QueueAggregator> aggregator)
-    -> void {
+    std::stop_token st, std::shared_ptr<SimTasks::SystemQueue> queue_ptr,
+    std::shared_ptr<SimTasks::QueueAggregator> aggregator) -> void {
+    auto &queue = *queue_ptr;
+    auto policy = SimSystemPolicy();
+    auto task = system_task::SystemTask(queue, aggregator.get());
+
+    queue.set_stop_token(st);
     while (!st.stop_requested()) {
+        try {
+            task.run_once(policy);
+        } catch (const SimTasks::SystemQueue::StopDuringMsgWait sdmw) {
+            return;
+        }
     }
 }
 
 auto tasks::run_ui_task(std::stop_token st,
+                        std::shared_ptr<SimTasks::UIQueue> queue_ptr,
                         std::shared_ptr<SimTasks::QueueAggregator> aggregator)
     -> void {
+    auto &queue = *queue_ptr;
+    auto policy = SimUIPolicy();
+    auto task = ui_task::UITask(queue, aggregator.get());
+
+    queue.set_stop_token(st);
     while (!st.stop_requested()) {
+        try {
+            task.run_once(policy);
+        } catch (const SimTasks::UIQueue::StopDuringMsgWait sdmw) {
+            return;
+        }
     }
 }
 
 auto tasks::run_thermal_task(
-    std::stop_token st, std::shared_ptr<SimTasks::QueueAggregator> aggregator)
-    -> void {
+    std::stop_token st, std::shared_ptr<SimTasks::ThermalQueue> queue_ptr,
+    std::shared_ptr<SimTasks::QueueAggregator> aggregator) -> void {
+    auto &queue = *queue_ptr;
+    auto policy = SimThermalPolicy();
+    auto task = thermal_task::ThermalTask(queue, aggregator.get());
+
+    queue.set_stop_token(st);
     while (!st.stop_requested()) {
+        try {
+            task.run_once(policy);
+        } catch (const SimTasks::ThermalQueue::StopDuringMsgWait sdmw) {
+            return;
+        }
     }
 }
 
 auto tasks::run_thermistor_task(
     std::stop_token st, std::shared_ptr<SimTasks::QueueAggregator> aggregator)
     -> void {
+    auto policy = SimThermistorPolicy();
+    auto task = thermistor_task::ThermistorTask<SimulatorMessageQueue>(
+        aggregator.get());
+
     while (!st.stop_requested()) {
+        policy.sleep_ms(100);
+        task.run_once(policy);
     }
 }

--- a/stm32-modules/tempdeck-gen3/simulator/socket_sim_driver.cpp
+++ b/stm32-modules/tempdeck-gen3/simulator/socket_sim_driver.cpp
@@ -1,0 +1,112 @@
+#include "simulator/socket_sim_driver.hpp"
+
+#include <algorithm>
+#include <boost/asio.hpp>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <regex>
+
+#include "hal/double_buffer.hpp"
+#include "simulator/simulator_queue.hpp"
+
+using namespace socket_sim_driver;
+
+const std::string SOCKET_DRIVER_NAME = "Socket";
+
+std::unique_ptr<boost::asio::ip::tcp::socket> connect_to_socket(
+    std::string host, int port) {
+    boost::asio::io_service io_context;
+    boost::asio::ip::tcp::resolver resolver(io_context);
+    std::string parsed_host;
+    try {
+        auto endpoints = resolver.resolve(host, std::to_string(port));
+        parsed_host = endpoints.begin()->endpoint().address().to_string();
+    } catch (const boost::system::system_error& ex) {
+        std::cerr << "Failed to resolve passed host/ip: \"" << host << "\""
+                  << std::endl;
+        exit(1);
+    }
+
+    auto socket = std::make_unique<boost::asio::ip::tcp::socket>(io_context);
+    boost::asio::ip::tcp::endpoint endpoint(
+        boost::asio::ip::address::from_string(parsed_host), port);
+    boost::system::error_code ec;
+    socket->connect(endpoint, ec);
+    if (ec) {
+        std::cerr << "Failed to create socket: " << ec.category().name() << ": "
+                  << ec.value() << std::endl;
+        exit(ec.value());
+    }
+    return socket;
+}
+
+socket_sim_driver::SocketSimDriver::SocketSimDriver(std::string url) {
+    std::regex url_regex(":\\/\\/([a-zA-Z0-9.-]*):(\\d*)$");
+    std::smatch url_match_result;
+
+    if (std::regex_search(url, url_match_result, url_regex)) {
+        address_info = socket_sim_driver::AddressInfo{
+            url_match_result[1], std::stoi(url_match_result[2])};
+        s = connect_to_socket(address_info.host, address_info.port);
+
+    } else {
+        std::cerr << "Malformed url." << std::endl;
+        exit(1);
+    }
+}
+
+const std::string socket_sim_driver::SocketSimDriver::name = SOCKET_DRIVER_NAME;
+
+const std::string& socket_sim_driver::SocketSimDriver::get_host() const {
+    return this->address_info.host;
+}
+
+int socket_sim_driver::SocketSimDriver::get_port() const {
+    return this->address_info.port;
+}
+
+const std::string& socket_sim_driver::SocketSimDriver::get_name() const {
+    return this->name;
+}
+
+void socket_sim_driver::SocketSimDriver::write(const std::string& message) {
+    std::cout << "Sending response: " << message << std::endl;
+    this->s->write_some(boost::asio::buffer(message));
+}
+
+int has_char(const char* char_array, const char* end, char value_to_find) {
+    const char* position = std::find(char_array, end, value_to_find);
+    return end != position;
+}
+
+void socket_sim_driver::SocketSimDriver::read(
+    sim_driver::SendToCommsFunc&& send_to_comms) {
+    char pBuff[30];
+    boost::asio::mutable_buffer buff(pBuff, sizeof(pBuff));
+    auto write_buffer =
+        std::make_shared<double_buffer::DoubleBuffer<char, 2048>>();
+    size_t l = this->s->read_some(buff);
+    char* end_of_input = std::begin(*write_buffer->accessible());
+    char* end_of_buffer = std::end(*write_buffer->accessible());
+
+    for (; l > 0; l = this->s->read_some(buff)) {
+        if (end_of_input + l > end_of_buffer) {
+            end_of_input = std::begin(*write_buffer->accessible());
+        }
+        char* data = write_buffer->accessible()->data();
+        end_of_input =
+            std::copy(reinterpret_cast<char*>(buff.data()),
+                      reinterpret_cast<char*>(buff.data()) + l, end_of_input);
+        if (has_char(data, end_of_input, '\n')) {
+            std::cout << "Received complete message: "
+                      << write_buffer->accessible()->data() << std::endl;
+            auto message = messages::IncomingMessageFromHost(
+                std::begin(*write_buffer->accessible()), end_of_input);
+            send_to_comms(message);
+            write_buffer->swap();
+            end_of_input = std::begin(*write_buffer->accessible());
+            end_of_buffer = std::end(*write_buffer->accessible());
+        }
+    }
+}

--- a/stm32-modules/tempdeck-gen3/simulator/stdin_sim_driver.cpp
+++ b/stm32-modules/tempdeck-gen3/simulator/stdin_sim_driver.cpp
@@ -1,0 +1,35 @@
+#include "simulator/stdin_sim_driver.hpp"
+
+#include <boost/asio.hpp>
+#include <iostream>
+#include <regex>
+
+#include "simulator/simulator_queue.hpp"
+
+using namespace stdin_sim_driver;
+
+const std::string STDIN_DRIVER_NAME = "Stdin";
+
+stdin_sim_driver::StdinSimDriver::StdinSimDriver() {}
+const std::string stdin_sim_driver::StdinSimDriver::name = STDIN_DRIVER_NAME;
+const std::string& stdin_sim_driver::StdinSimDriver::get_name() const {
+    return this->name;
+}
+void stdin_sim_driver::StdinSimDriver::write(const std::string& message) {
+    std::cout << message;
+}
+void stdin_sim_driver::StdinSimDriver::read(
+    sim_driver::SendToCommsFunc&& send_to_comms) {
+    auto linebuf = std::make_shared<std::string>(1024, 'c');
+    while (true) {
+        if (!std::cin.getline(linebuf->data(), linebuf->size() - 1, '\n')) {
+            return;
+        }
+        auto wrote_to = std::cin.gcount();
+
+        linebuf->at(wrote_to - 1) = '\n';
+        auto message = messages::IncomingMessageFromHost(
+            linebuf->data(), linebuf->data() + wrote_to);
+        send_to_comms(message);
+    }
+}


### PR DESCRIPTION
Adds an initial working version of the simulator. It doesn't have any actual simulated temperatures yet, but each task gets spun up and message passing works as intended.

Tested by running the simulator with `--stdin` and sending some gcodes, responses come back as expected.