### PR TITLE
feat(tempdeck-gen3): add fan driver

### DIFF
--- a/stm32-modules/include/tempdeck-gen3/firmware/thermal_hardware.h
+++ b/stm32-modules/include/tempdeck-gen3/firmware/thermal_hardware.h
@@ -47,6 +47,8 @@ bool thermal_hardware_set_peltier_heat(double power);
  */
 bool thermal_hardware_set_peltier_cool(double power);
 
+bool thermal_hardware_set_fan_power(double power);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/stm32-modules/include/tempdeck-gen3/firmware/thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/firmware/thermal_policy.hpp
@@ -11,4 +11,6 @@ class ThermalPolicy {
     auto set_peltier_heat_power(double power) -> bool;
 
     auto set_peltier_cool_power(double power) -> bool;
+
+    auto set_fan_power(double power) -> bool;
 };

--- a/stm32-modules/include/tempdeck-gen3/simulator/sim_thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/sim_thermal_policy.hpp
@@ -28,8 +28,8 @@ struct SimThermalPolicy {
         _fan = std::clamp(power, double(0.0), double(1.0));
         return true;
     }
-  private:
 
+  private:
     bool _enabled = false;
     double _power = 0.0F;  // Positive for heat, negative for cool
     double _fan = 0.0F;

--- a/stm32-modules/include/tempdeck-gen3/simulator/sim_thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/sim_thermal_policy.hpp
@@ -24,12 +24,13 @@ struct SimThermalPolicy {
         return true;
     }
 
-    // Test integration functions
-
-    auto is_cooling() -> bool { return _enabled && (_power < 0.0); }
-
-    auto is_heating() -> bool { return _enabled && (_power > 0.0); }
+    auto set_fan_power(double power) -> bool {
+        _fan = std::clamp(power, double(0.0), double(1.0));
+        return true;
+    }
+  private:
 
     bool _enabled = false;
     double _power = 0.0F;  // Positive for heat, negative for cool
+    double _fan = 0.0F;
 };

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/gcodes.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/gcodes.hpp
@@ -292,8 +292,8 @@ struct SetFanManual {
             return std::make_pair(ParseResult(), input);
         }
         auto ret = SetFanManual{.power = std::get<0>(arguments).value};
-        if(ret.power < min_power || ret.power > max_power) {
-            return std::make_pair(ParseResult(), input); 
+        if (ret.power < min_power || ret.power > max_power) {
+            return std::make_pair(ParseResult(), input);
         }
         return std::make_pair(ret, res.second);
     }

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/gcodes.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/gcodes.hpp
@@ -242,4 +242,90 @@ struct SetPeltierDebug {
     }
 };
 
+struct SetFanManual {
+    /**
+     * SetFanManual uses M106. Sets the PWM of the fans as a percentage
+     * between 0 and 1.
+     *
+     * M106 S[power]
+     *
+     * Power will be maintained at the specified level until:
+     * - An error occurs
+     * - Another M106 is set
+     * - A Set Fan Auto command is sent
+     * - The heatsink temperature exceeds the safety limit
+     */
+    using ParseResult = std::optional<SetFanManual>;
+    static constexpr auto prefix = std::array{'M', '1', '0', '6'};
+    static constexpr const char* response = "M106 OK\n";
+    static constexpr double min_power = 0.0F;
+    static constexpr double max_power = 1.0F;
+
+    struct PowerArg {
+        static constexpr auto prefix = std::array{'S'};
+        static constexpr bool required = true;
+        bool present = false;
+        float value = 0.0F;
+    };
+
+    double power;
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+
+    template <typename InputIt, typename Limit>
+    requires std::contiguous_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto res =
+            gcode::SingleParser<PowerArg>::parse_gcode(input, limit, prefix);
+        if (!res.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+        auto arguments = res.first.value();
+        if (!std::get<0>(arguments).present) {
+            return std::make_pair(ParseResult(), input);
+        }
+        auto ret = SetFanManual{.power = std::get<0>(arguments).value};
+        if(ret.power < min_power || ret.power > max_power) {
+            return std::make_pair(ParseResult(), input); 
+        }
+        return std::make_pair(ret, res.second);
+    }
+};
+
+struct SetFanAutomatic {
+    /**
+     * SetFanAutomatic uses M107. It has no parameters and just
+     * activates automatic fan control.
+     */
+    using ParseResult = std::optional<SetFanAutomatic>;
+    static constexpr auto prefix = std::array{'M', '1', '0', '7'};
+    static constexpr const char* response = "M107 OK\n";
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(SetFanAutomatic()), working);
+    }
+};
+
 };  // namespace gcode

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
@@ -116,6 +116,15 @@ struct SetPeltierDebugMessage {
     double power;
 };
 
+struct SetFanManualMessage {
+    uint32_t id;
+    double power;
+};
+
+struct SetFanAutomaticMessage {
+    uint32_t id;
+};
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
@@ -126,5 +135,6 @@ using SystemMessage =
 using UIMessage = ::std::variant<std::monostate, UpdateUIMessage>;
 using ThermalMessage =
     ::std::variant<std::monostate, ThermistorReadings, GetTempDebugMessage,
-                   SetPeltierDebugMessage>;
+                   SetPeltierDebugMessage, SetFanManualMessage,
+                   SetFanAutomaticMessage>;
 };  // namespace messages

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -60,6 +60,7 @@ class ThermalTask {
           _readings(),
           _converter(THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM, ADC_BIT_MAX,
                      false),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
           _fan() {}
     ThermalTask(const ThermalTask& other) = delete;
     auto operator=(const ThermalTask& other) -> ThermalTask& = delete;

--- a/stm32-modules/include/tempdeck-gen3/test/test_thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/test/test_thermal_policy.hpp
@@ -24,6 +24,11 @@ struct TestThermalPolicy {
         return true;
     }
 
+    auto set_fan_power(double power) -> bool {
+        _fans = std::clamp(power, (double)0.0F, (double)1.0F);
+        return true;
+    }
+
     // Test integration functions
 
     auto is_cooling() -> bool { return _enabled && (_power < 0.0); }
@@ -32,4 +37,5 @@ struct TestThermalPolicy {
 
     bool _enabled = false;
     double _power = 0.0F;  // Positive for heat, negative for cool
+    double _fans = 0.0F;
 };

--- a/stm32-modules/tempdeck-gen3/firmware/system/stm32g4xx_hal_msp.c
+++ b/stm32-modules/tempdeck-gen3/firmware/system/stm32g4xx_hal_msp.c
@@ -38,6 +38,15 @@ void HAL_MspDeInit(void)
     HAL_NVIC_DisableIRQ(PendSV_IRQn);
 }
 
+void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim_base)
+{
+    if(htim_base->Instance==TIM16)
+    {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM16_CLK_ENABLE();
+    }
+}
+
 /**
 * @brief TIM_Base MSP De-Initialization
 * @param htim_base: TIM_Base handle pointer
@@ -51,6 +60,11 @@ void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* htim_base)
         __HAL_RCC_TIM7_CLK_DISABLE();
         /* TIM6 interrupt DeInit */
         HAL_NVIC_DisableIRQ(TIM7_IRQn);
+    }
+    else if(htim_base->Instance==TIM16)
+    {
+        /* Peripheral clock disable */
+        __HAL_RCC_TIM16_CLK_DISABLE();
     }
 }
 

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
@@ -190,14 +190,13 @@ bool thermal_hardware_set_fan_power(double power) {
     if(power > 1.0F) {
         return false;
     }
-    if(power == 0.0) {
-        // The fan controller will default to full power if it thinks the
-        // control line is disconnected, and unfortunately it thinks a 0% PWM
-        // is a disconnection. So the lowest allowable PWM is 0.01, which 
-        // still results in the fan staying still.
-        power = 0.01;
-    }
     uint32_t pwm = power * (double)FAN_MAX_PWM;
+    
+    // The fan controller will default to full power if it thinks the
+    // control line is disconnected, and unfortunately it thinks a 0% PWM
+    // is a disconnection. So the lowest allowable PWM is 0.01, which 
+    // still results in the fan staying still.
+    if(pwm == 0) { pwm = 1; }
     __HAL_TIM_SET_COMPARE(&hardware.fan_timer, FAN_CHANNEL, pwm);
     return true;
 }

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
@@ -21,3 +21,8 @@ auto ThermalPolicy::set_peltier_heat_power(double power) -> bool {
 auto ThermalPolicy::set_peltier_cool_power(double power) -> bool {
     return thermal_hardware_set_peltier_cool(power);
 }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto ThermalPolicy::set_fan_power(double power) -> bool {
+    return thermal_hardware_set_fan_power(power);
+}

--- a/stm32-modules/tempdeck-gen3/scripts/test_utils.py
+++ b/stm32-modules/tempdeck-gen3/scripts/test_utils.py
@@ -26,7 +26,7 @@ class Tempdeck():
         '''Internal utility to send a command and receive the response'''
         self._ser.write(msg.encode())
         if self._debug:
-            print(f'Sending: {msg}\n')
+            print(f'Sending: {msg}')
         ret = self._ser.readline()
         if guard_ret:
             if not ret.startswith(guard_ret.encode()):
@@ -34,7 +34,7 @@ class Tempdeck():
         if ret.startswith('ERR'.encode()):
             raise RuntimeError(ret)
         if self._debug:
-            print(f'Received: {ret.decode()}\n')
+            print(f'Received: {ret.decode()}')
         return ret.decode()
 
     _TEMP_RE = re.compile('^M105.D PT:(?P<plate>.+) HST:(?P<heatsink>.+) PA:(.+) HSA:(.+) OK\n')
@@ -57,3 +57,22 @@ class Tempdeck():
         '''
         send = f'M104.D S{power}\n'
         self._send_and_recv(send, 'M104.D OK')
+
+    def set_fan_power(self, power: float = 0):
+        '''
+        Set the fan output PWM
+        '''
+        send = f'M106 S{power}\n'
+        self._send_and_recv(send, 'M106 OK')
+    
+    def set_fan_automatic(self):
+        '''
+        Set the fan to automatic mode
+        '''
+        self._send_and_recv('M107\n', 'M107 OK')
+
+    def dfu(self):
+        '''
+        Enter the bootloader. This will cause future comms to fail.
+        '''
+        self._ser.write(b'dfu\n')

--- a/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
@@ -15,6 +15,8 @@ add_executable(${TARGET_MODULE_NAME}
     # gcode tests
     test_m104d.cpp
     test_m105d.cpp
+    test_m106.cpp
+    test_m107.cpp 
     test_m115.cpp
     test_m996.cpp
     test_dfu_gcode.cpp

--- a/stm32-modules/tempdeck-gen3/tests/test_host_comms_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_host_comms_task.cpp
@@ -275,6 +275,126 @@ SCENARIO("host comms commands to thermal task") {
             }
         }
     }
+    WHEN("sending gcode M106") {
+        auto message_text = std::string("M106 S0.1\n");
+        auto message_obj =
+            messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                &*message_text.begin(), &*message_text.end()));
+        REQUIRE(tasks->_comms_queue.try_send(message_obj));
+        auto written =
+            tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+        THEN("the task does not immediately ack") {
+            REQUIRE(written == tx_buf.begin());
+        }
+        THEN("a message is sent to the thermal task") {
+            REQUIRE(tasks->_thermal_queue.has_message());
+            auto thermal_msg = tasks->_thermal_queue.backing_deque.front();
+            REQUIRE(std::holds_alternative<messages::SetFanManualMessage>(
+                thermal_msg));
+            auto id = std::get<messages::SetFanManualMessage>(thermal_msg).id;
+            REQUIRE_THAT(
+                std::get<messages::SetFanManualMessage>(thermal_msg).power,
+                Catch::Matchers::WithinAbs(0.1, 0.001));
+            AND_WHEN("sending response with wrong id") {
+                auto response =
+                    messages::AcknowledgePrevious{.responding_to_id = id + 1};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an error is printed") {
+                    auto expected = errorstring(
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+            AND_WHEN("sending an error response") {
+                auto response = messages::AcknowledgePrevious{
+                    .responding_to_id = id,
+                    .with_error = errors::ErrorCode::THERMAL_PELTIER_ERROR};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an ack is printed") {
+                    auto expected =
+                        errorstring(errors::ErrorCode::THERMAL_PELTIER_ERROR);
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+            AND_WHEN("sending a good response") {
+                auto response =
+                    messages::AcknowledgePrevious{.responding_to_id = id};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an ack is printed") {
+                    auto expected = "M106 OK\n";
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+        }
+    }
+    WHEN("sending gcode M107") {
+        auto message_text = std::string("M107\n");
+        auto message_obj =
+            messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                &*message_text.begin(), &*message_text.end()));
+        REQUIRE(tasks->_comms_queue.try_send(message_obj));
+        auto written =
+            tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+        THEN("the task does not immediately ack") {
+            REQUIRE(written == tx_buf.begin());
+        }
+        THEN("a message is sent to the thermal task") {
+            REQUIRE(tasks->_thermal_queue.has_message());
+            auto thermal_msg = tasks->_thermal_queue.backing_deque.front();
+            REQUIRE(std::holds_alternative<messages::SetFanAutomaticMessage>(
+                thermal_msg));
+            auto id =
+                std::get<messages::SetFanAutomaticMessage>(thermal_msg).id;
+            AND_WHEN("sending response with wrong id") {
+                auto response =
+                    messages::AcknowledgePrevious{.responding_to_id = id + 1};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an error is printed") {
+                    auto expected = errorstring(
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+            AND_WHEN("sending an error response") {
+                auto response = messages::AcknowledgePrevious{
+                    .responding_to_id = id,
+                    .with_error = errors::ErrorCode::THERMAL_PELTIER_ERROR};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an ack is printed") {
+                    auto expected =
+                        errorstring(errors::ErrorCode::THERMAL_PELTIER_ERROR);
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+            AND_WHEN("sending a good response") {
+                auto response =
+                    messages::AcknowledgePrevious{.responding_to_id = id};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an ack is printed") {
+                    auto expected = "M107 OK\n";
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+        }
+    }
 }
 
 SCENARIO("host comms usb disconnect") {

--- a/stm32-modules/tempdeck-gen3/tests/test_m106.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_m106.cpp
@@ -1,0 +1,65 @@
+#include "catch2/catch.hpp"
+#include "tempdeck-gen3/gcodes.hpp"
+
+SCENARIO("SetFanManual (M106) parser works", "[gcode][parse][m106]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(64, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetFanManual::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M106 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetFanManual::write_response_into(
+                buffer.begin(), buffer.begin() + 3);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M10ccccccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("Valid parameters") {
+        WHEN("Setting power to 1.0") {
+            std::string buffer = "M106 S1.0\n";
+            auto parsed =
+                gcode::SetFanManual::parse(buffer.begin(), buffer.end());
+            THEN("the power should be 1.0") {
+                auto &val = parsed.first;
+                REQUIRE(parsed.second != buffer.begin());
+                REQUIRE(val.has_value());
+                REQUIRE(val.value().power == 1.0F);
+            }
+        }
+        WHEN("Setting power to 0.0") {
+            std::string buffer = "M106 S0\n";
+            auto parsed =
+                gcode::SetFanManual::parse(buffer.begin(), buffer.end());
+            THEN("the power should be 0.0") {
+                auto &val = parsed.first;
+                REQUIRE(parsed.second != buffer.begin());
+                REQUIRE(val.has_value());
+                REQUIRE(val.value().power == 0.0F);
+            }
+        }
+    }
+    GIVEN("Invalid power") {
+        WHEN("Setting power to 2.0") {
+            std::string buffer = "M106 S2.0\n";
+            auto parsed =
+                gcode::SetFanManual::parse(buffer.begin(), buffer.end());
+            THEN("parsing should fail") {
+                auto &val = parsed.first;
+                REQUIRE(!val.has_value());
+                REQUIRE(parsed.second == buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/tempdeck-gen3/tests/test_m107.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_m107.cpp
@@ -1,0 +1,58 @@
+#include "catch2/catch.hpp"
+
+// Push this diagnostic to avoid a compiler error about printing to too
+// small of a buffer... which we're doing on purpose!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "tempdeck-gen3/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("SetFanAutomatic (M107) parser works", "[gcode][parse][m107]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetFanAutomatic::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M107 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetFanAutomatic::write_response_into(
+                buffer.begin(), buffer.begin() + 5);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M107 ccccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a valid input") {
+        std::string buffer = "M107\n";
+        WHEN("parsing") {
+            auto res =
+                gcode::SetFanAutomatic::parse(buffer.begin(), buffer.end());
+            THEN("a valid gcode should be produced") {
+                REQUIRE(res.first.has_value());
+                REQUIRE(res.second != buffer.begin());
+            }
+        }
+    }
+    GIVEN("an invalid input") {
+        std::string buffer = "M 108\n";
+        WHEN("parsing") {
+            auto res =
+                gcode::SetFanAutomatic::parse(buffer.begin(), buffer.end());
+            THEN("an error should be produced") {
+                REQUIRE(!res.first.has_value());
+                REQUIRE(res.second == buffer.begin());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds code to drive the fan on the Tempdeck. Uses TIM16 as a PWM generator on pin A6.

- Adds M106 SetFanManual to set the power of the fan from 0-1
- Adds M107 SetFanAutomatic to set the fan to automatic mode - right now this just sets the power to 0
- _For now,_ the PWM to turn the fan off is 0.01% instead of 0%. This is because we cannot turn off the 12v rail (because it is also used for the peltier driver), and a PWM of 0% causes the fan driver to think there is no control line connected and set the output to 100%.
  - Testing hasn't been done with the final fan part yet so this may change!

Verified on hardware that M106 sets the power accordingly, and sending `M106 S0` or `M107` turns off the fan.