### PR TITLE
feat(thermocycler-gen2): front button LED pulsing and blinking

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/firmware/system_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/firmware/system_policy.hpp
@@ -26,6 +26,8 @@ class SystemPolicy {
         -> errors::ErrorCode;
     auto get_serial_number() -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH>;
     [[nodiscard]] auto get_front_button_status() -> bool;
+    auto set_front_button_led(bool set) -> void;
+
     // Functions for XT1511 setting
     auto start_send(LedBuffer& buffer) -> bool;
     auto end_send() -> void;

--- a/stm32-modules/include/thermocycler-gen2/test/test_system_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/test/test_system_policy.hpp
@@ -14,6 +14,7 @@ class TestSystemPolicy : public TestXT1511Policy<16> {
     std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> system_serial_number = {};
     errors::ErrorCode set_serial_number_return = errors::ErrorCode::NO_ERROR;
     bool front_button = false;
+    bool front_led = false;
 
   public:
     TestSystemPolicy() : TestXT1511Policy<16>(213) {}
@@ -27,6 +28,9 @@ class TestSystemPolicy : public TestXT1511Policy<16> {
         -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH>;
     auto get_front_button_status() -> bool;
 
+    auto set_front_button_led(bool set) -> void;
+
     // For test integration
     auto set_front_button_status(bool set) -> void;
+    auto get_front_led() -> bool;
 };

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -334,6 +334,15 @@ struct UpdatePlateState {
     PlateState state;
 };
 
+// This message is sent to the System Task by just the Motor Task
+// to update what the current state of the motor subsystem is. This
+// dictates how the Front Button LED is controlled.
+struct UpdateMotorState {
+    enum class MotorState : uint8_t { IDLE, OPENING_OR_CLOSING, PLATE_LIFT };
+
+    MotorState state;
+};
+
 struct GetLidStatusMessage {
     uint32_t id;
 };
@@ -392,7 +401,7 @@ using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage,
                    UpdateUIMessage, SetLedMode, UpdateTaskErrorState,
-                   UpdatePlateState, GetFrontButtonMessage>;
+                   UpdatePlateState, GetFrontButtonMessage, UpdateMotorState>;
 using HostCommsMessage = ::std::variant<
     std::monostate, IncomingMessageFromHost, AcknowledgePrevious, ErrorMessage,
     ForceUSBDisconnectMessage, GetSystemInfoResponse,

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -963,65 +963,91 @@ class MotorTask {
     auto handle_lid_state_enter(LidState::Status state, Policy& policy)
         -> errors::ErrorCode {
         auto error = errors::ErrorCode::NO_ERROR;
+        auto state_for_system_task =
+            messages::UpdateMotorState::MotorState::IDLE;
         switch (state) {
             case LidState::Status::IDLE:
                 lid_response_send_and_clear();
+                state_for_system_task =
+                    messages::UpdateMotorState::MotorState::IDLE;
                 break;
             case LidState::Status::OPENING_RETRACT_SEAL:
                 // The seal stepper is retracted to the limit switch
                 error = start_seal_movement(
                     SealStepperState::FULL_RETRACT_MICROSTEPS, true, policy);
+                state_for_system_task =
+                    messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING;
                 break;
             case LidState::Status::OPENING_RETRACT_SEAL_BACKOFF:
                 // The seal stepper is extended to back off the limit switch
                 error = start_seal_movement(
                     SealStepperState::SWITCH_BACKOFF_MICROSTEPS_EXTEND, false,
                     policy);
+                state_for_system_task =
+                    messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING;
                 break;
             case LidState::Status::OPENING_OPEN_HINGE:
                 if (!start_lid_hinge_open(INVALID_ID, policy)) {
                     error = errors::ErrorCode::LID_MOTOR_BUSY;
                 }
+                state_for_system_task =
+                    messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING;
                 break;
             case LidState::Status::CLOSING_RETRACT_SEAL:
                 // The seal stepper is retracted to a stall
                 error = start_seal_movement(
                     SealStepperState::FULL_RETRACT_MICROSTEPS, true, policy);
+                state_for_system_task =
+                    messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING;
                 break;
             case LidState::Status::CLOSING_RETRACT_SEAL_BACKOFF:
                 // The seal stepper is extended to back off the limit switch
                 error = start_seal_movement(
                     SealStepperState::SWITCH_BACKOFF_MICROSTEPS_EXTEND, false,
                     policy);
+                state_for_system_task =
+                    messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING;
                 break;
             case LidState::Status::CLOSING_CLOSE_HINGE:
                 if (!start_lid_hinge_close(INVALID_ID, policy)) {
                     error = errors::ErrorCode::LID_MOTOR_BUSY;
                 }
+                state_for_system_task =
+                    messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING;
                 break;
             case LidState::Status::CLOSING_EXTEND_SEAL:
                 // The seal stepper is extended to engage with the plate
                 error = start_seal_movement(
                     SealStepperState::FULL_EXTEND_MICROSTEPS, true, policy);
+                state_for_system_task =
+                    messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING;
                 break;
             case LidState::Status::CLOSING_EXTEND_SEAL_BACKOFF:
                 // The seal stepper is extended to back off the limit switch
                 error = start_seal_movement(
                     SealStepperState::SWITCH_BACKOFF_MICROSTEPS_RETRACT, false,
                     policy);
+                state_for_system_task =
+                    messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING;
                 break;
             case LidState::Status::PLATE_LIFTING:
                 // The lid state machine handles everything
                 if (!start_lid_hinge_plate_lift(INVALID_ID, policy)) {
                     error = errors::ErrorCode::LID_MOTOR_FAULT;
                 }
+                state_for_system_task =
+                    messages::UpdateMotorState::MotorState::PLATE_LIFT;
                 break;
         }
         if (error == errors::ErrorCode::NO_ERROR) {
             _state.status = state;
         } else {
             _state.status = LidState::Status::IDLE;
+            state_for_system_task =
+                messages::UpdateMotorState::MotorState::IDLE;
         }
+        static_cast<void>(_task_registry->system->get_message_queue().try_send(
+            messages::UpdateMotorState{.state = state_for_system_task}));
         return error;
     }
 

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
@@ -84,11 +84,9 @@ class FrontButtonBlink {
     static constexpr uint32_t ticks_per_rep = off_time + on_time;
     static constexpr uint32_t total_ticks = ticks_per_rep * repetitions;
 
-    uint32_t _count;
+    uint32_t _count = 0;
 
   public:
-    FrontButtonBlink() : _count(0) {}
-
     auto reset() -> void { _count = 0; }
 
     [[nodiscard]] auto tick() -> bool {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
@@ -22,6 +22,84 @@ struct Tasks;
 
 namespace system_task {
 
+// Structure to hold runtime info for pulsing an LED.
+// The LED is run with a psuedo-pwm to modulate the brightness, and
+// to provide a smooth triangular pulse
+class Pulse {
+  private:
+    // This gives a pleasant visual effect
+    static constexpr uint32_t default_period = 25;
+    const uint32_t _period;
+    uint8_t _pwm = 0;
+    uint8_t _count = 0;
+    int8_t _direction = 1;
+
+  public:
+    explicit Pulse(uint32_t period = default_period) : _period(period) {}
+
+    auto reset() -> void {
+        _count = 0;
+        _pwm = 0;
+    }
+
+    /**
+     * @brief Increment heartbeat counter. This provides a pseudo-pwm
+     * setup where a "pwm" counter runs from 0 to a configurable period
+     * value, and the LED is turned on and off based on whether the repeating
+     * counter is below the PWM value.
+     *
+     * @return true if the LED should be set to on, false if it should
+     * be set to off.
+     */
+    auto tick() -> bool {
+        ++_count;
+        if (_count == _period) {
+            _count = 0;
+            _pwm += _direction;
+            if (_pwm == _period) {
+                _direction = -1;
+            } else if (_pwm == 0) {
+                _direction = 1;
+            }
+        }
+        return (_pwm > 2) && (_count < _pwm);
+    }
+
+    // Get the current pwm period
+    [[nodiscard]] auto pwm() const -> uint8_t { return _pwm; }
+};
+
+// Class to hold runtime info for blinking the front button. This steps
+// through a preprogrammed sequence where the front LED blinks twice and
+// then holds steady.
+class FrontButtonBlink {
+  private:
+    // In milliseconds
+    static constexpr uint32_t off_time = 200;
+    // In milliseconds
+    static constexpr uint32_t on_time = 200;
+    // Number of repetitions
+    static constexpr uint32_t repetitions = 2;
+    // Max ticks is precalculated
+    static constexpr uint32_t ticks_per_rep = off_time + on_time;
+    static constexpr uint32_t total_ticks = ticks_per_rep * repetitions;
+
+    uint32_t _count;
+
+  public:
+    FrontButtonBlink() : _count(0) {}
+
+    auto reset() -> void { _count = 0; }
+
+    [[nodiscard]] auto tick() -> bool {
+        _count = std::min(_count + 1, total_ticks);
+        if (_count == total_ticks) {
+            return true;
+        }
+        return (_count % ticks_per_rep) > off_time;
+    }
+};
+
 using PWM_T = uint16_t;
 
 template <typename Policy>
@@ -36,6 +114,8 @@ concept SystemExecutionPolicy = requires(Policy& p, const Policy& cp) {
         } -> std::same_as<std::array<char, SYSTEM_WIDE_SERIAL_NUMBER_LENGTH>>;
     // A function to read the current status of the front button
     { p.get_front_button_status() } -> std::same_as<bool>;
+    // A function to set the LED on the front button on or off
+    { p.set_front_button_led(true) } -> std::same_as<void>;
 };
 
 struct LedState {
@@ -64,8 +144,13 @@ class SystemTask {
   public:
     using Queue = QueueImpl<Message>;
     using PlateState = messages::UpdatePlateState::PlateState;
+    using MotorState = messages::UpdateMotorState::MotorState;
     // Time between each write to the LED strip
     static constexpr uint32_t LED_UPDATE_PERIOD_MS = 13;
+    // Time between each write to the front button
+    static constexpr uint32_t FRONT_BUTTON_PERIOD_MS = 1;
+    // Total max PWM count for the front button pulsing
+    static constexpr uint32_t FRONT_BUTTON_MAX_PULSE = 20;
     // Time that each full "pulse" action should take (sine wave)
     static constexpr uint32_t LED_PULSE_PERIOD_MS = 1000;
     // Max brightness to set for automatic LED actions
@@ -84,7 +169,11 @@ class SystemTask {
           _plate_error(errors::ErrorCode::NO_ERROR),
           _lid_error(errors::ErrorCode::NO_ERROR),
           _motor_error(errors::ErrorCode::NO_ERROR),
-          _plate_state(PlateState::IDLE) {}
+          _plate_state(PlateState::IDLE),
+          _motor_state(MotorState::IDLE),
+          _front_button_pulse(FRONT_BUTTON_MAX_PULSE),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
+          _front_button_blink() {}
     SystemTask(const SystemTask& other) = delete;
     auto operator=(const SystemTask& other) -> SystemTask& = delete;
     SystemTask(SystemTask&& other) noexcept = delete;
@@ -311,6 +400,24 @@ class SystemTask {
     }
 
     template <SystemExecutionPolicy Policy>
+    auto visit_message(const messages::UpdateMotorState& message,
+                       Policy& policy) -> void {
+        if (message.state != _motor_state) {
+            switch (message.state) {
+                case MotorState::IDLE:
+                    policy.set_front_button_led(true);
+                    break;
+                case MotorState::OPENING_OR_CLOSING:
+                    _front_button_pulse.reset();
+                    break;
+                case MotorState::PLATE_LIFT:
+                    _front_button_blink.reset();
+            }
+        }
+        _motor_state = message.state;
+    }
+
+    template <SystemExecutionPolicy Policy>
     auto visit_message(const messages::GetFrontButtonMessage& message,
                        Policy& policy) {
         auto response = messages::GetFrontButtonResponse{
@@ -340,6 +447,20 @@ class SystemTask {
     auto front_button_callback() -> void {
         static_cast<void>(_task_registry->motor->get_message_queue().try_send(
             messages::FrontButtonPressMessage()));
+    }
+
+    template <SystemExecutionPolicy Policy>
+    auto front_button_led_callback(Policy& policy) -> void {
+        switch (_motor_state) {
+            case MotorState::IDLE:
+                break;
+            case MotorState::OPENING_OR_CLOSING:
+                policy.set_front_button_led(_front_button_pulse.tick());
+                break;
+            case MotorState::PLATE_LIFT:
+                policy.set_front_button_led(_front_button_blink.tick());
+                break;
+        }
     }
 
     // To be used for tests
@@ -390,6 +511,11 @@ class SystemTask {
     errors::ErrorCode _lid_error;
     errors::ErrorCode _motor_error;
     PlateState _plate_state;
+    // Must be atomic because it is used directly in a callback
+    // that executes in a different task context
+    std::atomic<MotorState> _motor_state;
+    Pulse _front_button_pulse;
+    FrontButtonBlink _front_button_blink;
 };
 
 };  // namespace system_task

--- a/stm32-modules/thermocycler-gen2/firmware/system/freertos_system_task.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/system/freertos_system_task.cpp
@@ -50,8 +50,8 @@ static timer::GenericTimer<freertos_timer::FreeRTOSTimer> _led_timer(
     [ObjectPtr = &_task] { ObjectPtr->led_timer_callback(); });
 
 // Periodic timer for Front Button LED Updates
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static timer::GenericTimer<freertos_timer::FreeRTOSTimer>
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     _front_button_led_timer("button led",
                             decltype(_task)::FRONT_BUTTON_PERIOD_MS, true,
                             [ObjectPtr = &_task] {

--- a/stm32-modules/thermocycler-gen2/firmware/system/freertos_system_task.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/system/freertos_system_task.cpp
@@ -31,6 +31,9 @@ static FreeRTOSMessageQueue<system_task::Message>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _task = system_task::SystemTask(_system_queue);
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto policy = SystemPolicy();
+
 static constexpr uint32_t stack_size = 500;
 // Stack as a std::array because why not. Quiet lint because, well, we have to
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -45,6 +48,15 @@ static StaticTask_t
 static timer::GenericTimer<freertos_timer::FreeRTOSTimer> _led_timer(
     "led timer", decltype(_task)::LED_UPDATE_PERIOD_MS, true,
     [ObjectPtr = &_task] { ObjectPtr->led_timer_callback(); });
+
+// Periodic timer for Front Button LED Updates
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static timer::GenericTimer<freertos_timer::FreeRTOSTimer>
+    _front_button_led_timer("button led",
+                            decltype(_task)::FRONT_BUTTON_PERIOD_MS, true,
+                            [ObjectPtr = &_task] {
+                                ObjectPtr->front_button_led_callback(policy);
+                            });
 
 // One shot timer for front button events.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -72,8 +84,9 @@ static void run(void *param) {
     system_led_initialize();
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto *task = reinterpret_cast<decltype(_task) *>(param);
-    auto policy = SystemPolicy();
+
     _led_timer.start();
+    _front_button_led_timer.start();
     while (true) {
         task->run_once(policy);
     }

--- a/stm32-modules/thermocycler-gen2/firmware/system/system_policy.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/system/system_policy.cpp
@@ -65,6 +65,11 @@ auto SystemPolicy::get_serial_number()
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto SystemPolicy::set_front_button_led(bool set) -> void {
+    return system_front_button_led_set(set);
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto SystemPolicy::start_send(LedBuffer &buffer) -> bool {
     return system_led_start_send(buffer.data(), buffer.size());
 }

--- a/stm32-modules/thermocycler-gen2/simulator/system_thread.cpp
+++ b/stm32-modules/thermocycler-gen2/simulator/system_thread.cpp
@@ -61,6 +61,9 @@ struct SimSystemPolicy {
         // Just always simulate a non-pressed button
         return false;
     }
+
+    auto set_front_button_led(bool set) { static_cast<void>(set); }
+
     // Functions for XT1511 setting
     auto start_send(LedBuffer& buffer) -> bool {
         if (_led_active) {

--- a/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_main.cpp
     test_system_policy.cpp
     test_system_task.cpp
+    test_system_pulse.cpp
     test_thermal_plate_task.cpp
     test_plate_control.cpp
     test_tmc2130.cpp

--- a/stm32-modules/thermocycler-gen2/tests/test_system_policy.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_system_policy.cpp
@@ -39,3 +39,9 @@ auto TestSystemPolicy::get_front_button_status() -> bool {
 auto TestSystemPolicy::set_front_button_status(bool set) -> void {
     front_button = set;
 }
+
+auto TestSystemPolicy::set_front_button_led(bool set) -> void {
+    front_led = set;
+}
+
+auto TestSystemPolicy::get_front_led() -> bool { return front_led; }

--- a/stm32-modules/thermocycler-gen2/tests/test_system_pulse.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_system_pulse.cpp
@@ -1,0 +1,73 @@
+#include <array>
+
+#include "catch2/catch.hpp"
+#include "thermocycler-gen2/system_task.hpp"
+
+TEST_CASE("Heartbeat class functionality") {
+    GIVEN("a heartbeat with a period of 5") {
+        const uint32_t PERIOD = 5;
+        auto subject = system_task::Pulse(PERIOD);
+        THEN("the pwm starts at 0") { REQUIRE(subject.pwm() == 0); }
+        THEN("the first two PERIOD worth of ticks are all off") {
+            for (size_t i = 0; i < PERIOD * 2; ++i) {
+                DYNAMIC_SECTION("tick " + i) {
+                    for (size_t j = 0; j < i; ++j) {
+                        subject.tick();
+                    }
+                    REQUIRE(!subject.tick());
+                }
+            }
+        }
+        THEN("the pwm changes every 5 ticks") {
+            auto values = std::array<uint8_t, 14>{
+                {0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3}};
+            for (size_t i = 0; i < values.size(); ++i) {
+                DYNAMIC_SECTION("pwm value: " + values[i]) {
+                    REQUIRE(subject.pwm() == 0);
+                    for (size_t j = 0; j < PERIOD * i; ++j) {
+                        subject.tick();
+                    }
+                    REQUIRE(subject.pwm() == values[i]);
+                }
+            }
+        }
+        AND_GIVEN("the heartbeat has been ticked to a PWM of 3") {
+            while (subject.pwm() < 3) {
+                subject.tick();
+            }
+            THEN("the next two ticks should turn on the LED") {
+                REQUIRE(subject.tick());
+                REQUIRE(subject.tick());
+                AND_THEN("the next tick should turn the LED off") {
+                    REQUIRE(!subject.tick());
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("FrontButtonBlink class functionality") {
+    auto subject = system_task::FrontButtonBlink();
+    WHEN("ticking through the entire sequence") {
+        auto intended = std::vector<bool>();
+        for(int i = 0; i < 200; ++i) {
+            intended.push_back(false);
+        }
+        for(int i = 0; i < 199; ++i) {
+            intended.push_back(true);
+        }
+        for(int i = 0; i < 201; ++i) {
+            intended.push_back(false);
+        }
+        for(int i = 0; i < 1000; ++i) {
+            intended.push_back(true);
+        }
+        auto results = std::vector<bool>();
+        while(results.size() < intended.size()) {
+            results.push_back(subject.tick());
+        }
+        THEN("the results match") {
+            REQUIRE_THAT(results, Catch::Matchers::Equals(intended));
+        }
+    }
+}

--- a/stm32-modules/thermocycler-gen2/tests/test_system_pulse.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_system_pulse.cpp
@@ -50,20 +50,20 @@ TEST_CASE("FrontButtonBlink class functionality") {
     auto subject = system_task::FrontButtonBlink();
     WHEN("ticking through the entire sequence") {
         auto intended = std::vector<bool>();
-        for(int i = 0; i < 200; ++i) {
+        for (int i = 0; i < 200; ++i) {
             intended.push_back(false);
         }
-        for(int i = 0; i < 199; ++i) {
+        for (int i = 0; i < 199; ++i) {
             intended.push_back(true);
         }
-        for(int i = 0; i < 201; ++i) {
+        for (int i = 0; i < 201; ++i) {
             intended.push_back(false);
         }
-        for(int i = 0; i < 1000; ++i) {
+        for (int i = 0; i < 1000; ++i) {
             intended.push_back(true);
         }
         auto results = std::vector<bool>();
-        while(results.size() < intended.size()) {
+        while (results.size() < intended.size()) {
             results.push_back(subject.tick());
         }
         THEN("the results match") {

--- a/stm32-modules/thermocycler-gen2/tests/test_system_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_system_task.cpp
@@ -375,3 +375,78 @@ SCENARIO("system task message passing") {
         }
     }
 }
+
+TEST_CASE("system task front button led behavior") {
+    auto tasks = TaskBuilder::build();
+
+    WHEN("the motor mode is set to idle from another state") {
+        tasks->get_system_policy().set_front_button_led(false);
+        auto msg = messages::UpdateMotorState{
+            .state =
+                messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING};
+        tasks->get_system_queue().backing_deque.push_back(msg);
+        tasks->run_system_task();
+        msg.state = messages::UpdateMotorState::MotorState::IDLE;
+        tasks->get_system_queue().backing_deque.push_back(msg);
+        tasks->run_system_task();
+        THEN("the front LED is turned on") {
+            REQUIRE(tasks->get_system_policy().get_front_led());
+            AND_WHEN("the led callback is invoked") {
+                auto led_status = GENERATE(false, true);
+                tasks->get_system_policy().set_front_button_led(led_status);
+                tasks->get_system_task().front_button_led_callback(
+                    tasks->get_system_policy());
+                THEN("the front LED is not refreshed") {
+                    REQUIRE(tasks->get_system_policy().get_front_led() ==
+                            led_status);
+                }
+            }
+        }
+    }
+
+    WHEN("the motor mode is set to open or close") {
+        auto msg = messages::UpdateMotorState{
+            .state =
+                messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING};
+        tasks->get_system_queue().backing_deque.push_back(msg);
+        tasks->run_system_task();
+        THEN("calling the front button led callback") {
+            auto pulse = system_task::Pulse(
+                tasks->get_system_task().FRONT_BUTTON_MAX_PULSE);
+            auto expected = std::vector<bool>();
+            auto result = std::vector<bool>();
+            for (int i = 0; i < 1000; ++i) {
+                expected.push_back(pulse.tick());
+
+                tasks->get_system_task().front_button_led_callback(
+                    tasks->get_system_policy());
+                result.push_back(tasks->get_system_policy().get_front_led());
+            }
+            THEN("the front led status matches the expected pulse") {
+                REQUIRE_THAT(result, Catch::Matchers::Equals(expected));
+            }
+        }
+    }
+
+    WHEN("the motor mode is set to plate lift") {
+        auto msg = messages::UpdateMotorState{
+            .state = messages::UpdateMotorState::MotorState::PLATE_LIFT};
+        tasks->get_system_queue().backing_deque.push_back(msg);
+        tasks->run_system_task();
+        THEN("calling the front button led callback") {
+            auto blink = system_task::FrontButtonBlink();
+            auto expected = std::vector<bool>();
+            auto result = std::vector<bool>();
+            for (int i = 0; i < 1000; ++i) {
+                expected.push_back(blink.tick());
+
+                tasks->get_system_task().front_button_led_callback(
+                    tasks->get_system_policy());
+                result.push_back(tasks->get_system_policy().get_front_led());
+            }
+            THEN("the front led status matches the expected pulse") {
+                REQUIRE_THAT(result, Catch::Matchers::Equals(expected));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds pulsing and blinking behaviors to the front button LED. The LED isn't connected to any timer line, so it has to be pulsed manually with a periodic timer (in this case a FreeRTOS soft timer).

The callback for the front LED _could_ send a message to the system task that then updates the message when the task runs, but this ends up causing very noticeable jitter to the LED blinking whenever the seal motor runs (which is a high priority and high frequency interrupt). Keeping the LED handling to a single callback invoked by the FreeRTOS timer task keeps jitter invisible to the naked eye.

The LED behavior is as follows:
* When the lid is opening or closing (including seal motor movements), the LED pulses
* When the lid begins a Plate Lift action, the LED blinks two times
* At all other times, the LED is just left on

Video of the updated LED behavior on a physical unit was approved by Design.