### PR TITLE
feat(thermocycler-gen2): run plate lift with long button press

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/firmware/system_hardware.h
+++ b/stm32-modules/include/thermocycler-gen2/firmware/system_hardware.h
@@ -8,6 +8,8 @@ extern "C" {
 
 // Front button can only be pressed at 200ms increments
 #define FRONT_BUTTON_DEBOUNCE_MS (200)
+// Front button should be queried at this frequency after debouncing
+#define FRONT_BUTTON_QUERY_RATE_MS (50)
 
 // Type for callback when the button has been pressed
 typedef void (*front_button_callback_t)(void);

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -365,7 +365,9 @@ struct PlateLiftMessage {
     uint32_t id;
 };
 
-struct FrontButtonPressMessage {};
+struct FrontButtonPressMessage {
+    bool long_press;
+};
 
 // This is a two-stage message that is first sent to the Plate task,
 // and then the Lid task.

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -608,11 +608,19 @@ class MotorTask {
         if (lid_position == motor_util::LidStepper::Position::UNKNOWN) {
             return;
         }
-        if (lid_position == motor_util::LidStepper::Position::OPEN) {
-            static_cast<void>(start_lid_close(INVALID_ID, policy));
+        if(msg.long_press) {
+            // Long presses are for plate lift
+            if (lid_position == motor_util::LidStepper::Position::OPEN) {
+                static_cast<void>(start_plate_lift(INVALID_ID, policy));
+            }
         } else {
-            // Default to opening the lid if the status is in-between switches
-            static_cast<void>(start_lid_open(INVALID_ID, policy));
+            // Short presses are for opening/closing the lid
+            if (lid_position == motor_util::LidStepper::Position::OPEN) {
+                static_cast<void>(start_lid_close(INVALID_ID, policy));
+            } else {
+                // Default to opening the lid if the status is in-between switches
+                static_cast<void>(start_lid_open(INVALID_ID, policy));
+            }
         }
     }
 

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -608,7 +608,7 @@ class MotorTask {
         if (lid_position == motor_util::LidStepper::Position::UNKNOWN) {
             return;
         }
-        if(msg.long_press) {
+        if (msg.long_press) {
             // Long presses are for plate lift
             if (lid_position == motor_util::LidStepper::Position::OPEN) {
                 static_cast<void>(start_plate_lift(INVALID_ID, policy));
@@ -618,7 +618,8 @@ class MotorTask {
             if (lid_position == motor_util::LidStepper::Position::OPEN) {
                 static_cast<void>(start_lid_close(INVALID_ID, policy));
             } else {
-                // Default to opening the lid if the status is in-between switches
+                // Default to opening the lid if the status is in-between
+                // switches
                 static_cast<void>(start_lid_open(INVALID_ID, policy));
             }
         }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
@@ -119,7 +119,8 @@ class ButtonPress {
 
   public:
     explicit ButtonPress(Callback cb, size_t long_press_threshold)
-        : _send_press(std::move(cb)), _long_press_threshold(long_press_threshold) {}
+        : _send_press(std::move(cb)),
+          _long_press_threshold(long_press_threshold) {}
 
     /**
      * @brief Resets the state of the button press. This should be called
@@ -217,7 +218,7 @@ class SystemTask {
     static constexpr uint8_t LED_MAX_BRIGHTNESS = 0x20;
     // Number of milliseconds to consider a button press "long" is 3 seconds
     static constexpr uint32_t LONG_PRESS_TIME_MS = 3000;
-    
+
     explicit SystemTask(Queue& q)
         : _message_queue(q),
           _task_registry(nullptr),

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
@@ -98,6 +98,68 @@ class FrontButtonBlink {
     }
 };
 
+// Class to hold runtime info for pressing the front button. The button
+// has a
+class ButtonPress {
+  public:
+    // The completion callback accepts one parameter, a bool for whether this
+    // was a LONG (true) or SHORT (false) button press.
+    using Callback = std::function<void(bool)>;
+
+  private:
+    // The callback for when the press is completed
+    Callback _send_press;
+    // The number of milliseconds the button must be held to count as
+    // a "long press"
+    const uint32_t _long_press_threshold;
+    // Number of milliseconds the button has been held for
+    uint32_t _ms_count = 0;
+    // Whether a message has been sent since the last reset
+    bool _press_sent = false;
+
+  public:
+    explicit ButtonPress(Callback cb, size_t long_press_threshold)
+        : _send_press(std::move(cb)), _long_press_threshold(long_press_threshold) {}
+
+    /**
+     * @brief Resets the state of the button press. This should be called
+     * when the button is initially pressed (e.g. when the IRQ for the button
+     * is triggered).
+     */
+    auto reset() -> void {
+        _ms_count = 0;
+        _press_sent = false;
+    }
+
+    /**
+     * @brief Update the button state while it is being held. If the amount
+     * of time it has been held exceeds the threshold for being a long press,
+     * this function will call the callback and mark that a message was sent.
+     *
+     * @param delta_ms The number of milliseconds that has passed since the
+     * last time this or `reset()` was invoked.
+     */
+    auto update_held(uint32_t delta_ms) -> void {
+        if (!_press_sent) {
+            _ms_count += delta_ms;
+            if (_ms_count >= _long_press_threshold) {
+                // Did  cross the long threshold, so signal a short press.
+                _send_press(true);
+                _press_sent = true;
+            }
+        }
+    }
+
+    auto released(uint32_t delta_ms) -> void {
+        update_held(delta_ms);
+        if (!_press_sent) {
+            // Did not cross the long threshold, so signal a short press.
+            _send_press(false);
+            _press_sent = true;
+        }
+    }
+};
+
 using PWM_T = uint16_t;
 
 template <typename Policy>
@@ -153,6 +215,9 @@ class SystemTask {
     static constexpr uint32_t LED_PULSE_PERIOD_MS = 1000;
     // Max brightness to set for automatic LED actions
     static constexpr uint8_t LED_MAX_BRIGHTNESS = 0x20;
+    // Number of milliseconds to consider a button press "long" is 3 seconds
+    static constexpr uint32_t LONG_PRESS_TIME_MS = 3000;
+    
     explicit SystemTask(Queue& q)
         : _message_queue(q),
           _task_registry(nullptr),
@@ -442,9 +507,9 @@ class SystemTask {
     // Should be provided to the front button timer to send Front Button
     // messages. Ensure the timer implementation does NOT execute in an
     // interrupt context.
-    auto front_button_callback() -> void {
+    auto front_button_callback(bool long_press) -> void {
         static_cast<void>(_task_registry->motor->get_message_queue().try_send(
-            messages::FrontButtonPressMessage()));
+            messages::FrontButtonPressMessage{.long_press = long_press}));
     }
 
     template <SystemExecutionPolicy Policy>

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
@@ -461,11 +461,22 @@ SCENARIO("motor task message passing") {
         }
         WHEN("sending a Front Button message with lid in unknown position") {
             tasks->get_motor_queue().backing_deque.push_back(
-                messages::FrontButtonPressMessage());
+                messages::FrontButtonPressMessage{.long_press = false});
             tasks->run_motor_task();
             THEN("the lid starts to open") {
                 REQUIRE(motor_task.get_lid_state() ==
                         motor_task::LidState::Status::OPENING_RETRACT_SEAL);
+            }
+        }
+        WHEN(
+            "sending a Long Front Button message with lid in unknown "
+            "position") {
+            tasks->get_motor_queue().backing_deque.push_back(
+                messages::FrontButtonPressMessage{.long_press = true});
+            tasks->run_motor_task();
+            THEN("nothing happens") {
+                REQUIRE(motor_task.get_lid_state() ==
+                        motor_task::LidState::Status::IDLE);
             }
         }
         GIVEN("lid closed sensor triggered") {
@@ -475,11 +486,20 @@ SCENARIO("motor task message passing") {
             motor_policy.set_retraction_switch_triggered(false);
             WHEN("sending a Front Button message") {
                 tasks->get_motor_queue().backing_deque.push_back(
-                    messages::FrontButtonPressMessage());
+                    messages::FrontButtonPressMessage{.long_press = false});
                 tasks->run_motor_task();
                 THEN("the lid starts to open") {
                     REQUIRE(motor_task.get_lid_state() ==
                             motor_task::LidState::Status::OPENING_RETRACT_SEAL);
+                }
+            }
+            WHEN("sending a Long Front Button message") {
+                tasks->get_motor_queue().backing_deque.push_back(
+                    messages::FrontButtonPressMessage{.long_press = true});
+                tasks->run_motor_task();
+                THEN("the lid does nothing") {
+                    REQUIRE(motor_task.get_lid_state() ==
+                            motor_task::LidState::Status::IDLE);
                 }
             }
             WHEN("sending a GetLidSwitches message") {
@@ -511,11 +531,20 @@ SCENARIO("motor task message passing") {
             motor_policy.set_retraction_switch_triggered(false);
             WHEN("sending a Front Button message") {
                 tasks->get_motor_queue().backing_deque.push_back(
-                    messages::FrontButtonPressMessage());
+                    messages::FrontButtonPressMessage{.long_press = false});
                 tasks->run_motor_task();
                 THEN("the lid starts to close") {
                     REQUIRE(motor_task.get_lid_state() ==
                             motor_task::LidState::Status::CLOSING_RETRACT_SEAL);
+                }
+            }
+            WHEN("sending a Long Front Button message") {
+                tasks->get_motor_queue().backing_deque.push_back(
+                    messages::FrontButtonPressMessage{.long_press = true});
+                tasks->run_motor_task();
+                THEN("the lid starts to lift the plate") {
+                    REQUIRE(motor_task.get_lid_state() ==
+                            motor_task::LidState::Status::PLATE_LIFTING);
                 }
             }
             WHEN("sending a GetLidSwitches message") {

--- a/stm32-modules/thermocycler-gen2/tests/test_system_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_system_task.cpp
@@ -92,12 +92,16 @@ SCENARIO("system task message passing") {
         }
 
         WHEN("calling button press callback") {
-            tasks->get_system_task().front_button_callback();
+            auto long_press = GENERATE(false, true);
+            tasks->get_system_task().front_button_callback(long_press);
             THEN("a Front Button message is sent to motor task") {
                 REQUIRE(tasks->get_motor_queue().has_message());
                 REQUIRE(
                     std::holds_alternative<messages::FrontButtonPressMessage>(
                         tasks->get_motor_queue().backing_deque.front()));
+                auto button_msg = std::get<messages::FrontButtonPressMessage>(
+                    tasks->get_motor_queue().backing_deque.front());
+                REQUIRE(button_msg.long_press == long_press);
             }
         }
 


### PR DESCRIPTION
Updates the behavior of the front button to activate a plate lift action when the button is held for 3 seconds. This includes a complete refactor in how the button is controlled; rather than using a software timer, there is a dedicated task that handles monitoring the button. This task waits for an IRQ from the button being pressed, and then starts polling the state of the button (including debouncing for press & release) to check for when it is released. A dedicated class handles when to send a message to the Motor Task, and whether it should classify that message as a short or long button press.

Tested on a unit that:
* Pressing the button and releasing it before 3 seconds results in the lid opening or closing as it did before
* Pressing the button for more than 3 seconds results in nothing happening if the lid is closed
* Pressing the button for more than 3 seconds results in a plate lift action if the lid is open
* If the button is held down to trigger a plate lift, and isn't released until the plate lift is over, the debounce handling prevents a false positive button press.