### PR TITLE
feat(thermocycler-gen2): add lid fan control

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/firmware/lid_heater_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/firmware/lid_heater_policy.hpp
@@ -12,4 +12,6 @@ class LidHeaterPolicy {
     auto set_heater_power(double power) -> bool;
 
     [[nodiscard]] auto get_heater_power() const -> double;
+
+    auto set_lid_fans(bool enable) -> void;
 };

--- a/stm32-modules/include/thermocycler-gen2/firmware/thermal_heater_hardware.h
+++ b/stm32-modules/include/thermocycler-gen2/firmware/thermal_heater_hardware.h
@@ -30,6 +30,11 @@ bool thermal_heater_set_power(double power);
  */
 double thermal_heater_get_power(void);
 
+/**
+ * @brief Set the lid fans enabled or disabled
+ */
+void thermal_heater_set_lid_fans(bool enable);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/stm32-modules/include/thermocycler-gen2/test/test_lid_heater_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/test/test_lid_heater_policy.hpp
@@ -10,6 +10,11 @@ class TestLidHeaterPolicy {
     }
     auto get_heater_power() const -> double { return _power; }
 
+    auto set_lid_fans(bool enable) -> void { _lid_fans = enable; }
+
+    auto lid_fans_enabled() const -> bool { return _lid_fans; }
+
   private:
     double _power = 0.0F;
+    bool _lid_fans = false;
 };

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -400,6 +400,11 @@ struct GetFrontButtonResponse {
     bool button_pressed;
 };
 
+struct SetLidFansMessage {
+    uint32_t id;
+    bool enable;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage,
@@ -421,12 +426,11 @@ using ThermalPlateMessage =
                    SetPIDConstantsMessage, SetFanAutomaticMessage,
                    GetThermalPowerMessage, SetOffsetConstantsMessage,
                    GetOffsetConstantsMessage, DeactivateAllMessage>;
-using LidHeaterMessage =
-    ::std::variant<std::monostate, LidTempReadComplete,
-                   GetLidTemperatureDebugMessage, SetHeaterDebugMessage,
-                   GetLidTempMessage, SetLidTemperatureMessage,
-                   DeactivateLidHeatingMessage, SetPIDConstantsMessage,
-                   GetThermalPowerMessage, DeactivateAllMessage>;
+using LidHeaterMessage = ::std::variant<
+    std::monostate, LidTempReadComplete, GetLidTemperatureDebugMessage,
+    SetHeaterDebugMessage, GetLidTempMessage, SetLidTemperatureMessage,
+    DeactivateLidHeatingMessage, SetPIDConstantsMessage, GetThermalPowerMessage,
+    DeactivateAllMessage, SetLidFansMessage>;
 using MotorMessage = ::std::variant<
     std::monostate, ActuateSolenoidMessage, LidStepperDebugMessage,
     LidStepperComplete, SealStepperDebugMessage, SealStepperComplete,

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/lid_heater_policy.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/lid_heater_policy.cpp
@@ -15,3 +15,8 @@ auto LidHeaterPolicy::set_heater_power(double power) -> bool {
 [[nodiscard]] auto LidHeaterPolicy::get_heater_power() const -> double {
     return thermal_heater_get_power();
 }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto LidHeaterPolicy::set_lid_fans(bool enable) -> void {
+    return thermal_heater_set_lid_fans(enable);
+}

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_heater_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_heater_hardware.c
@@ -24,6 +24,9 @@
 // PWM should be scaled from 0 to MAX_PWM, inclusive
 #define MAX_PWM (TIM15_RELOAD + 1)
 
+#define LID_FAN_ENABLE_PORT (GPIOF)
+#define LID_FAN_ENABLE_PIN (GPIO_PIN_9)
+
 // Private typedefs
 
 struct Heater {
@@ -69,6 +72,7 @@ void thermal_heater_initialize(void) {
 
     __GPIOA_CLK_ENABLE();
     __GPIOD_CLK_ENABLE();
+    __GPIOF_CLK_ENABLE();
 
     // Disable the enable pin first
     GPIO_InitStruct.Pin = _heater.enable_pin;
@@ -128,7 +132,14 @@ void thermal_heater_initialize(void) {
     GPIO_InitStruct.Alternate = GPIO_AF9_TIM15;
     HAL_GPIO_Init(HEATER_PWM_GPIO_Port, &GPIO_InitStruct);
 
+    // Initialize the GPIO for the lid fans
+    GPIO_InitStruct.Pin = LID_FAN_ENABLE_PIN;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    HAL_GPIO_Init(LID_FAN_ENABLE_PORT, &GPIO_InitStruct);
+
     _heater.initialized = true;
+
+    thermal_heater_set_lid_fans(false);
 }
 
 
@@ -165,6 +176,12 @@ bool thermal_heater_set_power(double power) {
 double thermal_heater_get_power(void) {
     return _heater.power;
 }
+
+void thermal_heater_set_lid_fans(bool enable) {
+    HAL_GPIO_WritePin(LID_FAN_ENABLE_PORT, LID_FAN_ENABLE_PIN,
+        enable ? GPIO_PIN_SET : GPIO_PIN_RESET);
+}
+
 
 // Local function implementations
 

--- a/stm32-modules/thermocycler-gen2/simulator/lid_heater_thread.cpp
+++ b/stm32-modules/thermocycler-gen2/simulator/lid_heater_thread.cpp
@@ -12,6 +12,7 @@ using namespace lid_heater_thread;
 class SimLidHeaterPolicy {
   private:
     double _power = 0.0F;
+    bool _lid_fans = false;
     std::shared_ptr<periodic_data_thread::PeriodicDataThread> _periodic_data;
 
   public:
@@ -27,6 +28,8 @@ class SimLidHeaterPolicy {
     }
 
     auto get_heater_power() const -> double { return _power; }
+
+    auto set_lid_fans(bool enable) -> void { _lid_fans = enable; }
 };
 
 struct lid_heater_thread::TaskControlBlock {

--- a/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_m900d.cpp 
     test_m901d.cpp 
     test_m902d.cpp
+    test_m903d.cpp
 )
 
 target_include_directories(${TARGET_MODULE_NAME} 

--- a/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
@@ -2453,6 +2453,60 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                 }
             }
         }
+        WHEN("sending a SetLidFans message") {
+            auto message_text = std::string("M903.D S1\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the lid task "
+                "and not immediately ack") {
+                REQUIRE(tasks->get_lid_heater_queue().has_message());
+                auto lid_message =
+                    tasks->get_lid_heater_queue().backing_deque.front();
+                auto fan_message =
+                    std::get<messages::SetLidFansMessage>(lid_message);
+                tasks->get_lid_heater_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::AcknowledgePrevious{
+                        .responding_to_id = fan_message.id};
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(
+                            tx_buf, Catch::Matchers::StartsWith("M903.D OK\n"));
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending a bad response back to the comms task") {
+                    auto response = messages::AcknowledgePrevious{
+                        .responding_to_id = fan_message.id + 1};
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/stm32-modules/thermocycler-gen2/tests/test_m903d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m903d.cpp
@@ -1,0 +1,69 @@
+#include <array>
+
+#include "catch2/catch.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-gen2/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("GetLidTemperatureDebug (M903.D) parser works",
+         "[gcode][parse][M903.d]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetLidFans::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::StartsWith("M903.D OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetLidFans::write_response_into(
+                buffer.begin(), buffer.begin() + 7);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M903.D ccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("valid input to enable fans") {
+        std::string input = "M903.D S1\n";
+        WHEN("parsing input") {
+            auto result = gcode::SetLidFans::parse(input.begin(), input.end());
+            THEN("parsing is succesful") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.second != input.begin());
+                REQUIRE(result.first.value().enable);
+            }
+        }
+    }
+    GIVEN("valid input to disable fans") {
+        std::string input = "M903.D S0\n";
+        WHEN("parsing input") {
+            auto result = gcode::SetLidFans::parse(input.begin(), input.end());
+            THEN("parsing is succesful") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.second != input.begin());
+                REQUIRE(!result.first.value().enable);
+            }
+        }
+    }
+    GIVEN("invalid input") {
+        std::string input = GENERATE("M903.D S\n", "M903.D\n");
+        WHEN("parsing input") {
+            auto result = gcode::SetLidFans::parse(input.begin(), input.end());
+            THEN("parsing is not succesful") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == input.begin());
+            }
+        }
+    }
+}


### PR DESCRIPTION
The lid fan output driver is unused in the current Thermocycler Gen2 design, but incoming PCB tests will test that the output can be driven correctly. This PR adds a command (M903.D) to set the fans enabled or disabled, as well as the firmware required to enable or disable the lid fan LDO.

Tested on a board that the output is 0.0V on startup, can be set to 3.0V (the configured output of the LDO), and can be reset back to 0.0V with the M903.D command.