### PR TITLE
feat(thermocycler-gen2): light strip debug command

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -1740,4 +1740,52 @@ struct SetLidFans {
     }
 };
 
+/**
+ * @brief SetLightsDebug sets the output of the lights to a fully bright
+ * white setting. This is used for checking that the light strip is pulling
+ * the correct amount of current.
+ *
+ * The only parameter is whether to set the light debug mode on or off
+ * (1 or 0)
+ *
+ * M904.D S[value]\n
+ *
+ */
+struct SetLightsDebug {
+    using ParseResult = std::optional<SetLightsDebug>;
+    static constexpr auto prefix = std::array{'M', '9', '0', '4', '.', 'D'};
+    static constexpr const char* response = "M904.D OK\n";
+
+    struct SetArg {
+        static constexpr auto prefix = std::array{'S'};
+        static constexpr bool required = true;
+        bool present = false;
+        int value = 0;
+    };
+
+    bool enable;
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto res =
+            gcode::SingleParser<SetArg>::parse_gcode(input, limit, prefix);
+        if (!res.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+        auto arguments = res.first.value();
+        auto ret = SetLightsDebug{.enable = std::get<0>(arguments).value > 0};
+        return std::make_pair(ret, res.second);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+};
+
 }  // namespace gcode

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -51,7 +51,8 @@ class HostCommsTask {
         gcode::GetThermalPowerDebug, gcode::SetOffsetConstants,
         gcode::GetOffsetConstants, gcode::OpenLid, gcode::CloseLid,
         gcode::LiftPlate, gcode::DeactivateAll, gcode::GetBoardRevision,
-        gcode::GetLidSwitches, gcode::GetFrontButton, gcode::SetLidFans>;
+        gcode::GetLidSwitches, gcode::GetFrontButton, gcode::SetLidFans,
+        gcode::SetLightsDebug>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::ActuateSolenoid, gcode::ActuateLidStepperDebug,
@@ -61,7 +62,7 @@ class HostCommsTask {
                  gcode::SetPlateTemperature, gcode::DeactivatePlate,
                  gcode::SetFanAutomatic, gcode::SetSealParameter,
                  gcode::SetOffsetConstants, gcode::OpenLid, gcode::CloseLid,
-                 gcode::LiftPlate, gcode::SetLidFans>;
+                 gcode::LiftPlate, gcode::SetLidFans, gcode::SetLightsDebug>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetLidTempDebugCache = AckCache<8, gcode::GetLidTemperatureDebug>;
     using GetPlateTempDebugCache = AckCache<8, gcode::GetPlateTemperatureDebug>;
@@ -1465,6 +1466,29 @@ class HostCommsTask {
         auto message =
             messages::SetLidFansMessage{.id = id, .enable = gcode.enable};
         if (!task_registry->lid_heater->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::SetLightsDebug& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message =
+            messages::SetLightsDebugMessage{.id = id, .enable = gcode.enable};
+        if (!task_registry->system->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -405,11 +405,17 @@ struct SetLidFansMessage {
     bool enable;
 };
 
+struct SetLightsDebugMessage {
+    uint32_t id;
+    bool enable;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage,
                    UpdateUIMessage, SetLedMode, UpdateTaskErrorState,
-                   UpdatePlateState, GetFrontButtonMessage, UpdateMotorState>;
+                   UpdatePlateState, GetFrontButtonMessage, UpdateMotorState,
+                   SetLightsDebugMessage>;
 using HostCommsMessage = ::std::variant<
     std::monostate, IncomingMessageFromHost, AcknowledgePrevious, ErrorMessage,
     ForceUSBDisconnectMessage, GetSystemInfoResponse,

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
@@ -495,6 +495,7 @@ class SystemTask {
     template <SystemExecutionPolicy Policy>
     auto visit_message(const messages::SetLightsDebugMessage& message,
                        Policy& policy) {
+        std::ignore = policy;
         auto response =
             messages::AcknowledgePrevious{.responding_to_id = message.id};
         _light_debug_mode = message.enable;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
@@ -237,7 +237,8 @@ class SystemTask {
           _motor_state(MotorState::IDLE),
           _front_button_pulse(FRONT_BUTTON_MAX_PULSE),
           // NOLINTNEXTLINE(readability-redundant-member-init)
-          _front_button_blink() {}
+          _front_button_blink(),
+          _light_debug_mode(false) {}
     SystemTask(const SystemTask& other) = delete;
     auto operator=(const SystemTask& other) -> SystemTask& = delete;
     SystemTask(SystemTask&& other) noexcept = delete;
@@ -491,6 +492,16 @@ class SystemTask {
             _task_registry->comms->get_message_queue().try_send(response));
     }
 
+    template <SystemExecutionPolicy Policy>
+    auto visit_message(const messages::SetLightsDebugMessage& message,
+                       Policy& policy) {
+        auto response =
+            messages::AcknowledgePrevious{.responding_to_id = message.id};
+        _light_debug_mode = message.enable;
+        static_cast<void>(
+            _task_registry->comms->get_message_queue().try_send(response));
+    }
+
     template <typename Policy>
     requires SystemExecutionPolicy<Policy>
     auto visit_message(const std::monostate& message, Policy& policy) -> void {
@@ -534,6 +545,13 @@ class SystemTask {
     // Update current state of the UI based on task errors and plate action
     auto update_led_mode_from_system() -> void {
         using namespace colors;
+
+        if (_light_debug_mode) {
+            _led_state.color = get_color(Colors::WHITE);
+            _led_state.mode = Mode::SOLID;
+            return;
+        }
+
         if (_plate_error != errors::ErrorCode::NO_ERROR ||
             _lid_error != errors::ErrorCode::NO_ERROR ||
             _motor_error != errors::ErrorCode::NO_ERROR) {
@@ -580,6 +598,8 @@ class SystemTask {
     std::atomic<MotorState> _motor_state;
     Pulse _front_button_pulse;
     FrontButtonBlink _front_button_blink;
+    // If this is true, set the LED's to all-white no matter what.
+    bool _light_debug_mode;
 };
 
 };  // namespace system_task

--- a/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_m901d.cpp 
     test_m902d.cpp
     test_m903d.cpp
+    test_m904d.cpp
 )
 
 target_include_directories(${TARGET_MODULE_NAME} 

--- a/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
@@ -2507,6 +2507,60 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                 }
             }
         }
+        WHEN("sending a SetLightsDebug message") {
+            auto message_text = std::string("M904.D S1\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            auto written_firstpass = tasks->get_host_comms_task().run_once(
+                tx_buf.begin(), tx_buf.end());
+            THEN(
+                "the task should pass the message on to the lid task "
+                "and not immediately ack") {
+                REQUIRE(tasks->get_system_queue().has_message());
+                auto system_message =
+                    tasks->get_system_queue().backing_deque.front();
+                auto lights_message =
+                    std::get<messages::SetLightsDebugMessage>(system_message);
+                tasks->get_system_queue().backing_deque.pop_front();
+                REQUIRE(written_firstpass == tx_buf.begin());
+                REQUIRE(tasks->get_host_comms_queue().backing_deque.empty());
+                AND_WHEN("sending a good response back to the comms task") {
+                    auto response = messages::AcknowledgePrevious{
+                        .responding_to_id = lights_message.id};
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN("the task should ack the previous message") {
+                        REQUIRE_THAT(
+                            tx_buf, Catch::Matchers::StartsWith("M904.D OK\n"));
+                        REQUIRE(written_secondpass != tx_buf.begin());
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("sending a bad response back to the comms task") {
+                    auto response = messages::AcknowledgePrevious{
+                        .responding_to_id = lights_message.id + 1};
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response);
+                    auto written_secondpass =
+                        tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                              tx_buf.end());
+                    THEN(
+                        "the task should pull the message and print an error") {
+                        REQUIRE(written_secondpass > tx_buf.begin());
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/stm32-modules/thermocycler-gen2/tests/test_m904d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m904d.cpp
@@ -1,0 +1,71 @@
+#include <array>
+
+#include "catch2/catch.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-gen2/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("SetLightsDebug (M904.D) parser works", "[gcode][parse][M904.d]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetLightsDebug::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::StartsWith("M904.D OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetLightsDebug::write_response_into(
+                buffer.begin(), buffer.begin() + 7);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M904.D ccccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("valid input to enable fans") {
+        std::string input = "M904.D S1\n";
+        WHEN("parsing input") {
+            auto result =
+                gcode::SetLightsDebug::parse(input.begin(), input.end());
+            THEN("parsing is succesful") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.second != input.begin());
+                REQUIRE(result.first.value().enable);
+            }
+        }
+    }
+    GIVEN("valid input to disable fans") {
+        std::string input = "M904.D S0\n";
+        WHEN("parsing input") {
+            auto result =
+                gcode::SetLightsDebug::parse(input.begin(), input.end());
+            THEN("parsing is succesful") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.second != input.begin());
+                REQUIRE(!result.first.value().enable);
+            }
+        }
+    }
+    GIVEN("invalid input") {
+        std::string input = GENERATE("M904.D S\n", "M904.D\n");
+        WHEN("parsing input") {
+            auto result =
+                gcode::SetLightsDebug::parse(input.begin(), input.end());
+            THEN("parsing is not succesful") {
+                REQUIRE(!result.first.has_value());
+                REQUIRE(result.second == input.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-gen2/tests/test_system_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_system_task.cpp
@@ -297,6 +297,34 @@ SCENARIO("system task message passing") {
                     REQUIRE(led.color ==
                             colors::get_color(colors::Colors::RED));
                 }
+                AND_WHEN("setting debug mode") {
+                    auto dbg_msg = messages::SetLightsDebugMessage{
+                        .id = 123, .enable = true};
+                    tasks->get_system_queue().backing_deque.push_back(dbg_msg);
+                    tasks->get_system_task().run_once(
+                        tasks->get_system_policy());
+                    tasks->get_system_queue().backing_deque.push_back(
+                        messages::SystemMessage(messages::UpdateUIMessage()));
+                    tasks->get_system_task().run_once(
+                        tasks->get_system_policy());
+                    THEN("the task should set the LED outputs to solid white") {
+                        auto &led = tasks->get_system_task().get_led_state();
+                        REQUIRE(led.mode == colors::Mode::SOLID);
+                        REQUIRE(led.color ==
+                                colors::get_color(colors::Colors::WHITE));
+                    }
+                    THEN("the system task should ack the message") {
+                        REQUIRE(tasks->get_host_comms_queue().has_message());
+                        auto host_msg =
+                            tasks->get_host_comms_queue().backing_deque.front();
+                        REQUIRE(std::holds_alternative<
+                                messages::AcknowledgePrevious>(host_msg));
+                        auto ack =
+                            std::get<messages::AcknowledgePrevious>(host_msg);
+                        REQUIRE(ack.responding_to_id == dbg_msg.id);
+                        REQUIRE(ack.with_error == errors::ErrorCode::NO_ERROR);
+                    }
+                }
             }
         }
         WHEN("sending a UpdatePlateStatus message with a cooling plate") {
@@ -316,6 +344,34 @@ SCENARIO("system task message passing") {
                     REQUIRE(led.color ==
                             colors::get_color(colors::Colors::BLUE));
                 }
+                AND_WHEN("setting debug mode") {
+                    auto dbg_msg = messages::SetLightsDebugMessage{
+                        .id = 123, .enable = true};
+                    tasks->get_system_queue().backing_deque.push_back(dbg_msg);
+                    tasks->get_system_task().run_once(
+                        tasks->get_system_policy());
+                    tasks->get_system_queue().backing_deque.push_back(
+                        messages::SystemMessage(messages::UpdateUIMessage()));
+                    tasks->get_system_task().run_once(
+                        tasks->get_system_policy());
+                    THEN("the task should set the LED outputs to solid white") {
+                        auto &led = tasks->get_system_task().get_led_state();
+                        REQUIRE(led.mode == colors::Mode::SOLID);
+                        REQUIRE(led.color ==
+                                colors::get_color(colors::Colors::WHITE));
+                    }
+                    THEN("the system task should ack the message") {
+                        REQUIRE(tasks->get_host_comms_queue().has_message());
+                        auto host_msg =
+                            tasks->get_host_comms_queue().backing_deque.front();
+                        REQUIRE(std::holds_alternative<
+                                messages::AcknowledgePrevious>(host_msg));
+                        auto ack =
+                            std::get<messages::AcknowledgePrevious>(host_msg);
+                        REQUIRE(ack.responding_to_id == dbg_msg.id);
+                        REQUIRE(ack.with_error == errors::ErrorCode::NO_ERROR);
+                    }
+                }
             }
         }
         WHEN("sending a UpdatePlateStatus message with plate at cool temp") {
@@ -334,6 +390,34 @@ SCENARIO("system task message passing") {
                     REQUIRE(led.mode == colors::Mode::SOLID);
                     REQUIRE(led.color ==
                             colors::get_color(colors::Colors::BLUE));
+                }
+                AND_WHEN("setting debug mode") {
+                    auto dbg_msg = messages::SetLightsDebugMessage{
+                        .id = 123, .enable = true};
+                    tasks->get_system_queue().backing_deque.push_back(dbg_msg);
+                    tasks->get_system_task().run_once(
+                        tasks->get_system_policy());
+                    tasks->get_system_queue().backing_deque.push_back(
+                        messages::SystemMessage(messages::UpdateUIMessage()));
+                    tasks->get_system_task().run_once(
+                        tasks->get_system_policy());
+                    THEN("the task should set the LED outputs to solid white") {
+                        auto &led = tasks->get_system_task().get_led_state();
+                        REQUIRE(led.mode == colors::Mode::SOLID);
+                        REQUIRE(led.color ==
+                                colors::get_color(colors::Colors::WHITE));
+                    }
+                    THEN("the system task should ack the message") {
+                        REQUIRE(tasks->get_host_comms_queue().has_message());
+                        auto host_msg =
+                            tasks->get_host_comms_queue().backing_deque.front();
+                        REQUIRE(std::holds_alternative<
+                                messages::AcknowledgePrevious>(host_msg));
+                        auto ack =
+                            std::get<messages::AcknowledgePrevious>(host_msg);
+                        REQUIRE(ack.responding_to_id == dbg_msg.id);
+                        REQUIRE(ack.with_error == errors::ErrorCode::NO_ERROR);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adds command M904.D, which is intended for integration with the ICT fixture to verify LED strip connectivity. When the command enables the LED Debug Mode, the lights stay on in the White setting until the command disables this mode. The debug mode takes precedence over any other statuses in order to ensure the setting on the LED's will be predictable.

Tested on a unit that, when the debug mode is enabled, setting plate temperature or having an error doesn't change the LED color.