### PR TITLE
chore(thermocycler-gen2, tempdeck-gen3): remove sha from generated version

### DIFF
--- a/stm32-modules/tempdeck-gen3/src/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/src/CMakeLists.txt
@@ -29,7 +29,7 @@ execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --match "${TARGET_MODU
   OUTPUT_VARIABLE TAGNAME
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 if (NOT TAGNAME)
-  set(TAGNAME "@(dev)-")
+  set(TAGNAME "@(dev)")
 endif()
 
 string(REGEX MATCH "@.*$" PREPENDED_VERSION ${TAGNAME})
@@ -37,12 +37,8 @@ string(SUBSTRING "${PREPENDED_VERSION}" 1 -1 VERSION)
 if (NOT VERSION)
   set(VERSION "(dev)")
 endif()
-execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  OUTPUT_VARIABLE HASH
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-set(${TARGET_MODULE_NAME}_VERSION "${VERSION}-${HASH}")
+set(${TARGET_MODULE_NAME}_VERSION "${VERSION}")
 
 configure_file(./version.cpp.in ./version.cpp)
 

--- a/stm32-modules/thermocycler-gen2/src/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/src/CMakeLists.txt
@@ -28,7 +28,7 @@ execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --match "${TARGET_MODU
   OUTPUT_VARIABLE TAGNAME
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 if (NOT TAGNAME)
-  set(TAGNAME "@(dev)-")
+  set(TAGNAME "@(dev)")
 endif()
 
 string(REGEX MATCH "@.*$" PREPENDED_VERSION ${TAGNAME})
@@ -36,12 +36,8 @@ string(SUBSTRING "${PREPENDED_VERSION}" 1 -1 VERSION)
 if (NOT VERSION)
   set(VERSION "(dev)")
 endif()
-execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  OUTPUT_VARIABLE HASH
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-set(${TARGET_MODULE_NAME}_VERSION "${VERSION}-${HASH}")
+set(${TARGET_MODULE_NAME}_VERSION "${VERSION}")
 
 configure_file(./version.cpp.in ./version.cpp)
 


### PR DESCRIPTION
Copies the fix from #363 

Tested regenerating build files with a local tag, the version number is now just the tag's version number. If there's no tag, it's still the latest relevant version number with the correct suffix.