### PR TITLE
feat(thermocycler-gen2, startup): better hardfault handling

### DIFF
--- a/stm32-modules/common/module-startup/module-startup.S
+++ b/stm32-modules/common/module-startup/module-startup.S
@@ -88,6 +88,12 @@ Fault_Handler:
     ldr     r0, =Post_Fault_Handler
     str     r0, [sp,#0x18]
 
+    /* In case the PSR is in invalid state, force it to user mode*/
+    ldr r1, [sp,#0x1C]
+    and r1, r1, #0xFFFFFFF8
+    orr r1, r1, #0x8
+    str r1, [sp,#0x1C]
+
     /* LR should hold an EXC_RETURN code, but there is a chance that it is
      * either an invalid value, or simply marks exception behavior that we
      * don't want. We always want to return to Handler mode so the Fault

--- a/stm32-modules/common/module-startup/module-startup.S
+++ b/stm32-modules/common/module-startup/module-startup.S
@@ -90,8 +90,8 @@ Fault_Handler:
 
     /* In case the PSR is in invalid state, force it to user mode*/
     ldr r1, [sp,#0x1C]
-    and r1, r1, #0xFFFFFFF8
-    orr r1, r1, #0x8
+    and r1, r1, #0xFFFFFFF0
+    orr r1, r1, #0x10
     str r1, [sp,#0x1C]
 
     /* LR should hold an EXC_RETURN code, but there is a chance that it is

--- a/stm32-modules/include/thermocycler-gen2/firmware/system_hardware.h
+++ b/stm32-modules/include/thermocycler-gen2/firmware/system_hardware.h
@@ -59,6 +59,8 @@ void system_front_button_led_set(bool set);
  */
 void system_front_button_callback(void);
 
+void system_hardware_jump_from_exception(void) __attribute__((naked));
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/stm32-modules/thermocycler-gen2/firmware/system/stm32g4xx_it.c
+++ b/stm32-modules/thermocycler-gen2/firmware/system/stm32g4xx_it.c
@@ -22,6 +22,8 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32g4xx_it.h"
 
+#include "FreeRTOSConfig.h"
+
 #include "stm32g4xx_hal.h"
 #include "stm32g4xx_hal_tim.h"
 #include "stm32g4xx_hal_pcd.h"
@@ -67,9 +69,10 @@ void NMI_Handler(void) {}
  * @retval None
  */
 void HardFault_Handler(void) {
-    /* Go to infinite loop when Hard Fault exception occurs */
-    while (1) {
-    }
+    // If assertions are enabled, lock up here
+    configASSERT(false);
+    /* Go to bootloader when Hard Fault exception occurs */
+    system_hardware_jump_from_exception();
 }
 
 /**
@@ -78,9 +81,10 @@ void HardFault_Handler(void) {
  * @retval None
  */
 void MemManage_Handler(void) {
-    /* Go to infinite loop when Memory Manage exception occurs */
-    while (1) {
-    }
+    // If assertions are enabled, lock up here
+    configASSERT(false);
+    /* Go to bootloader when Memory Manage exception occurs */
+    system_hardware_jump_from_exception();
 }
 
 /**
@@ -89,9 +93,10 @@ void MemManage_Handler(void) {
  * @retval None
  */
 void BusFault_Handler(void) {
-    /* Go to infinite loop when Bus Fault exception occurs */
-    while (1) {
-    }
+    // If assertions are enabled, lock up here
+    configASSERT(false);
+    /* Go to bootloader when Bus Fault exception occurs */
+    system_hardware_jump_from_exception();
 }
 
 /**
@@ -100,9 +105,10 @@ void BusFault_Handler(void) {
  * @retval None
  */
 void UsageFault_Handler(void) {
-    /* Go to infinite loop when Usage Fault exception occurs */
-    while (1) {
-    }
+    // If assertions are enabled, lock up here
+    configASSERT(false);
+    /* Go to bootloader when Usage Fault exception occurs */
+    system_hardware_jump_from_exception();
 }
 
 /**

--- a/stm32-modules/thermocycler-gen2/firmware/system/stm32g4xx_it.h
+++ b/stm32-modules/thermocycler-gen2/firmware/system/stm32g4xx_it.h
@@ -32,10 +32,10 @@ extern "C" {
 /* Exported functions ------------------------------------------------------- */
 
 void NMI_Handler(void);
-void HardFault_Handler(void);
-void MemManage_Handler(void);
-void BusFault_Handler(void);
-void UsageFault_Handler(void);
+void HardFault_Handler(void) __attribute__((naked));
+void MemManage_Handler(void) __attribute__((naked));
+void BusFault_Handler(void) __attribute__((naked));
+void UsageFault_Handler(void) __attribute__((naked));
 void DebugMon_Handler(void);
 void USB_LP_IRQHandler(void);
 void TIM7_IRQHandler(void);

--- a/stm32-modules/thermocycler-gen2/firmware/system/system_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/system/system_hardware.c
@@ -93,6 +93,9 @@ void system_debug_led(int set)
     HAL_GPIO_WritePin(GPIOE, GPIO_PIN_6, state);
 }
 
+// WARNING: it is VITAL that this function never returns! It has the chance to
+// be invoked via PC overwrite in an exception handler, and if the function
+// ever returns then catastrophic errors will ensue.
 void system_hardware_enter_bootloader(void) {
 
     // We have to uninitialize as many of the peripherals as possible, because the bootloader

--- a/stm32-modules/thermocycler-gen2/firmware/system/system_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/system/system_hardware.c
@@ -176,7 +176,7 @@ void system_hardware_jump_from_exception(void) {
     //      assembly code is allowed.
     //   3. Update the execution mode of the PSR in the exception stack frame.
     //      If this is an invalid value, the processor will be locked forever,
-    //      so we force it to 0x8 for User Mode.
+    //      so we force it to 0x10 for User Mode.
     //   3. Ovewrite the link register with a known exception pattern, and
     //      then return to our overwritten PC value by bx'ing to it
     asm volatile (
@@ -194,8 +194,8 @@ void system_hardware_jump_from_exception(void) {
         "str r0, [sp,#0x18]\n"
         /* In case the PSR is in invalid state, force to user mode*/
         "ldr r1, [sp,#0x1C]\n"
-        "and r1, r1, #0xFFFFFFF8\n"
-        "orr r1, r1, #0x8\n"
+        "and r1, r1, #0xFFFFFFF0\n"
+        "orr r1, r1, #0x10\n"
         "str r1, [sp,#0x1C]\n"
         /* Leave the exception handler */
         "ldr lr,=0xFFFFFFF1\n"

--- a/stm32-modules/thermocycler-gen2/firmware/system/system_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/system/system_hardware.c
@@ -163,3 +163,46 @@ void system_front_button_callback(void) {
         }
     }
 }
+
+void system_hardware_jump_from_exception(void) {
+    // Okay, so we're in an exception (hard fault, bus fault, etc) and want to
+    // jump to the DFU bootloader. We are going to jump to the function for
+    // jumping to the bootloader, but to get there we have to exit this 
+    // exception context. In order to do this, we have to do a few things:
+    //   1. Clear the CFSR and HFSR status registers, or the bootloader will
+    //      refuse to run.
+    //   2. Update the PC in the exception stack frame. This step means that
+    //      we HAVE to run only naked function calls, which means nothing but
+    //      assembly code is allowed.
+    //   3. Update the execution mode of the PSR in the exception stack frame.
+    //      If this is an invalid value, the processor will be locked forever,
+    //      so we force it to 0x8 for User Mode.
+    //   3. Ovewrite the link register with a known exception pattern, and
+    //      then return to our overwritten PC value by bx'ing to it
+    asm volatile (
+        /* Clear CFSR register.*/
+        "ldr r0, =0xE000ED28\n"
+        "ldr r1, [r0]\n"
+        "str r1, [r0]\n"
+        /* Clear HFSR register.*/
+        "ldr r0, =0xE000ED2C\n"
+        "ldr r1, [r0]\n"
+        "str r1, [r0]\n"
+        /* Update the PC in the stack frame.*/
+        /* https://developer.arm.com/documentation/dui0552/a/the-cortex-m3-processor/exception-model/exception-entry-and-return */
+        "ldr r0, bootloader_address_const\n"
+        "str r0, [sp,#0x18]\n"
+        /* In case the PSR is in invalid state, force to user mode*/
+        "ldr r1, [sp,#0x1C]\n"
+        "and r1, r1, #0xFFFFFFF8\n"
+        "orr r1, r1, #0x8\n"
+        "str r1, [sp,#0x1C]\n"
+        /* Leave the exception handler */
+        "ldr lr,=0xFFFFFFF1\n"
+        "bx  lr\n"
+        "bootloader_address_const: .word system_hardware_enter_bootloader"
+        : // no outputs
+        : // no inputs
+        : "memory"  
+    );
+}


### PR DESCRIPTION
This PR adds functionality for the Thermocycler Gen2 firmware to jump to the bootloader after any fatal exceptions that occur during runtime.

If assertions are enabled (presumably for debugging purposes), the firmware locks up permanently in the fault handlers. Otherwise, an inline assembly function adjusts the exception stack frame & the exception handling registers and then returns to the function for entering the bootloader.

This PR also adds a small change to the startup shim; the Program Status Register execution mode wasn't being checked, and if it was in an invalid state then an endless loop of hardfaults would ensue.

Tested the application fault handling by adding a null-dereference to the code. With the new code, the firmware ends up enumerating as a DFU device over USB.