### PR TITLE
chore(all): add image-bin and zip targets, speed up CI

### DIFF
--- a/.github/workflows/heater-shaker-create-release.yaml
+++ b/.github/workflows/heater-shaker-create-release.yaml
@@ -28,13 +28,13 @@ jobs:
       - name: 'Configure'
         run: cmake --preset=stm32-cross .
       - name: 'Build'
-        run: cmake --build ./build-stm32-cross --target heater-shaker-hex
+        run: cmake --build --preset cross --target heater-shaker-hex
       - name: 'Build Combo Image Hex'
-        run: cmake --build ./build-stm32-cross --target heater-shaker-image-hex
+        run: cmake --build --preset cross --target heater-shaker-image-hex
       - name: 'Build Combo Image Binary'
-        run: cmake --build ./build-stm32-cross --target heater-shaker-image-bin
+        run: cmake --build --preset cross --target heater-shaker-image-bin
       - name: 'Build Combo Image Zip'
-        run: cmake --build ./build-stm32-cross --target heater-shaker-zip
+        run: cmake --build --preset cross --target heater-shaker-zip
       - name: 'Prep for install'
         run: cmake --install ./build-stm32-cross
       - if: github.event_name != 'pull_request'

--- a/.github/workflows/heater-shaker.yaml
+++ b/.github/workflows/heater-shaker.yaml
@@ -59,15 +59,15 @@ jobs:
       - name: 'Configure'
         run: cmake --preset=stm32-cross .
       - name: 'Format'
-        run: cmake --build ./build-stm32-cross --target heater-shaker-format-ci
+        run: cmake --build --preset cross --target heater-shaker-format-ci
       - name: 'Lint'
-        run: cmake --build ./build-stm32-cross --target heater-shaker-lint
+        run: cmake --build --preset cross --target heater-shaker-lint
       - name: 'Build'
-        run: cmake --build ./build-stm32-cross --target heater-shaker-hex
+        run: cmake --build --preset cross --target heater-shaker-hex
       - name: 'Build Combo Image Hex'
-        run: cmake --build ./build-stm32-cross --target heater-shaker-image-hex
+        run: cmake --build --preset cross --target heater-shaker-image-hex
       - name: 'Build Combo Image Binary'
-        run: cmake --build ./build-stm32-cross --target heater-shaker-image-bin
+        run: cmake --build --preset cross --target heater-shaker-image-bin
   host-compile-test:
     name: 'Host-Compile/Test'
     runs-on: 'ubuntu-20.04'
@@ -90,6 +90,6 @@ jobs:
       - name: 'Configure'
         run: cmake --preset=stm32-host .
       - name: 'Build Simulator'
-        run: cmake --build ./build-stm32-host --target heater-shaker-simulator
+        run: cmake --build --preset host --target heater-shaker-simulator
       - name: 'Build and Test'
-        run: cmake --build ./build-stm32-host --target heater-shaker-build-and-test
+        run: cmake --build --preset host --target heater-shaker-build-and-test

--- a/.github/workflows/stm32-common.yaml
+++ b/.github/workflows/stm32-common.yaml
@@ -56,13 +56,13 @@ jobs:
       - name: 'Configure'
         run: cmake --preset=stm32-cross .
       - name: 'Format'
-        run: cmake --build ./build-stm32-cross --target common-format-ci
+        run: cmake --build --preset cross --target common-format-ci
       - name: 'Lint'
-        run: cmake --build ./build-stm32-cross --target common-lint
+        run: cmake --build --preset cross --target common-lint
       - name: 'Build STM32F303 startup script'
-        run: cmake --build ./build-stm32-cross --target STM32F303-startup
+        run: cmake --build --preset cross --target STM32F303-startup
       - name: 'Build STM32G491 startup script'
-        run: cmake --build ./build-stm32-cross --target STM32G491-startup
+        run: cmake --build --preset cross --target STM32G491-startup
   host-compile-test:
     name: 'Host-Compile/Test'
     runs-on: 'ubuntu-20.04'
@@ -85,4 +85,4 @@ jobs:
       - name: 'Configure'
         run: cmake --preset=stm32-host .
       - name: 'Build and Test'
-        run: cmake --build ./build-stm32-host --target common-build-and-test
+        run: cmake --build --preset host --target common-build-and-test

--- a/.github/workflows/tempdeck-gen3.yaml
+++ b/.github/workflows/tempdeck-gen3.yaml
@@ -66,6 +66,8 @@ jobs:
         run: cmake --build --preset cross --target tempdeck-gen3-hex
       - name: 'Build full image'
         run: cmake --build --preset cross --target tempdeck-gen3-image-hex
+      - name: 'Build full image binary'
+        run: cmake --build --preset cross --target tempdeck-gen3-image-bin
   host-compile-test:
     name: 'Host-Compile/Test'
     runs-on: 'ubuntu-20.04'

--- a/.github/workflows/tempdeck-gen3.yaml
+++ b/.github/workflows/tempdeck-gen3.yaml
@@ -59,13 +59,13 @@ jobs:
       - name: 'Configure'
         run: cmake --preset=stm32-cross .
       - name: 'Format'
-        run: cmake --build ./build-stm32-cross --target tempdeck-gen3-format-ci
+        run: cmake --build --preset cross --target tempdeck-gen3-format-ci
       - name: 'Lint'
-        run: cmake --build ./build-stm32-cross --target tempdeck-gen3-lint
+        run: cmake --build --preset cross --target tempdeck-gen3-lint
       - name: 'Build'
-        run: cmake --build ./build-stm32-cross --target tempdeck-gen3-hex
+        run: cmake --build --preset cross --target tempdeck-gen3-hex
       - name: 'Build full image'
-        run: cmake --build ./build-stm32-cross --target tempdeck-gen3-image-hex
+        run: cmake --build --preset cross --target tempdeck-gen3-image-hex
   host-compile-test:
     name: 'Host-Compile/Test'
     runs-on: 'ubuntu-20.04'
@@ -88,6 +88,6 @@ jobs:
       - name: 'Configure'
         run: cmake --preset=stm32-host .
       - name: 'Build Simulator'
-        run: cmake --build ./build-stm32-host --target tempdeck-gen3-simulator
+        run: cmake --build --preset host --target tempdeck-gen3-simulator
       - name: 'Build and Test'
         run: cmake --build --preset tempdeck-gen3-tests

--- a/.github/workflows/thermocycler-gen2.yaml
+++ b/.github/workflows/thermocycler-gen2.yaml
@@ -66,6 +66,8 @@ jobs:
         run: cmake --build --preset cross --target thermocycler-gen2-hex
       - name: 'Build full image'
         run: cmake --build --preset cross --target thermocycler-gen2-image-hex
+      - name: 'Build full image binary'
+        run: cmake --build --preset cross --target thermocycler-gen2-image-bin
   host-compile-test:
     name: 'Host-Compile/Test'
     runs-on: 'ubuntu-20.04'

--- a/.github/workflows/thermocycler-gen2.yaml
+++ b/.github/workflows/thermocycler-gen2.yaml
@@ -59,13 +59,13 @@ jobs:
       - name: 'Configure'
         run: cmake --preset=stm32-cross .
       - name: 'Format'
-        run: cmake --build ./build-stm32-cross --target thermocycler-gen2-format-ci
+        run: cmake --build --preset cross --target thermocycler-gen2-format-ci
       - name: 'Lint'
-        run: cmake --build ./build-stm32-cross --target thermocycler-gen2-lint
+        run: cmake --build --preset cross --target thermocycler-gen2-lint
       - name: 'Build'
-        run: cmake --build ./build-stm32-cross --target thermocycler-gen2-hex
+        run: cmake --build --preset cross --target thermocycler-gen2-hex
       - name: 'Build full image'
-        run: cmake --build ./build-stm32-cross --target thermocycler-gen2-image-hex
+        run: cmake --build --preset cross --target thermocycler-gen2-image-hex
   host-compile-test:
     name: 'Host-Compile/Test'
     runs-on: 'ubuntu-20.04'
@@ -88,6 +88,6 @@ jobs:
       - name: 'Configure'
         run: cmake --preset=stm32-host .
       - name: 'Build Simulator'
-        run: cmake --build ./build-stm32-host --target thermocycler-gen2-simulator
+        run: cmake --build --preset host --target thermocycler-gen2-simulator
       - name: 'Build and Test'
         run: cmake --build --preset thermocycler-gen2-tests

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -70,6 +70,30 @@
     ],
     "buildPresets": [
         {
+            "name": "cross",
+            "displayName": "cross",
+            "description": "Base preset for cross-compilation",
+            "configurePreset": "stm32-cross",
+            "jobs": 8,
+            "targets": [
+                "thermocycler-gen2",
+                "heater-shaker",
+                "tempdeck-gen3"
+            ]
+        },
+        {
+            "name": "host",
+            "displayName": "host",
+            "description": "Base preset for host-compilation",
+            "configurePreset": "stm32-host",
+            "jobs": 8,
+            "targets": [
+                "thermocycler-gen2-build-and-test",
+                "heater-shaker-build-and-test",
+                "tempdeck-gen3-build-and-test"
+            ]
+        },
+        {
             "name": "thermocycler-gen2-binary",
             "displayName": "thermocycler gen2 binary",
             "description": "Build the thermocycler-gen2 cross binary",

--- a/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
@@ -186,15 +186,50 @@ add_custom_target(${TARGET_MODULE_NAME}-flash
   COMMENT "Flashing board"
   DEPENDS ${TARGET_MODULE_NAME})
 
+set(HEX_IMG_NAME "${TARGET_MODULE_NAME}-image@${${TARGET_MODULE_NAME}_VERSION}.hex")
+
+set(BIN_IMG_NAME "${TARGET_MODULE_NAME}-image@${${TARGET_MODULE_NAME}_VERSION}.bin")
+  
 # Targets to create full image hex file containing both bootloader and application
 add_custom_command(
-    OUTPUT ${TARGET_MODULE_NAME}-image.hex
+    OUTPUT ${HEX_IMG_NAME}
     DEPENDS $<TARGET_FILE_DIR:${TARGET_MODULE_NAME}>/${TARGET_MODULE_NAME}.hex
     DEPENDS STM32G491-startup-hex
     DEPENDS $<TARGET_FILE_DIR:STM32G491-startup>/STM32G491-startup.hex
-    COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py ${TARGET_MODULE_NAME}-image.hex $<TARGET_FILE_DIR:STM32G491-startup>/STM32G491-startup.hex ${TARGET_MODULE_NAME}.hex
+    COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py ${HEX_IMG_NAME} $<TARGET_FILE_DIR:STM32G491-startup>/STM32G491-startup.hex ${TARGET_MODULE_NAME}.hex
     VERBATIM
     COMMENT "Generating full image")
 add_custom_target(${TARGET_MODULE_NAME}-image-hex ALL
-    DEPENDS ${TARGET_MODULE_NAME}-image.hex
+    DEPENDS STM32G491-startup-hex
     DEPENDS ${TARGET_MODULE_NAME})
+
+add_custom_command(OUTPUT "${BIN_IMG_NAME}"
+    COMMAND ${CROSS_OBJCOPY} ARGS "-Iihex" "-Obinary" "${HEX_IMG_NAME}" "${BIN_IMG_NAME}"
+    DEPENDS "${HEX_IMG_NAME}"
+    VERBATIM)
+add_custom_target(${TARGET_MODULE_NAME}-image-bin ALL
+    DEPENDS "${BIN_IMG_NAME}")
+
+set(ZIP_NAME "${CMAKE_BINARY_DIR}/${TARGET_MODULE_NAME}@${${TARGET_MODULE_NAME}_VERSION}.zip")
+
+add_custom_command(
+    OUTPUT ${ZIP_NAME}
+    DEPENDS ${TARGET_MODULE_NAME}-image-hex
+    DEPENDS ${TARGET_MODULE_NAME}-image-bin
+    COMMAND ${CMAKE_COMMAND} -E tar c
+            "${ZIP_NAME}"
+            --format=zip
+            --
+            "${BIN_IMG_NAME}"
+            "${HEX_IMG_NAME}"
+    VERBATIM )
+    
+add_custom_target(${TARGET_MODULE_NAME}-zip
+    DEPENDS "${ZIP_NAME}" )
+    
+install(FILES
+    "${ZIP_NAME}"
+    "${BIN_IMG_NAME}"
+    "${HEX_IMG_NAME}"
+    DESTINATION "${TARGET_MODULE_NAME}" )
+      

--- a/stm32-modules/tempdeck-gen3/src/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/src/CMakeLists.txt
@@ -38,7 +38,7 @@ if (NOT VERSION)
   set(VERSION "(dev)")
 endif()
 
-set(${TARGET_MODULE_NAME}_VERSION "${VERSION}")
+set(${TARGET_MODULE_NAME}_VERSION "${VERSION}" CACHE STRING "${TARGET_MODULE_NAME} fw version" FORCE)
 
 configure_file(./version.cpp.in ./version.cpp)
 

--- a/stm32-modules/thermocycler-gen2/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/firmware/CMakeLists.txt
@@ -188,15 +188,50 @@ add_custom_target(${TARGET_MODULE_NAME}-flash
   COMMENT "Flashing board"
   DEPENDS ${TARGET_MODULE_NAME})
 
+set(HEX_IMG_NAME "${TARGET_MODULE_NAME}-image@${${TARGET_MODULE_NAME}_VERSION}.hex")
+
+set(BIN_IMG_NAME "${TARGET_MODULE_NAME}-image@${${TARGET_MODULE_NAME}_VERSION}.bin")
+
 # Targets to create full image hex file containing both bootloader and application
 add_custom_command(
-    OUTPUT ${TARGET_MODULE_NAME}-image.hex
+    OUTPUT ${HEX_IMG_NAME}
     DEPENDS $<TARGET_FILE_DIR:${TARGET_MODULE_NAME}>/${TARGET_MODULE_NAME}.hex
     DEPENDS STM32G491-startup-hex
     DEPENDS $<TARGET_FILE_DIR:STM32G491-startup>/STM32G491-startup.hex
-    COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py ${TARGET_MODULE_NAME}-image.hex $<TARGET_FILE_DIR:STM32G491-startup>/STM32G491-startup.hex ${TARGET_MODULE_NAME}.hex
+    COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py ${HEX_IMG_NAME} $<TARGET_FILE_DIR:STM32G491-startup>/STM32G491-startup.hex ${TARGET_MODULE_NAME}.hex
     VERBATIM
     COMMENT "Generating full image")
 add_custom_target(${TARGET_MODULE_NAME}-image-hex ALL
-    DEPENDS ${TARGET_MODULE_NAME}-image.hex
+    DEPENDS STM32G491-startup-hex
     DEPENDS ${TARGET_MODULE_NAME})
+
+add_custom_command(OUTPUT "${BIN_IMG_NAME}"
+    COMMAND ${CROSS_OBJCOPY} ARGS "-Iihex" "-Obinary" "${HEX_IMG_NAME}" "${BIN_IMG_NAME}"
+    DEPENDS "${HEX_IMG_NAME}"
+    VERBATIM)
+add_custom_target(${TARGET_MODULE_NAME}-image-bin ALL
+    DEPENDS "${BIN_IMG_NAME}")
+
+set(ZIP_NAME "${CMAKE_BINARY_DIR}/${TARGET_MODULE_NAME}@${${TARGET_MODULE_NAME}_VERSION}.zip")
+
+add_custom_command(
+    OUTPUT ${ZIP_NAME}
+    DEPENDS ${TARGET_MODULE_NAME}-image-hex
+    DEPENDS ${TARGET_MODULE_NAME}-image-bin
+    COMMAND ${CMAKE_COMMAND} -E tar c
+            "${ZIP_NAME}"
+            --format=zip
+            --
+            "${BIN_IMG_NAME}"
+            "${HEX_IMG_NAME}"
+    VERBATIM )
+    
+add_custom_target(${TARGET_MODULE_NAME}-zip
+    DEPENDS "${ZIP_NAME}" )
+    
+install(FILES
+    "${ZIP_NAME}"
+    "${BIN_IMG_NAME}"
+    "${HEX_IMG_NAME}"
+    DESTINATION "${TARGET_MODULE_NAME}" )
+      

--- a/stm32-modules/thermocycler-gen2/src/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/src/CMakeLists.txt
@@ -37,7 +37,7 @@ if (NOT VERSION)
   set(VERSION "(dev)")
 endif()
 
-set(${TARGET_MODULE_NAME}_VERSION "${VERSION}")
+set(${TARGET_MODULE_NAME}_VERSION "${VERSION}" CACHE STRING "${TARGET_MODULE_NAME} fw version" FORCE)
 
 configure_file(./version.cpp.in ./version.cpp)
 


### PR DESCRIPTION
* Adds targets `-image-bin` and `-zip` for thermocycler-gen2 and tempdeck-gen3
* Parallelizes compilation for host & cross builds for all stm32 targets to speed up CI. This doesn't help much with the cross compilation since most of the time is actually spent in the linter, but it helps a bit with host compilation