### PR TITLE
chore(startup): allocate more space for startup app

### DIFF
--- a/stm32-modules/common/STM32F303/STM32F303RETx_FLASH.ld
+++ b/stm32-modules/common/STM32F303/STM32F303RETx_FLASH.ld
@@ -39,7 +39,7 @@ __stack = _estack;
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
 
-_flash_offset = 0x800; /* first page is occupied by bootloader shim */
+_flash_offset = 32K; /* first 32K is occupied by bootloader shim */
 _flash_start = 0x8000000;
 _app_flash_start  = _flash_start + _flash_offset;
 _flash_size = 512K;

--- a/stm32-modules/common/STM32G491/STM32G491VETx_FLASH.ld
+++ b/stm32-modules/common/STM32G491/STM32G491VETx_FLASH.ld
@@ -58,7 +58,7 @@ _estack = ORIGIN(RAM) + LENGTH(RAM);	/* end of "RAM" Ram type memory */
 _Min_Heap_Size = 0x800;	/* required amount of heap  */
 _Min_Stack_Size = 0x600;	/* required amount of stack */
 
-_flash_offset = 0x800; /* first page is occupied by bootloader shim */
+_flash_offset = 32K; /* first 32K is occupied by bootloader shim */
 _flash_start = 0x8000000;
 _app_flash_start  = _flash_start + _flash_offset;
 _flash_size = 512K;

--- a/stm32-modules/common/module-startup/STM32_MODULE_STARTUP.ld
+++ b/stm32-modules/common/module-startup/STM32_MODULE_STARTUP.ld
@@ -54,7 +54,7 @@ _Min_Stack_Size = 0;	/* required amount of stack */
 /* Starting address of flash region.*/
 _flash_start = 0x8000000;
 /* User application start.*/
-_user_app_offset = 0x800;
+_user_app_offset = 32K;
 _user_app_start = _flash_start + _user_app_offset + 0x4;
 /* Bootloader memory address.*/
 _sysmem_start = 0x1FFF0000;
@@ -67,7 +67,7 @@ MEMORY
      * than enough for this application.
      */
     RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 32K 
-    /* Only the first page is populated.*/
+    /* First 32K of flash.*/
     FLASH (rx)     : ORIGIN = _flash_start,  LENGTH = _user_app_offset
 }
 

--- a/stm32-modules/heater-shaker/firmware/system/system_stm32f3xx.c
+++ b/stm32-modules/heater-shaker/firmware/system/system_stm32f3xx.c
@@ -115,7 +115,7 @@
 #else
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
-#define VECT_TAB_OFFSET         0x00000800U     /*!< Vector Table base offset field.
+#define VECT_TAB_OFFSET         0x8000     /*!< Vector Table base offset field.
                                                      This value must be a multiple of 0x200. */
 #endif /* VECT_TAB_SRAM */
 #endif /* USER_VECT_TAB_ADDRESS */

--- a/stm32-modules/tempdeck-gen3/firmware/system/system_stm32g4xx.c
+++ b/stm32-modules/tempdeck-gen3/firmware/system/system_stm32g4xx.c
@@ -110,7 +110,7 @@
      Internal SRAM. */
 /* #define VECT_TAB_SRAM */
 
-#define VECT_TAB_OFFSET (0x800) 
+#define VECT_TAB_OFFSET (0x8000) 
             /*!< Vector Table base offset field. \
               This value must be a multiple of 0x200. */
 /******************************************************************************/

--- a/stm32-modules/thermocycler-gen2/firmware/system/system_stm32g4xx.c
+++ b/stm32-modules/thermocycler-gen2/firmware/system/system_stm32g4xx.c
@@ -110,7 +110,7 @@
      Internal SRAM. */
 /* #define VECT_TAB_SRAM */
 
-#define VECT_TAB_OFFSET (0x800) 
+#define VECT_TAB_OFFSET (0x8000) 
             /*!< Vector Table base offset field. \
               This value must be a multiple of 0x200. */
 /******************************************************************************/


### PR DESCRIPTION
Changes the linker settings for the startup app to allocate 32K, or the first 16 pages of memory. Also changes the linkage for the applications and accordingly changes the vector table relocation to match.

Tested that programming the new combined .bin still lets the startup app and the main application work fine. Linker output confirms that the region size for the startup app is increased and the main app is decreased.