### PR TITLE
feat(all): startup app CRC validation

### DIFF
--- a/scripts/calculate_checksum.py
+++ b/scripts/calculate_checksum.py
@@ -13,8 +13,6 @@ import zlib # for crc calc
 import sys
 from pathlib import Path
 
-INITIAL_CRC = 0xFFFFFFFF
-
 class HexRecord:
     """Represents a single record in a hex file."""
     PATTERN = re.compile(r"^:([A-F0-9]{2})([A-F0-9]{4})(\d{2})([A-F0-9]*)([A-F0-9]{2})$")
@@ -191,7 +189,7 @@ class BinInfo:
             bin_file.seek(self._start_offset)
             data = bin_file.read()
             self._size = len(data)
-            self._crc = zlib.crc32(data, INITIAL_CRC) & 0xffffffff
+            self._crc = zlib.crc32(data) & 0xffffffff
             
     def crc(self) -> int:
         return self._crc

--- a/stm32-modules/common/STM32F303/CMakeLists.txt
+++ b/stm32-modules/common/STM32F303/CMakeLists.txt
@@ -4,6 +4,7 @@ find_package(GDBSVDTools)
 
 # Fills in the template with values specified by the find_package(OpenOCD) call above
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gdbinit.template ./gdbinit)
+set(GDBINIT_PATH "${CMAKE_CURRENT_BINARY_DIR}/gdbinit")
 
 set(STM_HAL_PREFIX "stm32f3xx")
 configure_file(
@@ -56,3 +57,28 @@ target_sources(STM32F303-startup PUBLIC
 # Link to the F303
 target_link_libraries(STM32F303-startup PUBLIC
     STM32F303BSP_Drivers_startup)
+
+# Startup Debug target
+find_program(ARM_GDB
+    arm-none-eabi-gdb-py
+    PATHS "${CrossGCC_BINDIR}"
+    NO_DEFAULT_PATH
+    REQUIRED)
+message(STATUS "Found svd exe at ${GDBSVDTools_gdbsvd_EXECUTABLE}")
+# Configure gdb (full path to cross-gdb set in the toolchain) to use the gdbinit in
+# this dir
+set_target_properties(STM32F303-startup
+    PROPERTIES
+    CROSSCOMPILING_EMULATOR
+    "${ARM_GDB};--command=${GDBINIT_PATH}")
+# Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
+# arguable misuse of the concept) to the appropriate cross-gdb with
+# remote-target. You should make sure st-util is running; that's not
+# done here because it won't be multi-os compatible, and also it
+# should be running the entire time and that's tough to accomplish
+# in a custom command
+add_custom_target(STM32F303-startup-debug
+    COMMENT "Starting gdb and openocd"
+    COMMAND STM32F303-startup
+    USES_TERMINAL
+    )

--- a/stm32-modules/common/STM32F303/CMakeLists.txt
+++ b/stm32-modules/common/STM32F303/CMakeLists.txt
@@ -53,7 +53,8 @@ add_executable(STM32F303-startup)
 target_module_startup(STM32F303-startup)
 
 target_sources(STM32F303-startup PUBLIC 
-    startup_stm32f303xe.s)
+    startup_stm32f303xe.s
+    startup_system_stm32f3xx.c)
 # Link to the F303
 target_link_libraries(STM32F303-startup PUBLIC
     STM32F303BSP_Drivers_startup)

--- a/stm32-modules/common/STM32F303/startup_hal.h
+++ b/stm32-modules/common/STM32F303/startup_hal.h
@@ -6,8 +6,11 @@
 #ifndef STARTUP_HAL_H_
 #define STARTUP_HAL_H_
 
+#include "startup_system_stm32f3xx.h"
 #include "stm32f3xx_hal.h"
+#include "stm32f3xx_hal_conf.h"
 #include "stm32f3xx_hal_cortex.h"
+#include "stm32f3xx_hal_crc.h"
 #include "stm32f3xx_hal_rcc.h"
 
 #define SYSMEM_ADDRESS (0x1FFFD800)

--- a/stm32-modules/common/STM32F303/startup_system_stm32f3xx.c
+++ b/stm32-modules/common/STM32F303/startup_system_stm32f3xx.c
@@ -1,0 +1,275 @@
+
+#include "stm32f3xx.h"
+#include "stm32f3xx_hal.h"
+#include "startup_system_stm32f3xx.h"
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F3xx_System_Private_TypesDefinitions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F3xx_System_Private_Defines
+  * @{
+  */
+#if !defined  (HSE_VALUE) 
+  #define HSE_VALUE    ((uint32_t)8000000) /*!< Default value of the External oscillator in Hz.
+                                                This value can be provided and adapted by the user application. */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)8000000) /*!< Default value of the Internal oscillator in Hz.
+                                                This value can be provided and adapted by the user application. */
+#endif /* HSI_VALUE */
+
+/* Note: Following vector table addresses must be defined in line with linker
+         configuration. */
+/*!< Uncomment the following line if you need to relocate the vector table
+     anywhere in Flash or Sram, else the vector table is kept at the automatic
+     remap of boot address selected */
+#define USER_VECT_TAB_ADDRESS
+
+#if defined(USER_VECT_TAB_ADDRESS)
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done in Flash. */
+/* #define VECT_TAB_SRAM */
+#if defined(VECT_TAB_SRAM)
+#define VECT_TAB_BASE_ADDRESS   SRAM_BASE       /*!< Vector Table base address field.
+                                                     This value must be a multiple of 0x200. */
+#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
+                                                     This value must be a multiple of 0x200. */
+#else
+#define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
+                                                     This value must be a multiple of 0x200. */
+#define VECT_TAB_OFFSET         0     /*!< Vector Table base offset field.
+                                                     This value must be a multiple of 0x200. */
+#endif /* VECT_TAB_SRAM */
+#endif /* USER_VECT_TAB_ADDRESS */
+
+/******************************************************************************/
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F3xx_System_Private_Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F3xx_System_Private_Variables
+  * @{
+  */
+  /* This variable is updated in three ways:
+      1) by calling CMSIS function SystemCoreClockUpdate()
+      2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
+         Note: If you use this function to configure the system clock there is no need to
+               call the 2 first functions listed above, since SystemCoreClock variable is 
+               updated automatically.
+  */
+uint32_t SystemCoreClock = 8000000;
+
+const uint8_t AHBPrescTable[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
+const uint8_t APBPrescTable[8]  = {0, 0, 0, 0, 1, 2, 3, 4};
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F3xx_System_Private_FunctionPrototypes
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F3xx_System_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Setup the microcontroller system
+  * @param  None
+  * @retval None
+  */
+void SystemInit(void)
+{
+/* FPU settings --------------------------------------------------------------*/
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+  SCB->CPACR |= ((3UL << 10*2)|(3UL << 11*2));  /* set CP10 and CP11 Full Access */
+#endif
+
+  /* Configure the Vector Table location -------------------------------------*/
+#if defined(USER_VECT_TAB_ADDRESS)
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
+#endif /* USER_VECT_TAB_ADDRESS */
+}
+
+
+/**
+  * @brief  System Clock Configuration
+  *         The system Clock is configured as follow :
+  *            System Clock source            = PLL (HSE)
+  *            SYSCLK(Hz)                     = 72000000
+  *            HCLK(Hz)                       = 72000000
+  *            AHB Prescaler                  = 1
+  *            APB1 Prescaler                 = 2
+  *            APB2 Prescaler                 = 1
+  *            HSE Frequency(Hz)              = 8000000
+  *            PREDIV                         = RCC_PREDIV_DIV1 (1)
+  *            PLLMUL                         = RCC_PLL_MUL9 (9)
+  *            Flash Latency(WS)              = 2
+  * @param  None
+  * @retval None
+  */
+void SystemClock_Config(void)
+{
+  RCC_ClkInitTypeDef RCC_ClkInitStruct;
+  RCC_OscInitTypeDef RCC_OscInitStruct;
+
+  /* Enable HSE Oscillator and activate PLL with HSE as source */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+  RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+  RCC_OscInitStruct.PLL.PREDIV = RCC_PREDIV_DIV1;
+  RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL9;
+  HAL_RCC_OscConfig(&RCC_OscInitStruct);
+
+  /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2
+  clocks dividers */
+  RCC_ClkInitStruct.ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV2;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+  HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2);
+}
+
+
+/**
+   * @brief  Update SystemCoreClock variable according to Clock Register Values.
+  *         The SystemCoreClock variable contains the core clock (HCLK), it can
+  *         be used by the user application to setup the SysTick timer or configure
+  *         other parameters.
+  *
+  * @note   Each time the core clock (HCLK) changes, this function must be called
+  *         to update SystemCoreClock variable value. Otherwise, any configuration
+  *         based on this variable will be incorrect.
+  *
+  * @note   - The system frequency computed by this function is not the real
+  *           frequency in the chip. It is calculated based on the predefined
+  *           constant and the selected clock source:
+  *
+  *           - If SYSCLK source is HSI, SystemCoreClock will contain the HSI_VALUE(*)
+  *
+  *           - If SYSCLK source is HSE, SystemCoreClock will contain the HSE_VALUE(**)
+  *
+  *           - If SYSCLK source is PLL, SystemCoreClock will contain the HSE_VALUE(**)
+  *             or HSI_VALUE(*) multiplied/divided by the PLL factors.
+  *
+  *         (*) HSI_VALUE is a constant defined in stm32f3xx_hal.h file (default value
+  *             8 MHz) but the real value may vary depending on the variations
+  *             in voltage and temperature.
+  *
+  *         (**) HSE_VALUE is a constant defined in stm32f3xx_hal.h file (default value
+  *              8 MHz), user has to ensure that HSE_VALUE is same as the real
+  *              frequency of the crystal used. Otherwise, this function may
+  *              have wrong result.
+  *
+  *         - The result of this function could be not correct when using fractional
+  *           value for HSE crystal.
+  *
+  * @param  None
+  * @retval None
+  */
+void SystemCoreClockUpdate (void)
+{
+  uint32_t tmp = 0, pllmull = 0, pllsource = 0, predivfactor = 0;
+
+  /* Get SYSCLK source -------------------------------------------------------*/
+  tmp = RCC->CFGR & RCC_CFGR_SWS;
+
+  switch (tmp)
+  {
+    case RCC_CFGR_SWS_HSI:  /* HSI used as system clock */
+      SystemCoreClock = HSI_VALUE;
+      break;
+    case RCC_CFGR_SWS_HSE:  /* HSE used as system clock */
+      SystemCoreClock = HSE_VALUE;
+      break;
+    case RCC_CFGR_SWS_PLL:  /* PLL used as system clock */
+      /* Get PLL clock source and multiplication factor ----------------------*/
+      pllmull = RCC->CFGR & RCC_CFGR_PLLMUL;
+      pllsource = RCC->CFGR & RCC_CFGR_PLLSRC;
+      pllmull = ( pllmull >> 18) + 2;
+
+#if defined (STM32F302xE) || defined (STM32F303xE) || defined (STM32F398xx)
+        predivfactor = (RCC->CFGR2 & RCC_CFGR2_PREDIV) + 1;
+      if (pllsource == RCC_CFGR_PLLSRC_HSE_PREDIV)
+      {
+        /* HSE oscillator clock selected as PREDIV1 clock entry */
+        SystemCoreClock = (HSE_VALUE / predivfactor) * pllmull;
+      }
+      else
+      {
+        /* HSI oscillator clock selected as PREDIV1 clock entry */
+        SystemCoreClock = (HSI_VALUE / predivfactor) * pllmull;
+      }
+#else      
+      if (pllsource == RCC_CFGR_PLLSRC_HSI_DIV2)
+      {
+        /* HSI oscillator clock divided by 2 selected as PLL clock entry */
+        SystemCoreClock = (HSI_VALUE >> 1) * pllmull;
+      }
+      else
+      {
+        predivfactor = (RCC->CFGR2 & RCC_CFGR2_PREDIV) + 1;
+        /* HSE oscillator clock selected as PREDIV1 clock entry */
+        SystemCoreClock = (HSE_VALUE / predivfactor) * pllmull;
+      }
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+      break;
+    default: /* HSI used as system clock */
+      SystemCoreClock = HSI_VALUE;
+      break;
+  }
+  /* Compute HCLK clock frequency ----------------*/
+  /* Get HCLK prescaler */
+  tmp = AHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> 4)];
+  /* HCLK clock frequency */
+  SystemCoreClock >>= tmp;
+}
+
+void HardwareInit(void) {
+  HAL_Init();
+  SystemClock_Config();
+  SystemCoreClockUpdate();
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/stm32-modules/common/STM32F303/startup_system_stm32f3xx.c
+++ b/stm32-modules/common/STM32F303/startup_system_stm32f3xx.c
@@ -3,21 +3,6 @@
 #include "stm32f3xx_hal.h"
 #include "startup_system_stm32f3xx.h"
 
-/**
-  * @}
-  */
-
-/** @addtogroup STM32F3xx_System_Private_TypesDefinitions
-  * @{
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup STM32F3xx_System_Private_Defines
-  * @{
-  */
 #if !defined  (HSE_VALUE) 
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Default value of the External oscillator in Hz.
                                                 This value can be provided and adapted by the user application. */
@@ -52,18 +37,6 @@
 #endif /* VECT_TAB_SRAM */
 #endif /* USER_VECT_TAB_ADDRESS */
 
-/******************************************************************************/
-/**
-  * @}
-  */
-
-/** @addtogroup STM32F3xx_System_Private_Macros
-  * @{
-  */
-
-/**
-  * @}
-  */
 
 /** @addtogroup STM32F3xx_System_Private_Variables
   * @{
@@ -80,22 +53,6 @@ uint32_t SystemCoreClock = 8000000;
 
 const uint8_t AHBPrescTable[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
 const uint8_t APBPrescTable[8]  = {0, 0, 0, 0, 1, 2, 3, 4};
-
-/**
-  * @}
-  */
-
-/** @addtogroup STM32F3xx_System_Private_FunctionPrototypes
-  * @{
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup STM32F3xx_System_Private_Functions
-  * @{
-  */
 
 /**
   * @brief  Setup the microcontroller system
@@ -257,19 +214,3 @@ void HardwareInit(void) {
   SystemClock_Config();
   SystemCoreClockUpdate();
 }
-
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-

--- a/stm32-modules/common/STM32F303/startup_system_stm32f3xx.h
+++ b/stm32-modules/common/STM32F303/startup_system_stm32f3xx.h
@@ -1,0 +1,13 @@
+#ifndef __SYSTEM_STM32F3XX_H_
+#define __SYSTEM_STM32F3XX_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+void HardwareInit(void);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
+
+#endif  // __SYSTEM_STM32F3XX_H_

--- a/stm32-modules/common/STM32G491/CMakeLists.txt
+++ b/stm32-modules/common/STM32G491/CMakeLists.txt
@@ -6,6 +6,7 @@ set(G4_BOARD_FILE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/stm32g4discovery.cfg")
 
 # Fills in the template with values specified by the find_package(OpenOCD) call above
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gdbinit.template ./gdbinit)
+set(GDBINIT_PATH "${CMAKE_CURRENT_BINARY_DIR}/gdbinit")
 
 set(STM_HAL_PREFIX "stm32g4xx")
 configure_file(
@@ -53,7 +54,33 @@ add_executable(STM32G491-startup)
 target_module_startup(STM32G491-startup)
 
 target_sources(STM32G491-startup PUBLIC 
-    startup_stm32g491vetx.s)
+    startup_stm32g491vetx.s
+    startup_system_stm32g4xx.c)
 # Link to the F303
 target_link_libraries(STM32G491-startup PUBLIC
     STM32G4xx_Drivers_startup)
+
+# Startup Debug target
+find_program(ARM_GDB
+    arm-none-eabi-gdb-py
+    PATHS "${CrossGCC_BINDIR}"
+    NO_DEFAULT_PATH
+    REQUIRED)
+message(STATUS "Found svd exe at ${GDBSVDTools_gdbsvd_EXECUTABLE}")
+# Configure gdb (full path to cross-gdb set in the toolchain) to use the gdbinit in
+# this dir
+set_target_properties(STM32G491-startup
+    PROPERTIES
+    CROSSCOMPILING_EMULATOR
+    "${ARM_GDB};--command=${GDBINIT_PATH}")
+# Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
+# arguable misuse of the concept) to the appropriate cross-gdb with
+# remote-target. You should make sure st-util is running; that's not
+# done here because it won't be multi-os compatible, and also it
+# should be running the entire time and that's tough to accomplish
+# in a custom command
+add_custom_target(STM32G491-startup-debug
+    COMMENT "Starting gdb and openocd"
+    COMMAND STM32G491-startup
+    USES_TERMINAL
+    )

--- a/stm32-modules/common/STM32G491/startup_hal.h
+++ b/stm32-modules/common/STM32G491/startup_hal.h
@@ -6,7 +6,9 @@
 #ifndef STARTUP_HAL_H_
 #define STARTUP_HAL_H_
 
+#include "startup_system_stm32g4xx.h"
 #include "stm32g4xx_hal.h"
+#include "stm32g4xx_hal_conf.h"
 #include "stm32g4xx_hal_cortex.h"
 #include "stm32g4xx_hal_rcc.h"
 #include "stm32g4xx_hal_tim.h"

--- a/stm32-modules/common/STM32G491/startup_system_stm32g4xx.c
+++ b/stm32-modules/common/STM32G491/startup_system_stm32g4xx.c
@@ -1,0 +1,235 @@
+/**
+ ******************************************************************************
+ * @file    system_stm32g4xx.c
+ * @author  MCD Application Team
+ * @brief   CMSIS Cortex-M4 Device Peripheral Access Layer System Source File
+ *
+ *   This file provides two functions and one global variable to be called from
+ *   user application:
+ *      - SystemInit(): This function is called at startup just after reset and
+ *                      before branch to main program. This call is made inside
+ *                      the "startup_stm32g4xx.s" file.
+ *
+ *      - SystemCoreClock variable: Contains the core clock (HCLK), it can be
+ *used by the user application to setup the SysTick timer or configure other
+ *parameters.
+ *
+ *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
+ *                                 be called whenever the core clock is changed
+ *                                 during program execution.
+ *
+ */
+
+
+#include "startup_system_stm32g4xx.h"
+
+#include "stm32g4xx.h"
+#include "stm32g4xx_hal.h"
+
+#if !defined(HSE_VALUE)
+#define HSE_VALUE 24000000U /*!< Value of the External oscillator in Hz */
+#endif                      /* HSE_VALUE */
+
+#if !defined(HSI_VALUE)
+#define HSI_VALUE 16000000U /*!< Value of the Internal oscillator in Hz*/
+#endif                      /* HSI_VALUE */
+
+
+/** @addtogroup STM32G4xx_System_Private_TypesDefinitions
+ * @{
+ */
+
+/**
+ * @}
+ */
+
+/** @addtogroup STM32G4xx_System_Private_Defines
+ * @{
+ */
+
+/************************* Miscellaneous Configuration ************************/
+/*!< Uncomment the following line if you need to relocate your vector Table in
+     Internal SRAM. */
+/* #define VECT_TAB_SRAM */
+
+#define VECT_TAB_OFFSET (0) 
+            /*!< Vector Table base offset field. \
+              This value must be a multiple of 0x200. */
+/******************************************************************************/
+/**
+ * @}
+ */
+
+/** @addtogroup STM32G4xx_System_Private_Macros
+ * @{
+ */
+
+/**
+ * @}
+ */
+
+/** @addtogroup STM32G4xx_System_Private_Variables
+ * @{
+ */
+/* The SystemCoreClock variable is updated in three ways:
+    1) by calling CMSIS function SystemCoreClockUpdate()
+    2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+    3) each time HAL_RCC_ClockConfig() is called to configure the system clock
+   frequency Note: If you use this function to configure the system clock; then
+   there is no need to call the 2 first functions listed above, since
+   SystemCoreClock variable is updated automatically.
+*/
+uint32_t SystemCoreClock = HSI_VALUE;
+
+const uint8_t AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
+                                   1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
+const uint8_t APBPrescTable[8] = {0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U};
+
+
+void SystemInit(void) {
+    SCB->VTOR = FLASH_BASE;
+}
+
+void SystemClock_Config(void) {
+    RCC_OscInitTypeDef RCC_OscInitStruct = {0};
+    RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+
+    /** Configure the main internal regulator output voltage
+     */
+    HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE1_BOOST);
+    /** Initializes the RCC Oscillators according to the specified parameters
+     * in the RCC_OscInitTypeDef structure.
+     */
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+    RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+    RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+    RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;
+    RCC_OscInitStruct.PLL.PLLN = 85;
+    RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
+    RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
+    RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;
+    HAL_RCC_OscConfig(&RCC_OscInitStruct);
+
+    /** Initializes the CPU, AHB and APB buses clocks
+     */
+    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK |
+                                  RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+    RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+    RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV2;
+    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+
+    HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4);
+}
+
+/**
+ * @brief  Update SystemCoreClock variable according to Clock Register Values.
+ *         The SystemCoreClock variable contains the core clock (HCLK), it can
+ *         be used by the user application to setup the SysTick timer or
+ * configure other parameters.
+ *
+ * @note   Each time the core clock (HCLK) changes, this function must be called
+ *         to update SystemCoreClock variable value. Otherwise, any
+ * configuration based on this variable will be incorrect.
+ *
+ * @note   - The system frequency computed by this function is not the real
+ *           frequency in the chip. It is calculated based on the predefined
+ *           constant and the selected clock source:
+ *
+ *           - If SYSCLK source is HSI, SystemCoreClock will contain the
+ * HSI_VALUE(**)
+ *
+ *           - If SYSCLK source is HSE, SystemCoreClock will contain the
+ * HSE_VALUE(***)
+ *
+ *           - If SYSCLK source is PLL, SystemCoreClock will contain the
+ * HSE_VALUE(***) or HSI_VALUE(*) multiplied/divided by the PLL factors.
+ *
+ *         (**) HSI_VALUE is a constant defined in stm32g4xx_hal.h file (default
+ * value 16 MHz) but the real value may vary depending on the variations in
+ * voltage and temperature.
+ *
+ *         (***) HSE_VALUE is a constant defined in stm32g4xx_hal.h file
+ * (default value 24 MHz), user has to ensure that HSE_VALUE is same as the real
+ *              frequency of the crystal used. Otherwise, this function may
+ *              have wrong result.
+ *
+ *         - The result of this function could be not correct when using
+ * fractional value for HSE crystal.
+ *
+ * @param  None
+ * @retval None
+ */
+void SystemCoreClockUpdate(void) {
+    uint32_t tmp, pllvco, pllr, pllsource, pllm;
+
+    /* Get SYSCLK source
+     * -------------------------------------------------------*/
+    switch (RCC->CFGR & RCC_CFGR_SWS) {
+        case 0x04: /* HSI used as system clock source */
+            SystemCoreClock = HSI_VALUE;
+            break;
+
+        case 0x08: /* HSE used as system clock source */
+            SystemCoreClock = HSE_VALUE;
+            break;
+
+        case 0x0C: /* PLL used as system clock  source */
+            /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM) * PLLN
+               SYSCLK = PLL_VCO / PLLR
+               */
+            pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC);
+            pllm = ((RCC->PLLCFGR & RCC_PLLCFGR_PLLM) >> 4) + 1U;
+            if (pllsource == 0x02UL) /* HSI used as PLL clock source */
+            {
+                pllvco = (HSI_VALUE / pllm);
+            } else /* HSE used as PLL clock source */
+            {
+                pllvco = (HSE_VALUE / pllm);
+            }
+            pllvco = pllvco * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> 8);
+            pllr = (((RCC->PLLCFGR & RCC_PLLCFGR_PLLR) >> 25) + 1U) * 2U;
+            SystemCoreClock = pllvco / pllr;
+            break;
+
+        default:
+            break;
+    }
+    /* Compute HCLK clock frequency
+     * --------------------------------------------*/
+    /* Get HCLK prescaler */
+    tmp = AHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> 4)];
+    /* HCLK clock frequency */
+    SystemCoreClock >>= tmp;
+}
+
+void HardwareInit(void) {
+    HAL_Init();
+    SystemClock_Config();
+    SystemCoreClockUpdate();
+}
+
+// Implementatino of Error_Handler for STM32 HAL drivers
+void Error_Handler(void) {
+    while(1) {}
+}
+
+/**
+  * Initializes the Global MSP.
+  */
+void HAL_MspInit(void)
+{
+
+  __HAL_RCC_SYSCFG_CLK_ENABLE();
+  __HAL_RCC_PWR_CLK_ENABLE();
+
+  /* System interrupt init*/
+  /* PendSV_IRQn interrupt configuration */
+  HAL_NVIC_SetPriority(PendSV_IRQn, 15, 0);
+
+  /** Disable the internal Pull-Up in Dead Battery pins of UCPD peripheral
+  */
+  HAL_PWREx_DisableUCPDDeadBattery();
+}

--- a/stm32-modules/common/STM32G491/startup_system_stm32g4xx.h
+++ b/stm32-modules/common/STM32G491/startup_system_stm32g4xx.h
@@ -1,0 +1,38 @@
+
+/**
+ * @brief Define to prevent recursive inclusion
+ */
+#include <stdint.h>
+
+#ifndef __SYSTEM_STM32G4XX_H
+#define __SYSTEM_STM32G4XX_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup STM32G4xx_System_Exported_Variables
+ * @{
+ */
+/* The SystemCoreClock variable is updated in three ways:
+    1) by calling CMSIS function SystemCoreClockUpdate()
+    2) by calling HAL API function HAL_RCC_GetSysClockFreq()
+    3) each time HAL_RCC_ClockConfig() is called to configure the system clock
+   frequency Note: If you use this function to configure the system clock; then
+   there is no need to call the 2 first functions listed above, since
+   SystemCoreClock variable is updated automatically.
+*/
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock) */
+
+extern const uint8_t AHBPrescTable[16]; /*!< AHB prescalers table values */
+extern const uint8_t APBPrescTable[8];  /*!< APB prescalers table values */
+
+extern void SystemInit(void);
+extern void SystemCoreClockUpdate(void);
+void HardwareInit(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__SYSTEM_STM32G4XX_H */

--- a/stm32-modules/common/module-startup/startup_checks.c
+++ b/stm32-modules/common/module-startup/startup_checks.c
@@ -108,6 +108,8 @@ static uint32_t calculate_crc(uint32_t start, uint32_t count) {
     init_hardware();
 
     __HAL_CRC_DR_RESET(&check_hardware.crc);
+    // We return the INVERTED calculated checksum in order to match
+    // standard crc32 calculations
     return ~HAL_CRC_Calculate(
         &check_hardware.crc, 
         (uint32_t *)start,

--- a/stm32-modules/common/module-startup/startup_checks.c
+++ b/stm32-modules/common/module-startup/startup_checks.c
@@ -8,6 +8,41 @@
 
 #define INVALID_ADDR_MASK (0xFFFFFFF0)
 
+// Take the start address and filter out to just the page
+#define APPLICATION_VTABLE_START (APPLICATION_START_ADDRESS & 0xFFFFF000)
+// Application integrity region starts 0x200 from 
+#define APPLICATION_INTEGRITY_REGION (APPLICATION_VTABLE_START + 0x200)
+#define APPLICATION_CRC_CALC_START_ADDRESS (APPLICATION_VTABLE_START + 0x400)
+
+/** STATIC DATA */
+
+typedef struct {
+    bool init;
+    CRC_HandleTypeDef crc;
+} CheckHardware_t;
+
+typedef struct __packed {
+    uint32_t crc;
+    uint32_t app_length;
+    uint32_t app_start_address;
+    char name;
+} IntegrityRegion_t;
+
+static CheckHardware_t check_hardware = {
+    .init = false,
+    .crc = {0}
+};
+
+static const IntegrityRegion_t  *const integrity_region = (IntegrityRegion_t *)APPLICATION_INTEGRITY_REGION;
+
+/** STATIC FUNCTION DECLARATIONS */
+
+static void init_hardware();
+static void init_crc();
+static uint32_t calculate_crc(uint32_t start, uint32_t count);
+
+/** PUBLIC FUNCTION IMPLEMENTATIONS */
+
 bool check_app_exists() {
     const uint32_t boot_address = *(uint32_t*)APPLICATION_START_ADDRESS;
     // If the address is mostly 1's, it is unprogrammed
@@ -20,4 +55,83 @@ bool check_app_exists() {
         return false;
     }
     return true;
+}
+
+bool check_crc() {
+    init_hardware();
+
+    // Check that start address makes sense
+    if(integrity_region->app_start_address 
+            != APPLICATION_CRC_CALC_START_ADDRESS) {
+        return false;
+    }
+    // Check that the length is programmed
+    if(integrity_region->app_length == 0xFFFFFFFF) {
+        return false;
+    }
+    // Run a CRC calc
+    uint32_t crc = calculate_crc(
+        integrity_region->app_start_address, 
+        integrity_region->app_length);
+    
+    if(crc != integrity_region->crc) {
+        return false;
+    }
+    
+    return true;
+}
+
+/** STATIC FUNCTION IMPLEMENTATIONS */
+
+static void init_hardware() {
+    if(check_hardware.init) {
+        return;
+    }
+
+    init_crc();
+
+    check_hardware.init = true;
+}
+
+static void init_crc() {
+    check_hardware.crc.Instance = CRC;
+    check_hardware.crc.Init.DefaultPolynomialUse = DEFAULT_POLYNOMIAL_ENABLE;
+    check_hardware.crc.Init.DefaultInitValueUse = DEFAULT_INIT_VALUE_ENABLE;
+    check_hardware.crc.Init.InputDataInversionMode = CRC_INPUTDATA_INVERSION_BYTE;
+    check_hardware.crc.Init.OutputDataInversionMode = CRC_OUTPUTDATA_INVERSION_ENABLE;
+    check_hardware.crc.InputDataFormat = CRC_INPUTDATA_FORMAT_BYTES;
+
+    (void) HAL_CRC_Init(&check_hardware.crc);
+}
+
+static uint32_t calculate_crc(uint32_t start, uint32_t count) {
+    init_hardware();
+
+    __HAL_CRC_DR_RESET(&check_hardware.crc);
+    return ~HAL_CRC_Calculate(
+        &check_hardware.crc, 
+        (uint32_t *)start,
+        count);
+}
+
+/** OVERWRITTEN HAL FUNCTIONS */
+
+/**
+* @brief CRC MSP Initialization
+* @param hcrc: CRC handle pointer
+* @retval None
+ */
+void HAL_CRC_MspInit(CRC_HandleTypeDef* hcrc)
+{
+    __HAL_RCC_CRC_CLK_ENABLE();
+}
+
+/**
+* @brief CRC MSP De-Initialization
+* @param hcrc: CRC handle pointer
+* @retval None
+ */
+void HAL_CRC_MspDeInit(CRC_HandleTypeDef* hcrc)
+{
+    __HAL_RCC_CRC_CLK_DISABLE();
 }

--- a/stm32-modules/common/module-startup/startup_checks.h
+++ b/stm32-modules/common/module-startup/startup_checks.h
@@ -10,4 +10,11 @@
  */
 bool check_app_exists();
 
+/**
+ * Checks that:
+ *   - The Device Integrity region has the correct starting address
+ *   - The CRC in the Device Integrity region is correct
+ */
+bool check_crc();
+
 #endif /* STARTUP_CHECKS_H_ */

--- a/stm32-modules/common/module-startup/startup_it.c
+++ b/stm32-modules/common/module-startup/startup_it.c
@@ -5,6 +5,7 @@
  * 
  */
 
+#include "startup_hal.h"
 #include "startup_jumps.h"
 
 void HardFault_Handler(void) __attribute__((naked));
@@ -65,3 +66,11 @@ void UsageFault_Handler(void) {
  * @retval None
  */
 void DebugMon_Handler(void) {}
+
+// Interrupts that are normally handled by FreeRTOS 
+
+void SVC_Handler(void) {}
+void PendSV_Handler(void) {}
+void SysTick_Handler(void) {
+    HAL_IncTick();
+}

--- a/stm32-modules/common/module-startup/startup_main.c
+++ b/stm32-modules/common/module-startup/startup_main.c
@@ -2,14 +2,15 @@
 
 #include "startup_jumps.h"
 #include "startup_checks.h"
-
-uint32_t SystemCoreClock = 8000000;
-
-// SystemInit will be fine without any action
-void SystemInit(void) {}
+#include "startup_hal.h"
 
 int main() {
+    HardwareInit();
+    
     if(!check_app_exists()) {
+        jump_to_bootloader();
+    }
+    if(!check_crc()) {
         jump_to_bootloader();
     }
     

--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -175,7 +175,10 @@ add_custom_target(heater-shaker-hex ALL
   DEPENDS heater-shaker.hex)
 
 add_custom_command(OUTPUT heater-shaker.bin
-  COMMAND ${CROSS_OBJCOPY} ARGS heater-shaker.hex "-Iihex" "-Obinary" heater-shaker.bin
+  COMMAND ${CROSS_OBJCOPY} ARGS 
+    heater-shaker.hex 
+    "-Iihex" "-Obinary" "--gap-fill=0xFF"
+    heater-shaker.bin
   DEPENDS heater-shaker-hex
   VERBATIM)
 add_custom_target(heater-shaker-bin ALL
@@ -237,7 +240,10 @@ add_custom_target(heater-shaker-image-hex ALL
     DEPENDS heater-shaker)
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.bin"
-  COMMAND ${CROSS_OBJCOPY} ARGS "-Iihex" "-Obinary" "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex" "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.bin"
+  COMMAND ${CROSS_OBJCOPY} ARGS 
+    "-Iihex" "-Obinary"  "--gap-fill=0xFF"
+    "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex" 
+    "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.bin"
   DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex"
   VERBATIM)
 add_custom_target(heater-shaker-image-bin ALL

--- a/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
@@ -150,7 +150,10 @@ add_custom_target(${TARGET_MODULE_NAME}-hex ALL
   DEPENDS ${TARGET_MODULE_NAME}.hex)
 
 add_custom_command(OUTPUT ${TARGET_MODULE_NAME}.bin
-  COMMAND ${CROSS_OBJCOPY} ARGS ${TARGET_MODULE_NAME}.hex "-Iihex" "-Obinary" ${TARGET_MODULE_NAME}.bin
+  COMMAND ${CROSS_OBJCOPY} ARGS 
+    ${TARGET_MODULE_NAME}.hex 
+    "-Iihex" "-Obinary" "--gap-fill=0xFF"
+    ${TARGET_MODULE_NAME}.bin
   DEPENDS ${TARGET_MODULE_NAME}.hex
   VERBATIM)
 add_custom_target(${TARGET_MODULE_NAME}-bin ALL
@@ -218,7 +221,9 @@ add_custom_target(${TARGET_MODULE_NAME}-image-hex ALL
     DEPENDS ${HEX_IMG_NAME})
 
 add_custom_command(OUTPUT "${BIN_IMG_NAME}"
-    COMMAND ${CROSS_OBJCOPY} ARGS "-Iihex" "-Obinary" "${HEX_IMG_NAME}" "${BIN_IMG_NAME}"
+    COMMAND ${CROSS_OBJCOPY} ARGS 
+        "-Iihex" "-Obinary" "--gap-fill=0xFF"
+        "${HEX_IMG_NAME}" "${BIN_IMG_NAME}"
     DEPENDS "${HEX_IMG_NAME}"
     VERBATIM)
 add_custom_target(${TARGET_MODULE_NAME}-image-bin ALL

--- a/stm32-modules/thermocycler-gen2/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/firmware/CMakeLists.txt
@@ -151,8 +151,11 @@ add_custom_command(OUTPUT ${TARGET_MODULE_NAME}.hex
 add_custom_target(${TARGET_MODULE_NAME}-hex ALL
   DEPENDS ${TARGET_MODULE_NAME}.hex)
 
-add_custom_command(OUTPUT ${TARGET_MODULE_NAME}.bin
-  COMMAND ${CROSS_OBJCOPY} ARGS ${TARGET_MODULE_NAME}.hex "-Iihex" "-Obinary" ${TARGET_MODULE_NAME}.bin
+  add_custom_command(OUTPUT ${TARGET_MODULE_NAME}.bin
+  COMMAND ${CROSS_OBJCOPY} ARGS 
+    ${TARGET_MODULE_NAME}.hex 
+    "-Iihex" "-Obinary" "--gap-fill=0xFF"
+    ${TARGET_MODULE_NAME}.bin
   DEPENDS ${TARGET_MODULE_NAME}.hex
   VERBATIM)
 add_custom_target(${TARGET_MODULE_NAME}-bin ALL
@@ -220,7 +223,9 @@ add_custom_target(${TARGET_MODULE_NAME}-image-hex ALL
     DEPENDS ${HEX_IMG_NAME})
 
 add_custom_command(OUTPUT "${BIN_IMG_NAME}"
-    COMMAND ${CROSS_OBJCOPY} ARGS "-Iihex" "-Obinary" "${HEX_IMG_NAME}" "${BIN_IMG_NAME}"
+    COMMAND ${CROSS_OBJCOPY} ARGS 
+        "-Iihex" "-Obinary" "--gap-fill=0xFF"
+        "${HEX_IMG_NAME}" "${BIN_IMG_NAME}"
     DEPENDS "${HEX_IMG_NAME}"
     VERBATIM)
 add_custom_target(${TARGET_MODULE_NAME}-image-bin ALL


### PR DESCRIPTION
Adds functionality to the startup app to check the CRC of installed firmware images. If the CRC in the integrity region matches the CRC calculated by the startup app, it will boot into the app. If there's a mismatch, it will jump to the bootloader.

Changelist:
* Added debug targets for the startup apps
* Added explicit gap-fill of 0xFF to all bin targets in order to match the hex targets
* Added CRC check to startup app
* Removed unnecessary Initial Value from crc calc in python script
* Added clock/HAL initialization to the startup apps instead of relying on the clock config at startup. Also added deinitialization before jumping to the main app.

Tested on all STM32 modules by:
* Uploading the combined image-bin to the module and restarting to verify it jumps to the application
* Erasing a single page in the middle of the app to ensure the CRC check fails and the DFU bootloader activates
* Rewriting the base .hex (no startup app) through DFU and verifying the module starts up fine on reboot