### PR TITLE
feat(heater-shaker): hardfaults jump to bootloader

### DIFF
--- a/stm32-modules/heater-shaker/firmware/system/stm32f3xx_it.c
+++ b/stm32-modules/heater-shaker/firmware/system/stm32f3xx_it.c
@@ -23,6 +23,8 @@
 #include "system_hardware.h"
 #include "stm32f3xx_it.h"
 
+#include "FreeRTOSConfig.h"
+
 /** @addtogroup STM32F3xx_HAL_Examples
   * @{
   */
@@ -58,10 +60,10 @@ void NMI_Handler(void)
   */
 void HardFault_Handler(void)
 {
-  /* Go to infinite loop when Hard Fault exception occurs */
-  while (1)
-  {
-  }
+    // If assertions are enabled, lock up here
+    configASSERT(false);
+    /* Go to bootloader when Hard Fault exception occurs */
+    system_hardware_jump_from_exception();
 }
 
 /**
@@ -71,10 +73,10 @@ void HardFault_Handler(void)
   */
 void MemManage_Handler(void)
 {
-  /* Go to infinite loop when Memory Manage exception occurs */
-  while (1)
-  {
-  }
+    // If assertions are enabled, lock up here
+    configASSERT(false);
+    /* Go to bootloader when Hard Fault exception occurs */
+    system_hardware_jump_from_exception();
 }
 
 /**
@@ -84,10 +86,10 @@ void MemManage_Handler(void)
   */
 void BusFault_Handler(void)
 {
-  /* Go to infinite loop when Bus Fault exception occurs */
-  while (1)
-  {
-  }
+    // If assertions are enabled, lock up here
+    configASSERT(false);
+    /* Go to bootloader when Hard Fault exception occurs */
+    system_hardware_jump_from_exception();
 }
 
 /**
@@ -97,10 +99,10 @@ void BusFault_Handler(void)
   */
 void UsageFault_Handler(void)
 {
-  /* Go to infinite loop when Usage Fault exception occurs */
-  while (1)
-  {
-  }
+    // If assertions are enabled, lock up here
+    configASSERT(false);
+    /* Go to bootloader when Hard Fault exception occurs */
+    system_hardware_jump_from_exception();
 }
 
 /**

--- a/stm32-modules/heater-shaker/firmware/system/system_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/system/system_hardware.c
@@ -211,6 +211,49 @@ bool system_hardware_I2C_ready(void) {
   return (HAL_I2C_GetState(&I2cHandle) == HAL_I2C_STATE_READY);
 }
 
+void system_hardware_jump_from_exception(void) {
+    // Okay, so we're in an exception (hard fault, bus fault, etc) and want to
+    // jump to the DFU bootloader. We are going to jump to the function for
+    // jumping to the bootloader, but to get there we have to exit this 
+    // exception context. In order to do this, we have to do a few things:
+    //   1. Clear the CFSR and HFSR status registers, or the bootloader will
+    //      refuse to run.
+    //   2. Update the PC in the exception stack frame. This step means that
+    //      we HAVE to run only naked function calls, which means nothing but
+    //      assembly code is allowed.
+    //   3. Update the execution mode of the PSR in the exception stack frame.
+    //      If this is an invalid value, the processor will be locked forever,
+    //      so we force it to 0x10 for User Mode.
+    //   3. Ovewrite the link register with a known exception pattern, and
+    //      then return to our overwritten PC value by bx'ing to it
+    asm volatile (
+        /* Clear CFSR register.*/
+        "ldr r0, =0xE000ED28\n"
+        "ldr r1, [r0]\n"
+        "str r1, [r0]\n"
+        /* Clear HFSR register.*/
+        "ldr r0, =0xE000ED2C\n"
+        "ldr r1, [r0]\n"
+        "str r1, [r0]\n"
+        /* Update the PC in the stack frame.*/
+        /* https://developer.arm.com/documentation/dui0552/a/the-cortex-m3-processor/exception-model/exception-entry-and-return */
+        "ldr r0, bootloader_address_const\n"
+        "str r0, [sp,#0x18]\n"
+        /* In case the PSR is in invalid state, force to user mode*/
+        "ldr r1, [sp,#0x1C]\n"
+        "and r1, r1, #0xFFFFFFF0\n"
+        "orr r1, r1, #0x10\n"
+        "str r1, [sp,#0x1C]\n"
+        /* Leave the exception handler */
+        "ldr lr,=0xFFFFFFF1\n"
+        "bx  lr\n"
+        "bootloader_address_const: .word system_hardware_enter_bootloader"
+        : // no outputs
+        : // no inputs
+        : "memory"  
+    );
+}
+
 /******************************************************************************/
 /*                 STM32F3xx Peripherals Interrupt Handlers                  */
 /*  Add here the Interrupt Handler for the used peripheral(s) (PPP), for the  */

--- a/stm32-modules/heater-shaker/firmware/system/system_hardware.h
+++ b/stm32-modules/heater-shaker/firmware/system/system_hardware.h
@@ -46,6 +46,7 @@ bool system_hardware_set_led_send(uint16_t register_address,
                                   uint8_t* set_buffer, uint16_t buffer_size);
 void system_hardware_handle_i2c_callback(void);
 bool system_hardware_I2C_ready(void);
+void system_hardware_jump_from_exception(void) __attribute__((naked));
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Copied fix from thermocycler-gen2. Tested by adding a divide-by-zero and confirming the module enumerates as a DFU device.