### PR TITLE
feat(all): added module name check to startup app

### DIFF
--- a/.github/workflows/heater-shaker.yaml
+++ b/.github/workflows/heater-shaker.yaml
@@ -62,6 +62,8 @@ jobs:
         run: cmake --build --preset cross --target heater-shaker-format-ci
       - name: 'Lint'
         run: cmake --build --preset cross --target heater-shaker-lint
+      - name: 'Build startup app'
+        run: cmake --build --preset cross --target heater-shaker-startup
       - name: 'Build'
         run: cmake --build --preset cross --target heater-shaker-hex
       - name: 'Build Combo Image Hex'

--- a/.github/workflows/stm32-common.yaml
+++ b/.github/workflows/stm32-common.yaml
@@ -59,10 +59,6 @@ jobs:
         run: cmake --build --preset cross --target common-format-ci
       - name: 'Lint'
         run: cmake --build --preset cross --target common-lint
-      - name: 'Build STM32F303 startup script'
-        run: cmake --build --preset cross --target STM32F303-startup
-      - name: 'Build STM32G491 startup script'
-        run: cmake --build --preset cross --target STM32G491-startup
   host-compile-test:
     name: 'Host-Compile/Test'
     runs-on: 'ubuntu-20.04'

--- a/.github/workflows/tempdeck-gen3.yaml
+++ b/.github/workflows/tempdeck-gen3.yaml
@@ -62,6 +62,8 @@ jobs:
         run: cmake --build --preset cross --target tempdeck-gen3-format-ci
       - name: 'Lint'
         run: cmake --build --preset cross --target tempdeck-gen3-lint
+      - name: 'Build startup app'
+        run: cmake --build --preset cross --target tempdeck-gen3-startup
       - name: 'Build'
         run: cmake --build --preset cross --target tempdeck-gen3-hex
       - name: 'Build full image'

--- a/.github/workflows/thermocycler-gen2.yaml
+++ b/.github/workflows/thermocycler-gen2.yaml
@@ -62,6 +62,8 @@ jobs:
         run: cmake --build --preset cross --target thermocycler-gen2-format-ci
       - name: 'Lint'
         run: cmake --build --preset cross --target thermocycler-gen2-lint
+      - name: 'Build startup app'
+        run: cmake --build --preset cross --target thermocycler-gen2-startup
       - name: 'Build'
         run: cmake --build --preset cross --target thermocycler-gen2-hex
       - name: 'Build full image'

--- a/stm32-modules/common/STM32F303/CMakeLists.txt
+++ b/stm32-modules/common/STM32F303/CMakeLists.txt
@@ -49,16 +49,6 @@ target_compile_definitions(STM32F303BSP_Drivers_startup
 target_include_directories(STM32F303BSP_Drivers_startup
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_executable(STM32F303-startup)
-target_module_startup(STM32F303-startup)
-
-target_sources(STM32F303-startup PUBLIC 
-    startup_stm32f303xe.s
-    startup_system_stm32f3xx.c)
-# Link to the F303
-target_link_libraries(STM32F303-startup PUBLIC
-    STM32F303BSP_Drivers_startup)
-
 # Startup Debug target
 find_program(ARM_GDB
     arm-none-eabi-gdb-py
@@ -66,20 +56,36 @@ find_program(ARM_GDB
     NO_DEFAULT_PATH
     REQUIRED)
 message(STATUS "Found svd exe at ${GDBSVDTools_gdbsvd_EXECUTABLE}")
-# Configure gdb (full path to cross-gdb set in the toolchain) to use the gdbinit in
-# this dir
-set_target_properties(STM32F303-startup
-    PROPERTIES
-    CROSSCOMPILING_EMULATOR
-    "${ARM_GDB};--command=${GDBINIT_PATH}")
-# Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
-# arguable misuse of the concept) to the appropriate cross-gdb with
-# remote-target. You should make sure st-util is running; that's not
-# done here because it won't be multi-os compatible, and also it
-# should be running the entire time and that's tough to accomplish
-# in a custom command
-add_custom_target(STM32F303-startup-debug
-    COMMENT "Starting gdb and openocd"
-    COMMAND STM32F303-startup
-    USES_TERMINAL
-    )
+
+function(stm32f303_startup TARGET FW_NAME)
+    add_executable(${TARGET})
+
+    target_module_startup(${TARGET} ${FW_NAME})
+
+    target_sources(${TARGET} PUBLIC 
+        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_stm32f303xe.s
+        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_system_stm32f3xx.c)
+
+    # Link to the F303
+    target_link_libraries(${TARGET} PUBLIC
+        STM32F303BSP_Drivers_startup)
+
+    # Configure gdb (full path to cross-gdb set in the toolchain) to use the gdbinit in
+    # this dir
+    set_target_properties(${TARGET}
+        PROPERTIES
+        CROSSCOMPILING_EMULATOR
+        "${ARM_GDB};--command=${GDBINIT_PATH}")
+    # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
+    # arguable misuse of the concept) to the appropriate cross-gdb with
+    # remote-target. You should make sure st-util is running; that's not
+    # done here because it won't be multi-os compatible, and also it
+    # should be running the entire time and that's tough to accomplish
+    # in a custom command
+    add_custom_target(${TARGET}-debug
+        COMMENT "Starting gdb and openocd"
+        COMMAND ${TARGET}
+        USES_TERMINAL
+        )
+endfunction()
+

--- a/stm32-modules/common/STM32G491/CMakeLists.txt
+++ b/stm32-modules/common/STM32G491/CMakeLists.txt
@@ -50,16 +50,6 @@ target_compile_definitions(STM32G4xx_Drivers_startup
 target_include_directories(STM32G4xx_Drivers_startup
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_executable(STM32G491-startup)
-target_module_startup(STM32G491-startup)
-
-target_sources(STM32G491-startup PUBLIC 
-    startup_stm32g491vetx.s
-    startup_system_stm32g4xx.c)
-# Link to the F303
-target_link_libraries(STM32G491-startup PUBLIC
-    STM32G4xx_Drivers_startup)
-
 # Startup Debug target
 find_program(ARM_GDB
     arm-none-eabi-gdb-py
@@ -67,20 +57,35 @@ find_program(ARM_GDB
     NO_DEFAULT_PATH
     REQUIRED)
 message(STATUS "Found svd exe at ${GDBSVDTools_gdbsvd_EXECUTABLE}")
-# Configure gdb (full path to cross-gdb set in the toolchain) to use the gdbinit in
-# this dir
-set_target_properties(STM32G491-startup
-    PROPERTIES
-    CROSSCOMPILING_EMULATOR
-    "${ARM_GDB};--command=${GDBINIT_PATH}")
-# Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
-# arguable misuse of the concept) to the appropriate cross-gdb with
-# remote-target. You should make sure st-util is running; that's not
-# done here because it won't be multi-os compatible, and also it
-# should be running the entire time and that's tough to accomplish
-# in a custom command
-add_custom_target(STM32G491-startup-debug
-    COMMENT "Starting gdb and openocd"
-    COMMAND STM32G491-startup
-    USES_TERMINAL
-    )
+
+function(stm32g491_startup TARGET FW_NAME)
+    add_executable(${TARGET})
+
+    target_module_startup(${TARGET} ${FW_NAME})
+
+    target_sources(${TARGET} PUBLIC 
+        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_stm32g491vetx.s
+        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_system_stm32g4xx.c)
+
+    # Link to the F303
+    target_link_libraries(${TARGET} PUBLIC
+        STM32F303BSP_Drivers_startup)
+
+    # Configure gdb (full path to cross-gdb set in the toolchain) to use the gdbinit in
+    # this dir
+    set_target_properties(${TARGET}
+        PROPERTIES
+        CROSSCOMPILING_EMULATOR
+        "${ARM_GDB};--command=${GDBINIT_PATH}")
+    # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
+    # arguable misuse of the concept) to the appropriate cross-gdb with
+    # remote-target. You should make sure st-util is running; that's not
+    # done here because it won't be multi-os compatible, and also it
+    # should be running the entire time and that's tough to accomplish
+    # in a custom command
+    add_custom_target(${TARGET}-debug
+        COMMENT "Starting gdb and openocd"
+        COMMAND ${TARGET}
+        USES_TERMINAL
+        )
+endfunction()

--- a/stm32-modules/common/STM32G491/CMakeLists.txt
+++ b/stm32-modules/common/STM32G491/CMakeLists.txt
@@ -67,9 +67,9 @@ function(stm32g491_startup TARGET FW_NAME)
         ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_stm32g491vetx.s
         ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_system_stm32g4xx.c)
 
-    # Link to the F303
+    # Link to the G491 drivers
     target_link_libraries(${TARGET} PUBLIC
-        STM32F303BSP_Drivers_startup)
+        STM32G4xx_Drivers_startup)
 
     # Configure gdb (full path to cross-gdb set in the toolchain) to use the gdbinit in
     # this dir

--- a/stm32-modules/common/module-startup/CMakeLists.txt
+++ b/stm32-modules/common/module-startup/CMakeLists.txt
@@ -11,7 +11,7 @@ find_program(CROSS_OBJCOPY "${CrossGCC_TRIPLE}-objcopy"
 # Function to configure a target to compile the module startup for a specific
 # microcontroller. The target passed in should add an include directory with a
 # file `startup_hal.h` containing target-specific definitions
-function(target_module_startup TARGET)
+function(target_module_startup TARGET FW_NAME)
 
     target_sources(${TARGET} PUBLIC
         ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_main.c
@@ -25,6 +25,10 @@ function(target_module_startup TARGET)
     target_compile_options(${TARGET} PUBLIC
         -Wall
         -Werror)
+
+    # Pass along the name of the main application
+    target_compile_definitions(${TARGET} PUBLIC 
+        FIRMWARE_NAME=${FW_NAME})
 
     target_link_options(${TARGET} PUBLIC
         "LINKER:-T,${CMAKE_CURRENT_FUNCTION_LIST_DIR}/STM32_MODULE_STARTUP.ld"

--- a/stm32-modules/common/module-startup/CMakeLists.txt
+++ b/stm32-modules/common/module-startup/CMakeLists.txt
@@ -28,7 +28,7 @@ function(target_module_startup TARGET FW_NAME)
 
     # Pass along the name of the main application
     target_compile_definitions(${TARGET} PUBLIC 
-        FIRMWARE_NAME=${FW_NAME})
+        APPLICATION_FIRMWARE_NAME=\"${FW_NAME}\")
 
     target_link_options(${TARGET} PUBLIC
         "LINKER:-T,${CMAKE_CURRENT_FUNCTION_LIST_DIR}/STM32_MODULE_STARTUP.ld"

--- a/stm32-modules/common/module-startup/startup_checks.c
+++ b/stm32-modules/common/module-startup/startup_checks.c
@@ -1,5 +1,7 @@
 #include "startup_checks.h"
 
+#include <string.h>
+
 #include "startup_hal.h"
 
 #ifndef APPLICATION_START_ADDRESS
@@ -13,6 +15,10 @@
 // Application integrity region starts 0x200 from 
 #define APPLICATION_INTEGRITY_REGION (APPLICATION_VTABLE_START + 0x200)
 #define APPLICATION_CRC_CALC_START_ADDRESS (APPLICATION_VTABLE_START + 0x400)
+
+#ifndef APPLICATION_FIRMWARE_NAME
+#error APPLICATION_FIRMWARE_NAME must be defined
+#endif
 
 /** STATIC DATA */
 
@@ -34,6 +40,9 @@ static CheckHardware_t check_hardware = {
 };
 
 static const IntegrityRegion_t  *const integrity_region = (IntegrityRegion_t *)APPLICATION_INTEGRITY_REGION;
+
+static const char application_firmware_name[] __attribute__((used))  
+    = APPLICATION_FIRMWARE_NAME;
 
 /** STATIC FUNCTION DECLARATIONS */
 
@@ -79,6 +88,15 @@ bool check_crc() {
     }
     
     return true;
+}
+
+bool check_name() {
+    const int namelen = strlen(application_firmware_name);
+
+    return memcmp(
+        application_firmware_name, 
+        &integrity_region->name, 
+        namelen) == 0;
 }
 
 /** STATIC FUNCTION IMPLEMENTATIONS */

--- a/stm32-modules/common/module-startup/startup_checks.h
+++ b/stm32-modules/common/module-startup/startup_checks.h
@@ -17,4 +17,11 @@ bool check_app_exists();
  */
 bool check_crc();
 
+/**
+ * Checks that:
+ *   - The device name exists
+ *   - The device name is correct for this module
+ */
+bool check_name();
+
 #endif /* STARTUP_CHECKS_H_ */

--- a/stm32-modules/common/module-startup/startup_main.c
+++ b/stm32-modules/common/module-startup/startup_main.c
@@ -13,6 +13,9 @@ int main() {
     if(!check_crc()) {
         jump_to_bootloader();
     }
+    if(!check_name()) {
+        jump_to_bootloader();
+    }
     
     jump_to_application();
 

--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -226,13 +226,16 @@ add_custom_target(heater-shaker-flash
   COMMENT "Flashing board"
   DEPENDS heater-shaker)
 
+# Create a Startup App target for this module
+stm32f303_startup(heater-shaker-startup heater-shaker)
+
 # Targets to create full image hex and binary files containing both bootloader and application
 add_custom_command(
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex"
     DEPENDS $<TARGET_FILE_DIR:heater-shaker>/heater-shaker.hex
-    DEPENDS STM32F303-startup-hex
-    DEPENDS $<TARGET_FILE_DIR:STM32F303-startup>/STM32F303-startup.hex
-    COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex" $<TARGET_FILE_DIR:STM32F303-startup>/STM32F303-startup.hex heater-shaker.hex
+    DEPENDS heater-shaker-startup-hex
+    DEPENDS $<TARGET_FILE_DIR:heater-shaker-startup>/heater-shaker-startup.hex
+    COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex" $<TARGET_FILE_DIR:heater-shaker-startup>/heater-shaker-startup.hex heater-shaker.hex
     VERBATIM
     COMMENT "Generating full image")
 add_custom_target(heater-shaker-image-hex ALL

--- a/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
@@ -207,17 +207,21 @@ set(HEX_IMG_NAME "${TARGET_MODULE_NAME}-image@${${TARGET_MODULE_NAME}_VERSION}.h
 
 set(BIN_IMG_NAME "${TARGET_MODULE_NAME}-image@${${TARGET_MODULE_NAME}_VERSION}.bin")
   
+set(STARTUP_NAME ${TARGET_MODULE_NAME}-startup)
+
+stm32g491_startup(${STARTUP_NAME} ${TARGET_MODULE_NAME})
+
 # Targets to create full image hex file containing both bootloader and application
 add_custom_command(
     OUTPUT ${HEX_IMG_NAME}
     DEPENDS $<TARGET_FILE_DIR:${TARGET_MODULE_NAME}>/${TARGET_MODULE_NAME}.hex
-    DEPENDS STM32G491-startup-hex
-    DEPENDS $<TARGET_FILE_DIR:STM32G491-startup>/STM32G491-startup.hex
-    COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py ${HEX_IMG_NAME} $<TARGET_FILE_DIR:STM32G491-startup>/STM32G491-startup.hex ${TARGET_MODULE_NAME}.hex
+    DEPENDS ${STARTUP_NAME}-hex
+    DEPENDS $<TARGET_FILE_DIR:${STARTUP_NAME}>/${STARTUP_NAME}.hex
+    COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py ${HEX_IMG_NAME} $<TARGET_FILE_DIR:${STARTUP_NAME}>/${STARTUP_NAME}.hex ${TARGET_MODULE_NAME}.hex
     VERBATIM
     COMMENT "Generating full image")
 add_custom_target(${TARGET_MODULE_NAME}-image-hex ALL
-    DEPENDS STM32G491-startup-hex
+    DEPENDS ${STARTUP_NAME}-hex
     DEPENDS ${HEX_IMG_NAME})
 
 add_custom_command(OUTPUT "${BIN_IMG_NAME}"

--- a/stm32-modules/thermocycler-gen2/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/firmware/CMakeLists.txt
@@ -209,17 +209,21 @@ set(HEX_IMG_NAME "${TARGET_MODULE_NAME}-image@${${TARGET_MODULE_NAME}_VERSION}.h
 
 set(BIN_IMG_NAME "${TARGET_MODULE_NAME}-image@${${TARGET_MODULE_NAME}_VERSION}.bin")
 
+set(STARTUP_NAME ${TARGET_MODULE_NAME}-startup)
+
+stm32g491_startup(${STARTUP_NAME} ${TARGET_MODULE_NAME})
+
 # Targets to create full image hex file containing both bootloader and application
 add_custom_command(
     OUTPUT ${HEX_IMG_NAME}
     DEPENDS $<TARGET_FILE_DIR:${TARGET_MODULE_NAME}>/${TARGET_MODULE_NAME}.hex
-    DEPENDS STM32G491-startup-hex
-    DEPENDS $<TARGET_FILE_DIR:STM32G491-startup>/STM32G491-startup.hex
-    COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py ${HEX_IMG_NAME} $<TARGET_FILE_DIR:STM32G491-startup>/STM32G491-startup.hex ${TARGET_MODULE_NAME}.hex
+    DEPENDS ${STARTUP_NAME}-hex
+    DEPENDS $<TARGET_FILE_DIR:${STARTUP_NAME}>/${STARTUP_NAME}.hex
+    COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py ${HEX_IMG_NAME} $<TARGET_FILE_DIR:${STARTUP_NAME}>/${STARTUP_NAME}.hex ${TARGET_MODULE_NAME}.hex
     VERBATIM
     COMMENT "Generating full image")
 add_custom_target(${TARGET_MODULE_NAME}-image-hex ALL
-    DEPENDS STM32G491-startup-hex
+    DEPENDS ${STARTUP_NAME}-hex
     DEPENDS ${HEX_IMG_NAME})
 
 add_custom_command(OUTPUT "${BIN_IMG_NAME}"


### PR DESCRIPTION
Adds a check to the startup app to verify the name of the module that the firmware is intended for. This means that, in the case that a user erroneously sends the firmware intended for a different module (or completely random firmware that happens to pass the CRC check), the startup app will reject it.

Changelist:
- Updated the CMake for the startup app to create a unique startup app target for each module, in order to pass in module-specific values (i.e. the name)
- Added a check in the startup app to verify the name in the firmware matches the module it is intended for

Tested on heater-shaker and tempdeck-gen3 by:
- Uploading valid firmware, confirming the startup app boots to the main application
- Uploading firmware with the wrong name, confirming the startup app jumps to DFU
- Uploading firmware for a different module, confirming the startup app jumps to DFU