### PR TITLE
feat(all): application backup and recovery

### DIFF
--- a/stm32-modules/common/STM32F303/CMakeLists.txt
+++ b/stm32-modules/common/STM32F303/CMakeLists.txt
@@ -64,7 +64,8 @@ function(stm32f303_startup TARGET FW_NAME)
 
     target_sources(${TARGET} PUBLIC 
         ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_stm32f303xe.s
-        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_system_stm32f3xx.c)
+        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_system_stm32f3xx.c
+        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_hal.c)
 
     # Link to the F303
     target_link_libraries(${TARGET} PUBLIC

--- a/stm32-modules/common/STM32F303/STM32F303RETx_FLASH.ld
+++ b/stm32-modules/common/STM32F303/STM32F303RETx_FLASH.ld
@@ -32,6 +32,8 @@
 /* Entry Point */
 ENTRY(Reset_Handler)
 
+/* Total size of the flash memory is 512K, split into pages of 2K (0x800) */
+
 /* Highest address of the user mode stack */
 _estack = 0x20010000;    /* end of RAM */
 __stack = _estack;
@@ -46,7 +48,9 @@ _flash_size = 512K;
 /* Length reduced by 4K to reserve last two pages for 
  * serial number and thermal offsets storage */
 _serial_size = 4K; 
-_app_flash_size = _flash_size - _flash_offset - _serial_size;
+/* Remaining space is 512K - 32K - 4K =  476. This is divided in half to
+ * leave room for a backup image, giving 238K for the image.*/
+_app_flash_size = 238K;
 
 /* Specify the memory areas */
 MEMORY

--- a/stm32-modules/common/STM32F303/startup_hal.c
+++ b/stm32-modules/common/STM32F303/startup_hal.c
@@ -1,0 +1,18 @@
+#include "startup_hal.h"
+
+#include "stm32f3xx_hal_flash.h"
+#include "stm32f3xx_hal_flash_ex.h"
+
+// Each target has a different method to set the page for erasing
+bool startup_erase_flash_pages(uint32_t start_page, uint32_t page_count) {
+    FLASH_EraseInitTypeDef config = {
+        .TypeErase = FLASH_TYPEERASE_PAGES,
+        .PageAddress = start_page * FLASH_PAGE_SIZE,
+        .NbPages = page_count
+    };
+    uint32_t err = 0;
+    if (HAL_FLASHEx_Erase(&config, &err) == HAL_OK) {
+        return err == 0xFFFFFFFF;
+    }
+    return false;
+}

--- a/stm32-modules/common/STM32F303/startup_hal.h
+++ b/stm32-modules/common/STM32F303/startup_hal.h
@@ -17,6 +17,9 @@
 #define BOOTLOADER_START_ADDRESS (0x1FFFD804)
 #define APPLICATION_START_ADDRESS (0x08008004)
 
+// 238K for application
+#define APPLICATION_MAX_SIZE (0x400 * 238)
+
 #define DISABLE_CSS_FUNC() HAL_RCC_DisableCSS()
 
 #endif /* STARTUP_HAL_H_ */

--- a/stm32-modules/common/STM32F303/startup_hal.h
+++ b/stm32-modules/common/STM32F303/startup_hal.h
@@ -6,6 +6,8 @@
 #ifndef STARTUP_HAL_H_
 #define STARTUP_HAL_H_
 
+#include <stdbool.h>
+
 #include "startup_system_stm32f3xx.h"
 #include "stm32f3xx_hal.h"
 #include "stm32f3xx_hal_conf.h"
@@ -21,5 +23,11 @@
 #define APPLICATION_MAX_SIZE (0x400 * 238)
 
 #define DISABLE_CSS_FUNC() HAL_RCC_DisableCSS()
+
+// No flash init needed on F303
+#define startup_flash_init() (void)(0)
+
+// Each target has a different method to set the page for erasing
+bool startup_erase_flash_pages(uint32_t start_page, uint32_t page_count);
 
 #endif /* STARTUP_HAL_H_ */

--- a/stm32-modules/common/STM32G491/CMakeLists.txt
+++ b/stm32-modules/common/STM32G491/CMakeLists.txt
@@ -65,7 +65,8 @@ function(stm32g491_startup TARGET FW_NAME)
 
     target_sources(${TARGET} PUBLIC 
         ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_stm32g491vetx.s
-        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_system_stm32g4xx.c)
+        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_system_stm32g4xx.c
+        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_hal.c)
 
     # Link to the G491 drivers
     target_link_libraries(${TARGET} PUBLIC

--- a/stm32-modules/common/STM32G491/STM32G491VETx_FLASH.ld
+++ b/stm32-modules/common/STM32G491/STM32G491VETx_FLASH.ld
@@ -52,6 +52,8 @@
 /* Entry Point */
 ENTRY(Reset_Handler)
 
+/* Total size of the flash memory is 512K, split into pages of 2K (0x800) */
+
 /* Highest address of the user mode stack */
 _estack = ORIGIN(RAM) + LENGTH(RAM);	/* end of "RAM" Ram type memory */
 /* Generate a link error if heap and stack don't fit into RAM */
@@ -62,8 +64,12 @@ _flash_offset = 32K; /* first 32K is occupied by bootloader shim */
 _flash_start = 0x8000000;
 _app_flash_start  = _flash_start + _flash_offset;
 _flash_size = 512K;
-_serial_size = 0x800;
-_app_flash_size = _flash_size - _flash_offset - _serial_size;
+/* Length reduced by 4K to reserve last two pages for 
+ * serial number and general information storage */
+_serial_size = 4K; 
+/* Remaining space is 512K - 32K - 4K =  476. This is divided in half to
+ * leave room for a backup image, giving 238K for the image.*/
+_app_flash_size = 238K;
 
 /* Specify the memory areas */
 MEMORY

--- a/stm32-modules/common/STM32G491/startup_hal.c
+++ b/stm32-modules/common/STM32G491/startup_hal.c
@@ -1,0 +1,25 @@
+#include "startup_hal.h"
+
+#include <stdbool.h>
+
+#include "stm32g4xx_hal_flash.h"
+#include "stm32g4xx_hal_flash_ex.h"
+
+void startup_flash_init() {
+    __HAL_RCC_FLASH_CLK_ENABLE();
+}
+
+// Each target has a different method to set the page for erasing
+bool startup_erase_flash_pages(uint32_t start_page, uint32_t page_count) {
+    FLASH_EraseInitTypeDef config = {
+        .TypeErase = FLASH_TYPEERASE_PAGES,
+        .Banks = FLASH_BANK_1,
+        .Page = start_page,
+        .NbPages = page_count,
+    };
+    uint32_t err = 0;
+    if (HAL_FLASHEx_Erase(&config, &err) == HAL_OK) {
+        return err == 0xFFFFFFFF;
+    }
+    return false;
+}

--- a/stm32-modules/common/STM32G491/startup_hal.h
+++ b/stm32-modules/common/STM32G491/startup_hal.h
@@ -1,6 +1,6 @@
 /**
  * @file startup_hal.h
- * @brief Provides HAL files specific to the F303
+ * @brief Provides HAL files specific to the G491
  */
 
 #ifndef STARTUP_HAL_H_
@@ -16,6 +16,9 @@
 #define SYSMEM_ADDRESS (0x1FFF0000)
 #define BOOTLOADER_START_ADDRESS (0x1FFF0004)
 #define APPLICATION_START_ADDRESS (0x08008004)
+
+// 238K for application
+#define APPLICATION_MAX_SIZE (0x400 * 238)
 
 #define DISABLE_CSS_FUNC() HAL_RCC_DisableLSECSS()
 

--- a/stm32-modules/common/STM32G491/startup_hal.h
+++ b/stm32-modules/common/STM32G491/startup_hal.h
@@ -6,6 +6,8 @@
 #ifndef STARTUP_HAL_H_
 #define STARTUP_HAL_H_
 
+#include <stdbool.h>
+
 #include "startup_system_stm32g4xx.h"
 #include "stm32g4xx_hal.h"
 #include "stm32g4xx_hal_conf.h"
@@ -21,5 +23,11 @@
 #define APPLICATION_MAX_SIZE (0x400 * 238)
 
 #define DISABLE_CSS_FUNC() HAL_RCC_DisableLSECSS()
+
+// Needs to init the RCC
+void startup_flash_init();
+
+// Each target has a different method to set the page for erasing
+bool startup_erase_flash_pages(uint32_t start_page, uint32_t page_count);
 
 #endif /* STARTUP_HAL_H_ */

--- a/stm32-modules/common/module-startup/CMakeLists.txt
+++ b/stm32-modules/common/module-startup/CMakeLists.txt
@@ -17,7 +17,8 @@ function(target_module_startup TARGET FW_NAME)
         ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_main.c
         ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_checks.c
         ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_it.c
-        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_jumps.c)
+        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_jumps.c
+        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/startup_memory.c)
     
     target_include_directories(${TARGET} 
         PUBLIC ${CMAKE_CURRENT_FUNCTION_LIST_DIR})

--- a/stm32-modules/common/module-startup/startup_checks.c
+++ b/stm32-modules/common/module-startup/startup_checks.c
@@ -8,6 +8,10 @@
 #error APPLICATION_START_ADDRESS must be defined
 #endif
 
+#ifndef APPLICATION_MAX_SIZE
+#error APPLICATION_MAX_SIZE must be defined
+#endif
+
 #define INVALID_ADDR_MASK (0xFFFFFFF0)
 
 // Take the start address and filter out to just the page

--- a/stm32-modules/common/module-startup/startup_checks.c
+++ b/stm32-modules/common/module-startup/startup_checks.c
@@ -14,11 +14,16 @@
 
 #define INVALID_ADDR_MASK (0xFFFFFFF0)
 
+#define APPLICATION_FOOTER_TOTAL_LENGTH (0x400)
+
 // Take the start address and filter out to just the page
-#define APPLICATION_VTABLE_START (APPLICATION_START_ADDRESS & 0xFFFFF000)
-// Application integrity region starts 0x200 from 
-#define APPLICATION_INTEGRITY_REGION (APPLICATION_VTABLE_START + 0x200)
-#define APPLICATION_CRC_CALC_START_ADDRESS (APPLICATION_VTABLE_START + 0x400)
+#define APPLICATION_VTABLE_START(address) (address & 0xFFFFF800)
+// Application integrity region starts 0x200 from vtable
+#define APPLICATION_INTEGRITY_REGION(address) \
+    (APPLICATION_VTABLE_START(address) + 0x200)
+// Actual application is stored 0x400 from vtable
+#define APPLICATION_CRC_CALC_START_ADDRESS(address) \
+    (APPLICATION_VTABLE_START(address) + APPLICATION_FOOTER_TOTAL_LENGTH)
 
 #ifndef APPLICATION_FIRMWARE_NAME
 #error APPLICATION_FIRMWARE_NAME must be defined
@@ -43,8 +48,6 @@ static CheckHardware_t check_hardware = {
     .crc = {0}
 };
 
-static const IntegrityRegion_t  *const integrity_region = (IntegrityRegion_t *)APPLICATION_INTEGRITY_REGION;
-
 static const char application_firmware_name[] __attribute__((used))  
     = APPLICATION_FIRMWARE_NAME;
 
@@ -56,8 +59,27 @@ static uint32_t calculate_crc(uint32_t start, uint32_t count);
 
 /** PUBLIC FUNCTION IMPLEMENTATIONS */
 
-bool check_app_exists() {
-    const uint32_t boot_address = *(uint32_t*)APPLICATION_START_ADDRESS;
+uint32_t slot_start_address(APP_SLOT_ENUM slot) {
+    if(slot == APP_SLOT_BACKUP) {
+        return APPLICATION_VTABLE_START( APPLICATION_START_ADDRESS ) +
+                APPLICATION_MAX_SIZE;
+    }
+    // Default to the base slot
+    return APPLICATION_VTABLE_START( APPLICATION_START_ADDRESS );
+}
+
+bool check_slot(APP_SLOT_ENUM slot) {
+    if(slot > APP_SLOT_BACKUP) {
+        return false;
+    }
+
+    return check_app_exists(slot) &&
+           check_crc(slot) &&
+           check_name(slot);
+}
+
+bool check_app_exists(APP_SLOT_ENUM slot) {
+    const uint32_t boot_address = *(uint32_t*)(slot_start_address(slot) + 0x4);
     // If the address is mostly 1's, it is unprogrammed
     if( (boot_address & INVALID_ADDR_MASK) 
           == INVALID_ADDR_MASK) {
@@ -70,21 +92,32 @@ bool check_app_exists() {
     return true;
 }
 
-bool check_crc() {
+bool check_crc(APP_SLOT_ENUM slot) {
+    const IntegrityRegion_t  *const integrity_region = 
+        (IntegrityRegion_t *)APPLICATION_INTEGRITY_REGION(slot_start_address(slot));
+    const uint32_t crc_start = 
+        APPLICATION_CRC_CALC_START_ADDRESS(slot_start_address(slot));
+    const uint32_t crc_start_expected = 
+        APPLICATION_CRC_CALC_START_ADDRESS(slot_start_address(APP_SLOT_MAIN));
     init_hardware();
 
     // Check that start address makes sense
     if(integrity_region->app_start_address 
-            != APPLICATION_CRC_CALC_START_ADDRESS) {
+            != crc_start_expected) {
         return false;
     }
     // Check that the length is programmed
     if(integrity_region->app_length == 0xFFFFFFFF) {
         return false;
     }
+    // Check that the length is less than the max
+    if(integrity_region->app_length > 
+            APPLICATION_MAX_SIZE - APPLICATION_FOOTER_TOTAL_LENGTH) {
+        return false;
+    }
     // Run a CRC calc
     uint32_t crc = calculate_crc(
-        integrity_region->app_start_address, 
+        crc_start, 
         integrity_region->app_length);
     
     if(crc != integrity_region->crc) {
@@ -94,13 +127,29 @@ bool check_crc() {
     return true;
 }
 
-bool check_name() {
+bool check_name(APP_SLOT_ENUM slot) {
+    const IntegrityRegion_t  *const integrity_region = 
+        (IntegrityRegion_t *)APPLICATION_INTEGRITY_REGION(slot_start_address(slot));
     const int namelen = strlen(application_firmware_name);
 
     return memcmp(
         application_firmware_name, 
         &integrity_region->name, 
         namelen) == 0;
+}
+
+bool check_backup_matches_main() {
+    uint32_t start_main = slot_start_address(APP_SLOT_MAIN);
+    uint32_t start_backup = slot_start_address(APP_SLOT_BACKUP);
+    // Get the byte count from the main region
+    const IntegrityRegion_t  *const main_integrity_region = 
+        (IntegrityRegion_t *)APPLICATION_INTEGRITY_REGION(start_main);
+
+    return memcmp(
+        (void *)start_main,
+        (void *)start_backup,
+        main_integrity_region->app_length + APPLICATION_FOOTER_TOTAL_LENGTH
+        ) == 0;
 }
 
 /** STATIC FUNCTION IMPLEMENTATIONS */

--- a/stm32-modules/common/module-startup/startup_checks.h
+++ b/stm32-modules/common/module-startup/startup_checks.h
@@ -2,26 +2,44 @@
 #define STARTUP_CHECKS_H_
 
 #include <stdbool.h>
+#include <stdint.h>
+
+typedef enum {
+    APP_SLOT_MAIN = 0,
+    APP_SLOT_BACKUP = 1,
+} APP_SLOT_ENUM;
+
+/** Get the starting address of a slot */
+uint32_t slot_start_address(APP_SLOT_ENUM slot);
+
+/** Runs every check for a slot */
+bool check_slot(APP_SLOT_ENUM slot);
 
 /**
  * Checks that:
  *   - The vector table exists (not all 1's)
  *   - The reset vector points to a valid arm thumb instruction
  */
-bool check_app_exists();
+bool check_app_exists(APP_SLOT_ENUM slot);
 
 /**
  * Checks that:
  *   - The Device Integrity region has the correct starting address
  *   - The CRC in the Device Integrity region is correct
  */
-bool check_crc();
+bool check_crc(APP_SLOT_ENUM slot);
 
 /**
  * Checks that:
  *   - The device name exists
  *   - The device name is correct for this module
  */
-bool check_name();
+bool check_name(APP_SLOT_ENUM slot);
+
+/**
+ * Checks if the main app and the backup slot are identical. This check
+ * assumes that both regions have had their integrity verified.
+ */
+bool check_backup_matches_main();
 
 #endif /* STARTUP_CHECKS_H_ */

--- a/stm32-modules/common/module-startup/startup_main.c
+++ b/stm32-modules/common/module-startup/startup_main.c
@@ -2,19 +2,33 @@
 
 #include "startup_jumps.h"
 #include "startup_checks.h"
+#include "startup_memory.h"
 #include "startup_hal.h"
 
 int main() {
     HardwareInit();
+
+    bool main_app_exists = check_slot(APP_SLOT_MAIN);
+    bool backup_app_exists = check_slot(APP_SLOT_BACKUP);
     
-    if(!check_app_exists()) {
-        jump_to_bootloader();
+    if(!main_app_exists && backup_app_exists) {
+        // No main app but backup app = try to recover with backup app
+        (void)memory_copy_backup_to_main();
+        if(!check_slot(APP_SLOT_MAIN)) {
+            // We failed to recover, jump to bootloader
+            jump_to_bootloader();
+        }
     }
-    if(!check_crc()) {
+    else if(!main_app_exists) {
+        // In this case, we don't have any backup app
         jump_to_bootloader();
-    }
-    if(!check_name()) {
-        jump_to_bootloader();
+    } else {
+        // We have a main app, tbd backup
+        if(!backup_app_exists || !check_backup_matches_main()) {
+            // Try to update the backup. If this fails we boot to the main app
+            // anyways.
+            (void)memory_copy_main_to_backup();
+        }
     }
     
     jump_to_application();

--- a/stm32-modules/common/module-startup/startup_memory.c
+++ b/stm32-modules/common/module-startup/startup_memory.c
@@ -1,0 +1,72 @@
+
+#include "startup_memory.h"
+
+#include "startup_checks.h"
+#include "startup_hal.h"
+
+/** STATIC FUNCTION DECLARATIONS */
+static bool erase_app(APP_SLOT_ENUM slot);
+
+/** 
+ * @brief Copy an image from src to dst. Assumes that src and dst are both
+ * addresses in the Flash region, and that \p bytes is small enough to fit 
+ * in the alloted space.
+ */
+static bool memory_copy_image(uint32_t src, uint32_t dst, uint32_t bytes);
+
+/** Public function implementation */
+
+bool memory_copy_backup_to_main() {
+    startup_flash_init();
+    if(!erase_app(APP_SLOT_MAIN)) {
+        return false;
+    }
+    return memory_copy_image(
+        slot_start_address(APP_SLOT_BACKUP),
+        slot_start_address(APP_SLOT_MAIN),
+        APPLICATION_MAX_SIZE);
+}
+
+bool memory_copy_main_to_backup() {
+    startup_flash_init();
+    if(!erase_app(APP_SLOT_BACKUP)) {
+        return false;
+    }
+    return memory_copy_image(
+        slot_start_address(APP_SLOT_MAIN),
+        slot_start_address(APP_SLOT_BACKUP),
+        APPLICATION_MAX_SIZE);
+}
+
+/** STATIC FUNCTION IMPLEMENTATIONS */
+
+static bool erase_app(APP_SLOT_ENUM slot) {
+    uint32_t start_page = slot_start_address(slot) / FLASH_PAGE_SIZE;
+    uint32_t page_count = APPLICATION_MAX_SIZE / FLASH_PAGE_SIZE;
+    
+    HAL_FLASH_Unlock();
+    bool ret = startup_erase_flash_pages(start_page, page_count);
+    HAL_FLASH_Lock();
+
+    return ret;
+}
+
+static bool memory_copy_image(uint32_t src, uint32_t dst, uint32_t bytes) {
+    HAL_FLASH_Unlock();
+
+    HAL_StatusTypeDef ret = HAL_ERROR;
+    // All platforms support programming by doubleword, so we do that here.
+    for(uint32_t offset = 0; offset < bytes; offset += 8) {
+        ret = HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, 
+            dst + offset, 
+            *(uint64_t *)(src + offset));
+
+        if(ret != HAL_OK) {
+            break;
+        }
+    }
+    
+    HAL_FLASH_Lock();
+
+    return ret == HAL_OK;
+}

--- a/stm32-modules/common/module-startup/startup_memory.h
+++ b/stm32-modules/common/module-startup/startup_memory.h
@@ -1,0 +1,12 @@
+#ifndef STARTUP_MEMORY_H_
+#define STARTUP_MEMORY_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/** Overwrite the main section with the backup */
+bool memory_copy_backup_to_main();
+/** Overwrite the backup with the main section */
+bool memory_copy_main_to_backup();
+
+#endif /* STARTUP_MEMORY_H_ */


### PR DESCRIPTION
This PR adds functionality to the startup app to recover from a bad firmware update (primarily intended for failures during transfer).
- The linkerfiles for the main applications have been edited to use _half_ of the available flash memory, leaving room for an identical copy of the firmware. 
- When the firmware is updated through DFU, it will ovewrite the _first_ image in memory. However, the second image will be left alone.
- On system restart, the startup app checks if the main image and the backup image exist:
  - If they both exist, and they match, just jump to the application firmware
  - If they exist and there's a mismatch, overwrite the backup with the main firmware and then jump to the application
  - If only one exists (i.e. there is an error with the integrity of **one** of the images), overwrite the faulty one and then jump to the main application
  - If neither image exists, jump to the DFU bootloader

In practice, any normal failure during the operation of dfu-util will only result in an extended reboot time while the system recovers its firmware from a backup, instead of bricking the module or getting it stuck in the bootloader.

Tested on heater-shaker and tempdeck-gen3 boards by replicating each of the above scenarios by manually erasing sectors, and then restarting the system to verify that it recovers in the intended fashion.

Startups where an image must be duplicated take a noticeable amount of time before jumping to the application, but normal startups take less than half a second.