### PR TITLE
feat(all): lock startup region flash

### DIFF
--- a/stm32-modules/common/STM32F303/startup_hal.c
+++ b/stm32-modules/common/STM32F303/startup_hal.c
@@ -16,3 +16,46 @@ bool startup_erase_flash_pages(uint32_t start_page, uint32_t page_count) {
     }
     return false;
 }
+
+bool startup_lock_pages(uint32_t start_page, uint32_t page_count) {
+    // On the STM32F303, write protection is configured with a bitmask. Each
+    // bit in the bitmask represents 2 pages, and each page is 2k. This means
+    // that the inputs to this function must both be even!
+    FLASH_OBProgramInitTypeDef init = {0};
+
+    HAL_FLASHEx_OBGetConfig(&init);
+
+    if((start_page & 0x1 )|| (page_count & 0x1) || (page_count == 0)) {
+        // Cannot configure odd pages by themselves
+        return false;
+    }
+    uint32_t mask = 0;
+    for(uint32_t i = 0; i < (page_count / 2); ++i) {
+        mask |= 1 << ((start_page / 2) + i);
+    }
+
+    // 1's indicate unlocked pages, so we invert for the check
+    uint32_t set_pages = ~init.WRPPage;
+
+    // If the mask is all already set, we can leave silently
+    if((set_pages & mask) == mask) { 
+        return true;
+    }
+
+    // We only want to update read protection
+    init.OptionType = OPTIONBYTE_WRP;
+    init.WRPState = OB_WRPSTATE_ENABLE;
+    init.WRPPage = mask;
+
+    HAL_FLASH_Unlock();
+    HAL_FLASH_OB_Unlock();
+    bool ret = HAL_FLASHEx_OBProgram(&init) == HAL_OK;
+    HAL_FLASH_OB_Lock();
+    HAL_FLASH_Lock();
+    // This restarts the device
+    if(ret) {
+        HAL_FLASH_OB_Launch();
+    }
+    // If we were succesful, we shouldn't return at all
+    return false;
+}

--- a/stm32-modules/common/STM32F303/startup_hal.c
+++ b/stm32-modules/common/STM32F303/startup_hal.c
@@ -50,12 +50,12 @@ bool startup_lock_pages(uint32_t start_page, uint32_t page_count) {
     HAL_FLASH_Unlock();
     HAL_FLASH_OB_Unlock();
     bool ret = HAL_FLASHEx_OBProgram(&init) == HAL_OK;
-    HAL_FLASH_OB_Lock();
-    HAL_FLASH_Lock();
     // This restarts the device
     if(ret) {
         HAL_FLASH_OB_Launch();
     }
+    HAL_FLASH_OB_Lock();
+    HAL_FLASH_Lock();
     // If we were succesful, we shouldn't return at all
     return false;
 }

--- a/stm32-modules/common/STM32F303/startup_hal.h
+++ b/stm32-modules/common/STM32F303/startup_hal.h
@@ -30,4 +30,7 @@
 // Each target has a different method to set the page for erasing
 bool startup_erase_flash_pages(uint32_t start_page, uint32_t page_count);
 
+// Each target has a different method to lock pages
+bool startup_lock_pages(uint32_t start_page, uint32_t page_count);
+
 #endif /* STARTUP_HAL_H_ */

--- a/stm32-modules/common/STM32G491/startup_hal.c
+++ b/stm32-modules/common/STM32G491/startup_hal.c
@@ -23,3 +23,45 @@ bool startup_erase_flash_pages(uint32_t start_page, uint32_t page_count) {
     }
     return false;
 }
+
+bool startup_lock_pages(uint32_t start_page, uint32_t page_count) {
+    // On the STM32G491, write protection is configured with a two page
+    // indices, a start and end. The region is inclusive of the end page,
+    // so to protect one page you would have to set both start and end
+    // to the same value.
+    FLASH_OBProgramInitTypeDef init = {0};
+    init.WRPArea = OB_WRPAREA_BANK1_AREAA; // Get Area A info
+
+    HAL_FLASHEx_OBGetConfig(&init);
+
+    if((page_count == 0)) {
+        // Cannot configure 1 page at a time
+        return false;
+    }
+
+    uint32_t end_page = start_page + page_count - 1;
+
+    // If the mask is all already set, we can leave silently
+    if(init.WRPStartOffset == start_page && 
+       init.WRPEndOffset == end_page) { 
+        return true;
+    }
+
+    // We only want to update read protection
+    init.OptionType = OPTIONBYTE_WRP;
+    init.WRPArea = OB_WRPAREA_BANK1_AREAA;
+    init.WRPStartOffset = start_page;
+    init.WRPEndOffset = end_page;
+
+    HAL_FLASH_Unlock();
+    HAL_FLASH_OB_Unlock();
+    bool ret = HAL_FLASHEx_OBProgram(&init) == HAL_OK;
+    HAL_FLASH_OB_Lock();
+    HAL_FLASH_Lock();
+    // This restarts the device
+    if(ret) {
+        HAL_FLASH_OB_Launch();
+    }
+    // If we were succesful, we shouldn't return at all
+    return false;
+}

--- a/stm32-modules/common/STM32G491/startup_hal.c
+++ b/stm32-modules/common/STM32G491/startup_hal.c
@@ -56,12 +56,12 @@ bool startup_lock_pages(uint32_t start_page, uint32_t page_count) {
     HAL_FLASH_Unlock();
     HAL_FLASH_OB_Unlock();
     bool ret = HAL_FLASHEx_OBProgram(&init) == HAL_OK;
-    HAL_FLASH_OB_Lock();
-    HAL_FLASH_Lock();
     // This restarts the device
     if(ret) {
         HAL_FLASH_OB_Launch();
     }
+    HAL_FLASH_OB_Lock();
+    HAL_FLASH_Lock();
     // If we were succesful, we shouldn't return at all
     return false;
 }

--- a/stm32-modules/common/STM32G491/startup_hal.h
+++ b/stm32-modules/common/STM32G491/startup_hal.h
@@ -30,4 +30,7 @@ void startup_flash_init();
 // Each target has a different method to set the page for erasing
 bool startup_erase_flash_pages(uint32_t start_page, uint32_t page_count);
 
+// Each target has a different method to lock pages
+bool startup_lock_pages(uint32_t start_page, uint32_t page_count);
+
 #endif /* STARTUP_HAL_H_ */

--- a/stm32-modules/common/module-startup/startup_main.c
+++ b/stm32-modules/common/module-startup/startup_main.c
@@ -8,6 +8,16 @@
 int main() {
     HardwareInit();
 
+    // Because this lock is performed almost immediately on reset, it becomes
+    // impossible in practice to unlock the flash region, even with a
+    // debugger attached - the reset will simply occur too quickly and the
+    // option bits will get rewritten.
+    // 
+    // In order to update the startup region, the best option is to set
+    // the Read Protection Mode to Level 1, and then back to Level 0. This
+    // will clear the entire main flash region, including this startup app,
+    // allowing a debugger to clear out the Write Protection bits.
+    (void)memory_lock_startup_region();
 
     bool main_app_exists = check_slot(APP_SLOT_MAIN);
     bool backup_app_exists = check_slot(APP_SLOT_BACKUP);
@@ -32,11 +42,6 @@ int main() {
         }
     }
     
-    // Perform this lock at the last minute, after running all of the 
-    // other checks. This means that, when debugging & trying to unlock
-    // the flash with a debugger, the host has a chance to restart the
-    // device and reprogram it without it jumping right into the firmware.
-    (void)memory_lock_startup_region();
     jump_to_application();
 
     while(1) {}

--- a/stm32-modules/common/module-startup/startup_main.c
+++ b/stm32-modules/common/module-startup/startup_main.c
@@ -8,6 +8,7 @@
 int main() {
     HardwareInit();
 
+
     bool main_app_exists = check_slot(APP_SLOT_MAIN);
     bool backup_app_exists = check_slot(APP_SLOT_BACKUP);
     
@@ -31,6 +32,11 @@ int main() {
         }
     }
     
+    // Perform this lock at the last minute, after running all of the 
+    // other checks. This means that, when debugging & trying to unlock
+    // the flash with a debugger, the host has a chance to restart the
+    // device and reprogram it without it jumping right into the firmware.
+    (void)memory_lock_startup_region();
     jump_to_application();
 
     while(1) {}

--- a/stm32-modules/common/module-startup/startup_main.c
+++ b/stm32-modules/common/module-startup/startup_main.c
@@ -8,16 +8,7 @@
 int main() {
     HardwareInit();
 
-    // Because this lock is performed almost immediately on reset, it becomes
-    // impossible in practice to unlock the flash region, even with a
-    // debugger attached - the reset will simply occur too quickly and the
-    // option bits will get rewritten.
-    // 
-    // In order to update the startup region, the best option is to set
-    // the Read Protection Mode to Level 1, and then back to Level 0. This
-    // will clear the entire main flash region, including this startup app,
-    // allowing a debugger to clear out the Write Protection bits.
-    (void)memory_lock_startup_region();
+    bool ok_to_start_app = true;
 
     bool main_app_exists = check_slot(APP_SLOT_MAIN);
     bool backup_app_exists = check_slot(APP_SLOT_BACKUP);
@@ -27,12 +18,12 @@ int main() {
         (void)memory_copy_backup_to_main();
         if(!check_slot(APP_SLOT_MAIN)) {
             // We failed to recover, jump to bootloader
-            jump_to_bootloader();
+            ok_to_start_app = false;
         }
     }
     else if(!main_app_exists) {
         // In this case, we don't have any backup app
-        jump_to_bootloader();
+        ok_to_start_app = false;
     } else {
         // We have a main app, tbd backup
         if(!backup_app_exists || !check_backup_matches_main()) {
@@ -42,7 +33,23 @@ int main() {
         }
     }
     
-    jump_to_application();
+    // Because this lock is performed relatively quickly on reset, it may be
+    // difficult in practice to unlock the flash region, even with a debugger 
+    // attached - the reset will simply occur too quickly and the option bits 
+    // will get rewritten. This is mostly applicable if there is no app
+    // loaded.
+    // 
+    // In order to update the startup region, the most consistent option is 
+    // to set the Read Protection Mode to Level 1, and then back to Level 0. 
+    // This will clear the entire main flash region, including this startup 
+    // app, allowing a debugger to clear out the Write Protection bits.
+    (void)memory_lock_startup_region();
+
+    if(ok_to_start_app) {
+        jump_to_application();
+    } else {
+        jump_to_bootloader();
+    }
 
     while(1) {}
 }

--- a/stm32-modules/common/module-startup/startup_memory.c
+++ b/stm32-modules/common/module-startup/startup_memory.c
@@ -5,6 +5,10 @@
 #include "startup_hal.h"
 
 /** STATIC FUNCTION DECLARATIONS */
+
+/**
+ * @brief Erase one of the applications, either the main or backup slot.
+ */
 static bool erase_app(APP_SLOT_ENUM slot);
 
 /** 
@@ -14,7 +18,19 @@ static bool erase_app(APP_SLOT_ENUM slot);
  */
 static bool memory_copy_image(uint32_t src, uint32_t dst, uint32_t bytes);
 
+/** STATIC VARIABLES */
+
+// _user_app_offset should be declared in the linker script
+extern uint8_t _user_app_offset;
+
+static uint32_t user_app_len = (uint32_t)&_user_app_offset;
+
 /** Public function implementation */
+
+bool memory_lock_startup_region() {
+    uint32_t page_count = user_app_len / FLASH_PAGE_SIZE;
+    return startup_lock_pages(0, page_count);
+}
 
 bool memory_copy_backup_to_main() {
     startup_flash_init();

--- a/stm32-modules/common/module-startup/startup_memory.h
+++ b/stm32-modules/common/module-startup/startup_memory.h
@@ -4,6 +4,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/** Lock the startup app (this application) */
+bool memory_lock_startup_region();
 /** Overwrite the main section with the backup */
 bool memory_copy_backup_to_main();
 /** Overwrite the backup with the main section */


### PR DESCRIPTION
### Summary

Adds functionality for the startup app to lock its own flash region, preventing firmware updates from overwriting it. In practice, this also makes it pretty much impossible to update the startup app without erasing the entire chip - see comments in `startup_main.c` for details.

Adds a specialized function for each MCU target to update the flash region protection bytes, which is now the first step taken by the startup app. The option bytes work pretty differently in the F303 and G491 so these functions have to implement pretty much the entire process.

Tested on heater-shaker and tempdeck-gen3. Confirmed that the region gets locked, and if you try to unlock it (e.g. with a debugger and STM32CubeProgrammer) it gets locked again as soon as the system restarts. 

### Review Requests

Based on testing, it seems that moving the lock to be the last thing done by the startup app would actually let a debugger have enough time to update the option bytes, restart it to load the new bytes, and then halt the device before the startup app locks the region again. Would it make sense to move the lock action to the end of the startup app, and maybe even put a small wait in to make sure there's some time before the lock occurs?