### PR TITLE
feat(all): added flash-erase targets

### DIFF
--- a/stm32-modules/common/STM32F303/CMakeLists.txt
+++ b/stm32-modules/common/STM32F303/CMakeLists.txt
@@ -92,6 +92,11 @@ endfunction()
 
 # Adds a target to clear an STM32F303-based module
 function(stm32f303_clear_target TARGET)
+    # Each step in this target is forced to succed (|| true) because, when
+    # the target reboots to load the option bytes, OpenOCD exits with a
+    # failure code because it was not expecting the reboot. For that same
+    # reason, each of these steps is its own script because they will not
+    # be able to run in a single session sequentially.
     add_custom_target(${TARGET}
         COMMAND ${OpenOCD_EXECUTABLE}
             -f ${OpenOCD_SCRIPTROOT}/board/st_nucleo_f3.cfg

--- a/stm32-modules/common/STM32F303/CMakeLists.txt
+++ b/stm32-modules/common/STM32F303/CMakeLists.txt
@@ -90,3 +90,26 @@ function(stm32f303_startup TARGET FW_NAME)
         )
 endfunction()
 
+# Adds a target to clear an STM32F303-based module
+function(stm32f303_clear_target TARGET)
+    add_custom_target(${TARGET}
+        COMMAND ${OpenOCD_EXECUTABLE}
+            -f ${OpenOCD_SCRIPTROOT}/board/st_nucleo_f3.cfg
+            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/lock_stm32f303.cfg
+            || true
+        COMMAND ${OpenOCD_EXECUTABLE}
+            -f ${OpenOCD_SCRIPTROOT}/board/st_nucleo_f3.cfg
+            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/unlock_stm32f303.cfg
+            || true
+        COMMAND ${OpenOCD_EXECUTABLE}
+            -f ${OpenOCD_SCRIPTROOT}/board/st_nucleo_f3.cfg
+            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/clear_wp_stm32f303.cfg
+            || true
+        COMMAND ${OpenOCD_EXECUTABLE}
+            -f ${OpenOCD_SCRIPTROOT}/board/st_nucleo_f3.cfg
+            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/unlock_stm32f303.cfg
+            || true
+        VERBATIM
+        COMMENT "Clearing flash"
+    )
+endfunction()

--- a/stm32-modules/common/STM32F303/clear_wp_stm32f303.cfg
+++ b/stm32-modules/common/STM32F303/clear_wp_stm32f303.cfg
@@ -1,0 +1,28 @@
+# Script to clear the write protect registers
+init
+reset halt 
+
+sleep 1000
+# First unlock flash
+echo "unlocking flash"
+mww 0x40022004 0x45670123
+sleep 100
+mww 0x40022004 0xCDEF89AB
+sleep 100
+# Next unlock option bytes
+echo "unlocking option bytes"
+mww 0x40022008 0x45670123
+sleep 100
+mww 0x40022008 0xCDEF89AB
+sleep 100
+# Erase option bytes
+echo "enable an option byte erase"
+mww 0x40022010 0x00000220
+mww 0x40022010 0x00000260
+sleep 1000
+
+# Load new option bits
+echo "restarting"
+sleep 100
+stm32f1x options_load 0
+shutdown

--- a/stm32-modules/common/STM32F303/lock_stm32f303.cfg
+++ b/stm32-modules/common/STM32F303/lock_stm32f303.cfg
@@ -1,0 +1,8 @@
+# Set RDP to level 1
+init
+reset halt
+stm32f1x lock 0
+echo "loading..."
+stm32f1x options_load 0
+echo "bye"
+shutdown

--- a/stm32-modules/common/STM32F303/lock_stm32f303.cfg
+++ b/stm32-modules/common/STM32F303/lock_stm32f303.cfg
@@ -2,7 +2,5 @@
 init
 reset halt
 stm32f1x lock 0
-echo "loading..."
 stm32f1x options_load 0
-echo "bye"
 shutdown

--- a/stm32-modules/common/STM32F303/unlock_stm32f303.cfg
+++ b/stm32-modules/common/STM32F303/unlock_stm32f303.cfg
@@ -1,0 +1,6 @@
+# Set RDP back to level 0
+init
+reset halt
+stm32f1x unlock 0
+stm32f1x options_load 0
+shutdown

--- a/stm32-modules/common/STM32G491/CMakeLists.txt
+++ b/stm32-modules/common/STM32G491/CMakeLists.txt
@@ -90,3 +90,27 @@ function(stm32g491_startup TARGET FW_NAME)
         USES_TERMINAL
         )
 endfunction()
+
+# Adds a target to clear an STM32F303-based module
+function(stm32g491_clear_target TARGET)
+    add_custom_target(${TARGET}
+        COMMAND ${OpenOCD_EXECUTABLE}
+            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/stm32g4discovery.cfg
+            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/lock_stm32g491.cfg
+            || true
+        COMMAND ${OpenOCD_EXECUTABLE}
+            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/stm32g4discovery.cfg
+            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/unlock_stm32g491.cfg
+            || true
+        COMMAND ${OpenOCD_EXECUTABLE}
+            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/stm32g4discovery.cfg
+            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/clear_wp_stm32g491.cfg
+            || true
+        COMMAND ${OpenOCD_EXECUTABLE}
+            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/stm32g4discovery.cfg
+            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/unlock_stm32g491.cfg
+            || true
+        VERBATIM
+        COMMENT "Clearing flash"
+    )
+endfunction()

--- a/stm32-modules/common/STM32G491/CMakeLists.txt
+++ b/stm32-modules/common/STM32G491/CMakeLists.txt
@@ -111,10 +111,6 @@ function(stm32g491_clear_target TARGET)
             -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/stm32g4discovery.cfg
             -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/clear_wp_stm32g491.cfg
             || true
-        COMMAND ${OpenOCD_EXECUTABLE}
-            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/stm32g4discovery.cfg
-            -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/unlock_stm32g491.cfg
-            || true
         VERBATIM
         COMMENT "Clearing flash"
     )

--- a/stm32-modules/common/STM32G491/CMakeLists.txt
+++ b/stm32-modules/common/STM32G491/CMakeLists.txt
@@ -93,6 +93,11 @@ endfunction()
 
 # Adds a target to clear an STM32F303-based module
 function(stm32g491_clear_target TARGET)
+    # Each step in this target is forced to succed (|| true) because, when
+    # the target reboots to load the option bytes, OpenOCD exits with a
+    # failure code because it was not expecting the reboot. For that same
+    # reason, each of these steps is its own script because they will not
+    # be able to run in a single session sequentially.
     add_custom_target(${TARGET}
         COMMAND ${OpenOCD_EXECUTABLE}
             -f ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/stm32g4discovery.cfg

--- a/stm32-modules/common/STM32G491/clear_wp_stm32g491.cfg
+++ b/stm32-modules/common/STM32G491/clear_wp_stm32g491.cfg
@@ -1,0 +1,37 @@
+# Script to clear the write protect registers
+init
+reset halt 
+
+# 0x40022000
+
+sleep 1000
+# First unlock flash
+echo "unlocking flash"
+mww 0x40022008 0x45670123
+sleep 100
+mww 0x40022008 0xCDEF89AB
+sleep 100
+# Next unlock option bytes
+echo "unlocking option bytes"
+mww 0x4002200C 0x08192A3B
+sleep 100
+mww 0x4002200C 0x4C5D6E7F
+sleep 100
+
+# Set WRP values
+echo "setting write protect regions"
+mww 0x4002202C 0x00FF00FF
+sleep 100
+mww 0x40022030 0x00FF00FF
+sleep 100
+
+# Set OPTSTRT bit
+mww 0x40022014 0x00020000
+sleep 1000
+
+# Load new option bits
+echo "restarting"
+mww 0x40022014 0x08000000
+sleep 100
+reset halt 
+shutdown

--- a/stm32-modules/common/STM32G491/lock_stm32g491.cfg
+++ b/stm32-modules/common/STM32G491/lock_stm32g491.cfg
@@ -1,0 +1,33 @@
+source [find mem_helper.tcl]
+
+# Set RDP to level 1
+init
+reset halt
+
+# First unlock flash
+echo "unlocking flash"
+mww 0x40022008 0x45670123
+sleep 100
+mww 0x40022008 0xCDEF89AB
+sleep 100
+# Next unlock option bytes
+echo "unlocking option bytes"
+mww 0x4002200C 0x08192A3B
+sleep 100
+mww 0x4002200C 0x4C5D6E7F
+sleep 100
+
+# Set read protection to 0xBB
+mmw 0x40022020 0 0x000000FF
+mmw 0x40022020 0x000000BB 0
+
+# Set OPTSTRT bit
+mww 0x40022014 0x00020000
+sleep 1000
+
+# Load new option bits
+echo "restarting"
+mww 0x40022014 0x08000000
+sleep 100
+reset halt 
+shutdown

--- a/stm32-modules/common/STM32G491/unlock_stm32g491.cfg
+++ b/stm32-modules/common/STM32G491/unlock_stm32g491.cfg
@@ -1,0 +1,33 @@
+source [find mem_helper.tcl]
+
+# Set RDP to level 0
+init
+reset halt
+
+# First unlock flash
+echo "unlocking flash"
+mww 0x40022008 0x45670123
+sleep 100
+mww 0x40022008 0xCDEF89AB
+sleep 100
+# Next unlock option bytes
+echo "unlocking option bytes"
+mww 0x4002200C 0x08192A3B
+sleep 100
+mww 0x4002200C 0x4C5D6E7F
+sleep 100
+
+# Set read protection to 0xAA
+mmw 0x40022020 0 0x000000FF
+mmw 0x40022020 0x000000AA 0
+
+# Set OPTSTRT bit
+mww 0x40022014 0x00020000
+sleep 1000
+
+# Load new option bits
+echo "restarting"
+mww 0x40022014 0x08000000
+sleep 100
+reset halt 
+shutdown

--- a/stm32-modules/heater-shaker/README.md
+++ b/stm32-modules/heater-shaker/README.md
@@ -13,6 +13,8 @@ When cross-compiling the firmware (using the `stm32-cross` cmake preset, running
 - Flash the firmware to a board: `cmake --build ./build-stm32-cross --target heater-shaker-flash`
 - Builds heater-shaker-image.hex, suitable for use with stm's programmer: `cmake --build ./build-stm32-cross --target heater-shaker-image-hex`
 - Builds heater-shaker-image.bin, suitable for some other programmers: `cmake --build ./build-stm32-cross --target heater-shaker-image-bin`
+- Build the startup app, which is also packaged into the image files: `cmake --build ./build-stm32-cross --target heater-shaker-startup`
+- Delete all of the contents on a heater-shaker MCU, and wipe any memory protection: `cmake --build ./build-stm32-cross --target heater-shaker-clear`
 
 ### Debugging
 There's a target called `heater-shaker-debug` that will build the firmware and then spin up a gdb, spin up an openocd, and connect the two; load some useful python scripts; connect to an st-link that should be already plugged in; automatically upload the firmware, and drop you at a breakpoint at boot time. This should all download itself and be ready as soon as `cmake --preset=stm32-cross .` completes, with one exception: Gdb python support is incredibly weird and will somehow always find your python2 that the system has, no matter how hard you try to avoid this. The scripts should work fine, but you have to install setuptools so `pkg_resources` is available, since this isn't really something we want to "install" by downloading it to some random directory and dropping it in gdb's embedded python interpreter's package path, so do the lovely

--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -219,6 +219,8 @@ add_custom_target(heater-shaker-debug
   USES_TERMINAL
   )
 
+stm32f303_clear_target(heater-shaker-clear)
+
 # Runs openocd to flash the board (without using a debugger)
 add_custom_target(heater-shaker-flash
   COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${OpenOCD_SCRIPTROOT}/board/st_nucleo_f3.cfg" "-c" "program $<TARGET_FILE:heater-shaker>;exit"

--- a/stm32-modules/tempdeck-gen3/README.md
+++ b/stm32-modules/tempdeck-gen3/README.md
@@ -46,6 +46,8 @@ When cross-compiling the firmware (using the `stm32-cross` cmake preset, running
 - Flash the firmware to a board: `cmake --build ./build-stm32-cross --target tempdeck-gen3-flash`
 - Build a .hex file suitable for use with stm's programmer: `cmake --build ./build-stm32-cross --target tempdeck-gen3-hex`
 - Build a .bin file suitable for some other programmers: `cmake --build ./build-stm32-cross --target tempdeck-gen3-bin`
+- Build the startup app, which is also packaged into the image files: `cmake --build ./build-stm32-cross --target tempdeck-gen3-startup`
+- Delete all of the contents on a tempdeck-gen3 MCU, and wipe any memory protection: `cmake --build ./build-stm32-cross --target tempdeck-gen3-clear`
 
 ### Debugging
 There's a target called `tempdeck-gen3-debug` that will build the firmware and then spin up a gdb, spin up an openocd, and connect the two; load some useful python scripts; connect to an st-link that should be already plugged in; automatically upload the firmware, and drop you at a breakpoint at boot time. This should all download itself and be ready as soon as `cmake --preset=stm32-cross .` completes, with one exception: Gdb python support is incredibly weird and will somehow always find your python2 that the system has, no matter how hard you try to avoid this. The scripts should work fine, but you have to install setuptools so `pkg_resources` is available, since this isn't really something we want to "install" by downloading it to some random directory and dropping it in gdb's embedded python interpreter's package path, so do the lovely

--- a/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
@@ -209,6 +209,8 @@ set(BIN_IMG_NAME "${TARGET_MODULE_NAME}-image@${${TARGET_MODULE_NAME}_VERSION}.b
   
 set(STARTUP_NAME ${TARGET_MODULE_NAME}-startup)
 
+stm32g491_clear_target(${TARGET_MODULE_NAME}-clear)
+
 stm32g491_startup(${STARTUP_NAME} ${TARGET_MODULE_NAME})
 
 # Targets to create full image hex file containing both bootloader and application

--- a/stm32-modules/thermocycler-gen2/README.md
+++ b/stm32-modules/thermocycler-gen2/README.md
@@ -44,6 +44,8 @@ When cross-compiling the firmware (using the `stm32-cross` cmake preset, running
 - Flash the firmware to a board: `cmake --build ./build-stm32-cross --target thermocycler-gen2-flash`
 - Build a .hex file suitable for use with stm's programmer: `cmake --build ./build-stm32-cross --target thermocycler-gen2-hex`
 - Build a .bin file suitable for some other programmers: `cmake --build ./build-stm32-cross --target thermocycler-gen2-bin`
+- Build the startup app, which is also packaged into the image files: `cmake --build ./build-stm32-cross --target thermocycler-gen2-startup`
+- Delete all of the contents on a thermocycler MCU, and wipe any memory protection: `cmake --build ./build-stm32-cross --target thermocycler-gen2-clear`
 
 ### Debugging
 There's a target called `thermocycler-gen2-debug` that will build the firmware and then spin up a gdb, spin up an openocd, and connect the two; load some useful python scripts; connect to an st-link that should be already plugged in; automatically upload the firmware, and drop you at a breakpoint at boot time. This should all download itself and be ready as soon as `cmake --preset=stm32-cross .` completes, with one exception: Gdb python support is incredibly weird and will somehow always find your python2 that the system has, no matter how hard you try to avoid this. The scripts should work fine, but you have to install setuptools so `pkg_resources` is available, since this isn't really something we want to "install" by downloading it to some random directory and dropping it in gdb's embedded python interpreter's package path, so do the lovely

--- a/stm32-modules/thermocycler-gen2/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/firmware/CMakeLists.txt
@@ -211,6 +211,8 @@ set(BIN_IMG_NAME "${TARGET_MODULE_NAME}-image@${${TARGET_MODULE_NAME}_VERSION}.b
 
 set(STARTUP_NAME ${TARGET_MODULE_NAME}-startup)
 
+stm32g491_clear_target(${TARGET_MODULE_NAME}-clear)
+
 stm32g491_startup(${STARTUP_NAME} ${TARGET_MODULE_NAME})
 
 # Targets to create full image hex file containing both bootloader and application


### PR DESCRIPTION
Adds a target for each stm32 module to erase the flash contents. This is required because the startup app automatically locks its own flash, which means that a simple mass-erase won't work.

Simply clearing the option bits and then erasing isn't an option because, in the case that no firmware is loaded to either slot on the device, the startup app will re-lock before the host is able to halt it and start the erase. Therefore, the process is as follows:
- Enable the read protection, and then disable it to trigger a mass-erase (which affects even write-protected regions)
- Disable write protection
- On the STM32F303 target which clears the write-protect by erasing all of the option bytes, re-unlock the read protection

Tested on Heater-Shaker and Thermocycler-Gen2. Running the corresponding targets results in the board memory getting wiped and the write protection being fully disabled.