### PR TITLE
fix(all): regenerate hex and bin targets more consistently

### DIFF
--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -175,6 +175,7 @@ add_custom_target(heater-shaker-integrity ALL
 # flashable targets should derive from the initial hex.
 add_custom_command(OUTPUT heater-shaker.hex
   COMMAND ${CROSS_OBJCOPY} ARGS heater-shaker "-Oihex" heater-shaker.hex
+  DEPENDS heater-shaker
   DEPENDS heater-shaker-integrity
   DEPENDS ${CMAKE_SOURCE_DIR}/scripts/calculate_checksum.py
   VERBATIM)
@@ -190,6 +191,7 @@ add_custom_command(OUTPUT heater-shaker.bin
   VERBATIM)
 add_custom_target(heater-shaker-bin ALL
   DEPENDS heater-shaker.bin)
+add_dependencies(heater-shaker-bin heater-shaker-hex)
 
 # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html
 # which is a catch-all static analyzer/linter
@@ -235,15 +237,15 @@ stm32f303_startup(heater-shaker-startup heater-shaker)
 # Targets to create full image hex and binary files containing both bootloader and application
 add_custom_command(
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex"
-    DEPENDS $<TARGET_FILE_DIR:heater-shaker>/heater-shaker.hex
+    DEPENDS heater-shaker-hex
     DEPENDS heater-shaker-startup-hex
     DEPENDS $<TARGET_FILE_DIR:heater-shaker-startup>/heater-shaker-startup.hex
     COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex" $<TARGET_FILE_DIR:heater-shaker-startup>/heater-shaker-startup.hex heater-shaker.hex
-    VERBATIM
-    COMMENT "Generating full image")
+    VERBATIM)
 add_custom_target(heater-shaker-image-hex ALL
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex"
-    DEPENDS heater-shaker)
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex")
+add_dependencies(heater-shaker-image-hex
+    heater-shaker-hex)
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.bin"
   COMMAND ${CROSS_OBJCOPY} ARGS 
@@ -251,9 +253,12 @@ add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-sh
     "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex" 
     "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.bin"
   DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex"
+  DEPENDS heater-shaker-image-hex
   VERBATIM)
 add_custom_target(heater-shaker-image-bin ALL
   DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.bin")
+add_dependencies(heater-shaker-image-bin
+    heater-shaker-image-hex)
 
 add_custom_command(
   OUTPUT "${CMAKE_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.zip"
@@ -275,7 +280,7 @@ add_custom_target(heater-shaker-flash
         "-c" "program heater-shaker.hex reset;exit"
     VERBATIM
     COMMENT "Flashing board"
-    DEPENDS heater-shaker-hex)
+    DEPENDS heater-shaker.hex)
 # Runs openocd to flash the board with the full image (startup included)
 add_custom_target(heater-shaker-image-flash
     COMMAND "${OpenOCD_EXECUTABLE}" 
@@ -283,7 +288,7 @@ add_custom_target(heater-shaker-image-flash
         "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex reset;exit"
     VERBATIM
     COMMENT "Flashing board"
-    DEPENDS heater-shaker-image-hex)
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.hex")
 
 add_custom_target(heater-shaker-zip
   DEPENDS "${CMAKE_BINARY_DIR}/heater-shaker@${heater-shaker_VERSION}.zip")

--- a/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
@@ -150,6 +150,7 @@ add_custom_target(${TARGET_MODULE_NAME}-integrity ALL
 # flashable targets should derive from the initial hex.
 add_custom_command(OUTPUT ${TARGET_MODULE_NAME}.hex
   COMMAND ${CROSS_OBJCOPY} ARGS ${TARGET_MODULE_NAME} "-Oihex" ${TARGET_MODULE_NAME}.hex
+  DEPENDS ${TARGET_MODULE_NAME}
   DEPENDS ${TARGET_MODULE_NAME}-integrity
   DEPENDS ${CMAKE_SOURCE_DIR}/scripts/calculate_checksum.py
   VERBATIM)
@@ -165,6 +166,7 @@ add_custom_command(OUTPUT ${TARGET_MODULE_NAME}.bin
   VERBATIM)
 add_custom_target(${TARGET_MODULE_NAME}-bin ALL
   DEPENDS ${TARGET_MODULE_NAME}.bin)
+add_dependencies(${TARGET_MODULE_NAME}-bin ${TARGET_MODULE_NAME}-hex)
 
 # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html
 # which is a catch-all static analyzer/linter
@@ -217,24 +219,27 @@ stm32g491_startup(${STARTUP_NAME} ${TARGET_MODULE_NAME})
 # Targets to create full image hex file containing both bootloader and application
 add_custom_command(
     OUTPUT ${HEX_IMG_NAME}
-    DEPENDS $<TARGET_FILE_DIR:${TARGET_MODULE_NAME}>/${TARGET_MODULE_NAME}.hex
+    DEPENDS ${TARGET_MODULE_NAME}-hex
     DEPENDS ${STARTUP_NAME}-hex
-    DEPENDS $<TARGET_FILE_DIR:${STARTUP_NAME}>/${STARTUP_NAME}.hex
+    DEPENDS ${TARGET_MODULE_NAME}.hex
     COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py ${HEX_IMG_NAME} $<TARGET_FILE_DIR:${STARTUP_NAME}>/${STARTUP_NAME}.hex ${TARGET_MODULE_NAME}.hex
-    VERBATIM
-    COMMENT "Generating full image")
+    VERBATIM)
 add_custom_target(${TARGET_MODULE_NAME}-image-hex ALL
-    DEPENDS ${STARTUP_NAME}-hex
     DEPENDS ${HEX_IMG_NAME})
+add_dependencies(${TARGET_MODULE_NAME}-image-hex
+    ${TARGET_MODULE_NAME}-hex)
 
 add_custom_command(OUTPUT "${BIN_IMG_NAME}"
     COMMAND ${CROSS_OBJCOPY} ARGS 
         "-Iihex" "-Obinary" "--gap-fill=0xFF"
         "${HEX_IMG_NAME}" "${BIN_IMG_NAME}"
     DEPENDS "${HEX_IMG_NAME}"
+    DEPENDS ${TARGET_MODULE_NAME}-image-hex
     VERBATIM)
 add_custom_target(${TARGET_MODULE_NAME}-image-bin ALL
-    DEPENDS "${BIN_IMG_NAME}")
+    DEPENDS ${BIN_IMG_NAME})
+add_dependencies(${TARGET_MODULE_NAME}-image-bin
+    ${TARGET_MODULE_NAME}-image-hex)
 
 set(ZIP_NAME "${CMAKE_BINARY_DIR}/${TARGET_MODULE_NAME}@${${TARGET_MODULE_NAME}_VERSION}.zip")
 
@@ -245,7 +250,7 @@ add_custom_target(${TARGET_MODULE_NAME}-flash
         "-c" "program ${TARGET_MODULE_NAME}.hex reset;exit"
     VERBATIM
     COMMENT "Flashing board"
-    DEPENDS ${TARGET_MODULE_NAME}-hex)
+    DEPENDS ${TARGET_MODULE_NAME}.hex)
 # Runs openocd to flash the board with the full image (startup included)
 add_custom_target(${TARGET_MODULE_NAME}-image-flash
     COMMAND "${OpenOCD_EXECUTABLE}" 
@@ -253,7 +258,7 @@ add_custom_target(${TARGET_MODULE_NAME}-image-flash
         "-c" "program ${HEX_IMG_NAME} reset;exit"
     VERBATIM
     COMMENT "Flashing board"
-    DEPENDS ${TARGET_MODULE_NAME}-image-hex)
+    DEPENDS ${HEX_IMG_NAME})
 
 add_custom_command(
     OUTPUT ${ZIP_NAME}

--- a/stm32-modules/thermocycler-gen2/firmware/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/firmware/CMakeLists.txt
@@ -152,6 +152,7 @@ add_custom_target(${TARGET_MODULE_NAME}-integrity ALL
 # flashable targets should derive from the initial hex.
 add_custom_command(OUTPUT ${TARGET_MODULE_NAME}.hex
   COMMAND ${CROSS_OBJCOPY} ARGS ${TARGET_MODULE_NAME} "-Oihex" ${TARGET_MODULE_NAME}.hex
+  DEPENDS ${TARGET_MODULE_NAME}
   DEPENDS ${TARGET_MODULE_NAME}-integrity
   DEPENDS ${CMAKE_SOURCE_DIR}/scripts/calculate_checksum.py
   VERBATIM)
@@ -167,6 +168,7 @@ add_custom_command(OUTPUT ${TARGET_MODULE_NAME}.bin
   VERBATIM)
 add_custom_target(${TARGET_MODULE_NAME}-bin ALL
   DEPENDS ${TARGET_MODULE_NAME}.bin)
+add_dependencies(${TARGET_MODULE_NAME}-bin ${TARGET_MODULE_NAME}-hex)
 
 # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html
 # which is a catch-all static analyzer/linter
@@ -219,24 +221,27 @@ stm32g491_startup(${STARTUP_NAME} ${TARGET_MODULE_NAME})
 # Targets to create full image hex file containing both bootloader and application
 add_custom_command(
     OUTPUT ${HEX_IMG_NAME}
-    DEPENDS $<TARGET_FILE_DIR:${TARGET_MODULE_NAME}>/${TARGET_MODULE_NAME}.hex
+    DEPENDS ${TARGET_MODULE_NAME}-hex
     DEPENDS ${STARTUP_NAME}-hex
-    DEPENDS $<TARGET_FILE_DIR:${STARTUP_NAME}>/${STARTUP_NAME}.hex
+    DEPENDS ${TARGET_MODULE_NAME}.hex
     COMMAND ${CMAKE_SOURCE_DIR}/scripts/hex_combine.py ${HEX_IMG_NAME} $<TARGET_FILE_DIR:${STARTUP_NAME}>/${STARTUP_NAME}.hex ${TARGET_MODULE_NAME}.hex
-    VERBATIM
-    COMMENT "Generating full image")
+    VERBATIM)
 add_custom_target(${TARGET_MODULE_NAME}-image-hex ALL
-    DEPENDS ${STARTUP_NAME}-hex
     DEPENDS ${HEX_IMG_NAME})
+add_dependencies(${TARGET_MODULE_NAME}-image-hex
+    ${TARGET_MODULE_NAME}-hex)
 
 add_custom_command(OUTPUT "${BIN_IMG_NAME}"
     COMMAND ${CROSS_OBJCOPY} ARGS 
         "-Iihex" "-Obinary" "--gap-fill=0xFF"
         "${HEX_IMG_NAME}" "${BIN_IMG_NAME}"
     DEPENDS "${HEX_IMG_NAME}"
+    DEPENDS ${TARGET_MODULE_NAME}-image-hex
     VERBATIM)
 add_custom_target(${TARGET_MODULE_NAME}-image-bin ALL
-    DEPENDS "${BIN_IMG_NAME}")
+    DEPENDS ${BIN_IMG_NAME})
+add_dependencies(${TARGET_MODULE_NAME}-image-bin
+    ${TARGET_MODULE_NAME}-image-hex)
 
 set(ZIP_NAME "${CMAKE_BINARY_DIR}/${TARGET_MODULE_NAME}@${${TARGET_MODULE_NAME}_VERSION}.zip")
 
@@ -247,7 +252,7 @@ add_custom_target(${TARGET_MODULE_NAME}-flash
         "-c" "program ${TARGET_MODULE_NAME}.hex reset;exit"
     VERBATIM
     COMMENT "Flashing board"
-    DEPENDS ${TARGET_MODULE_NAME}-hex)
+    DEPENDS ${TARGET_MODULE_NAME}.hex)
 # Runs openocd to flash the board with the full image (startup included)
 add_custom_target(${TARGET_MODULE_NAME}-image-flash
     COMMAND "${OpenOCD_EXECUTABLE}" 
@@ -255,7 +260,7 @@ add_custom_target(${TARGET_MODULE_NAME}-image-flash
         "-c" "program ${HEX_IMG_NAME} reset;exit"
     VERBATIM
     COMMENT "Flashing board"
-    DEPENDS ${TARGET_MODULE_NAME}-image-hex)
+    DEPENDS ${HEX_IMG_NAME})
 
 add_custom_command(
     OUTPUT ${ZIP_NAME}


### PR DESCRIPTION
There were some issues with the way dependencies between targets were defined.
* Some custom commands didn't have dependencies on all of the targets needed to cause regeneration (e.g. the hex targets need to depend on the base module target)
* Some custom targets were trying to define target-level dependencies in their definition, which is not allowed for some reason unbeknownst to me. This needs to happen in a separate `add_dependencies` call.

In general, we want to make the dependencies for custom _commands_ be custom targets when possible, because those will rerun unconditionally. 