### PR TITLE
fix(heater-shaker): force USB disconnect on startup

### DIFF
--- a/stm32-modules/heater-shaker/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/host_comms_task/freertos_comms_task.cpp
@@ -104,6 +104,9 @@ extern __ALIGN_BEGIN uint8_t
 
 static std::atomic_bool UartReady = true;
 
+// Wait a whole second to ensure host detects the change
+static constexpr uint32_t _usb_reset_time_ms = 1000;
+
 // Actual function that runs in the task
 void run(void *param) {  // NOLINT(misc-unused-parameters)
     auto *task_pair = static_cast<decltype(_tasks) *>(param);
@@ -118,6 +121,7 @@ void run(void *param) {  // NOLINT(misc-unused-parameters)
     USBD_CDC_CfgHSDesc[30] = 0;
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     USBD_CDC_CfgFSDesc[30] = 0;
+    usb_device_reset(_usb_reset_time_ms);
     USBD_Init(&local_task->usb_handle, &CDC_Desc, 0);
     USBD_RegisterClass(&local_task->usb_handle, USBD_CDC_CLASS);
     USBD_CDC_RegisterInterface(&local_task->usb_handle,

--- a/stm32-modules/heater-shaker/firmware/host_comms_task/usbd_conf.c
+++ b/stm32-modules/heater-shaker/firmware/host_comms_task/usbd_conf.c
@@ -32,6 +32,27 @@
 static uint8_t cdc_classhandle_backing_store[sizeof(USBD_CDC_HandleTypeDef)];
 static PCD_HandleTypeDef pcd_handle;
 
+void usb_device_reset(uint32_t delay_ms) {
+    GPIO_InitTypeDef init;
+
+    /* Enable the GPIOA clock for USB DataLines */
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    /* Configure USB DP pin */
+    init.Pin = (GPIO_PIN_12);
+    init.Mode = GPIO_MODE_OUTPUT_PP;
+    init.Pull = GPIO_NOPULL;
+    init.Speed = GPIO_SPEED_FREQ_HIGH;
+    HAL_GPIO_Init(GPIOA, &init);
+
+    // Write 0 for a single ended 0
+    HAL_GPIO_WritePin(GPIOA, init.Pin, GPIO_PIN_RESET);
+    
+    vTaskDelay(pdMS_TO_TICKS(delay_ms));
+
+    // Deinit the GPIO to make sure USB initialization works
+    HAL_GPIO_DeInit(GPIOA, init.Pin);
+}
+
 // All the HAL_PCD functions here are statically-defined callbacks from the HAL.
 // The ones that don't do anything are present only as a reminder they exist.
 //

--- a/stm32-modules/heater-shaker/firmware/host_comms_task/usbd_conf.h
+++ b/stm32-modules/heater-shaker/firmware/host_comms_task/usbd_conf.h
@@ -31,6 +31,20 @@ extern "C" {
 #include "stm32f3xx.h"
 #include "stm32f3xx_hal_pcd.h"
 
+/**
+ * @brief This function is intended to be called BEFORE the USB
+ * peripheral is initialized. It will set USB D+ to 0v to try to signal
+ * that no device is connected.
+ * 
+ * This is required due to the hard-wired pullup on the D+ line. When
+ * the Heater Shaker powers on, a USB Host will expect a valid device
+ * even though the USB isn't initialized. This function should signal
+ * to the host that the device is restarted and prompt re-enumeration.
+ * 
+ * @param delay_ms Milliseconds to delay before returning
+ */
+void usb_device_reset(uint32_t delay_ms);
+
 extern void *cdc_classhandle_malloc(size_t size);
 // extern void free_noop(void* _ignored) {(void)_ignored;}
 

--- a/stm32-modules/heater-shaker/firmware/host_comms_task/usbd_conf.h
+++ b/stm32-modules/heater-shaker/firmware/host_comms_task/usbd_conf.h
@@ -35,12 +35,12 @@ extern "C" {
  * @brief This function is intended to be called BEFORE the USB
  * peripheral is initialized. It will set USB D+ to 0v to try to signal
  * that no device is connected.
- * 
+ *
  * This is required due to the hard-wired pullup on the D+ line. When
  * the Heater Shaker powers on, a USB Host will expect a valid device
  * even though the USB isn't initialized. This function should signal
  * to the host that the device is restarted and prompt re-enumeration.
- * 
+ *
  * @param delay_ms Milliseconds to delay before returning
  */
 void usb_device_reset(uint32_t delay_ms);


### PR DESCRIPTION
The heater-shaker PCB has a hardwired pullup on the D+ line to indicate that it is a valid Full Speed device. Unfortunately, with the addition of the startup app, sometimes it takes ~10 seconds until the peripheral is actually initialized. During that time, the USB host expects a valid USB device to be connected, and will attempt enumeration.

This PR fixes the issue by forcing the D+ line on the USB low for a second, right before initializing the USB peripheral. This forces the USB host to re-enumerate the bus even if it failed previously, and it successfully detects the heater-shaker.

Tested with by my Mac and with an OT-2 by updating from v1.0.1 to v1.0.2. When the device restarts, it is detected as a USB CDC device correctly once it starts the application firmware.