### PR TITLE
chore(heater-shaker): save zip output when creating release

### DIFF
--- a/.github/workflows/heater-shaker-create-release.yaml
+++ b/.github/workflows/heater-shaker-create-release.yaml
@@ -37,6 +37,10 @@ jobs:
         run: cmake --build --preset cross --target heater-shaker-zip
       - name: 'Prep for install'
         run: cmake --install ./build-stm32-cross --component heater-shaker
+      - name: 'Save firmware artifacts'
+        uses: actions/upload-artifact@v3
+        with:
+          path: dist/heater-shaker/*.zip
       - if: github.event_name != 'pull_request'
         name: 'Deploy'
         env:

--- a/.github/workflows/heater-shaker.yaml
+++ b/.github/workflows/heater-shaker.yaml
@@ -13,6 +13,7 @@ on:
       - '.clang-format'
       - '.clang-tidy'
       - 'cpp-utils/**/*'
+      - '.github/workflows/heater-shaker-create-release.yaml'
     paths_ignore:
       - 'cmake/Arduino*'
   push:


### PR DESCRIPTION
Store the output of the heater-shaker-zip target as an artifact in github actions. Will test by triggering the workflow on this branch.

**EDIT** tested by manually running the github action, and confirmed that it stores the zipfile artifact for download.