### PR TITLE
chore(thermocycler-gen2): deploy releases to aws

### DIFF
--- a/.github/workflows/heater-shaker-create-release.yaml
+++ b/.github/workflows/heater-shaker-create-release.yaml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - 'heater-shaker@*'
+  pull_request:
+    paths:
+      - '.github/workflows/heater-shaker-create-release.yaml'
   workflow_dispatch:
 
 

--- a/.github/workflows/thermocycler-gen2-create-release.yaml
+++ b/.github/workflows/thermocycler-gen2-create-release.yaml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - 'thermocycler-gen2@*'
+  pull_request:
+    paths:
+      - '.github/workflows/thermocycler-gen2-create-release.yaml'
   workflow_dispatch:
 
 

--- a/.github/workflows/thermocycler-gen2-create-release.yaml
+++ b/.github/workflows/thermocycler-gen2-create-release.yaml
@@ -1,8 +1,8 @@
-name: 'Heater-shaker create release from tag'
+name: 'Thermocycler-gen2 create release from tag'
 on:
   push:
     tags:
-      - 'heater-shaker@*'
+      - 'thermocycler-gen2@*'
   workflow_dispatch:
 
 
@@ -28,20 +28,20 @@ jobs:
       - name: 'Configure'
         run: cmake --preset=stm32-cross .
       - name: 'Build'
-        run: cmake --build --preset cross --target heater-shaker-hex
+        run: cmake --build --preset cross --target thermocycler-gen2-hex
       - name: 'Build Combo Image Hex'
-        run: cmake --build --preset cross --target heater-shaker-image-hex
+        run: cmake --build --preset cross --target thermocycler-gen2-image-hex
       - name: 'Build Combo Image Binary'
-        run: cmake --build --preset cross --target heater-shaker-image-bin
+        run: cmake --build --preset cross --target thermocycler-gen2-image-bin
       - name: 'Build Combo Image Zip'
-        run: cmake --build --preset cross --target heater-shaker-zip
+        run: cmake --build --preset cross --target thermocycler-gen2-zip
       - name: 'Prep for install'
-        run: cmake --install ./build-stm32-cross --component heater-shaker
+        run: cmake --install ./build-stm32-cross --component thermocycler-gen2
       - name: 'Save firmware artifacts'
         uses: actions/upload-artifact@v3
         with:
-          name: heater-shaker-build
-          path: dist/heater-shaker/*.zip
+          name: thermocycler-gen2-build
+          path: dist/thermocycler-gen2/*.zip
       - if: github.event_name != 'pull_request'
         name: 'Deploy'
         env:

--- a/.github/workflows/thermocycler-gen2.yaml
+++ b/.github/workflows/thermocycler-gen2.yaml
@@ -13,6 +13,7 @@ on:
       - '.clang-format'
       - '.clang-tidy'
       - 'cpp-utils/**/*'
+      - '.github/workflows/thermocycler-gen2-create-release.yaml'
     paths_ignore:
       - 'cmake/Arduino*'
   push:

--- a/scripts/set_build_vars.sh
+++ b/scripts/set_build_vars.sh
@@ -27,6 +27,11 @@ case $TRAVIS_TAG in
     export RELEASE_UPLOAD_DIR="heater-shaker/${RELEASE_VERSION}"
     ;;
 
+  thermocycler-gen2@v*)
+    export RELEASE_LOCAL_DIR="${DIST_DIR}/thermocycler-gen2"
+    export RELEASE_UPLOAD_DIR="thermocycler-gen2/${RELEASE_VERSION}"
+    ;;
+
   *)
     export RELEASE_LOCAL_DIR=$DIST_DIR
     export RELEASE_UPLOAD_DIR="modules-${THIS_BUILD_TAG}-${TRAVIS_BRANCH}"


### PR DESCRIPTION

* Added explicit naming of artifacts for heater-shaker releases
* Added workflow to deploy TC2 firmware to AWS

- [x] Test that this succeeds when run manually against this branch
- [x] Does the target directory in AWS have to be set up manually before this can succeed?