### PR TITLE
fix(heater-shaker): update LED debug behavior

### DIFF
--- a/stm32-modules/heater-shaker/tests/test_system_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_system_task.cpp
@@ -161,7 +161,7 @@ SCENARIO("system task message passing") {
             THEN("the task should process the message") {
                 REQUIRE(tasks->get_system_queue().backing_deque.empty());
                 REQUIRE(tasks->get_system_task().get_led_mode() ==
-                        LED_MODE::SOLID_HOLDING);
+                        LED_MODE::PULSE);
                 REQUIRE(tasks->get_system_task().get_led_color() ==
                         LED_COLOR::AMBER);
                 AND_THEN(

--- a/stm32-modules/include/heater-shaker/heater-shaker/system_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/system_task.hpp
@@ -224,7 +224,7 @@ class SystemTask {
     auto visit_message(const messages::SetLEDMessage& msg, Policy& policy)
         -> void {
         _led_state.current_color = msg.color;
-        _led_state.current_mode = LED_MODE::SOLID_HOLDING;
+        _led_state.current_mode = LED_MODE::PULSE;
 
         if (msg.from_host) {
             auto response =


### PR DESCRIPTION
For better QC testing, pulse LED in requested color instead of holding at that color