### PR TITLE
fix(all): mark HAL structs in RESET state

### DIFF
--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
@@ -146,6 +146,7 @@ static void adc_setup(ADC_HandleTypeDef* adc) {
 }
 
 static void tim_setup(TIM_HandleTypeDef* tim) {
+    tim->State = HAL_TIM_STATE_RESET;
     tim->Instance = TIM4;
     tim->Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
     tim->Init.CounterMode = TIM_COUNTERMODE_UP;

--- a/stm32-modules/heater-shaker/firmware/host_comms_task/uart_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/host_comms_task/uart_hardware.c
@@ -10,6 +10,8 @@ void UART_Init(UART_HandleTypeDef *huart)
   HAL_StatusTypeDef ret;
   uart_handle = huart;
 
+  // huart state does not need to be preset to RESET because the call to
+  // DeInit the peripheral handles that
   huart->Instance        = USARTx;
   huart->Init.BaudRate   = 115200;
   huart->Init.WordLength = UART_WORDLENGTH_8B;

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
@@ -218,6 +218,7 @@ static void MX_TIM1_Init(TIM_HandleTypeDef* tim1)
   /* USER CODE BEGIN TIM1_Init 1 */
 
   /* USER CODE END TIM1_Init 1 */
+  tim1->State = HAL_TIM_STATE_RESET;
   tim1->Instance = TIM1;
   tim1->Init.Prescaler = ((TIM_CLOCK_DIVIDER) - 1);
   tim1->Init.CounterMode = TIM_COUNTERMODE_CENTERALIGNED1;
@@ -312,6 +313,7 @@ static void MX_TIM2_Init(TIM_HandleTypeDef* tim2)
   /* USER CODE BEGIN TIM2_Init 1 */
 
   /* USER CODE END TIM2_Init 1 */
+  tim2->State = HAL_TIM_STATE_RESET;
   tim2->Instance = TIM2;
   tim2->Init.Prescaler = 0;
   tim2->Init.CounterMode = TIM_COUNTERMODE_UP;
@@ -349,6 +351,7 @@ static void MX_TIM2_Init(TIM_HandleTypeDef* tim2)
 
 static void PlateLockTIM_Init(TIM_HandleTypeDef* tim3) {
   __HAL_RCC_TIM3_CLK_ENABLE();
+  tim3->State = HAL_TIM_STATE_RESET;
   tim3->Instance = PLATE_LOCK_TIM;
   tim3->Init.Prescaler = 0;
   tim3->Init.CounterMode = TIM_COUNTERMODE_UP;

--- a/stm32-modules/heater-shaker/firmware/system/system_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/system/system_hardware.c
@@ -47,6 +47,7 @@ void system_hardware_setup(void) {
     HAL_GPIO_Init(SOFTPOWER_PORT, &gpio_init);
 
     /*##-1- Configure the I2C peripheral ######################################*/
+    I2cHandle.State                = HAL_I2C_STATE_RESET;
     I2cHandle.Instance             = I2Cx;
     I2cHandle.Init.Timing          = I2C_TIMING;
     I2cHandle.Init.OwnAddress1     = I2C_ADDRESS;

--- a/stm32-modules/tempdeck-gen3/firmware/system/hal_tick.c
+++ b/stm32-modules/tempdeck-gen3/firmware/system/hal_tick.c
@@ -53,6 +53,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
   + ClockDivision = 0
   + Counter direction = Up
   */
+  htim7.State = HAL_TIM_STATE_RESET;
   htim7.Init.Period = (1000000U / 1000U) - 1U;
   htim7.Init.Prescaler = uwPrescalerValue;
   htim7.Init.ClockDivision = 0;

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
@@ -211,6 +211,7 @@ static void init_peltier_timer() {
     TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
     GPIO_InitTypeDef GPIO_InitStruct = {0};
 
+    hardware.peltier_timer.State = HAL_TIM_STATE_RESET;
     hardware.peltier_timer.Instance = TIM1;
     hardware.peltier_timer.Init.Prescaler = TIM1_PRESCALER;
     hardware.peltier_timer.Init.CounterMode = TIM_COUNTERMODE_UP;
@@ -297,6 +298,7 @@ static void init_fan_timer() {
 
 
     // Configure timer 16 for PWMN control on channel 1
+    hardware.fan_timer.State = HAL_TIM_STATE_RESET;
     hardware.fan_timer.Instance = TIM16;
     hardware.fan_timer.Init.Prescaler = TIM16_PRESCALER;
     hardware.fan_timer.Init.CounterMode = TIM_COUNTERMODE_UP;

--- a/stm32-modules/tempdeck-gen3/firmware/thermistor/thermistor_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermistor/thermistor_hardware.c
@@ -83,6 +83,7 @@ void thermistor_hardware_init() {
 
     HAL_StatusTypeDef hal_ret;
     // Initialize I2C 
+    hardware.i2c_handle.State = HAL_I2C_STATE_RESET;
     hardware.i2c_handle.Instance = I2C_INSTANCE;
     hardware.i2c_handle.Init.Timing = I2C_TIMING;
     hardware.i2c_handle.Init.OwnAddress1 = 0;

--- a/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_hardware.c
@@ -551,6 +551,7 @@ static void init_dac1(DAC_HandleTypeDef* hdac) {
 
     __HAL_RCC_DAC1_CLK_ENABLE();
     hdac->Instance = DAC1;
+    hdac->State = HAL_DAC_STATE_RESET;
     hal_ret = HAL_DAC_Init(hdac);
     configASSERT(hal_ret == HAL_OK);
 
@@ -583,6 +584,7 @@ static void init_tim2(TIM_HandleTypeDef* htim) {
     htim->Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
     htim->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+    htim->State = HAL_TIM_STATE_RESET;
     hal_ret = HAL_TIM_OC_Init(htim);
     configASSERT(hal_ret == HAL_OK);
     
@@ -605,6 +607,7 @@ static void init_tim6(TIM_HandleTypeDef* htim) {
     htim->Init.CounterMode = TIM_COUNTERMODE_UP;
     htim->Init.Period = TIM6_PERIOD;
     htim->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    htim->State = HAL_TIM_STATE_RESET;
     hal_ret = HAL_TIM_Base_Init(htim);
     configASSERT(hal_ret == HAL_OK);
 

--- a/stm32-modules/thermocycler-gen2/firmware/system/stm32g4xx_hal_timebase_tim.c
+++ b/stm32-modules/thermocycler-gen2/firmware/system/stm32g4xx_hal_timebase_tim.c
@@ -76,6 +76,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
   htim7.Init.Prescaler = uwPrescalerValue;
   htim7.Init.ClockDivision = 0;
   htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
+  htim7.State = HAL_TIM_STATE_RESET;
 
   status = HAL_TIM_Base_Init(&htim7);
   if (status == HAL_OK)

--- a/stm32-modules/thermocycler-gen2/firmware/system/system_led_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/system/system_led_hardware.c
@@ -73,6 +73,7 @@ void system_led_initialize(void) {
     HAL_NVIC_SetPriority(DMAMUX_OVR_IRQn, 5, 0);
     HAL_NVIC_EnableIRQ(DMAMUX_OVR_IRQn);
 
+    _leds.tim.State = HAL_TIM_STATE_RESET;
     _leds.tim.Instance = TIM17;
     _leds.tim.Init.Prescaler = TIM17_PRESCALER;
     _leds.tim.Init.CounterMode = TIM_COUNTERMODE_UP;
@@ -136,6 +137,7 @@ void system_led_msp_init(void) {
 
     /* TIM17 DMA Init */
     /* TIM17_CH1 Init */
+    _leds.dma.State = HAL_DMA_STATE_RESET;
     _leds.dma.Instance = DMA1_Channel1;
     _leds.dma.Init.Request = DMA_REQUEST_TIM17_CH1;
     _leds.dma.Init.Direction = DMA_MEMORY_TO_PERIPH;

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_fan_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_fan_hardware.c
@@ -112,6 +112,7 @@ void thermal_fan_initialize(void) {
     HAL_GPIO_WritePin(_fans.enable_port, _fans.enable_pin, GPIO_PIN_RESET);
 
     // Configure timer 16 for PWMN control on channel 1
+    _fans.timer.State = HAL_TIM_STATE_RESET;
     _fans.timer.Instance = TIM16;
     _fans.timer.Init.Prescaler = TIM16_PRESCALER;
     _fans.timer.Init.CounterMode = TIM_COUNTERMODE_UP;
@@ -277,6 +278,7 @@ static void thermal_fan_init_tach(struct Tachometer *tach) {
     TIM_MasterConfigTypeDef sMasterConfig = {0};
     TIM_IC_InitTypeDef sConfigIC = {0};
 
+    tach->timer.State = HAL_TIM_STATE_RESET;
     tach->timer.Instance = TIM4;
     tach->timer.Init.Prescaler = TACH_TIMER_PRESCALE;
     tach->timer.Init.CounterMode = TIM_COUNTERMODE_UP;

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_hardware.c
@@ -122,6 +122,7 @@ static void thermal_gpio_init(void) {
 static void thermal_i2c_init(void) {
     HAL_StatusTypeDef hal_ret;
     // Initialize I2C 
+    _i2c_handle.State = HAL_I2C_STATE_RESET;
     _i2c_handle.Instance = I2C_INSTANCE;
     _i2c_handle.Init.Timing = I2C_TIMING;
     _i2c_handle.Init.OwnAddress1 = 0;

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_heater_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_heater_hardware.c
@@ -83,6 +83,7 @@ void thermal_heater_initialize(void) {
     HAL_GPIO_WritePin(_heater.enable_port, _heater.enable_pin, GPIO_PIN_RESET);
 
     // Configure timer 15 for PWMN control on channel 1
+    _heater.timer.State = HAL_TIM_STATE_RESET;
     _heater.timer.Instance = TIM15;
     _heater.timer.Init.Prescaler = TIM15_PRESCALER;
     _heater.timer.Init.CounterMode = TIM_COUNTERMODE_UP;

--- a/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_peltier_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/thermal/thermal_peltier_hardware.c
@@ -196,6 +196,7 @@ void thermal_peltier_initialize(void) {
     __GPIOB_CLK_ENABLE();
     __GPIOE_CLK_ENABLE();
 
+    _peltiers.timer.State = HAL_TIM_STATE_RESET;
     _peltiers.timer.Instance = TIM1;
     _peltiers.timer.Init.Prescaler = TIM1_PRESCALER;
     _peltiers.timer.Init.CounterMode = TIM_COUNTERMODE_UP;


### PR DESCRIPTION
Thermocycler-Gen2 firmware was exhibiting a bug where the seal motor interrupt would not fire if the following happened:
* `dfu` command sends the MCU to the system memory
* A dfu leave command causes the MCU to jump back to the application memory _without resetting power_
* A button press or a GCode starts a seal motor movement 

Running the firmware with a debugger and replicating this setup showed that the HAL Structure for the seal motor timer had an uninitialized State variable, which was set to `READY` instead of `RESET`. In this case, the HAL does not call the MSP initialization function and thus the interrupt for the timer is never enabled. This seems to be a side effect of the fact that the RAM does not get reset after leaving the system memory bootloader, because in any other situation (i.e. after a power cycle) the RAM is fully cleared.

This PR fixes the issue by manually setting the `State` variable in any relevant HAL structures to the `RESET` setting, which ensures that the initialization functions will configure the hardware for each peripheral.