### PR TITLE
fix(heater-shaker): differentiate sync and async error responses

### DIFF
--- a/stm32-modules/heater-shaker/tests/test_errors.cpp
+++ b/stm32-modules/heater-shaker/tests/test_errors.cpp
@@ -12,12 +12,14 @@ SCENARIO("testing error writing") {
                 errors::write_into(buffer.begin(), buffer.end(),
                                    errors::ErrorCode::USB_TX_OVERRUN);
             THEN("the error is written into the buffer") {
-                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
-                                         "ERR001:tx buffer overrun OK\n"));
+                REQUIRE_THAT(
+                    buffer,
+                    Catch::Matchers::StartsWith(
+                        "gcode response ERR001:tx buffer overrun OK\n"));
                 AND_THEN("the length was appropriately returned") {
                     REQUIRE(written ==
-                            buffer.begin() +
-                                strlen("ERR001:tx buffer overrun OK\n"));
+                            buffer.begin() + strlen("gcode response ERR001:tx "
+                                                    "buffer overrun OK\n"));
                 }
             }
         }
@@ -32,7 +34,7 @@ SCENARIO("testing error writing") {
                 "the error written into only the space available in the "
                 "buffer") {
                 REQUIRE_THAT(buffer,
-                             Catch::Matchers::Equals(std::string("ER")));
+                             Catch::Matchers::Equals(std::string("gc")));
                 AND_THEN("the amount written is 0") {
                     REQUIRE(written == buffer.begin() + 2);
                 }

--- a/stm32-modules/heater-shaker/tests/test_errors.cpp
+++ b/stm32-modules/heater-shaker/tests/test_errors.cpp
@@ -12,13 +12,11 @@ SCENARIO("testing error writing") {
                 errors::write_into(buffer.begin(), buffer.end(),
                                    errors::ErrorCode::USB_TX_OVERRUN);
             THEN("the error is written into the buffer") {
-                REQUIRE_THAT(
-                    buffer,
-                    Catch::Matchers::StartsWith(
-                        "gcode response ERR001:tx buffer overrun OK\n"));
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "ERR001:tx buffer overrun OK\n"));
                 AND_THEN("the length was appropriately returned") {
                     REQUIRE(written ==
-                            buffer.begin() + strlen("gcode response ERR001:tx "
+                            buffer.begin() + strlen("ERR001:tx "
                                                     "buffer overrun OK\n"));
                 }
             }
@@ -34,7 +32,7 @@ SCENARIO("testing error writing") {
                 "the error written into only the space available in the "
                 "buffer") {
                 REQUIRE_THAT(buffer,
-                             Catch::Matchers::Equals(std::string("gc")));
+                             Catch::Matchers::Equals(std::string("ER")));
                 AND_THEN("the amount written is 0") {
                     REQUIRE(written == buffer.begin() + 2);
                 }

--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -52,11 +52,9 @@ SCENARIO("usb message parsing") {
             auto written = tasks->get_host_comms_task().run_once(
                 small_buf.begin(), small_buf.end());
             REQUIRE_THAT(small_buf,
-                         Catch::Matchers::Equals(
-                             "gcode response ERR001:tx buffer overru"));
+                         Catch::Matchers::Equals("ERR001:tx buffer overru"));
             REQUIRE(written ==
-                    small_buf.begin() +
-                        strlen("gcode response ERR001:tx buffer overru"));
+                    small_buf.begin() + strlen("ERR001:tx buffer overru"));
         }
         WHEN("calling run_once() with a malformed gcode message") {
             auto message_text = std::string("aosjhdakljshd\n");
@@ -67,13 +65,10 @@ SCENARIO("usb message parsing") {
             THEN("the task writes an error to the transmit buffer") {
                 auto written = tasks->get_host_comms_task().run_once(
                     tx_buf.begin(), tx_buf.end());
-                REQUIRE_THAT(tx_buf,
-                             Catch::Matchers::StartsWith(
-                                 "gcode response ERR003:unhandled gcode OK\n"));
-                REQUIRE(
-                    written ==
-                    tx_buf.begin() +
-                        strlen("gcode response ERR003:unhandled gcode OK\n"));
+                REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                         "ERR003:unhandled gcode OK\n"));
+                REQUIRE(written ==
+                        tx_buf.begin() + strlen("ERR003:unhandled gcode OK\n"));
             }
         }
     }
@@ -134,8 +129,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -153,7 +148,7 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                                                               tx_buf.end());
                     THEN("the task should print the error rather than ack") {
                         REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR110:main "
+                                                 "ERR110:main "
                                                  "motor:unknown error OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
@@ -212,8 +207,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -231,7 +226,7 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                                                               tx_buf.end());
                     THEN("the task should print the error rather than ack") {
                         REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR110:main "
+                                                 "ERR110:main "
                                                  "motor:unknown error OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
@@ -290,8 +285,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -310,7 +305,7 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                                                               tx_buf.end());
                     THEN("the task should print the error rather than ack") {
                         REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR110:main "
+                                                 "ERR110:main "
                                                  "motor:unknown error OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
@@ -372,8 +367,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -390,11 +385,9 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should print the error rather than ack") {
-                        REQUIRE_THAT(
-                            tx_buf,
-                            Catch::Matchers::StartsWith(
-                                "gcode response ERR302:system:HAL error, "
-                                "busy, or timeout OK\n"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "ERR302:system:HAL error, "
+                                                 "busy, or timeout OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                         REQUIRE(written_secondpass != tx_buf.begin());
@@ -452,8 +445,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -470,10 +463,9 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should print the error rather than ack") {
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith(
-                                         "gcode response ERR123:main motor:not "
-                                         "home (required) OK\n"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "ERR123:main motor:not "
+                                                 "home (required) OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                         REQUIRE(written_secondpass != tx_buf.begin());
@@ -531,8 +523,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -552,7 +544,7 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         REQUIRE_THAT(
                             tx_buf,
                             Catch::Matchers::StartsWith(
-                                "gcode response ERR304:system:LED I2C "
+                                "ERR304:system:LED I2C "
                                 "transmission or "
                                 "FreeRTOS notification passing failed OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
@@ -611,8 +603,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -632,7 +624,7 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         REQUIRE_THAT(
                             tx_buf,
                             Catch::Matchers::StartsWith(
-                                "gcode response ERR304:system:LED I2C "
+                                "ERR304:system:LED I2C "
                                 "transmission or "
                                 "FreeRTOS notification passing failed OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
@@ -691,8 +683,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -712,7 +704,7 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         REQUIRE_THAT(
                             tx_buf,
                             Catch::Matchers::StartsWith(
-                                "gcode response ERR304:system:LED I2C "
+                                "ERR304:system:LED I2C "
                                 "transmission or "
                                 "FreeRTOS notification passing failed OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
@@ -775,8 +767,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -833,8 +825,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -854,7 +846,7 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN("the task should print the error rather than ack") {
                         REQUIRE_THAT(tx_buf,
                                      Catch::Matchers::StartsWith(
-                                         "gcode response ERR211:heater:heatpad "
+                                         "ERR211:heater:heatpad "
                                          "thermistor "
                                          "overtemp or disconnected OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
@@ -926,8 +918,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -946,8 +938,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -968,11 +960,9 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should write both the error and the "
                         "response") {
-                        REQUIRE_THAT(
-                            tx_buf,
-                            Catch::Matchers::StartsWith(
-                                "gcode response ERR206:heater:thermistor b "
-                                "short OK\n"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "ERR206:heater:thermistor b "
+                                                 "short OK\n"));
                     }
                 }
             }
@@ -1046,8 +1036,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1066,8 +1056,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1129,8 +1119,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1149,8 +1139,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1222,8 +1212,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1242,8 +1232,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1316,8 +1306,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1337,8 +1327,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1400,8 +1390,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "gcode response ERR005"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith("ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1480,7 +1470,7 @@ SCENARIO("message handling for other-task-initiated communication") {
             THEN("the task should write out the error") {
                 REQUIRE_THAT(tx_buf,
                              Catch::Matchers::StartsWith(
-                                 "ERR120:main motor:illegal speed OK\n"));
+                                 "async ERR120:main motor:illegal speed OK\n"));
                 REQUIRE(*written == 'c');
             }
         }

--- a/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_host_comms_task.cpp
@@ -52,9 +52,11 @@ SCENARIO("usb message parsing") {
             auto written = tasks->get_host_comms_task().run_once(
                 small_buf.begin(), small_buf.end());
             REQUIRE_THAT(small_buf,
-                         Catch::Matchers::Equals("ERR001:tx buffer overru"));
+                         Catch::Matchers::Equals(
+                             "gcode response ERR001:tx buffer overru"));
             REQUIRE(written ==
-                    small_buf.begin() + strlen("ERR001:tx buffer overru"));
+                    small_buf.begin() +
+                        strlen("gcode response ERR001:tx buffer overru"));
         }
         WHEN("calling run_once() with a malformed gcode message") {
             auto message_text = std::string("aosjhdakljshd\n");
@@ -65,10 +67,13 @@ SCENARIO("usb message parsing") {
             THEN("the task writes an error to the transmit buffer") {
                 auto written = tasks->get_host_comms_task().run_once(
                     tx_buf.begin(), tx_buf.end());
-                REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                         "ERR003:unhandled gcode OK\n"));
-                REQUIRE(written ==
-                        tx_buf.begin() + strlen("ERR003:unhandled gcode OK\n"));
+                REQUIRE_THAT(tx_buf,
+                             Catch::Matchers::StartsWith(
+                                 "gcode response ERR003:unhandled gcode OK\n"));
+                REQUIRE(
+                    written ==
+                    tx_buf.begin() +
+                        strlen("gcode response ERR003:unhandled gcode OK\n"));
             }
         }
     }
@@ -129,8 +134,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -147,10 +152,9 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should print the error rather than ack") {
-                        REQUIRE_THAT(
-                            tx_buf,
-                            Catch::Matchers::StartsWith(
-                                "ERR110:main motor:unknown error OK\n"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR110:main "
+                                                 "motor:unknown error OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                         REQUIRE(written_secondpass != tx_buf.begin());
@@ -208,8 +212,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -226,10 +230,9 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should print the error rather than ack") {
-                        REQUIRE_THAT(
-                            tx_buf,
-                            Catch::Matchers::StartsWith(
-                                "ERR110:main motor:unknown error OK\n"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR110:main "
+                                                 "motor:unknown error OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                         REQUIRE(written_secondpass != tx_buf.begin());
@@ -287,8 +290,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -306,10 +309,9 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should print the error rather than ack") {
-                        REQUIRE_THAT(
-                            tx_buf,
-                            Catch::Matchers::StartsWith(
-                                "ERR110:main motor:unknown error OK\n"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR110:main "
+                                                 "motor:unknown error OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                         REQUIRE(written_secondpass != tx_buf.begin());
@@ -370,8 +372,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -388,9 +390,11 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should print the error rather than ack") {
-                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
-                                                 "ERR302:system:HAL error, "
-                                                 "busy, or timeout OK\n"));
+                        REQUIRE_THAT(
+                            tx_buf,
+                            Catch::Matchers::StartsWith(
+                                "gcode response ERR302:system:HAL error, "
+                                "busy, or timeout OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                         REQUIRE(written_secondpass != tx_buf.begin());
@@ -448,8 +452,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -466,10 +470,10 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         tasks->get_host_comms_task().run_once(tx_buf.begin(),
                                                               tx_buf.end());
                     THEN("the task should print the error rather than ack") {
-                        REQUIRE_THAT(
-                            tx_buf,
-                            Catch::Matchers::StartsWith(
-                                "ERR123:main motor:not home (required) OK\n"));
+                        REQUIRE_THAT(tx_buf,
+                                     Catch::Matchers::StartsWith(
+                                         "gcode response ERR123:main motor:not "
+                                         "home (required) OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                         REQUIRE(written_secondpass != tx_buf.begin());
@@ -527,8 +531,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -548,7 +552,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         REQUIRE_THAT(
                             tx_buf,
                             Catch::Matchers::StartsWith(
-                                "ERR304:system:LED I2C transmission or "
+                                "gcode response ERR304:system:LED I2C "
+                                "transmission or "
                                 "FreeRTOS notification passing failed OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
@@ -606,8 +611,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -627,7 +632,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         REQUIRE_THAT(
                             tx_buf,
                             Catch::Matchers::StartsWith(
-                                "ERR304:system:LED I2C transmission or "
+                                "gcode response ERR304:system:LED I2C "
+                                "transmission or "
                                 "FreeRTOS notification passing failed OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
@@ -685,8 +691,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -706,7 +712,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                         REQUIRE_THAT(
                             tx_buf,
                             Catch::Matchers::StartsWith(
-                                "ERR304:system:LED I2C transmission or "
+                                "gcode response ERR304:system:LED I2C "
+                                "transmission or "
                                 "FreeRTOS notification passing failed OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
@@ -768,8 +775,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -826,8 +833,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -847,7 +854,8 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                     THEN("the task should print the error rather than ack") {
                         REQUIRE_THAT(tx_buf,
                                      Catch::Matchers::StartsWith(
-                                         "ERR211:heater:heatpad thermistor "
+                                         "gcode response ERR211:heater:heatpad "
+                                         "thermistor "
                                          "overtemp or disconnected OK\n"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
@@ -918,8 +926,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -938,8 +946,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -963,7 +971,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                         REQUIRE_THAT(
                             tx_buf,
                             Catch::Matchers::StartsWith(
-                                "ERR206:heater:thermistor b short OK\n"));
+                                "gcode response ERR206:heater:thermistor b "
+                                "short OK\n"));
                     }
                 }
             }
@@ -1037,8 +1046,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1057,8 +1066,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1120,8 +1129,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1140,8 +1149,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1213,8 +1222,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1233,8 +1242,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1307,8 +1316,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1328,8 +1337,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }
@@ -1391,8 +1400,8 @@ SCENARIO("message passing for response-carrying gcodes from usb input") {
                     THEN(
                         "the task should pull the message and print an error") {
                         REQUIRE(written_secondpass > tx_buf.begin());
-                        REQUIRE_THAT(tx_buf,
-                                     Catch::Matchers::StartsWith("ERR005"));
+                        REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(
+                                                 "gcode response ERR005"));
                         REQUIRE(tasks->get_host_comms_queue()
                                     .backing_deque.empty());
                     }

--- a/stm32-modules/include/heater-shaker/heater-shaker/errors.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/errors.hpp
@@ -78,6 +78,18 @@ auto errorstring(ErrorCode code) -> const char*;
 template <typename Input, typename Limit>
 requires std::forward_iterator<Input> && std::sized_sentinel_for<Limit, Input>
 constexpr auto write_into(Input start, Limit end, ErrorCode code) -> Input {
+    static constexpr const char* prefix = "gcode response";
+    char* char_next = &*start;
+    char* const char_limit = &*end;
+    char_next = write_string_to_iterpair(char_next, char_limit, prefix);
+
+    const char* error_str = errorstring(code);
+    return write_string_to_iterpair(char_next, char_limit, error_str);
+}
+
+template <typename Input, typename Limit>
+requires std::forward_iterator<Input> && std::sized_sentinel_for<Limit, Input>
+constexpr auto write_into_async(Input start, Limit end, ErrorCode code) -> Input {
     const char* str = errorstring(code);
     return write_string_to_iterpair(start, end, str);
 }

--- a/stm32-modules/include/heater-shaker/heater-shaker/errors.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/errors.hpp
@@ -78,18 +78,17 @@ auto errorstring(ErrorCode code) -> const char*;
 template <typename Input, typename Limit>
 requires std::forward_iterator<Input> && std::sized_sentinel_for<Limit, Input>
 constexpr auto write_into(Input start, Limit end, ErrorCode code) -> Input {
-    static constexpr const char* prefix = "gcode response";
-    char* char_next = &*start;
-    char* const char_limit = &*end;
-    char_next = write_string_to_iterpair(char_next, char_limit, prefix);
+    constexpr const char* prefix = "gcode response ";
+    auto next = write_string_to_iterpair(start, end, prefix);
 
     const char* error_str = errorstring(code);
-    return write_string_to_iterpair(char_next, char_limit, error_str);
+    return write_string_to_iterpair(next, end, error_str);
 }
 
 template <typename Input, typename Limit>
 requires std::forward_iterator<Input> && std::sized_sentinel_for<Limit, Input>
-constexpr auto write_into_async(Input start, Limit end, ErrorCode code) -> Input {
+constexpr auto write_into_async(Input start, Limit end, ErrorCode code)
+    -> Input {
     const char* str = errorstring(code);
     return write_string_to_iterpair(start, end, str);
 }

--- a/stm32-modules/include/heater-shaker/heater-shaker/errors.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/errors.hpp
@@ -78,18 +78,18 @@ auto errorstring(ErrorCode code) -> const char*;
 template <typename Input, typename Limit>
 requires std::forward_iterator<Input> && std::sized_sentinel_for<Limit, Input>
 constexpr auto write_into(Input start, Limit end, ErrorCode code) -> Input {
-    constexpr const char* prefix = "gcode response ";
-    auto next = write_string_to_iterpair(start, end, prefix);
-
     const char* error_str = errorstring(code);
-    return write_string_to_iterpair(next, end, error_str);
+    return write_string_to_iterpair(start, end, error_str);
 }
 
 template <typename Input, typename Limit>
 requires std::forward_iterator<Input> && std::sized_sentinel_for<Limit, Input>
 constexpr auto write_into_async(Input start, Limit end, ErrorCode code)
     -> Input {
-    const char* str = errorstring(code);
-    return write_string_to_iterpair(start, end, str);
+    constexpr const char* prefix = "async ";
+    auto next = write_string_to_iterpair(start, end, prefix);
+
+    const char* error_str = errorstring(code);
+    return write_string_to_iterpair(next, end, error_str);
 }
 };  // namespace errors

--- a/stm32-modules/include/heater-shaker/heater-shaker/host_comms_task.hpp
+++ b/stm32-modules/include/heater-shaker/heater-shaker/host_comms_task.hpp
@@ -239,7 +239,7 @@ class HostCommsTask {
         std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_message(const messages::ErrorMessage& msg, InputIt tx_into,
                        InputLimit tx_limit) -> InputIt {
-        return errors::write_into(tx_into, tx_limit, msg.code);
+        return errors::write_into_async(tx_into, tx_limit, msg.code);
     }
 
     template <typename InputIt, typename InputLimit>


### PR DESCRIPTION
Currently, all gcode messages sent by firmware contain the ack "OK". The hardware controller class doesn't have a way of differentiating responses to gcode commands from asynchronous error messages. This prepends the latter with an identifier "async", the firmware-side fix to RET-1178. The api-side fix is Opentrons/opentrons #11400.

Examples:
- successful response: `M3 OK`
- unsuccessful response: `ERRxxx:...`
- asynchronous error message: `async ERRxxx:...`

To-do: implement in TC2 and TD3 firmware