### PR TITLE
feat(heater-shaker): rpm data filtering

### DIFF
--- a/stm32-modules/heater-shaker/firmware/motor_task/mc_tasks.c
+++ b/stm32-modules/heater-shaker/firmware/motor_task/mc_tasks.c
@@ -289,7 +289,8 @@ void TSK_MediumFrequencyTaskM1(void)
   // order to prevent updating the buffer with the same measurement over 
   // and over, especially when the motor is at a low speed.
   if(HALL_M1.SpeedFIFOIdx != last_SpeedFIFOIdx ||
-     wAux != last_wAux) {
+     wAux != last_wAux ||
+     wAux == 0) {
     last_wAux = wAux;
     last_SpeedFIFOIdx = HALL_M1.SpeedFIFOIdx;
     motor_hardware_add_rpm_measurement(wAux);

--- a/stm32-modules/heater-shaker/firmware/motor_task/mc_tasks.c
+++ b/stm32-modules/heater-shaker/firmware/motor_task/mc_tasks.c
@@ -281,6 +281,8 @@ void TSK_MediumFrequencyTaskM1(void)
   int16_t wAux = 0;
 
   bool IsSpeedReliable = HALL_CalcAvrgMecSpeedUnit( &HALL_M1, &wAux );
+  // Add the new speed measurement to our speed filter
+  motor_hardware_add_rpm_measurement(wAux);
   PQD_CalcElMotorPower( pMPM[M1] );
 
   StateM1 = STM_GetState( &STM[M1] );

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
@@ -904,7 +904,6 @@ void motor_hardware_add_rpm_measurement(int16_t speed) {
 }
 
 int16_t motor_hardware_get_smoothed_rpm() {
-    //return motor_speed_filtered;
     int64_t sum = 0;
     for(uint8_t itr = 0; itr < MOTOR_SPEED_BUFFER_SIZE; ++itr) {
         sum += (int64_t)motor_speed_buffer[itr];

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
@@ -17,6 +17,8 @@ static void Error_Handler();
 
 motor_hardware_handles *MOTOR_HW_HANDLE = NULL;
 
+static int16_t motor_speed_filtered = 0;
+
 static void MX_NVIC_Init(void)
 {
   /* TIM1_BRK_TIM15_IRQn interrupt configuration */
@@ -890,6 +892,17 @@ void motor_hardware_plate_lock_brake(TIM_HandleTypeDef* tim3) {
   HAL_TIM_GenerateEvent(tim3, TIM_EVENTSOURCE_UPDATE);
   HAL_TIM_PWM_Start(tim3, PLATE_LOCK_IN_1_Chan);
   HAL_TIM_PWM_Start(tim3, PLATE_LOCK_IN_2_Chan);
+}
+
+void motor_hardware_add_rpm_measurement(int16_t speed) {
+    double old_val = (double)motor_speed_filtered;
+    double new_val = ((double)(speed) * (1 - RPM_SPEED_FILTER_ALPHA) )
+                     + (old_val * RPM_SPEED_FILTER_ALPHA);
+    motor_speed_filtered = (int16_t)new_val;
+}
+
+int16_t motor_hardware_get_smoothed_rpm() {
+    return motor_speed_filtered;
 }
 
 /******************************************************************************/

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.h
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.h
@@ -39,17 +39,23 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef* htim);
 
 /**
  * @brief To be called every time the motor control library updates its speed
- * measurement. This function filters the new speed value through an alpha
- * filter to reduce the noise in the data.
+ * measurement. This function adds new speed values to a circular buffer, 
+ * which can then be averaged to get a smoothed RPM value.
  * 
- * @param speed The new speed measurement to add to the average
+ * @param speed The new speed measurement to add to the buffer
  */
 void motor_hardware_add_rpm_measurement(int16_t speed);
 
+/**
+ * @brief Gets the smoothed RPM value by averaging the circular buffer
+ * maintained by \ref motor_hardware_add_rpm_measurement
+ * 
+ * @return int16_t of the averaged speed value. Must be converted to
+ * correct units by the caller.
+ */
 int16_t motor_hardware_get_smoothed_rpm();
 
-// When filtering the RPM values, use this alpha constant
-#define RPM_SPEED_FILTER_ALPHA (0.8)
+#define MOTOR_SPEED_BUFFER_SIZE (16)
 
 #define MC_HAL_IS_USED
 

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.h
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.h
@@ -39,9 +39,9 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef* htim);
 
 /**
  * @brief To be called every time the motor control library updates its speed
- * measurement. This function adds new speed values to a circular buffer, 
+ * measurement. This function adds new speed values to a circular buffer,
  * which can then be averaged to get a smoothed RPM value.
- * 
+ *
  * @param speed The new speed measurement to add to the buffer
  */
 void motor_hardware_add_rpm_measurement(int16_t speed);
@@ -49,13 +49,13 @@ void motor_hardware_add_rpm_measurement(int16_t speed);
 /**
  * @brief Gets the smoothed RPM value by averaging the circular buffer
  * maintained by \ref motor_hardware_add_rpm_measurement
- * 
+ *
  * @return int16_t of the averaged speed value. Must be converted to
  * correct units by the caller.
  */
 int16_t motor_hardware_get_smoothed_rpm();
 
-#define MOTOR_SPEED_BUFFER_SIZE (16)
+#define MOTOR_SPEED_BUFFER_SIZE (32)
 
 #define MC_HAL_IS_USED
 

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.h
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.h
@@ -37,6 +37,20 @@ bool motor_hardware_plate_lock_sensor_read(uint16_t GPIO_Pin);
 
 void HAL_TIM_MspPostInit(TIM_HandleTypeDef* htim);
 
+/**
+ * @brief To be called every time the motor control library updates its speed
+ * measurement. This function filters the new speed value through an alpha
+ * filter to reduce the noise in the data.
+ * 
+ * @param speed The new speed measurement to add to the average
+ */
+void motor_hardware_add_rpm_measurement(int16_t speed);
+
+int16_t motor_hardware_get_smoothed_rpm();
+
+// When filtering the RPM values, use this alpha constant
+#define RPM_SPEED_FILTER_ALPHA (0.8)
+
 #define MC_HAL_IS_USED
 
 // Drive and current sense pins

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
@@ -67,7 +67,7 @@ auto MotorPolicy::stop() -> void { MCI_StopMotor(hw_handles->mci[0]); }
 
 auto MotorPolicy::get_current_rpm() const -> int16_t {
     if (IDLE != MCI_GetSTMState(hw_handles->mci[0])) {
-        return -MCI_GetAvrgMecSpeedUnit(hw_handles->mci[0]) * _RPM / _01HZ;
+        return -motor_hardware_get_smoothed_rpm() * _RPM / _01HZ;
     }
     return 0;
 }

--- a/stm32-modules/heater-shaker/scripts/rpm_data.py
+++ b/stm32-modules/heater-shaker/scripts/rpm_data.py
@@ -1,0 +1,23 @@
+import test_utils
+import argparse
+import time
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Cycle temperatures")
+    parser.add_argument('-s', '--speed', required=False, default=100, help='rpm ')
+    parser.add_argument('-t', '--time', required=False, default=15, help='test time')
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    ser = test_utils.build_serial()
+    args = parse_args()
+
+    test_utils.set_speed(ser, speed=args.speed)
+    print('time,speed')
+    time.sleep(5)
+    start = time.time()
+    while time.time() < start + args.time:
+        speed = test_utils.get_speed(ser)
+        print(f'{time.time()},{speed[0]}')
+        time.sleep(0.1)
+    ser.write(b'G28\n')

--- a/stm32-modules/heater-shaker/scripts/rpm_data.py
+++ b/stm32-modules/heater-shaker/scripts/rpm_data.py
@@ -3,21 +3,39 @@ import argparse
 import time
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Cycle temperatures")
-    parser.add_argument('-s', '--speed', required=False, default=100, help='rpm ')
-    parser.add_argument('-t', '--time', required=False, default=15, help='test time')
+    parser = argparse.ArgumentParser(description="Test GetRPM data at a speed")
+    parser.add_argument('-s', '--speed', type=float, required=False, 
+        default=200, help='rpm ')
+    parser.add_argument('-t', '--time', type=float, required=False, 
+        default=15, help='test time')
+    parser.add_argument('-f', '--file', type=argparse.FileType('w'), 
+        required=False, help='file to write data to')
     return parser.parse_args()
 
 if __name__ == '__main__':
     ser = test_utils.build_serial()
     args = parse_args()
 
+    file = args.file
+
+    if file:
+        file.write('time,speed\n')
+
     test_utils.set_speed(ser, speed=args.speed)
-    print('time,speed')
     time.sleep(5)
     start = time.time()
+    min = test_utils.get_speed(ser)[0]
+    max = min
     while time.time() < start + args.time:
-        speed = test_utils.get_speed(ser)
-        print(f'{time.time()},{speed[0]}')
+        speed = test_utils.get_speed(ser)[0]
+        if speed < min:
+            min = speed 
+        if speed > max:
+            max = speed
+        if file:
+            file.write(f'{time.time()},{speed}\n')
         time.sleep(0.1)
     ser.write(b'G28\n')
+
+    print(f'Min speed: {min} rpm')
+    print(f'Max speed: {max} rpm')

--- a/stm32-modules/heater-shaker/scripts/test_utils.py
+++ b/stm32-modules/heater-shaker/scripts/test_utils.py
@@ -63,7 +63,7 @@ def guard_error(res: bytes, prefix: bytes=  None):
         raise RuntimeError(f'incorrect response: {res} (expected prefix {prefix})')
 
 
-_SPEED_RE = re.compile('^M123 C(?P<current>.+) T(?P<target>.+) OK\n')
+_SPEED_RE = re.compile('^M123 C:(?P<current>.+) T:(?P<target>.+) OK\n')
 def get_speed(ser: serial.Serial) -> Tuple[float, float]:
     ser.write(b'M123\n')
     res = ser.readline()


### PR DESCRIPTION
The Heater-Shaker uses a Hall effect sensor to detect the current RPM of the motor. The actual speed of the motor _as measured by an external tachometer_ is consistent and stays within the device's specified accuracy spec, but the speed as reported by the internal sensor varies severely. Therefore, it is reasonable to state that the values reported by the sensor work for the application and allow the motor control driver to control the motor accurately. However, it makes sense to create an RPM that is more representative of the motor speed over USB.

This PR adds in a circular buffer to keep track of the last 32 readings from the Hall sensor. When any of the higher level code needs to get the current RPM, it is calculated by averaging the contents of the buffer. The size of the filtering buffer was chosen by testing a few values - smaller values result in higher variability. 

The new script `rpm_data.py` was used to collect the min & max RPM reported at setpoints for both the original firmware and the updated firmware. The results are summarized in the table below; the updated firmware drastically decreases the variability of these numbers.

Setpoint (rpm) | Min rpm (No Filter) | Max rpm (No Filter) | Min rpm (With Filter) | Max rpm (With Filter)
-- | -- | -- | -- | --
200 | 126 | 246 | 180 | 210
1000 | 978 | 1020 | 984 | 996
2000 | 1968 | 2034 | 1992 | 1998
3000 | 2958 | 3054 | 2994 | 3000

