### PR TITLE
feat(thermocycler-gen2): update VID/PID to match buildroot

### DIFF
--- a/stm32-modules/thermocycler-gen2/firmware/host_comms_task/usbd_desc.c
+++ b/stm32-modules/thermocycler-gen2/firmware/host_comms_task/usbd_desc.c
@@ -26,12 +26,8 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-// TODO(frank 05-06-2022): Uncomment these VID/PID definitions and replace
-// the temporary values that replicate the Gen1 thermocycler.
-//#define USBD_VID                      0x04D8
-//#define USBD_PID                      0xed8c
-#define USBD_VID                      0x04D8  /* same as Gen1 TC */
-#define USBD_PID                      0xED8C  /* same as Gen1 TC */
+#define USBD_VID                      0x0483
+#define USBD_PID                      0xED8D
 #define USBD_LANGID_STRING            0x0409  /* Replace '0xbbb' with your device language ID */
 #define USBD_MANUFACTURER_STRING      "Opentrons" /* Add your manufacturer string */
 #define USBD_PRODUCT_HS_STRING        "Thermocycler HS" /* Add your product High Speed string */


### PR DESCRIPTION
Updates the Thermocycler-Gen2 Vendor ID and Product ID over USB to match the configuration in our buildroot config. This matches the VID with the actual MCU manufacturer and uses a unique PID (for Opentrons modules).

Verified the VID/PID with Mac System Information, and tested with the corresponding [Buildroot PR](https://github.com/Opentrons/buildroot/pull/165)