### PR TITLE
fix(thermocycler-gen2): update LED color to match Gen1

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/system_task.hpp
@@ -181,7 +181,7 @@ concept SystemExecutionPolicy = requires(Policy& p, const Policy& cp) {
 
 struct LedState {
     // Configured color of the LED, assuming
-    xt1511::XT1511 color = colors::get_color(colors::Colors::SOFT_WHITE);
+    xt1511::XT1511 color = colors::get_color(colors::Colors::WHITE);
     colors::Mode mode = colors::Mode::SOLID;
     // Utility counter for updating state in non-solid modes
     uint32_t counter = 0;
@@ -226,7 +226,7 @@ class SystemTask {
           _prep_cache(),
           // NOLINTNEXTLINE(readability-redundant-member-init)
           _leds(xt1511::Speed::HALF),
-          _led_state{.color = colors::get_color(colors::Colors::SOFT_WHITE),
+          _led_state{.color = colors::get_color(colors::Colors::WHITE),
                      .mode = colors::Mode::SOLID,
                      .counter = 0,
                      .period = LED_PULSE_PERIOD_MS},
@@ -575,7 +575,7 @@ class SystemTask {
         } else {
             switch (_plate_state) {
                 case PlateState::IDLE:
-                    _led_state.color = get_color(Colors::SOFT_WHITE);
+                    _led_state.color = get_color(Colors::WHITE);
                     _led_state.mode = Mode::SOLID;
                     break;
                 case PlateState::HEATING:

--- a/stm32-modules/thermocycler-gen2/tests/test_system_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_system_task.cpp
@@ -257,7 +257,7 @@ SCENARIO("system task message passing") {
                     auto &led = tasks->get_system_task().get_led_state();
                     REQUIRE(led.mode == colors::Mode::SOLID);
                     REQUIRE(led.color ==
-                            colors::get_color(colors::Colors::SOFT_WHITE));
+                            colors::get_color(colors::Colors::WHITE));
                 }
             }
         }


### PR DESCRIPTION
The white color on the Gen1 is actually generated by turning on the Red, Green, and Blue LED's instead of the White LED. This results in a much different color than the "soft white" from the actual White LED.

This PR updates the shade of white on the TC2 to match the TC1. 