### PR TITLE
fix(cmake): disable write protection when erasing flash

### DIFF
--- a/stm32-modules/common/STM32G491/clear_wp_stm32g491.cfg
+++ b/stm32-modules/common/STM32G491/clear_wp_stm32g491.cfg
@@ -20,9 +20,9 @@ sleep 100
 
 # Set WRP values
 echo "setting write protect regions"
-mww 0x4002202C 0x00FF00FF
+mww 0x4002202C 0x000000FF
 sleep 100
-mww 0x40022030 0x00FF00FF
+mww 0x40022030 0x000000FF
 sleep 100
 
 # Set OPTSTRT bit


### PR DESCRIPTION
The [module]-clear targets use a .cfg file to command OpenOCD to clear the write protection on the STM32 microcontrollers. There was a bug with the STM32G491-specific target where it set the start _and_ end sectors for write protection to 0xFF. The protection applies to the range [start,end] instead of [start,end), so this resulted in the last page being locked. That page is the one used for writing the serial number, so the bug was causing errors when firmware attempted to update the serial number.

This PR fixes the issue by setting the end sector of write protection to 0x00, which is earlier than the start sector and thus disables write protection entirely. Tested on a TC Gen2 PCB by clearing the flash, writing a complete image, and then setting the device serial number via gcode.