### PR TITLE
feat(thermocycler-gen2): decrease transition time between close temperatures

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -263,7 +263,8 @@ class PlateControl {
      * @pre Set the new setpoint and hold time configurations
      * @param[in] peltier The peltier to reset control for.
      */
-    auto reset_control(thermal_general::Peltier &peltier) -> void;
+    auto reset_control(thermal_general::Peltier &peltier, double setpoint)
+        -> void;
     /**
      * @brief Reset a fan for a new setpoint. Adjusts the PID
      * to prepare for a new ramp.

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -36,9 +36,9 @@ auto PlateControl::update_control(Seconds time) -> UpdateRet {
             if (at_target) {
                 _status = PlateStatus::OVERSHOOT;
                 _left.temp_target = _current_setpoint;
-                _right.temp_target =
+                _right.temp_target =_current_setpoint;
+                _center.temp_target = 
                     center_channel_target(_current_setpoint, heating);
-                _center.temp_target = _current_setpoint;
             } else {
                 update_ramp(_left, time, _current_setpoint);
                 update_ramp(_right, time, _current_setpoint);


### PR DESCRIPTION
Tests with standard PCR cycles of [94º, 70º, 72º] showed a very long transition time from 70 to 72. The root of the cause seems to be that the PID integral term gets wiped out when setting a new target. If two targets are very close, the P term will only result in a small amount of power, while the I term will take a significant amount of time to saturate. 

It seems reasonable to assume that the steady-state integral windup should be similar for two temperatures within a few degrees of each other. This PR removes the PID reset call when a new target temperature is very close to the last target temperature. Testing shows that the curve between 70 and 72 is faster with this change (charts below, using an external multiprobe for temperature data).

![image](https://user-images.githubusercontent.com/27798632/187494967-aa0af3eb-029b-41fb-bd28-481c673da660.png)

![image](https://user-images.githubusercontent.com/27798632/187495032-5757f5ec-702a-4e13-9902-8a230c119487.png)
