### PR TITLE
feat(tempdeck-gen3): add EEPROM driver

### DIFF
--- a/stm32-modules/include/tempdeck-gen3/firmware/thermal_hardware.h
+++ b/stm32-modules/include/tempdeck-gen3/firmware/thermal_hardware.h
@@ -49,6 +49,8 @@ bool thermal_hardware_set_peltier_cool(double power);
 
 bool thermal_hardware_set_fan_power(double power);
 
+void thermal_hardware_set_eeprom_write_protect(bool set);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/stm32-modules/include/tempdeck-gen3/firmware/thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/firmware/thermal_policy.hpp
@@ -1,6 +1,17 @@
 #pragma once
 
 #include <cstdint>
+#include <iterator>
+
+#include "firmware/thermistor_hardware.h"
+
+namespace thermal_policy {
+
+template <typename Iter>
+concept ByteIterator = requires {
+    {std::forward_iterator<Iter>};
+    {std::is_same_v<std::iter_value_t<Iter>, uint8_t>};
+};
 
 class ThermalPolicy {
   public:
@@ -13,4 +24,20 @@ class ThermalPolicy {
     auto set_peltier_cool_power(double power) -> bool;
 
     auto set_fan_power(double power) -> bool;
+
+    auto set_write_protect(bool set) -> void;
+
+    auto i2c_write(uint8_t addr, uint8_t data) -> bool;
+
+    template <ByteIterator Input>
+    auto i2c_write(uint8_t addr, Input data, size_t length) -> bool {
+        return thermal_i2c_write_data(addr, &(*data), length);
+    }
+
+    template <ByteIterator Output>
+    auto i2c_read(uint8_t addr, Output data, size_t length) -> bool {
+        return thermal_i2c_read_data(addr, &(*data), length);
+    }
 };
+
+}  // namespace thermal_policy

--- a/stm32-modules/include/tempdeck-gen3/firmware/thermistor_hardware.h
+++ b/stm32-modules/include/tempdeck-gen3/firmware/thermistor_hardware.h
@@ -36,6 +36,28 @@ bool thermal_i2c_write_16(uint16_t addr, uint8_t reg, uint16_t val);
 bool thermal_i2c_read_16(uint16_t addr, uint8_t reg, uint16_t *val);
 
 /**
+ * @brief Writes an arbitrary array of data to a device
+ * @note Thread safe
+ *
+ * @param addr I2C device address to write to
+ * @param data Pointer to array of data to write
+ * @param len Number of bytes in \c data
+ * @return True if the write was succesful, false otherwise
+ */
+bool thermal_i2c_write_data(uint16_t addr, uint8_t *data, uint16_t len);
+
+/**
+ * @brief Reads an arbitrary string of data from a device
+ * @note Thread safe
+ *
+ * @param addr I2C device address to reaad from
+ * @param data Pointer to array to store read data
+ * @param len Number of bytes to read into \c data
+ * @return True if the read was succesful, false otherwise
+ */
+bool thermal_i2c_read_data(uint16_t addr, uint8_t *data, uint16_t len);
+
+/**
  * @brief Configure the current task to become unblocked on the next call
  * to \ref thermal_adc_ready_callback
  */

--- a/stm32-modules/include/tempdeck-gen3/simulator/sim_thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/sim_thermal_policy.hpp
@@ -3,7 +3,9 @@
 #include <cmath>
 #include <cstdint>
 
-struct SimThermalPolicy {
+#include "simulator/sim_at24c0xc_policy.hpp"
+
+struct SimThermalPolicy : public at24c0xc_sim_policy::SimAT24C0XCPolicy<32> {
     auto enable_peltier() -> void { _enabled = true; }
 
     auto disable_peltier() -> void { _enabled = false; }

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/eeprom.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/eeprom.hpp
@@ -1,0 +1,193 @@
+/**
+ * @file eeprom.hpp
+ * @brief Implements an EEPROM class that is specialized towards
+ * holding the Thermal Offset Constants for the Temperature Deck plate.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "core/at24c0xc.hpp"
+
+namespace eeprom {
+
+/**
+ * @brief Constant values used for calculating the offset between
+ * the physical thermistors on the system and the actual temperature on
+ * the Temperature Deck's plate.
+ * @details
+ * The temperature difference between the thermistors and the surface
+ * of the thermocycler tends to scale with the magnitude of the thermistor
+ * readings. Using three constants, A B and C, the equation is:
+ *
+ * > Plate Temp = A * (heatsink temp) + ((B + 1) * Measured Temp) + C
+ *
+ * One of the EEPROM pages is reserved for a flag to indicate whether
+ * the values have been written. The \ref EEPROMFlag enum captures the
+ * valid states of this page. The page indicates what error detection,
+ * if any, is included with the EEPROM constant values.
+ *
+ */
+struct OffsetConstants {
+    // Constant A is the same for each channel
+    double a, b, c;
+};
+
+/**
+ * @brief Encapsulates interactions with the EEPROM on the Thermocycler
+ * mainboard. Allows reading and writing the thermal offset constants.
+ */
+template <size_t PAGES, uint8_t ADDRESS>
+class Eeprom {
+  public:
+    Eeprom() : _eeprom() {}
+
+    /**
+     * @brief Get the offset constants from the EEPROM
+     *
+     * @tparam Policy for reading from EEPROM
+     * @param defaults OffsetConstants containing default values to return
+     *                 in the case that the EEPROM is not written.
+     * @param policy Instance of Policy
+     * @return OffsetConstants containing the A, B and C constants, or the
+     * default values if the EEPROM doesn't have programmed values.
+     */
+    template <at24c0xc::AT24C0xC_Policy Policy>
+    [[nodiscard]] auto get_offset_constants(const OffsetConstants& defaults,
+                                            Policy& policy) -> OffsetConstants {
+        OffsetConstants ret = defaults;
+        // Read the constants
+        auto flag = read_const_flag(policy);
+
+        if (flag == EEPROMFlag::CONSTANTS_WRITTEN) {
+            ret.a = read_const(EEPROMPageMap::CONST_A, policy);
+            ret.b = read_const(EEPROMPageMap::CONST_B, policy);
+            ret.c = read_const(EEPROMPageMap::CONST_C, policy);
+        }
+        _initialized = true;
+        return ret;
+    }
+
+    /**
+     * @brief Write new offset constants to the EEPROM
+     *
+     * @tparam Policy for writing to the EEPROM
+     * @param constants OffsetConstants containing the constants to
+     * be written to EEPROM
+     * @param policy Instance of Policy
+     * @return True if the constants were written, false otherwise
+     */
+    template <at24c0xc::AT24C0xC_Policy Policy>
+    auto write_offset_constants(OffsetConstants constants, Policy& policy)
+        -> bool {
+        // Write the constants
+        auto ret = _eeprom.template write_value(
+            static_cast<uint8_t>(EEPROMPageMap::CONST_A), constants.a, policy);
+        if (ret) {
+            ret = _eeprom.template write_value(
+                static_cast<uint8_t>(EEPROMPageMap::CONST_B), constants.b,
+                policy);
+        }
+        if (ret) {
+            ret = _eeprom.template write_value(
+                static_cast<uint8_t>(EEPROMPageMap::CONST_C), constants.c,
+                policy);
+        }
+        if (ret) {
+            // Flag that the constants are good
+            ret = _eeprom.template write_value(
+                static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG),
+                static_cast<uint32_t>(EEPROMFlag::CONSTANTS_WRITTEN), policy);
+        }
+        if (!ret) {
+            // Attempt to flag that the constants are not valid
+            static_cast<void>(_eeprom.template write_value(
+                static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG),
+                static_cast<uint32_t>(EEPROMFlag::INVALID), policy));
+        }
+        return ret;
+    }
+
+    /**
+     * @brief Check if the EEPROM has been read since initialization.
+     *
+     * @return true if the eeprom has been read, false otherwise
+     */
+    [[nodiscard]] auto initialized() const -> bool { return _initialized; }
+
+  private:
+    // Enumeration of memory locations to be used on the EEPROM
+    enum class EEPROMPageMap : uint8_t {
+        CONST_FLAG,
+        CONST_A,
+        CONST_B,
+        CONST_C
+    };
+
+    // Enumeration of the EEPROM_CONST_FLAG values
+    enum class EEPROMFlag {
+        CONSTANTS_WRITTEN = 1,  // Values of all constants are written
+        INVALID = 0xFF          // No values are written
+    };
+
+    static_assert(sizeof(EEPROMPageMap) == sizeof(uint8_t),
+                  "EEPROM API requires uint8_t page address");
+
+    /** Default value for all constants.*/
+    static constexpr double OFFSET_DEFAULT_CONST = 0.0F;
+
+    /**
+     * @brief Read one of the constants on the device
+     *
+     * @tparam Policy class for reading from the eeprom
+     * @param page Which page to read. Must be a valid page
+     * @param policy Instance of Policy for reading
+     * @return double containing the constant
+     */
+    template <at24c0xc::AT24C0xC_Policy Policy>
+    [[nodiscard]] auto read_const(EEPROMPageMap page, Policy& policy)
+        -> double {
+        if (page != EEPROMPageMap::CONST_FLAG) {
+            auto val = _eeprom.template read_value<double>(
+                static_cast<uint8_t>(page), policy);
+            if (val.has_value()) {
+                return val.value();
+            }
+        }
+        return OFFSET_DEFAULT_CONST;
+    }
+
+    /**
+     * @brief Read the Constants Flag in the EEPROM. This flag provides the
+     * validity of the constants in memory.
+     *
+     * @tparam Policy class for reading from the eeprom
+     * @param policy Instance of Policy for reading
+     * @return EEPROMFlag containing the state of the constants in EEPROM
+     */
+    template <at24c0xc::AT24C0xC_Policy Policy>
+    [[nodiscard]] auto read_const_flag(Policy& policy) -> EEPROMFlag {
+        auto val = _eeprom.template read_value<uint32_t>(
+            static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG), policy);
+        if (val.has_value()) {
+            auto flag = val.value();
+            if (flag == static_cast<uint32_t>(EEPROMFlag::CONSTANTS_WRITTEN)) {
+                return EEPROMFlag::CONSTANTS_WRITTEN;
+            }
+        }
+        // Default
+        return EEPROMFlag::INVALID;
+    }
+
+    // Handle for the actual EEPROM IC
+    at24c0xc::AT24C0xC<PAGES, ADDRESS> _eeprom;
+    // Whether the constants have been read from the EEPROM since startup.
+    // Even if the EEPROM is empty, this flag is set after attempting
+    // to read so that the firmware doesn't try to keep making redundant
+    // reads.
+    bool _initialized = false;
+};
+
+}  // namespace eeprom

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
@@ -139,10 +139,26 @@ struct SetPIDConstantsMessage {
     double p, i, d;
 };
 
+struct GetOffsetConstantsMessage {
+    uint32_t id;
+};
+
+struct GetOffsetConstantsResponse {
+    uint32_t responding_to_id;
+    double a, b, c;
+};
+
+struct SetOffsetConstantsMessage {
+    uint32_t id = 0;
+    std::optional<double> a = std::nullopt;
+    std::optional<double> b = std::nullopt;
+    std::optional<double> c = std::nullopt;
+};
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
-                   GetTempDebugResponse>;
+                   GetTempDebugResponse, GetOffsetConstantsResponse>;
 using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,
                    SetSerialNumberMessage, EnterBootloaderMessage>;
@@ -151,5 +167,6 @@ using ThermalMessage =
     ::std::variant<std::monostate, ThermistorReadings, GetTempDebugMessage,
                    SetPeltierDebugMessage, SetFanManualMessage,
                    SetFanAutomaticMessage, DeactivateAllMessage,
-                   SetTemperatureMessage, SetPIDConstantsMessage>;
+                   SetTemperatureMessage, SetPIDConstantsMessage,
+                   GetOffsetConstantsMessage, SetOffsetConstantsMessage>;
 };  // namespace messages

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -110,6 +110,7 @@ class ThermalTask {
           _peltier(),
           _pid(PELTIER_KP_DEFAULT, PELTIER_KI_DEFAULT, PELTIER_KD_DEFAULT, 1.0F,
                PELTIER_WINDUP_LIMIT, -PELTIER_WINDUP_LIMIT),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
           _eeprom(),
           _offset_constants{.a = OFFSET_DEFAULT_CONST_A,
                             .b = OFFSET_DEFAULT_CONST_B,

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -5,6 +5,7 @@
 #include "core/thermistor_conversion.hpp"
 #include "hal/message_queue.hpp"
 #include "ot_utils/core/pid.hpp"
+#include "tempdeck-gen3/eeprom.hpp"
 #include "tempdeck-gen3/messages.hpp"
 #include "tempdeck-gen3/tasks.hpp"
 #include "thermistor_lookups.hpp"
@@ -18,7 +19,8 @@ concept ThermalPolicy = requires(Policy& p) {
     { p.set_peltier_heat_power(1.0) } -> std::same_as<bool>;
     { p.set_peltier_cool_power(1.0) } -> std::same_as<bool>;
     { p.set_fan_power(1.0) } -> std::same_as<bool>;
-};
+}
+&&at24c0xc::AT24C0xC_Policy<Policy>;
 
 using Message = messages::ThermalMessage;
 
@@ -88,6 +90,13 @@ class ThermalTask {
 
     static constexpr double MILLISECONDS_TO_SECONDS = 0.001F;
 
+    static constexpr size_t EEPROM_PAGES = 32;
+    static constexpr uint8_t EEPROM_ADDRESS = 0b1010001;
+
+    static constexpr const double OFFSET_DEFAULT_CONST_A = 0.0F;
+    static constexpr const double OFFSET_DEFAULT_CONST_B = 0.0F;
+    static constexpr const double OFFSET_DEFAULT_CONST_C = 0.0F;
+
     explicit ThermalTask(Queue& q, Aggregator* aggregator)
         : _message_queue(q),
           _task_registry(aggregator),
@@ -100,7 +109,11 @@ class ThermalTask {
           // NOLINTNEXTLINE(readability-redundant-member-init)
           _peltier(),
           _pid(PELTIER_KP_DEFAULT, PELTIER_KI_DEFAULT, PELTIER_KD_DEFAULT, 1.0F,
-               PELTIER_WINDUP_LIMIT, -PELTIER_WINDUP_LIMIT) {}
+               PELTIER_WINDUP_LIMIT, -PELTIER_WINDUP_LIMIT),
+          _eeprom(),
+          _offset_constants{.a = OFFSET_DEFAULT_CONST_A,
+                            .b = OFFSET_DEFAULT_CONST_B,
+                            .c = OFFSET_DEFAULT_CONST_C} {}
     ThermalTask(const ThermalTask& other) = delete;
     auto operator=(const ThermalTask& other) -> ThermalTask& = delete;
     ThermalTask(ThermalTask&& other) noexcept = delete;
@@ -115,6 +128,12 @@ class ThermalTask {
     auto run_once(Policy& policy) -> void {
         if (!_task_registry) {
             return;
+        }
+        // If the EEPROM data hasn't been read, read it before doing
+        // anything else.
+        if (!_eeprom.initialized()) {
+            _offset_constants =
+                _eeprom.get_offset_constants(_offset_constants, policy);
         }
 
         auto message = Message(std::monostate());
@@ -369,6 +388,8 @@ class ThermalTask {
     Fan _fan;
     Peltier _peltier;
     ot_utils::pid::PID _pid;
+    eeprom::Eeprom<EEPROM_PAGES, EEPROM_ADDRESS> _eeprom;
+    eeprom::OffsetConstants _offset_constants;
 };
 
 };  // namespace thermal_task

--- a/stm32-modules/include/tempdeck-gen3/test/test_thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/test/test_thermal_policy.hpp
@@ -3,7 +3,9 @@
 #include <cmath>
 #include <cstdint>
 
-struct TestThermalPolicy {
+#include "test/test_at24c0xc_policy.hpp"
+
+struct TestThermalPolicy : public at24c0xc_test_policy::TestAT24C0XCPolicy<32> {
     auto enable_peltier() -> void { _enabled = true; }
 
     auto disable_peltier() -> void {

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
@@ -27,7 +27,7 @@ auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
 
     thermal_hardware_init();
 
-    auto policy = ThermalPolicy();
+    auto policy = thermal_policy::ThermalPolicy();
     while (true) {
         _top_task.run_once(policy);
     }

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
@@ -2,6 +2,7 @@
 
 #include "firmware/thermal_hardware.h"
 #include "firmware/thermal_policy.hpp"
+#include "firmware/thermistor_hardware.h"
 #include "tempdeck-gen3/thermal_task.hpp"
 
 namespace thermal_control_task {
@@ -26,6 +27,7 @@ auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
     _top_task.provide_aggregator(aggregator);
 
     thermal_hardware_init();
+    thermistor_hardware_init();
 
     auto policy = thermal_policy::ThermalPolicy();
     while (true) {

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
@@ -54,6 +54,10 @@
 
 #define FAN_CHANNEL (TIM_CHANNEL_1)
 
+// Write Protect config
+#define EEPROM_WP_PIN (GPIO_PIN_9)
+#define EEPROM_WP_PORT (GPIOC)
+
 // ***************************************************************************
 // Local typedefs
 
@@ -108,6 +112,7 @@ void thermal_hardware_init() {
 
         thermal_hardware_set_fan_power(0);
         thermal_hardware_disable_peltiers();
+        thermal_hardware_set_eeprom_write_protect(true);
     }
 }
 
@@ -199,6 +204,11 @@ bool thermal_hardware_set_fan_power(double power) {
     if(pwm == 0) { pwm = 1; }
     __HAL_TIM_SET_COMPARE(&hardware.fan_timer, FAN_CHANNEL, pwm);
     return true;
+}
+
+void thermal_hardware_set_eeprom_write_protect(bool set) {
+    HAL_GPIO_WritePin(EEPROM_WP_PORT, EEPROM_WP_PIN,
+        set ? GPIO_PIN_SET : GPIO_PIN_RESET);
 }
 
 // ***************************************************************************
@@ -346,6 +356,7 @@ static void init_gpio() {
     GPIO_InitTypeDef init = {0};
 
     __GPIOA_CLK_ENABLE();
+    __GPIOC_CLK_ENABLE();
 
     init.Pin = ENABLE_12V_PIN;
     init.Mode = GPIO_MODE_OUTPUT_PP;
@@ -356,6 +367,9 @@ static void init_gpio() {
 
     init.Pin = PELTIER_ENABLE_PIN;
     HAL_GPIO_Init(PELTIER_ENABLE_PORT, &init);
+
+    init.Pin = EEPROM_WP_PIN;
+    HAL_GPIO_Init(EEPROM_WP_PORT, &init);
 
     HAL_GPIO_WritePin(ENABLE_12V_PORT, ENABLE_12V_PIN, GPIO_PIN_SET);
 }

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
@@ -29,6 +29,7 @@ auto ThermalPolicy::set_fan_power(double power) -> bool {
     return thermal_hardware_set_fan_power(power);
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPolicy::set_write_protect(bool set) -> void {
     thermal_hardware_set_eeprom_write_protect(set);
 }

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
@@ -1,7 +1,9 @@
 #include "firmware/thermal_policy.hpp"
 
 #include "firmware/thermal_hardware.h"
+#include "firmware/thermistor_hardware.h"
 
+namespace thermal_policy {
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPolicy::enable_peltier() -> void {
     thermal_hardware_enable_peltiers();
@@ -26,3 +28,12 @@ auto ThermalPolicy::set_peltier_cool_power(double power) -> bool {
 auto ThermalPolicy::set_fan_power(double power) -> bool {
     return thermal_hardware_set_fan_power(power);
 }
+
+auto ThermalPolicy::set_write_protect(bool set) -> void { return; }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto ThermalPolicy::i2c_write(uint8_t addr, uint8_t data) -> bool {
+    return thermal_i2c_write_data(addr, &data, 1);
+}
+
+}  // namespace thermal_policy

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
@@ -29,7 +29,9 @@ auto ThermalPolicy::set_fan_power(double power) -> bool {
     return thermal_hardware_set_fan_power(power);
 }
 
-auto ThermalPolicy::set_write_protect(bool set) -> void { return; }
+auto ThermalPolicy::set_write_protect(bool set) -> void {
+    thermal_hardware_set_eeprom_write_protect(set);
+}
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPolicy::i2c_write(uint8_t addr, uint8_t data) -> bool {

--- a/stm32-modules/tempdeck-gen3/firmware/thermistor/thermistor_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermistor/thermistor_hardware.c
@@ -46,6 +46,7 @@ struct ThermistorHardware {
     StaticSemaphore_t i2c_semaphore_data;
     uint8_t i2c_buffer[I2C_BUF_MAX];
     _Atomic bool initialized;
+    _Atomic bool initialization_started;
 };
 
 /** Static variables */
@@ -58,6 +59,7 @@ static struct ThermistorHardware hardware = {
     .i2c_semaphore_data = {},
     .i2c_buffer = {0},
     .initialized = false,
+    .initialization_started = false,
 };
 
 /** Static function declaration */
@@ -69,44 +71,52 @@ static void handle_i2c_callback();
 void thermistor_hardware_init() {
     GPIO_InitTypeDef gpio_init = {0};
 
-    hardware.i2c_semaphore = 
-        xSemaphoreCreateMutexStatic(&hardware.i2c_semaphore_data);
+    // Enforce that only one task may initialize the I2C
+    if(atomic_exchange(&hardware.initialization_started, true)) {
+        hardware.i2c_semaphore = 
+            xSemaphoreCreateMutexStatic(&hardware.i2c_semaphore_data);
 
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-    __HAL_RCC_GPIOA_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        __HAL_RCC_GPIOA_CLK_ENABLE();
 
-    /* Configure the ADC Alert pin*/
-    gpio_init.Pin = ADC_ALERT_PIN;
-    gpio_init.Mode = GPIO_MODE_IT_FALLING;
-    gpio_init.Pull = GPIO_PULLUP;
-    HAL_GPIO_Init(ADC_ALERT_PORT, &gpio_init);
+        /* Configure the ADC Alert pin*/
+        gpio_init.Pin = ADC_ALERT_PIN;
+        gpio_init.Mode = GPIO_MODE_IT_FALLING;
+        gpio_init.Pull = GPIO_PULLUP;
+        HAL_GPIO_Init(ADC_ALERT_PORT, &gpio_init);
 
-    HAL_StatusTypeDef hal_ret;
-    // Initialize I2C 
-    hardware.i2c_handle.State = HAL_I2C_STATE_RESET;
-    hardware.i2c_handle.Instance = I2C_INSTANCE;
-    hardware.i2c_handle.Init.Timing = I2C_TIMING;
-    hardware.i2c_handle.Init.OwnAddress1 = 0;
-    hardware.i2c_handle.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
-    hardware.i2c_handle.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
-    hardware.i2c_handle.Init.OwnAddress2 = 0;
-    hardware.i2c_handle.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
-    hardware.i2c_handle.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
-    hardware.i2c_handle.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
-    hal_ret = HAL_I2C_Init(&hardware.i2c_handle);
-    configASSERT(hal_ret == HAL_OK);
-    /** Configure Analogue filter */
-    hal_ret = HAL_I2CEx_ConfigAnalogFilter(&hardware.i2c_handle, I2C_ANALOGFILTER_ENABLE);
-    configASSERT(hal_ret == HAL_OK);
-    /** Configure Digital filter */
-    hal_ret = HAL_I2CEx_ConfigDigitalFilter(&hardware.i2c_handle, 0);
-    configASSERT(hal_ret == HAL_OK);
+        HAL_StatusTypeDef hal_ret;
+        // Initialize I2C 
+        hardware.i2c_handle.State = HAL_I2C_STATE_RESET;
+        hardware.i2c_handle.Instance = I2C_INSTANCE;
+        hardware.i2c_handle.Init.Timing = I2C_TIMING;
+        hardware.i2c_handle.Init.OwnAddress1 = 0;
+        hardware.i2c_handle.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+        hardware.i2c_handle.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+        hardware.i2c_handle.Init.OwnAddress2 = 0;
+        hardware.i2c_handle.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+        hardware.i2c_handle.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+        hardware.i2c_handle.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+        hal_ret = HAL_I2C_Init(&hardware.i2c_handle);
+        configASSERT(hal_ret == HAL_OK);
+        /** Configure Analogue filter */
+        hal_ret = HAL_I2CEx_ConfigAnalogFilter(&hardware.i2c_handle, I2C_ANALOGFILTER_ENABLE);
+        configASSERT(hal_ret == HAL_OK);
+        /** Configure Digital filter */
+        hal_ret = HAL_I2CEx_ConfigDigitalFilter(&hardware.i2c_handle, 0);
+        configASSERT(hal_ret == HAL_OK);
 
-    /** Configure interrupt for ADC Alert pin */
-    HAL_NVIC_SetPriority(EXTI15_10_IRQn, 4, 0);
-    HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
+        /** Configure interrupt for ADC Alert pin */
+        HAL_NVIC_SetPriority(EXTI15_10_IRQn, 4, 0);
+        HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
 
-    hardware.initialized = true;
+        hardware.initialized = true;
+    } else {
+        // Spin until the hardware is initialized
+        while(!hardware.initialized) {
+            taskYIELD();
+        }
+    }
 }
 
 bool thermal_i2c_write_16(uint16_t addr, uint8_t reg, uint16_t val) {

--- a/stm32-modules/tempdeck-gen3/scripts/test_utils.py
+++ b/stm32-modules/tempdeck-gen3/scripts/test_utils.py
@@ -78,6 +78,38 @@ class Tempdeck():
         '''
         self._send_and_recv('M107\n', 'M107 OK')
 
+    def set_offsets(self, a: float = None, b: float = None, c: float = None):
+        '''
+        Set the offset constants. If any constants are not provided (left as
+        NONE), they will not be written.
+        '''
+        msg = 'M116'
+        if a:
+            msg += f' A{a}'
+        if b:
+            msg += f' B{b}'
+        if c:
+            msg += f' C{c}'
+        msg += '\n'
+        self._send_and_recv(msg, 'M116 OK')
+    
+    _OFFSETS_RE = re.compile('^M117 A:(?P<const_a>.+) B:(?P<const_b>.+) C:(?P<const_c>.+) OK\n')
+
+    def get_offsets(self) -> Tuple[float, float, float]:
+        '''
+        Get the thermal offset constants.
+
+        Returns:
+            tuple of [a, b, c] constants
+        '''
+        res = self._send_and_recv('M117\n', 'M117 A:')
+        match = re.match(self._OFFSETS_RE, res)
+        a = float(match.group('const_a'))
+        b = float(match.group('const_b'))
+        c = float(match.group('const_c'))
+        return a, b, c
+
+
     def dfu(self):
         '''
         Enter the bootloader. This will cause future comms to fail.

--- a/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
@@ -20,6 +20,8 @@ add_executable(${TARGET_MODULE_NAME}
     test_m106.cpp
     test_m107.cpp 
     test_m115.cpp
+    test_m116.cpp
+    test_m117.cpp
     test_m301.cpp
     test_m996.cpp
     test_dfu_gcode.cpp

--- a/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_main.cpp
     test_heartbeat.cpp
     test_host_comms_task.cpp
+    test_eeprom.cpp
     test_system_task.cpp
     test_ui_task.cpp
     test_thermistor_task.cpp

--- a/stm32-modules/tempdeck-gen3/tests/test_eeprom.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_eeprom.cpp
@@ -1,0 +1,65 @@
+#include "catch2/catch.hpp"
+#include "tempdeck-gen3/eeprom.hpp"
+#include "test/test_at24c0xc_policy.hpp"
+
+using namespace at24c0xc_test_policy;
+using namespace eeprom;
+
+static auto _default = OffsetConstants{.a = 68, .b = 5, .c = 9};
+
+TEST_CASE("eeprom class initialization tracking") {
+    GIVEN("an EEPROM") {
+        auto policy = TestAT24C0XCPolicy<32>();
+        auto eeprom = Eeprom<32, 0x10>();
+        THEN("it starts as noninitialized") { REQUIRE(!eeprom.initialized()); }
+        WHEN("reading from the EEPROM") {
+            auto defaults = _default;
+            static_cast<void>(eeprom.get_offset_constants(defaults, policy));
+            THEN("the EEPROM now shows as initialized") {
+                REQUIRE(eeprom.initialized());
+            }
+        }
+    }
+}
+
+TEST_CASE("blank eeprom reading") {
+    GIVEN("an EEPROM") {
+        auto policy = TestAT24C0XCPolicy<32>();
+        auto eeprom = Eeprom<32, 0x10>();
+        WHEN("reading before writing anything") {
+            auto defaults = _default;
+            auto readback = eeprom.get_offset_constants(defaults, policy);
+            THEN("the resulting constants are the defaults") {
+                REQUIRE_THAT(readback.a,
+                             Catch::Matchers::WithinAbs(defaults.a, 0.01));
+                REQUIRE_THAT(readback.b,
+                             Catch::Matchers::WithinAbs(defaults.b, 0.01));
+                REQUIRE_THAT(readback.c,
+                             Catch::Matchers::WithinAbs(defaults.c, 0.01));
+            }
+        }
+    }
+}
+
+TEST_CASE("eeprom reading and writing") {
+    GIVEN("an EEPROM and constants A= -3.5, B = 10 and C = -12") {
+        auto policy = TestAT24C0XCPolicy<32>();
+        auto eeprom = Eeprom<32, 0x10>();
+        OffsetConstants constants = {.a = 32, .b = -33, .c = -44};
+        WHEN("writing the constants") {
+            REQUIRE(eeprom.write_offset_constants(constants, policy));
+            AND_THEN("reading back the constants") {
+                auto defaults = _default;
+                auto readback = eeprom.get_offset_constants(defaults, policy);
+                THEN("the constants match") {
+                    REQUIRE_THAT(readback.a,
+                                 Catch::Matchers::WithinAbs(constants.a, 0.01));
+                    REQUIRE_THAT(readback.b,
+                                 Catch::Matchers::WithinAbs(constants.b, 0.01));
+                    REQUIRE_THAT(readback.c,
+                                 Catch::Matchers::WithinAbs(constants.c, 0.01));
+                }
+            }
+        }
+    }
+}

--- a/stm32-modules/tempdeck-gen3/tests/test_host_comms_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_host_comms_task.cpp
@@ -576,6 +576,117 @@ SCENARIO("host comms commands to thermal task") {
             }
         }
     }
+
+    WHEN("sending gcode M116") {
+        auto message_text = std::string("M116 A1 B2 C3.0\n");
+        auto message_obj =
+            messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                &*message_text.begin(), &*message_text.end()));
+        REQUIRE(tasks->_comms_queue.try_send(message_obj));
+        auto written =
+            tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+        THEN("the task does not immediately ack") {
+            REQUIRE(written == tx_buf.begin());
+        }
+        THEN("a message is sent to the thermal task") {
+            REQUIRE(tasks->_thermal_queue.has_message());
+            auto thermal_msg = tasks->_thermal_queue.backing_deque.front();
+            REQUIRE(std::holds_alternative<messages::SetOffsetConstantsMessage>(
+                thermal_msg));
+            auto offset_msg =
+                std::get<messages::SetOffsetConstantsMessage>(thermal_msg);
+            auto id = offset_msg.id;
+            REQUIRE(offset_msg.a == 1.0F);
+            REQUIRE(offset_msg.b == 2.0F);
+            REQUIRE(offset_msg.c == 3.0F);
+            AND_WHEN("sending response with wrong id") {
+                auto response =
+                    messages::AcknowledgePrevious{.responding_to_id = id + 1};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an error is printed") {
+                    auto expected = errorstring(
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+            AND_WHEN("sending an error response") {
+                auto response = messages::AcknowledgePrevious{
+                    .responding_to_id = id,
+                    .with_error = errors::ErrorCode::SYSTEM_EEPROM_ERROR};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an ack is printed") {
+                    auto expected =
+                        errorstring(errors::ErrorCode::SYSTEM_EEPROM_ERROR);
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+            AND_WHEN("sending a good response") {
+                auto response =
+                    messages::AcknowledgePrevious{.responding_to_id = id};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an ack is printed") {
+                    auto expected = "M116 OK\n";
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+        }
+    }
+
+    WHEN("sending gcode M117") {
+        auto message_text = std::string("M117\n");
+        auto message_obj =
+            messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                &*message_text.begin(), &*message_text.end()));
+        REQUIRE(tasks->_comms_queue.try_send(message_obj));
+        auto written =
+            tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+        THEN("the task does not immediately ack") {
+            REQUIRE(written == tx_buf.begin());
+        }
+        THEN("a message is sent to the thermal task") {
+            REQUIRE(tasks->_thermal_queue.has_message());
+            auto thermal_msg = tasks->_thermal_queue.backing_deque.front();
+            REQUIRE(std::holds_alternative<messages::GetOffsetConstantsMessage>(
+                thermal_msg));
+            auto offset_msg =
+                std::get<messages::GetOffsetConstantsMessage>(thermal_msg);
+            auto id = offset_msg.id;
+            AND_WHEN("sending response with wrong id") {
+                auto response = messages::GetOffsetConstantsResponse{
+                    .responding_to_id = id + 1, .a = 0, .b = 0, .c = 0};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an error is printed") {
+                    auto expected = errorstring(
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+            AND_WHEN("sending a good response") {
+                auto response = messages::GetOffsetConstantsResponse{
+                    .responding_to_id = id, .a = 0, .b = 0, .c = 0};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("a response is printed") {
+                    auto expected = "M117 A:0.0000 B:0.0000 C:0.0000 OK\n";
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+        }
+    }
 }
 
 SCENARIO("host comms usb disconnect") {

--- a/stm32-modules/tempdeck-gen3/tests/test_m116.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_m116.cpp
@@ -1,0 +1,110 @@
+#include "catch2/catch.hpp"
+#include "tempdeck-gen3/gcodes.hpp"
+
+SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(64, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetOffsetConstants::write_response_into(
+                buffer.begin(), buffer.end());
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M116 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::SetOffsetConstants::write_response_into(
+                buffer.begin(), buffer.begin() + 6);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M116 Occcccccccc";
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("input to set no constants") {
+        std::string input = "M116\n";
+        WHEN("parsing") {
+            auto parsed =
+                gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            THEN("parsing should be succesful") {
+                REQUIRE(parsed.second != input.begin());
+                REQUIRE(parsed.first.has_value());
+                auto &val = parsed.first.value();
+                REQUIRE(!val.const_a.has_value());
+                REQUIRE(!val.const_b.has_value());
+                REQUIRE(!val.const_c.has_value());
+            }
+        }
+    }
+    GIVEN("input to set B constant") {
+        std::string input = "M116 B-0.543\n";
+        WHEN("parsing") {
+            auto parsed =
+                gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            THEN("parsing should be succesful") {
+                REQUIRE(parsed.second != input.begin());
+                REQUIRE(parsed.first.has_value());
+                auto &val = parsed.first.value();
+                REQUIRE(!val.const_a.has_value());
+                REQUIRE(val.const_b.has_value());
+                REQUIRE_THAT(val.const_b.value(),
+                             Catch::Matchers::WithinAbs(-0.543, 0.01));
+                REQUIRE(!val.const_c.has_value());
+            }
+        }
+    }
+    GIVEN("input to set C constant") {
+        std::string input = "M116 C123.5\n";
+        WHEN("parsing") {
+            auto parsed =
+                gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            THEN("parsing should be succesful") {
+                REQUIRE(parsed.second != input.begin());
+                REQUIRE(parsed.first.has_value());
+                auto &val = parsed.first.value();
+                REQUIRE(!val.const_a.has_value());
+                REQUIRE(!val.const_b.has_value());
+                REQUIRE(val.const_c.has_value());
+                REQUIRE_THAT(val.const_c.value(),
+                             Catch::Matchers::WithinAbs(123.5, 0.01));
+            }
+        }
+    }
+    GIVEN("input to set all constants") {
+        std::string input = "M116 A-3 B543 C123.5\n";
+        WHEN("parsing") {
+            auto parsed =
+                gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            THEN("parsing should be succesful") {
+                REQUIRE(parsed.second != input.begin());
+                REQUIRE(parsed.first.has_value());
+                auto &val = parsed.first.value();
+                REQUIRE(val.const_a.has_value());
+                REQUIRE_THAT(val.const_a.value(),
+                             Catch::Matchers::WithinAbs(-3, 0.01));
+                REQUIRE(val.const_b.has_value());
+                REQUIRE_THAT(val.const_b.value(),
+                             Catch::Matchers::WithinAbs(543, 0.01));
+                REQUIRE(val.const_c.has_value());
+                REQUIRE_THAT(val.const_c.value(),
+                             Catch::Matchers::WithinAbs(123.5, 0.01));
+            }
+        }
+    }
+    GIVEN("invalid input") {
+        std::string input = "M1116\n";
+        WHEN("parsing") {
+            auto parsed =
+                gcode::SetOffsetConstants::parse(input.begin(), input.end());
+            THEN("parsing should not be succesful") {
+                REQUIRE(parsed.second == input.begin());
+                REQUIRE(!parsed.first.has_value());
+            }
+        }
+    }
+}

--- a/stm32-modules/tempdeck-gen3/tests/test_m117.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_m117.cpp
@@ -1,0 +1,56 @@
+#include "catch2/catch.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "tempdeck-gen3/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("GetOffsetConstants (M117) parser works", "[gcode][parse][m117]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetOffsetConstants::write_response_into(
+                buffer.begin(), buffer.end(), 0, 10.0, 15.0);
+            THEN("the response should be written in full") {
+                auto response_str = "M117 A:0.0000 B:10.0000 C:15.0000 OK\n";
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(response_str));
+                REQUIRE(written == buffer.begin() + strlen(response_str));
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetOffsetConstants::write_response_into(
+                buffer.begin(), buffer.begin() + 7, 0, 10.0, 15.0);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M117 Acccccccccc";
+                response.at(6) = '\0';
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("a valid input") {
+        std::string buffer = "M117\n";
+        WHEN("parsing") {
+            auto res =
+                gcode::GetOffsetConstants::parse(buffer.begin(), buffer.end());
+            THEN("a valid gcode should be produced") {
+                REQUIRE(res.first.has_value());
+                REQUIRE(res.second != buffer.begin());
+            }
+        }
+    }
+    GIVEN("an invalid input") {
+        std::string buffer = "M 117\n";
+        WHEN("parsing") {
+            auto res =
+                gcode::GetOffsetConstants::parse(buffer.begin(), buffer.end());
+            THEN("an error should be produced") {
+                REQUIRE(!res.first.has_value());
+                REQUIRE(res.second == buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
@@ -448,3 +448,64 @@ TEST_CASE("closed loop thermal control") {
         }
     }
 }
+
+TEST_CASE("thermal task offset constants message handling") {
+    auto *tasks = tasks::BuildTasks();
+    TestThermalPolicy policy;
+
+    WHEN("getting the offset constants") {
+        auto get_msg = messages::GetOffsetConstantsMessage{.id = 1};
+        REQUIRE(tasks->_thermal_queue.try_send(get_msg));
+        tasks->_thermal_task.run_once(policy);
+        THEN("the thermal task responds with the default constants") {
+            REQUIRE(tasks->_comms_queue.has_message());
+            auto response = tasks->_comms_queue.backing_deque.front();
+            REQUIRE(
+                std::holds_alternative<messages::GetOffsetConstantsResponse>(
+                    response));
+            auto response_msg =
+                std::get<messages::GetOffsetConstantsResponse>(response);
+            REQUIRE(response_msg.responding_to_id == get_msg.id);
+            REQUIRE(response_msg.a ==
+                    tasks->_thermal_task.OFFSET_DEFAULT_CONST_A);
+            REQUIRE(response_msg.b ==
+                    tasks->_thermal_task.OFFSET_DEFAULT_CONST_B);
+            REQUIRE(response_msg.c ==
+                    tasks->_thermal_task.OFFSET_DEFAULT_CONST_C);
+        }
+    }
+    WHEN("setting B and C constants") {
+        auto set_msg = messages::SetOffsetConstantsMessage{
+            .id = 456, .a = std::nullopt, .b = 1, .c = 2};
+        REQUIRE(tasks->_thermal_queue.try_send(set_msg));
+        tasks->_thermal_task.run_once(policy);
+        THEN("the thermal task responds with an ack") {
+            REQUIRE(tasks->_comms_queue.has_message());
+            auto response = tasks->_comms_queue.backing_deque.front();
+            REQUIRE(std::holds_alternative<messages::AcknowledgePrevious>(
+                response));
+            auto response_msg =
+                std::get<messages::AcknowledgePrevious>(response);
+            REQUIRE(response_msg.responding_to_id == set_msg.id);
+        }
+        AND_THEN("getting the offset constants") {
+            tasks->_comms_queue.backing_deque.clear();
+            auto get_msg = messages::GetOffsetConstantsMessage{.id = 1};
+            REQUIRE(tasks->_thermal_queue.try_send(get_msg));
+            tasks->_thermal_task.run_once(policy);
+            THEN("the thermal task responds with the default constants") {
+                REQUIRE(tasks->_comms_queue.has_message());
+                auto response = tasks->_comms_queue.backing_deque.front();
+                REQUIRE(std::holds_alternative<
+                        messages::GetOffsetConstantsResponse>(response));
+                auto response_msg =
+                    std::get<messages::GetOffsetConstantsResponse>(response);
+                REQUIRE(response_msg.responding_to_id == get_msg.id);
+                REQUIRE(response_msg.a ==
+                        tasks->_thermal_task.OFFSET_DEFAULT_CONST_A);
+                REQUIRE(response_msg.b == set_msg.b.value());
+                REQUIRE(response_msg.c == set_msg.c.value());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a driver for the EEPROM IC on the Tempdeck Gen3 PCB. The EEPROM is on the same I2C bus as the external ADC, and is used to store thermal offset constants just like on the Thermocycler-Gen2. Fittingly, most of this code is carried over from TC2.

One caveat here is that the EEPROM is DNP'd on the Revision 1 PCB's. A ticket has been added to test integration once the Rev2 PCB arrives, but in the meantime the code allows users to set the constants and read them back fine.

Tested on a Rev 1 PCB by setting and getting the constants over USB. They persist until the power cycles, but are reset on startup.