### PR TITLE
feat(tempdeck-gen3): get thermal power command

### DIFF
--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/host_comms_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/host_comms_task.hpp
@@ -36,7 +36,7 @@ class HostCommsTask {
         gcode::GetTemperatureDebug, gcode::SetTemperature, gcode::DeactivateAll,
         gcode::SetPeltierDebug, gcode::SetFanManual, gcode::SetFanAutomatic,
         gcode::SetPIDConstants, gcode::SetOffsetConstants,
-        gcode::GetOffsetConstants>;
+        gcode::GetOffsetConstants, gcode::GetThermalPowerDebug>;
     using AckOnlyCache =
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         AckCache<10, gcode::EnterBootloader, gcode::SetSerialNumber,
@@ -47,6 +47,7 @@ class HostCommsTask {
     using GetSystemInfoCache = AckCache<4, gcode::GetSystemInfo>;
     using GetTempDebugCache = AckCache<4, gcode::GetTemperatureDebug>;
     using GetOffsetConstantsCache = AckCache<4, gcode::GetOffsetConstants>;
+    using GetThermalPowerDebugCache = AckCache<4, gcode::GetThermalPowerDebug>;
 
   public:
     static constexpr size_t TICKS_TO_WAIT_ON_SEND = 10;
@@ -61,7 +62,9 @@ class HostCommsTask {
           // NOLINTNEXTLINE(readability-redundant-member-init)
           get_temp_debug_cache(),
           // NOLINTNEXTLINE(readability-redundant-member-init)
-          get_offset_constants_cache() {}
+          get_offset_constants_cache(),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
+          get_thermal_power_debug_cache() {}
     HostCommsTask(const HostCommsTask& other) = delete;
     auto operator=(const HostCommsTask& other) -> HostCommsTask& = delete;
     HostCommsTask(HostCommsTask&& other) noexcept = delete;
@@ -304,6 +307,29 @@ class HostCommsTask {
                 } else {
                     return cache_element.write_response_into(
                         tx_into, tx_limit, response.a, response.b, response.c);
+                }
+            },
+            cache_entry);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(const messages::GetThermalPowerDebugResponse& response,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto cache_entry = get_thermal_power_debug_cache.remove_if_present(
+            response.responding_to_id);
+        return std::visit(
+            [tx_into, tx_limit, response](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (std::is_same_v<std::monostate, T>) {
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                } else {
+                    return cache_element.write_response_into(
+                        tx_into, tx_limit, response.peltier_current,
+                        response.peltier_pwm, response.fan_pwm);
                 }
             },
             cache_entry);
@@ -589,6 +615,27 @@ class HostCommsTask {
         return std::make_pair(true, tx_into);
     }
 
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::GetThermalPowerDebug& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = get_thermal_power_debug_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::GetThermalPowerDebugMessage{.id = id};
+        if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            get_thermal_power_debug_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
     // Our error handler just writes an error and bails
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
@@ -607,6 +654,7 @@ class HostCommsTask {
     GetSystemInfoCache get_system_info_cache;
     GetTempDebugCache get_temp_debug_cache;
     GetOffsetConstantsCache get_offset_constants_cache;
+    GetThermalPowerDebugCache get_thermal_power_debug_cache;
     bool may_connect_latch = true;
 };
 

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
@@ -157,10 +157,20 @@ struct SetOffsetConstantsMessage {
     std::optional<double> c = std::nullopt;
 };
 
+struct GetThermalPowerDebugMessage {
+    uint32_t id;
+};
+
+struct GetThermalPowerDebugResponse {
+    uint32_t responding_to_id;
+    double peltier_current, peltier_pwm, fan_pwm;
+};
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
-                   GetTempDebugResponse, GetOffsetConstantsResponse>;
+                   GetTempDebugResponse, GetOffsetConstantsResponse,
+                   GetThermalPowerDebugResponse>;
 using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,
                    SetSerialNumberMessage, EnterBootloaderMessage>;
@@ -170,5 +180,6 @@ using ThermalMessage =
                    SetPeltierDebugMessage, SetFanManualMessage,
                    SetFanAutomaticMessage, DeactivateAllMessage,
                    SetTemperatureMessage, SetPIDConstantsMessage,
-                   GetOffsetConstantsMessage, SetOffsetConstantsMessage>;
+                   GetOffsetConstantsMessage, SetOffsetConstantsMessage,
+                   GetThermalPowerDebugMessage>;
 };  // namespace messages

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -418,6 +418,9 @@ class ThermalTask {
             .peltier_pwm = _peltier.power,
             .fan_pwm = _fan.power};
 
+        if(!_peltier.target_set && !_peltier.manual) {
+            response.peltier_pwm = 0.0F;
+        }
         static_cast<void>(
             _task_registry->send_to_address(response, Queues::HostAddress));
     }

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -418,7 +418,7 @@ class ThermalTask {
             .peltier_pwm = _peltier.power,
             .fan_pwm = _fan.power};
 
-        if(!_peltier.target_set && !_peltier.manual) {
+        if (!_peltier.target_set && !_peltier.manual) {
             response.peltier_pwm = 0.0F;
         }
         static_cast<void>(

--- a/stm32-modules/tempdeck-gen3/scripts/test_utils.py
+++ b/stm32-modules/tempdeck-gen3/scripts/test_utils.py
@@ -109,6 +109,22 @@ class Tempdeck():
         c = float(match.group('const_c'))
         return a, b, c
 
+    _POWER_RE = re.compile('^M103.D I:(?P<current>.+) P:(?P<p_pwm>.+) F:(?P<f_pwm>.+) OK\n')
+    def get_thermal_power(self) -> Tuple[float, float, float]:
+        """
+        Get the thermal power of the system.
+        
+        Returns:
+            peltier current in mA
+            peltier PWM [-1,1]
+            fan PWM [0,1]
+        """
+        res = self._send_and_recv('M103.D\n', 'M103.D I:')
+        match = re.match(self._POWER_RE, res)
+        current = float(match.group('current'))
+        peltier_pwm = float(match.group('p_pwm'))
+        fan_pwm = float(match.group('f_pwm'))
+        return current, peltier_pwm, fan_pwm
 
     def dfu(self):
         '''

--- a/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(${TARGET_MODULE_NAME}
     # gcode tests
     test_m18.cpp
     test_m104.cpp
+    test_m103d.cpp
     test_m104d.cpp
     test_m105d.cpp
     test_m106.cpp

--- a/stm32-modules/tempdeck-gen3/tests/test_host_comms_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_host_comms_task.cpp
@@ -687,6 +687,60 @@ SCENARIO("host comms commands to thermal task") {
             }
         }
     }
+
+    WHEN("sending gcode M103.D") {
+        auto message_text = std::string("M103.D\n");
+        auto message_obj =
+            messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                &*message_text.begin(), &*message_text.end()));
+        REQUIRE(tasks->_comms_queue.try_send(message_obj));
+        auto written =
+            tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+        THEN("the task does not immediately ack") {
+            REQUIRE(written == tx_buf.begin());
+        }
+        THEN("a message is sent to the thermal task") {
+            REQUIRE(tasks->_thermal_queue.has_message());
+            auto thermal_msg = tasks->_thermal_queue.backing_deque.front();
+            REQUIRE(
+                std::holds_alternative<messages::GetThermalPowerDebugMessage>(
+                    thermal_msg));
+            auto power_msg =
+                std::get<messages::GetThermalPowerDebugMessage>(thermal_msg);
+            auto id = power_msg.id;
+            AND_WHEN("sending response with wrong id") {
+                auto response = messages::GetThermalPowerDebugResponse{
+                    .responding_to_id = id + 1,
+                    .peltier_current = 10,
+                    .peltier_pwm = -1,
+                    .fan_pwm = 1};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("an error is printed") {
+                    auto expected = errorstring(
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+            AND_WHEN("sending a good response") {
+                auto response = messages::GetThermalPowerDebugResponse{
+                    .responding_to_id = id,
+                    .peltier_current = 10,
+                    .peltier_pwm = -1,
+                    .fan_pwm = 1};
+                tasks->_comms_queue.backing_deque.push_back(response);
+                written =
+                    tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
+                THEN("a response is printed") {
+                    auto expected = "M103.D I:10.000 P:-1.000 F:1.000 OK\n";
+                    REQUIRE(written == (tx_buf.begin() + strlen(expected)));
+                    REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
+                }
+            }
+        }
+    }
 }
 
 SCENARIO("host comms usb disconnect") {

--- a/stm32-modules/tempdeck-gen3/tests/test_m103d.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_m103d.cpp
@@ -1,0 +1,38 @@
+#include <array>
+
+#include "catch2/catch.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "tempdeck-gen3/gcodes.hpp"
+#pragma GCC diagnostic pop
+
+SCENARIO("GetThermalPowerDebug (M103.D) parser works",
+         "[gcode][parse][m103.d]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetThermalPowerDebug::write_response_into(
+                buffer.begin(), buffer.end(), 10.0, 10, 15);
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::StartsWith(
+                                 "M103.D I:10.000 P:10.000 F:15.000 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetThermalPowerDebug::write_response_into(
+                buffer.begin(), buffer.begin() + 7, 10.0, 10, 15);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M103.Dcccccccccc";
+                response.at(6) = '\0';
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
@@ -2,6 +2,30 @@
 #include "test/test_tasks.hpp"
 #include "test/test_thermal_policy.hpp"
 
+TEST_CASE("peltier current conversions") {
+    GIVEN("some ADC readings") {
+        std::vector<uint32_t> inputs = {0, 100, 1000};
+        WHEN("converting readings") {
+            std::vector<double> outputs(3);
+            std::transform(inputs.begin(), inputs.end(), outputs.begin(),
+                           thermal_task::PeltierReadback::adc_to_milliamps);
+            THEN("the readings are converted correctly") {
+                std::vector<double> expected = {0, 161.172, 1611.722};
+                REQUIRE_THAT(outputs, Catch::Matchers::Approx(expected));
+            }
+            AND_THEN("backconverting readings") {
+                std::vector<uint32_t> backconvert(3);
+                std::transform(outputs.begin(), outputs.end(),
+                               backconvert.begin(),
+                               thermal_task::PeltierReadback::milliamps_to_adc);
+                THEN("the backconversions match the original readings") {
+                    REQUIRE_THAT(backconvert, Catch::Matchers::Equals(inputs));
+                }
+            }
+        }
+    }
+}
+
 TEST_CASE("thermal task message handling") {
     auto *tasks = tasks::BuildTasks();
     TestThermalPolicy policy;


### PR DESCRIPTION
Adds a command M103.D to get the power of the thermal system. The command returns the actual PWM of the peltiers & fan, as well as the current measured on the Peltier subsystem in milliamperes. The ADC readings are converted to current based off of the schematic of the Non Form Factor board, this may change with the next rev of the board.