### PR TITLE
feat(tempdeck-gen3): get fan RPM measurements

### DIFF
--- a/stm32-modules/include/tempdeck-gen3/firmware/tachometer_hardware.h
+++ b/stm32-modules/include/tempdeck-gen3/firmware/tachometer_hardware.h
@@ -1,0 +1,14 @@
+#ifndef TACHOMETER_HARDWARE_H_
+#define TACHOMETER_HARDWARE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+void tachometer_hardware_init();
+double tachometer_hardware_get_rpm();
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  /* TACHOMETER_HARDWARE_H_ */

--- a/stm32-modules/include/tempdeck-gen3/firmware/thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/firmware/thermal_policy.hpp
@@ -25,6 +25,8 @@ class ThermalPolicy {
 
     auto set_fan_power(double power) -> bool;
 
+    auto get_fan_rpm() const -> double;
+
     auto set_write_protect(bool set) -> void;
 
     auto i2c_write(uint8_t addr, uint8_t data) -> bool;

--- a/stm32-modules/include/tempdeck-gen3/firmware/thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/firmware/thermal_policy.hpp
@@ -25,7 +25,7 @@ class ThermalPolicy {
 
     auto set_fan_power(double power) -> bool;
 
-    auto get_fan_rpm() const -> double;
+    [[nodiscard]] auto get_fan_rpm() const -> double;
 
     auto set_write_protect(bool set) -> void;
 

--- a/stm32-modules/include/tempdeck-gen3/simulator/sim_thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/sim_thermal_policy.hpp
@@ -31,6 +31,12 @@ struct SimThermalPolicy : public at24c0xc_sim_policy::SimAT24C0XCPolicy<32> {
         return true;
     }
 
+    auto get_fan_rpm() -> double {
+        // From the fan datasheet
+        static constexpr double MAX_RPM = 10800;
+        return _fan * MAX_RPM;
+    }
+
   private:
     bool _enabled = false;
     double _power = 0.0F;  // Positive for heat, negative for cool

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/gcodes.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/gcodes.hpp
@@ -230,7 +230,7 @@ struct GetTemperatureDebug {
  * @brief Uses M103.D to get the current power output for the thermal system
  *
  * Format: M103.D\n
- * Return: M103.D I:<peltier current> P:<Peltier PWM> F:<Fan PWM>
+ * Return: M103.D I:<peltier current> R:<Fan RPM> P:<Peltier PWM> F:<Fan PWM>
  *
  */
 struct GetThermalPowerDebug {
@@ -253,11 +253,12 @@ struct GetThermalPowerDebug {
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputIt, InLimit>
     static auto write_response_into(InputIt buf, InLimit limit,
-                                    double peltier_current, double peltier_pwm,
-                                    double fan_pwm) -> InputIt {
+                                    double peltier_current, double fan_rpm,
+                                    double peltier_pwm, double fan_pwm)
+        -> InputIt {
         auto res = snprintf(
-            &*buf, (limit - buf), "M103.D I:%0.3f P:%0.3f F:%0.3f OK\n",
-            static_cast<float>(peltier_current),
+            &*buf, (limit - buf), "M103.D I:%0.3f R:%0.3f P:%0.3f F:%0.3f OK\n",
+            static_cast<float>(peltier_current), static_cast<float>(fan_rpm),
             static_cast<float>(peltier_pwm), static_cast<float>(fan_pwm));
         if (res <= 0) {
             return buf;

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/host_comms_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/host_comms_task.hpp
@@ -329,7 +329,8 @@ class HostCommsTask {
                 } else {
                     return cache_element.write_response_into(
                         tx_into, tx_limit, response.peltier_current,
-                        response.peltier_pwm, response.fan_pwm);
+                        response.fan_rpm, response.peltier_pwm,
+                        response.fan_pwm);
                 }
             },
             cache_entry);

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/messages.hpp
@@ -163,7 +163,7 @@ struct GetThermalPowerDebugMessage {
 
 struct GetThermalPowerDebugResponse {
     uint32_t responding_to_id;
-    double peltier_current, peltier_pwm, fan_pwm;
+    double peltier_current, fan_rpm, peltier_pwm, fan_pwm;
 };
 
 using HostCommsMessage =

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -19,6 +19,7 @@ concept ThermalPolicy = requires(Policy& p) {
     { p.set_peltier_heat_power(1.0) } -> std::same_as<bool>;
     { p.set_peltier_cool_power(1.0) } -> std::same_as<bool>;
     { p.set_fan_power(1.0) } -> std::same_as<bool>;
+    { p.get_fan_rpm() } -> std::same_as<double>;
 }
 &&at24c0xc::AT24C0xC_Policy<Policy>;
 
@@ -415,12 +416,14 @@ class ThermalTask {
         auto response = messages::GetThermalPowerDebugResponse{
             .responding_to_id = message.id,
             .peltier_current = _readings.peltier_current_milliamps,
+            .fan_rpm = 0,
             .peltier_pwm = _peltier.power,
             .fan_pwm = _fan.power};
 
         if (!_peltier.target_set && !_peltier.manual) {
             response.peltier_pwm = 0.0F;
         }
+        response.fan_rpm = policy.get_fan_rpm();
         static_cast<void>(
             _task_registry->send_to_address(response, Queues::HostAddress));
     }

--- a/stm32-modules/include/tempdeck-gen3/test/test_thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/test/test_thermal_policy.hpp
@@ -34,13 +34,18 @@ struct TestThermalPolicy : public at24c0xc_test_policy::TestAT24C0XCPolicy<32> {
         return true;
     }
 
+    auto get_fan_rpm() -> double { return _fan_rpm; }
+
     // Test integration functions
 
     auto is_cooling() -> bool { return _enabled && (_power < 0.0); }
 
     auto is_heating() -> bool { return _enabled && (_power > 0.0); }
 
+    auto set_fan_rpm(double rpm) -> void { _fan_rpm = rpm; }
+
     bool _enabled = false;
     double _power = 0.0F;  // Positive for heat, negative for cool
     double _fans = 0.0F;
+    double _fan_rpm = 0.0F;  // Should be manually set by the test code
 };

--- a/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
@@ -41,6 +41,7 @@ set(${TARGET_MODULE_NAME}_FW_NONLINTABLE_SRCS
   ${SYSTEM_DIR}/stm32g4xx_it.c
   ${SYSTEM_DIR}/stm32g4xx_hal_msp.c
   ${THERMAL_DIR}/thermal_hardware.c
+  ${THERMAL_DIR}/tachometer_hardware.c
   ${THERMISTOR_DIR}/thermistor_hardware.c
   ${THERMISTOR_DIR}/internal_adc_hardware.c
   ${COMMS_DIR}/usbd_conf.c

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
@@ -1,9 +1,9 @@
 #include "firmware/freertos_thermal_task.hpp"
 
+#include "firmware/tachometer_hardware.h"
 #include "firmware/thermal_hardware.h"
 #include "firmware/thermal_policy.hpp"
 #include "firmware/thermistor_hardware.h"
-#include "firmware/tachometer_hardware.h"
 #include "tempdeck-gen3/thermal_task.hpp"
 
 namespace thermal_control_task {

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
@@ -3,6 +3,7 @@
 #include "firmware/thermal_hardware.h"
 #include "firmware/thermal_policy.hpp"
 #include "firmware/thermistor_hardware.h"
+#include "firmware/tachometer_hardware.h"
 #include "tempdeck-gen3/thermal_task.hpp"
 
 namespace thermal_control_task {
@@ -28,6 +29,7 @@ auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
 
     thermal_hardware_init();
     thermistor_hardware_init();
+    tachometer_hardware_init();
 
     auto policy = thermal_policy::ThermalPolicy();
     while (true) {

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/tachometer_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/tachometer_hardware.c
@@ -1,0 +1,208 @@
+/**
+ * @file tachometer_hardware.c
+ * @brief This file implements the low-level peripheral hardware to support 
+ * the fan tachometer on the Tempdeck.
+ * 
+ * The tachometer is connected to an Input Compare channel on a timer. The
+ * timer is configured to capture its counter value when the tach input
+ * switches from low to high, and the software in this file caches this
+ * register (CCR1). When a new pulse is received, the value of the most
+ * recent CCR1 value is subtracted by the last cached value to give an overall
+ * period for the timer. When the RPM is requested, the period is converted
+ * to an RPM value based off of the timer configuration.
+ * 
+ * The timer is set to overflow at 4Hz. If the timer overflows without ever
+ * seeing a pulse, then the RPM of the tachometer is set to a hardcoded 0.
+ * 
+ * Note that the *actual* capture rate is 8x slower than the tachometer pulse
+ * input. This alleviates some of the CPU burden for calculating the RPM in
+ * real time. There is no impact on the ability to read slow RPM values 
+ * because the minimum RPM of the fan is significantly above  the limit of
+ * 4Hz * 8 pulses * 2.
+ * 
+ */
+
+
+#include "firmware/tachometer_hardware.h"
+
+// Library includes
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdatomic.h>
+
+// HAL includes
+#include "stm32g4xx_hal.h"
+#include "stm32g4xx_hal_rcc.h"
+#include "stm32g4xx_it.h"
+#include "stm32g4xx_hal_tim.h"
+
+// FreeRTOS includes
+#include "FreeRTOS.h"
+#include "semphr.h"
+#include "task.h"
+
+/** Private definitions */
+
+// Timer handle for tachometer
+#define TACH_TIMER (TIM15)
+// Input channel for tachometer
+#define TACH_CHANNEL (TIM_CHANNEL_1)
+// Port for tachometer
+#define TACH_GPIO_PORT (GPIOA)
+// Pin for tachometer
+#define TACH_GPIO_PIN  (GPIO_PIN_2)
+// Interrupt vector for tach
+#define TACH_IRQ (TIM1_BRK_TIM15_IRQn)
+
+// Tachometer timer reload frequency
+#define TIMER_CLOCK_FREQ (170000000)
+#define TACH_TIMER_FREQ (4)
+#define TACH_TIMER_PRESCALE (1699)
+#define TACH_TIMER_PRESCALED_FREQ (TIMER_CLOCK_FREQ / (TACH_TIMER_PRESCALE + 1))
+#define SEC_PER_MIN (60)
+#define PULSES_PER_ROTATION (2)
+#define PULSES_PER_CAPTURE (8)
+
+#define TACH_TIMER_RELOAD ((TIMER_CLOCK_FREQ / (TACH_TIMER_FREQ * (TACH_TIMER_PRESCALE + 1))) -1)
+
+/** Private typedef */
+
+typedef struct {
+    TIM_HandleTypeDef timer;
+    // Holds the previous Capture Compare value, for computing the period
+    uint32_t last_ccr;
+    // Most recent period calculation. Set in interrupt and read by 
+    // thread contexts. Stored in units of raw timer counts.
+    atomic_long tach_period;
+    // Has there been an overflow in this timer period?
+    bool pulse_in_this_period;
+
+    atomic_bool initialized;
+    atomic_bool initialization_started;
+} tachometer_hardware_t;
+/** Static variables */
+
+static tachometer_hardware_t hardware = {
+    .timer = {0},
+    .last_ccr = 0,
+    .tach_period = 0,
+    .pulse_in_this_period = false,
+    .initialized = false,
+    .initialization_started = false,
+};
+
+/** Static function declaration */
+static void init_tach_timer(TIM_HandleTypeDef *handle);
+
+/** Public functions */
+
+void tachometer_hardware_init() {
+    if(atomic_exchange(&hardware.initialization_started, true) == false) {
+        init_tach_timer(&hardware.timer);
+        HAL_TIM_IC_Start_IT(&hardware.timer, TACH_CHANNEL);
+        __HAL_TIM_ENABLE_IT(&hardware.timer, TIM_IT_UPDATE);
+        hardware.initialized = true;
+    } else {
+        // Spin until the hardware is initialized
+        while(!hardware.initialized) {
+            taskYIELD();
+        }
+    }
+}
+
+double tachometer_hardware_get_rpm() {
+    if(hardware.tach_period == 0) {
+        return 0;
+    }
+
+    return ((double)SEC_PER_MIN * (double)(PULSES_PER_CAPTURE) * 
+            (double)TACH_TIMER_PRESCALED_FREQ)
+            / ((double)hardware.tach_period * PULSES_PER_ROTATION);
+}
+
+/** Static function implementation */
+
+static void init_tach_timer(TIM_HandleTypeDef *handle) {
+    HAL_StatusTypeDef hal_ret = HAL_ERROR;
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    TIM_IC_InitTypeDef sConfigIC = {0};
+
+    configASSERT(handle != NULL);
+
+    handle->Instance = TACH_TIMER;
+    handle->State = HAL_TIM_STATE_RESET;
+    handle->Init.Prescaler = TACH_TIMER_PRESCALE;
+    handle->Init.CounterMode = TIM_COUNTERMODE_UP;
+    handle->Init.Period = TACH_TIMER_RELOAD;
+    handle->Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    handle->Init.RepetitionCounter = 0;
+    handle->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    hal_ret = HAL_TIM_IC_Init(handle);
+    configASSERT(hal_ret == HAL_OK);
+
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_ENABLE;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    hal_ret = HAL_TIMEx_MasterConfigSynchronization(handle, &sMasterConfig);
+    configASSERT(hal_ret == HAL_OK);
+
+    sConfigIC.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
+    sConfigIC.ICSelection = TIM_ICSELECTION_DIRECTTI;
+    sConfigIC.ICPrescaler = TIM_ICPSC_DIV8;
+    sConfigIC.ICFilter = 0;
+
+    hal_ret = HAL_TIM_IC_ConfigChannel(handle, &sConfigIC, TACH_CHANNEL);
+    configASSERT(hal_ret == HAL_OK);
+}
+
+/** Overwritten HAL functions */
+
+// This interrupt does NOT go through the HAL system because that overhead is
+// not required for this application.
+void TIM1_BRK_TIM15_IRQHandler(void) {
+    if(__HAL_TIM_GET_FLAG(&hardware.timer, TIM_IT_CC1)) {
+        // New pulse input
+        __HAL_TIM_CLEAR_IT(&hardware.timer, TIM_IT_CC1);
+
+        uint32_t ccr = __HAL_TIM_GET_COMPARE(&hardware.timer, TACH_CHANNEL);
+
+        if(hardware.pulse_in_this_period) {
+            hardware.tach_period = ccr - hardware.last_ccr;
+        }
+        
+        hardware.last_ccr = ccr;
+        hardware.pulse_in_this_period = true;
+    }
+    if(__HAL_TIM_GET_FLAG(&hardware.timer, TIM_IT_UPDATE)) {
+        // Timer overflow is handled after pulses in case both are
+        // serviced at the same time.
+        __HAL_TIM_CLEAR_IT(&hardware.timer, TIM_IT_UPDATE);
+        if(hardware.pulse_in_this_period) {
+            hardware.pulse_in_this_period = false;
+        } else {
+            hardware.tach_period = 0;
+        }
+    }
+}
+
+void HAL_TIM_IC_MspInit(TIM_HandleTypeDef* htim_ic) 
+{
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    if(htim_ic->Instance==TACH_TIMER)
+    {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM15_CLK_ENABLE();
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+
+        /* CC1 input init */
+        GPIO_InitStruct.Pin = TACH_GPIO_PIN;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF9_TIM15;
+        HAL_GPIO_Init(TACH_GPIO_PORT, &GPIO_InitStruct);
+
+        /* Timer interrupt Init */
+        HAL_NVIC_SetPriority(TACH_IRQ, 5, 0);
+        HAL_NVIC_EnableIRQ(TACH_IRQ);
+    }
+}

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/tachometer_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/tachometer_hardware.c
@@ -111,13 +111,17 @@ void tachometer_hardware_init() {
 }
 
 double tachometer_hardware_get_rpm() {
-    if(hardware.tach_period == 0) {
+    // If we directly use the atomic variable after the if(),
+    // there's a chance we can divide by zero!
+    long period = hardware.tach_period;
+    
+    if(period == 0) {
         return 0;
     }
 
     return ((double)SEC_PER_MIN * (double)(PULSES_PER_CAPTURE) * 
             (double)TACH_TIMER_PRESCALED_FREQ)
-            / ((double)hardware.tach_period * PULSES_PER_ROTATION);
+            / ((double)period * PULSES_PER_ROTATION);
 }
 
 /** Static function implementation */

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
@@ -30,6 +30,7 @@ auto ThermalPolicy::set_fan_power(double power) -> bool {
     return thermal_hardware_set_fan_power(power);
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPolicy::get_fan_rpm() const -> double {
     return tachometer_hardware_get_rpm();
 }

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
@@ -31,7 +31,7 @@ auto ThermalPolicy::set_fan_power(double power) -> bool {
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-auto ThermalPolicy::get_fan_rpm() const -> double {
+[[nodiscard]] auto ThermalPolicy::get_fan_rpm() const -> double {
     return tachometer_hardware_get_rpm();
 }
 

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
@@ -1,5 +1,6 @@
 #include "firmware/thermal_policy.hpp"
 
+#include "firmware/tachometer_hardware.h"
 #include "firmware/thermal_hardware.h"
 #include "firmware/thermistor_hardware.h"
 
@@ -27,6 +28,10 @@ auto ThermalPolicy::set_peltier_cool_power(double power) -> bool {
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPolicy::set_fan_power(double power) -> bool {
     return thermal_hardware_set_fan_power(power);
+}
+
+auto ThermalPolicy::get_fan_rpm() const -> double {
+    return tachometer_hardware_get_rpm();
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/stm32-modules/tempdeck-gen3/scripts/test_utils.py
+++ b/stm32-modules/tempdeck-gen3/scripts/test_utils.py
@@ -109,22 +109,24 @@ class Tempdeck():
         c = float(match.group('const_c'))
         return a, b, c
 
-    _POWER_RE = re.compile('^M103.D I:(?P<current>.+) P:(?P<p_pwm>.+) F:(?P<f_pwm>.+) OK\n')
-    def get_thermal_power(self) -> Tuple[float, float, float]:
+    _POWER_RE = re.compile('^M103.D I:(?P<current>.+) R:(?P<rpm>.+) P:(?P<p_pwm>.+) F:(?P<f_pwm>.+) OK\n')
+    def get_thermal_power(self) -> Tuple[float, float, float, float]:
         """
         Get the thermal power of the system.
         
         Returns:
             peltier current in mA
+            fan RPM
             peltier PWM [-1,1]
             fan PWM [0,1]
         """
         res = self._send_and_recv('M103.D\n', 'M103.D I:')
         match = re.match(self._POWER_RE, res)
         current = float(match.group('current'))
+        rpm = float(match.group('rpm'))
         peltier_pwm = float(match.group('p_pwm'))
         fan_pwm = float(match.group('f_pwm'))
-        return current, peltier_pwm, fan_pwm
+        return current, rpm, peltier_pwm, fan_pwm
 
     def dfu(self):
         '''

--- a/stm32-modules/tempdeck-gen3/tests/test_host_comms_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_host_comms_task.cpp
@@ -712,6 +712,7 @@ SCENARIO("host comms commands to thermal task") {
                 auto response = messages::GetThermalPowerDebugResponse{
                     .responding_to_id = id + 1,
                     .peltier_current = 10,
+                    .fan_rpm = 10000,
                     .peltier_pwm = -1,
                     .fan_pwm = 1};
                 tasks->_comms_queue.backing_deque.push_back(response);
@@ -728,13 +729,15 @@ SCENARIO("host comms commands to thermal task") {
                 auto response = messages::GetThermalPowerDebugResponse{
                     .responding_to_id = id,
                     .peltier_current = 10,
+                    .fan_rpm = 10000,
                     .peltier_pwm = -1,
                     .fan_pwm = 1};
                 tasks->_comms_queue.backing_deque.push_back(response);
                 written =
                     tasks->_comms_task.run_once(tx_buf.begin(), tx_buf.end());
                 THEN("a response is printed") {
-                    auto expected = "M103.D I:10.000 P:-1.000 F:1.000 OK\n";
+                    auto expected =
+                        "M103.D I:10.000 R:10000.000 P:-1.000 F:1.000 OK\n";
                     REQUIRE(written == (tx_buf.begin() + strlen(expected)));
                     REQUIRE_THAT(tx_buf, Catch::Matchers::StartsWith(expected));
                 }

--- a/stm32-modules/tempdeck-gen3/tests/test_m103d.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_m103d.cpp
@@ -12,11 +12,12 @@ SCENARIO("GetThermalPowerDebug (M103.D) parser works",
         std::string buffer(256, 'c');
         WHEN("filling response") {
             auto written = gcode::GetThermalPowerDebug::write_response_into(
-                buffer.begin(), buffer.end(), 10.0, 10, 15);
+                buffer.begin(), buffer.end(), 10.0, 50, 10, 15);
             THEN("the response should be written in full") {
-                REQUIRE_THAT(buffer,
-                             Catch::Matchers::StartsWith(
-                                 "M103.D I:10.000 P:10.000 F:15.000 OK\n"));
+                REQUIRE_THAT(
+                    buffer,
+                    Catch::Matchers::StartsWith(
+                        "M103.D I:10.000 R:50.000 P:10.000 F:15.000 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }
@@ -26,7 +27,7 @@ SCENARIO("GetThermalPowerDebug (M103.D) parser works",
         std::string buffer(16, 'c');
         WHEN("filling response") {
             auto written = gcode::GetThermalPowerDebug::write_response_into(
-                buffer.begin(), buffer.begin() + 7, 10.0, 10, 15);
+                buffer.begin(), buffer.begin() + 7, 10.0, 50, 10, 15);
             THEN("the response should write only up to the available space") {
                 std::string response = "M103.Dcccccccccc";
                 response.at(6) = '\0';

--- a/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
@@ -579,6 +579,8 @@ TEST_CASE("thermal task power debug functionality") {
         decltype(tasks->_thermal_task)::ADC_BIT_MAX, false);
     auto temp_adc = converter.backconvert(temp);
 
+    policy.set_fan_rpm(12345.0);
+
     GIVEN("a thermal task with valid peltier current readings") {
         auto adc_msg = messages::ThermistorReadings{
             .timestamp = 123,
@@ -613,6 +615,8 @@ TEST_CASE("thermal task power debug functionality") {
                              Catch::Matchers::WithinAbs(0, .01));
                 REQUIRE_THAT(response.fan_pwm,
                              Catch::Matchers::WithinAbs(0, .001));
+                REQUIRE_THAT(response.fan_rpm,
+                             Catch::Matchers::WithinAbs(policy._fan_rpm, .001));
             }
         }
         AND_GIVEN("manual mode for peltiers and fans") {
@@ -655,6 +659,8 @@ TEST_CASE("thermal task power debug functionality") {
                         Catch::Matchers::WithinAbs(peltier_msg.power, .001));
                     REQUIRE_THAT(response.fan_pwm, Catch::Matchers::WithinAbs(
                                                        fan_msg.power, .001));
+                    REQUIRE_THAT(response.fan_rpm, Catch::Matchers::WithinAbs(
+                                                       policy._fan_rpm, .001));
                 }
             }
         }


### PR DESCRIPTION
Adds functionality to read the RPM of the fan on the tempdeck-gen3. Uses TIM15 in Input Capture Mode to read pulses. See `tachometer_hardware.c` for detailed explanation.

Tested with a Thermocycler Gen2 fan since the current fans we have don't have the tachometer installed. RPM measurements match that of the TC2 at given PWM values, and turning the fan properly shows the RPM drop down to 0.