### PR TITLE
feat(tempdeck-gen3): support multiple i2c buses

### DIFF
--- a/stm32-modules/include/tempdeck-gen3/firmware/i2c_hardware.h
+++ b/stm32-modules/include/tempdeck-gen3/firmware/i2c_hardware.h
@@ -1,0 +1,75 @@
+#ifndef I2C_HARDWARE_H_
+#define I2C_HARDWARE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef enum I2C_BUS {
+    I2C_BUS_THERMAL,
+    I2C_BUS_LED,
+    I2C_BUS_COUNT,
+} I2C_BUS;
+
+#define IS_I2C_BUS(bus) (bus == I2C_BUS_THERMAL || bus == I2C_BUS_LED)
+
+void i2c_hardware_init();
+
+/**
+ * @brief Writes a 16-bit value to an I2C bus
+ * @note Thread safe
+ * @warning This function should \e only be called from a FreeRTOS
+ * task context! It relies on a mutex to lock the commmunication
+ * @param[in] addr The device address to write to
+ * @param[in] reg The register address to write to
+ * @param[in] val The two-byte value to write. The MSB is the first
+ * byte written, and the LSB is the latter byte written.
+ * @return true on success, false  on error
+ */
+bool i2c_hardware_write_16(I2C_BUS bus, uint16_t addr, uint8_t reg,
+                           uint16_t val);
+/**
+ * @brief Reads a 16-bit value from an I2C bus
+ * @note Thread safe
+ * @warning This function should \e only be called from a FreeRTOS
+ * task context! It relies on a mutex to lock the commmunication!
+ * @param[in] addr The device address to read from
+ * @param[in] reg The register address to read from
+ * @param[out] val Returns the two-byte value that was read. The MSB is
+ * the first byte read, and the LSB is the latter byte read.
+ * @return true on success, false  on error
+ */
+bool i2c_hardware_read_16(I2C_BUS bus, uint16_t addr, uint8_t reg,
+                          uint16_t *val);
+
+/**
+ * @brief Writes an arbitrary array of data to a device
+ * @note Thread safe
+ *
+ * @param addr I2C device address to write to
+ * @param data Pointer to array of data to write
+ * @param len Number of bytes in \c data
+ * @return True if the write was succesful, false otherwise
+ */
+bool i2c_hardware_write_data(I2C_BUS bus, uint16_t addr, uint8_t *data,
+                             uint16_t len);
+
+/**
+ * @brief Reads an arbitrary string of data from a device
+ * @note Thread safe
+ *
+ * @param addr I2C device address to reaad from
+ * @param data Pointer to array to store read data
+ * @param len Number of bytes to read into \c data
+ * @return True if the read was succesful, false otherwise
+ */
+bool i2c_hardware_read_data(I2C_BUS bus, uint16_t addr, uint8_t *data,
+                            uint16_t len);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  /* I2C_HARDWARE_H_ */

--- a/stm32-modules/include/tempdeck-gen3/firmware/thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/firmware/thermal_policy.hpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <iterator>
 
-#include "firmware/thermistor_hardware.h"
+#include "firmware/i2c_hardware.h"
 
 namespace thermal_policy {
 
@@ -33,12 +33,12 @@ class ThermalPolicy {
 
     template <ByteIterator Input>
     auto i2c_write(uint8_t addr, Input data, size_t length) -> bool {
-        return thermal_i2c_write_data(addr, &(*data), length);
+        return i2c_hardware_write_data(I2C_BUS_THERMAL, addr, &(*data), length);
     }
 
     template <ByteIterator Output>
     auto i2c_read(uint8_t addr, Output data, size_t length) -> bool {
-        return thermal_i2c_read_data(addr, &(*data), length);
+        return i2c_hardware_read_data(I2C_BUS_THERMAL, addr, &(*data), length);
     }
 };
 

--- a/stm32-modules/include/tempdeck-gen3/firmware/thermistor_hardware.h
+++ b/stm32-modules/include/tempdeck-gen3/firmware/thermistor_hardware.h
@@ -11,53 +11,6 @@ extern "C" {
 void thermistor_hardware_init();
 
 /**
- * @brief Writes a 16-bit value to the thermal subsystem I2C bus
- * @note Thread safe
- * @warning This function should \e only be called from a FreeRTOS
- * task context! It relies on a mutex to lock the commmunication
- * @param[in] addr The device address to write to
- * @param[in] reg The register address to write to
- * @param[in] val The two-byte value to write. The MSB is the first
- * byte written, and the LSB is the latter byte written.
- * @return true on success, false  on error
- */
-bool thermal_i2c_write_16(uint16_t addr, uint8_t reg, uint16_t val);
-/**
- * @brief Reads a 16-bit value from the thermal subsystem I2C bus
- * @note Thread safe
- * @warning This function should \e only be called from a FreeRTOS
- * task context! It relies on a mutex to lock the commmunication!
- * @param[in] addr The device address to read from
- * @param[in] reg The register address to read from
- * @param[out] val Returns the two-byte value that was read. The MSB is
- * the first byte read, and the LSB is the latter byte read.
- * @return true on success, false  on error
- */
-bool thermal_i2c_read_16(uint16_t addr, uint8_t reg, uint16_t *val);
-
-/**
- * @brief Writes an arbitrary array of data to a device
- * @note Thread safe
- *
- * @param addr I2C device address to write to
- * @param data Pointer to array of data to write
- * @param len Number of bytes in \c data
- * @return True if the write was succesful, false otherwise
- */
-bool thermal_i2c_write_data(uint16_t addr, uint8_t *data, uint16_t len);
-
-/**
- * @brief Reads an arbitrary string of data from a device
- * @note Thread safe
- *
- * @param addr I2C device address to reaad from
- * @param data Pointer to array to store read data
- * @param len Number of bytes to read into \c data
- * @return True if the read was succesful, false otherwise
- */
-bool thermal_i2c_read_data(uint16_t addr, uint8_t *data, uint16_t len);
-
-/**
  * @brief Configure the current task to become unblocked on the next call
  * to \ref thermal_adc_ready_callback
  */

--- a/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/firmware/CMakeLists.txt
@@ -35,6 +35,7 @@ set(${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS
 # Add source files that should NOT be checked by clang-tidy here
 set(${TARGET_MODULE_NAME}_FW_NONLINTABLE_SRCS
   ${SYSTEM_DIR}/hal_tick.c
+  ${SYSTEM_DIR}/i2c_hardware.c
   ${SYSTEM_DIR}/system_stm32g4xx.c
   ${SYSTEM_DIR}/system_hardware.c
   ${SYSTEM_DIR}/system_serial_number.c

--- a/stm32-modules/tempdeck-gen3/firmware/README.md
+++ b/stm32-modules/tempdeck-gen3/firmware/README.md
@@ -4,8 +4,8 @@ This section provides a general overview of the firmware architecture for the Te
 ## Drivers
 Hardware peripherals attached to the STM32 are classified into drivers. These drivers are not given their own tasks, but are rather utilized _by_ the software tasks. Lower level hardware control, such as simple access to internal peripherals, is covered by 'Hardware Policy' code. Drivers are distinct in that they maintain their own state.
 
-- __EEPROM Driver__ - Provides functionality to read and write the EEPROM on teh system. See `../../include/common/core/at24c0xc.hpp`
-- __LED Driver__ - Provides functionality to write to the LED's on the system. See `../../include/common/core/xt1511.hpp`
+- __EEPROM Driver__ - Provides functionality to read and write the EEPROM on the system over I2C. See `../../include/common/core/at24c0xc.hpp`
+- __LED Driver__ - Provides functionality to write to the LED's on the system. Uses I2C.
 - __PID Driver__ - Provides a unified interface to calculate Proportional Integral Derivative control. See `../../include/common/core/pid.hpp`
 - __ADS1115 Driver__ - Provides an interface to control the ADS1115 ADC IC on the main board. See `../../include/common/core/ads1115.hpp`
 - __Thermistor Conversion Driver__ - Provides an interface to convert an ADC reading into a temperature in ºC.
@@ -67,7 +67,7 @@ Each task on the system is either _periodic_, running at a fixed frequency; or i
   - Enter the DFU bootloader
   - Write or read an array of I2C bytes (thread-safe via semaphore) for the EEPROM driver
 - __UI Task__: _(message-driven)_ See `./ui/`. This task is driven by a timer (__UI Timer__) to periodically update the LED's on the system based on the current thermal system state. Other tasks send their current state to the UI Task, which decides what to display based on the combined state of the main tasks. Policy functionality:
-  - Write data to the LED's
+  - Write data to the LED's over I2C
 - __Thermistor Task__: _(periodic)_ See `./thermistor/`. The thermistor task manages periodic reading of the thermistors on the system. At the end of each read, the data is sent to the Thermal Task. Policy functinonality includes:
   - Write or read a 16-byte I2C register (thread-safe via semaphore) for the ADS1115 driver
   - Sleep the task until a specific millisecond tick value

--- a/stm32-modules/tempdeck-gen3/firmware/system/i2c_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/system/i2c_hardware.c
@@ -324,7 +324,8 @@ static void handle_i2c_callback(I2C_HandleTypeDef *handle) {
     // Need to look up our struct based on the hardware handle...
     I2C_Instance *instance = 
         i2c_get_struct_from_hal_instance(handle->Instance);
-    if( instance->task_to_notify == NULL ) {
+    if( (instance == NULL) ||
+        instance->task_to_notify == NULL ) {
         return;
     }
     vTaskNotifyGiveFromISR(instance->task_to_notify, 
@@ -337,6 +338,10 @@ static void handle_i2c_callback(I2C_HandleTypeDef *handle) {
 // own structs with higher level data
 static inline I2C_Instance*
         i2c_get_struct_from_hal_instance(I2C_TypeDef *instance) {
+    if(instance == NULL) {
+        return NULL;
+    }
+    
     for(uint8_t i = 0; i < I2C_BUS_COUNT; ++i) {
         if(i2c_hardware.i2c[i].instance == instance) {
             return &i2c_hardware.i2c[i];

--- a/stm32-modules/tempdeck-gen3/firmware/system/i2c_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/system/i2c_hardware.c
@@ -1,0 +1,432 @@
+#include "firmware/i2c_hardware.h"
+
+#include <stdbool.h>
+#include <stdatomic.h>
+
+// HAL includes
+#include "stm32g4xx_hal.h"
+#include "stm32g4xx_hal_rcc.h"
+#include "stm32g4xx_it.h"
+#include "stm32g4xx_hal_i2c.h"
+
+// FreeRTOS includes
+#include "FreeRTOS.h"
+#include "semphr.h"
+#include "task.h"
+
+/** Private definitions */
+
+/** Max buffer: 2 data bytes*/
+#define I2C_BUF_MAX (2)
+
+/* Driven by PCLK1 to Fast Mode - just shy of 400kHz */
+#define I2C_TIMING   (0x80500D1D)
+/** Size of register address: 1 byte.*/
+#define REGISTER_ADDR_LEN (1)
+
+#define SDA_PIN (GPIO_PIN_8)
+#define SDA_PORT (GPIOA)
+#define SCL_PIN (GPIO_PIN_9)
+#define SCL_PORT (GPIOA)
+
+/** Private typedef */
+
+typedef struct {
+    I2C_TypeDef *instance;
+    I2C_HandleTypeDef handle;
+    // Used to signal the end of an I2C transaction
+    _Atomic TaskHandle_t task_to_notify;
+    // Used to maintain lock on i2c access.
+    SemaphoreHandle_t semaphore;
+    // Backing data for static semaphore
+    StaticSemaphore_t semaphore_data;
+    // Buffer for I2C data
+    uint8_t buffer[I2C_BUF_MAX];
+} I2C_Instance;
+
+typedef struct {
+    I2C_Instance i2c[I2C_BUS_COUNT];
+    _Atomic bool initialized;
+    _Atomic bool initialization_started;
+} I2C_Hardware;
+
+/** Static variables */
+
+static I2C_Hardware i2c_hardware = {
+    .i2c = { 
+        {
+            .instance = I2C2,
+            .handle = {},
+            .task_to_notify = NULL,
+            .semaphore = NULL,
+            .semaphore_data = {},
+            .buffer = {0}
+        },
+        {
+            .instance = I2C3,
+            .handle = {},
+            .task_to_notify = NULL,
+            .semaphore = NULL,
+            .semaphore_data = {},
+            .buffer = {0}
+        }
+    },
+    .initialized = false,
+    .initialization_started = false,
+};
+
+/** Static function declaration */
+
+/**
+ * @brief Initialize one of the I2C busses
+ * 
+ */
+static void i2c_instance_init(I2C_Instance *instance);
+static void handle_i2c_callback(I2C_HandleTypeDef *handle);
+static inline I2C_Instance*
+    i2c_get_struct_from_hal_instance(I2C_TypeDef *instance);
+
+/** Public functions */
+
+void i2c_hardware_init() {
+    // Enforce that only one task may initialize the I2C
+    if(atomic_exchange(&i2c_hardware.initialization_started, true) == false) {
+        for(uint8_t i = 0; i < I2C_BUS_COUNT; ++i) {
+            i2c_instance_init(&i2c_hardware.i2c[i]);
+        }
+        i2c_hardware.initialized = true;
+    } else {
+        // Spin until the hardware is initialized
+        while(!i2c_hardware.initialized) {
+            taskYIELD();
+        }
+    }
+}
+
+bool i2c_hardware_write_16(I2C_BUS bus, uint16_t addr, uint8_t reg, uint16_t val) {
+    const uint16_t bytes_to_send = 2;
+    const TickType_t max_block_time = pdMS_TO_TICKS(100);
+    BaseType_t sem_ret;
+    uint32_t notification_val = 0;
+    HAL_StatusTypeDef hal_ret;
+
+    if(!IS_I2C_BUS(bus)) {
+        return false;
+    }
+    
+    I2C_Instance *instance = &i2c_hardware.i2c[bus];
+    
+    if(!i2c_hardware.initialized) {
+        return false;
+    }
+
+    sem_ret = xSemaphoreTake(instance->semaphore, portMAX_DELAY);
+    if(sem_ret != pdTRUE) {
+        return false;
+    }
+
+    // Set up notification info
+    instance->task_to_notify = xTaskGetCurrentTaskHandle();
+
+    // Prepare buffer & send it
+    instance->buffer[0] = (val >> 8) & 0xFF;
+    instance->buffer[1] = (val & 0xFF);
+    hal_ret = HAL_I2C_Mem_Write_IT(&instance->handle, addr, (uint16_t)reg,
+                                   REGISTER_ADDR_LEN, instance->buffer, 
+                                   bytes_to_send);
+    if(hal_ret == HAL_OK) {
+        // Block on the interrupt for transmit_complete
+        notification_val = ulTaskNotifyTake(pdTRUE, max_block_time);
+    }
+
+    // Ignore return, we would not return an error here even if it fails
+    (void)xSemaphoreGive(instance->semaphore);
+
+    return (notification_val == 1) && (hal_ret == HAL_OK);
+}
+
+bool i2c_hardware_read_16(I2C_BUS bus, uint16_t addr, uint8_t reg, uint16_t *val) {
+    const uint16_t bytes_to_read = 2;
+    const TickType_t max_block_time = pdMS_TO_TICKS(100);
+    BaseType_t sem_ret;
+    uint32_t notification_val = 0;
+    HAL_StatusTypeDef hal_ret;
+
+    if(!IS_I2C_BUS(bus)) {
+        return false;
+    }
+
+    I2C_Instance *instance = &i2c_hardware.i2c[bus];
+    
+    if(!i2c_hardware.initialized) {
+        return false;
+    }
+
+    sem_ret = xSemaphoreTake(instance->semaphore, portMAX_DELAY);
+    if(sem_ret != pdTRUE) {
+        return false;
+    }
+    
+    // Set up notification info
+    if(instance->task_to_notify != NULL) {
+        xSemaphoreGive(instance->semaphore);
+        return false;
+    }
+    instance->task_to_notify = xTaskGetCurrentTaskHandle();
+    
+    hal_ret = HAL_I2C_Mem_Read_IT(&instance->handle, addr, (uint16_t)reg,
+                                  REGISTER_ADDR_LEN, instance->buffer,
+                                  bytes_to_read);
+    if(hal_ret == HAL_OK) {
+        // Block on the interrupt for transmit_complete
+        notification_val = ulTaskNotifyTake(pdTRUE, max_block_time);
+        if(notification_val == 1) {
+            // Only write an output value if we succesfully read from the device
+            *val = (((uint16_t)instance->buffer[0]) << 8) | ((uint16_t)instance->buffer[1]);
+        }
+    }
+
+    // Ignore return, we would not return an error here even if it fails
+    (void)xSemaphoreGive(instance->semaphore);
+
+    return (notification_val == 1) && (hal_ret == HAL_OK);
+}
+
+bool i2c_hardware_write_data(I2C_BUS bus, uint16_t addr, uint8_t *data, uint16_t len) {
+    const TickType_t max_block_time = pdMS_TO_TICKS(100);
+    HAL_StatusTypeDef hal_ret;
+    uint32_t notification_val = 0;
+    BaseType_t sem_ret;
+
+    if(!IS_I2C_BUS(bus)) {
+        return false;
+    }
+
+    I2C_Instance *instance = &i2c_hardware.i2c[bus];
+
+    if(!i2c_hardware.initialized) {
+        return false;
+    }
+
+    if(data == NULL) {
+        return false;
+    }
+
+    sem_ret = xSemaphoreTake(instance->semaphore, portMAX_DELAY);
+    if(sem_ret != pdTRUE) {
+        return false;
+    }
+
+    // Set up notification info
+    if(instance->task_to_notify != NULL) {
+        xSemaphoreGive(instance->semaphore);
+        return false;
+    }
+    instance->task_to_notify = xTaskGetCurrentTaskHandle();
+
+    hal_ret = HAL_I2C_Master_Transmit_IT(&instance->handle, addr, data, len);
+
+    if(hal_ret == HAL_OK) {
+        // Block on the interrupt for transmit_complete
+        notification_val = ulTaskNotifyTake(pdTRUE, max_block_time);
+    }
+
+    // Ignore return, we would not return an error here even if it fails
+    (void)xSemaphoreGive(instance->semaphore);
+
+    return (notification_val == 1) && (hal_ret == HAL_OK);
+}
+
+bool i2c_hardware_read_data(I2C_BUS bus, uint16_t addr, uint8_t *data, uint16_t len) {
+    const TickType_t max_block_time = pdMS_TO_TICKS(100);
+    HAL_StatusTypeDef hal_ret;
+    uint32_t notification_val = 0;
+    BaseType_t sem_ret;
+
+    if(!IS_I2C_BUS(bus)) {
+        return false;
+    }
+
+    I2C_Instance *instance = &i2c_hardware.i2c[bus];
+    
+    if(!i2c_hardware.initialized) {
+        return false;
+    }
+    
+    if(data == NULL) {
+        return false;
+    }
+
+    sem_ret = xSemaphoreTake(instance->semaphore, portMAX_DELAY);
+    if(sem_ret != pdTRUE) {
+        return false;
+    }
+
+    // Set up notification info
+    if(instance->task_to_notify != NULL) {
+        xSemaphoreGive(instance->semaphore);
+        return false;
+    }
+    instance->task_to_notify = xTaskGetCurrentTaskHandle();
+
+    hal_ret = HAL_I2C_Master_Receive_IT(&instance->handle, addr, data, len);
+
+    if(hal_ret == HAL_OK) {
+        // Block on the interrupt for transmit_complete
+        notification_val = ulTaskNotifyTake(pdTRUE, max_block_time);
+    }
+
+    // Ignore return, we would not return an error here even if it fails
+    (void)xSemaphoreGive(instance->semaphore);
+    
+    return (notification_val == 1) && (hal_ret == HAL_OK);
+
+}
+
+/*
+ * Static functions 
+ */
+
+static void i2c_instance_init(I2C_Instance *instance) {
+    HAL_StatusTypeDef ret = HAL_ERROR;
+    configASSERT(instance != NULL);
+
+    I2C_HandleTypeDef *handle = &instance->handle;
+
+    instance->semaphore =
+        xSemaphoreCreateMutexStatic(&instance->semaphore_data);
+    configASSERT(instance->semaphore != NULL);
+
+    handle->Instance = instance->instance;
+    handle->State = HAL_I2C_STATE_RESET;
+    handle->Init.Timing = I2C_TIMING;
+    handle->Init.OwnAddress1 = 0;
+    handle->Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+    handle->Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+    handle->Init.OwnAddress2 = 0;
+    handle->Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+    handle->Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+    handle->Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+    
+    ret = HAL_I2C_Init(handle);
+    configASSERT(ret == HAL_OK);
+    /** Configure Analogue filter */
+    ret = HAL_I2CEx_ConfigAnalogFilter(handle, I2C_ANALOGFILTER_ENABLE);
+    configASSERT(ret == HAL_OK);
+    /** Configure Digital filter */
+    ret = HAL_I2CEx_ConfigDigitalFilter(handle, 0);
+    configASSERT(ret == HAL_OK);
+}
+
+// Interrupt handling is the same for every type of transmission
+static void handle_i2c_callback(I2C_HandleTypeDef *handle) {
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    // Need to look up our struct based on the hardware handle...
+    I2C_Instance *instance = 
+        i2c_get_struct_from_hal_instance(handle->Instance);
+    if( instance->task_to_notify == NULL ) {
+        return;
+    }
+    vTaskNotifyGiveFromISR(instance->task_to_notify, 
+                           &xHigherPriorityTaskWoken);
+    instance->task_to_notify = NULL;
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+}
+
+// We need to perform lookups from the HAL I2C structs to our
+// own structs with higher level data
+static inline I2C_Instance*
+        i2c_get_struct_from_hal_instance(I2C_TypeDef *instance) {
+    for(uint8_t i = 0; i < I2C_BUS_COUNT; ++i) {
+        if(i2c_hardware.i2c[i].instance == instance) {
+            return &i2c_hardware.i2c[i];
+        }
+    }
+    return NULL;
+}
+
+void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c)
+{
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    if(hi2c->Instance==I2C2)
+    {
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        GPIO_InitStruct.Pin = SCL_PIN;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
+        HAL_GPIO_Init(SCL_PORT, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = SDA_PIN;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
+        HAL_GPIO_Init(SDA_PORT, &GPIO_InitStruct);
+
+        /* Peripheral clock enable */
+        __HAL_RCC_I2C2_CLK_ENABLE();
+        /* I2C2 interrupt Init */
+        HAL_NVIC_SetPriority(I2C2_EV_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(I2C2_EV_IRQn);
+        HAL_NVIC_SetPriority(I2C2_ER_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(I2C2_ER_IRQn);
+    }
+}
+
+void HAL_I2C_MspDeInit(I2C_HandleTypeDef* hi2c)
+{
+    if(hi2c->Instance==I2C2)
+    {
+        /* Peripheral clock disable */
+        __HAL_RCC_I2C2_CLK_DISABLE();
+
+        /**I2C2 GPIO Configuration
+        PC4     ------> I2C2_SCL
+        PA8     ------> I2C2_SDA
+        */
+        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_4);
+
+        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_8);
+
+        /* I2C2 interrupt DeInit */
+        HAL_NVIC_DisableIRQ(I2C2_EV_IRQn);
+        HAL_NVIC_DisableIRQ(I2C2_ER_IRQn);
+    }
+}
+
+/** Overwritten HAL functions */
+
+void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *i2c_handle){
+    handle_i2c_callback(i2c_handle);
+}
+
+void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *i2c_handle){
+    handle_i2c_callback(i2c_handle);
+}
+
+void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c) {
+    handle_i2c_callback(hi2c);
+}
+
+void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c) {
+    handle_i2c_callback(hi2c);
+}
+
+void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *i2c_handle)
+{
+    handle_i2c_callback(i2c_handle);
+}
+
+/** Interrupt handlers */
+
+void I2C2_EV_IRQHandler(void)
+{
+    HAL_I2C_EV_IRQHandler(&i2c_hardware.i2c[I2C_BUS_THERMAL].handle);
+}
+
+void I2C2_ER_IRQHandler(void)
+{
+    HAL_I2C_ER_IRQHandler(&i2c_hardware.i2c[I2C_BUS_THERMAL].handle);
+}

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/freertos_thermal_task.cpp
@@ -1,9 +1,9 @@
 #include "firmware/freertos_thermal_task.hpp"
 
+#include "firmware/i2c_hardware.h"
 #include "firmware/tachometer_hardware.h"
 #include "firmware/thermal_hardware.h"
 #include "firmware/thermal_policy.hpp"
-#include "firmware/thermistor_hardware.h"
 #include "tempdeck-gen3/thermal_task.hpp"
 
 namespace thermal_control_task {
@@ -28,7 +28,7 @@ auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
     _top_task.provide_aggregator(aggregator);
 
     thermal_hardware_init();
-    thermistor_hardware_init();
+    i2c_hardware_init();
     tachometer_hardware_init();
 
     auto policy = thermal_policy::ThermalPolicy();

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_policy.cpp
@@ -1,8 +1,8 @@
 #include "firmware/thermal_policy.hpp"
 
+#include "firmware/i2c_hardware.h"
 #include "firmware/tachometer_hardware.h"
 #include "firmware/thermal_hardware.h"
-#include "firmware/thermistor_hardware.h"
 
 namespace thermal_policy {
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
@@ -42,7 +42,7 @@ auto ThermalPolicy::set_write_protect(bool set) -> void {
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermalPolicy::i2c_write(uint8_t addr, uint8_t data) -> bool {
-    return thermal_i2c_write_data(addr, &data, 1);
+    return i2c_hardware_write_data(I2C_BUS_THERMAL, addr, &data, 1);
 }
 
 }  // namespace thermal_policy

--- a/stm32-modules/tempdeck-gen3/firmware/thermistor/freertos_thermistor_task.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermistor/freertos_thermistor_task.cpp
@@ -1,6 +1,7 @@
 #include "firmware/freertos_thermistor_task.hpp"
 
 #include "FreeRTOS.h"
+#include "firmware/i2c_hardware.h"
 #include "firmware/internal_adc_hardware.h"
 #include "firmware/thermistor_hardware.h"
 #include "firmware/thermistor_policy.hpp"
@@ -24,6 +25,7 @@ auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
                   "FreeRTOS tickrate must be at 1000 Hz");
 
     thermistor_hardware_init();
+    i2c_hardware_init();
     internal_adc_init();
 
     // Thermistor task has no queue, just need to provide aggregator handle

--- a/stm32-modules/tempdeck-gen3/firmware/thermistor/thermistor_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermistor/thermistor_hardware.c
@@ -20,17 +20,6 @@
 #define ADC_ALERT_PIN  (GPIO_PIN_11)
 #define ADC_ALERT_PORT (GPIOB)
 
-#define I2C_INSTANCE (I2C2)
-/* Driven by PCLK1 to Fast Mode - just shy of 400kHz */
-#define I2C_TIMING   (0x80500D1D)
-/** Size of register address: 1 byte.*/
-#define REGISTER_ADDR_LEN (1)
-
-#define SDA_PIN (GPIO_PIN_8)
-#define SDA_PORT (GPIOA)
-#define SCL_PIN (GPIO_PIN_9)
-#define SCL_PORT (GPIOA)
-
 /** Private typedef */
 
 struct ThermistorHardware {

--- a/stm32-modules/tempdeck-gen3/firmware/thermistor/thermistor_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermistor/thermistor_hardware.c
@@ -23,8 +23,6 @@
 #define I2C_INSTANCE (I2C2)
 /* Driven by PCLK1 to Fast Mode - just shy of 400kHz */
 #define I2C_TIMING   (0x80500D1D)
-/** Max buffer: 2 data bytes*/
-#define I2C_BUF_MAX (2)
 /** Size of register address: 1 byte.*/
 #define REGISTER_ADDR_LEN (1)
 
@@ -32,19 +30,12 @@
 #define SDA_PORT (GPIOA)
 #define SCL_PIN (GPIO_PIN_9)
 #define SCL_PORT (GPIOA)
-#define ENABLE_I2C_GPIO_CLK() __HAL_RCC_GPIOA_CLK_ENABLE()
 
 /** Private typedef */
 
 struct ThermistorHardware {
-    I2C_HandleTypeDef i2c_handle;
-    // Used to signal the end of an I2C transaction
-    _Atomic TaskHandle_t i2c_task_to_notify;
     // Used to signal the ADC Alert pin interrupt
     _Atomic TaskHandle_t gpio_task_to_notify;
-    SemaphoreHandle_t i2c_semaphore;
-    StaticSemaphore_t i2c_semaphore_data;
-    uint8_t i2c_buffer[I2C_BUF_MAX];
     _Atomic bool initialized;
     _Atomic bool initialization_started;
 };
@@ -52,30 +43,18 @@ struct ThermistorHardware {
 /** Static variables */
 
 static struct ThermistorHardware hardware = {
-    .i2c_handle = {0},
-    .i2c_task_to_notify = NULL,
     .gpio_task_to_notify = NULL,
-    .i2c_semaphore = NULL,
-    .i2c_semaphore_data = {},
-    .i2c_buffer = {0},
     .initialized = false,
     .initialization_started = false,
 };
 
-/** Static function declaration */
-static void handle_i2c_callback();
-
 /** Public functions */
-
 
 void thermistor_hardware_init() {
     GPIO_InitTypeDef gpio_init = {0};
 
     // Enforce that only one task may initialize the I2C
     if(atomic_exchange(&hardware.initialization_started, true) == false) {
-        hardware.i2c_semaphore = 
-            xSemaphoreCreateMutexStatic(&hardware.i2c_semaphore_data);
-
         __HAL_RCC_GPIOB_CLK_ENABLE();
         __HAL_RCC_GPIOA_CLK_ENABLE();
 
@@ -84,27 +63,6 @@ void thermistor_hardware_init() {
         gpio_init.Mode = GPIO_MODE_IT_FALLING;
         gpio_init.Pull = GPIO_PULLUP;
         HAL_GPIO_Init(ADC_ALERT_PORT, &gpio_init);
-
-        HAL_StatusTypeDef hal_ret;
-        // Initialize I2C 
-        hardware.i2c_handle.State = HAL_I2C_STATE_RESET;
-        hardware.i2c_handle.Instance = I2C_INSTANCE;
-        hardware.i2c_handle.Init.Timing = I2C_TIMING;
-        hardware.i2c_handle.Init.OwnAddress1 = 0;
-        hardware.i2c_handle.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
-        hardware.i2c_handle.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
-        hardware.i2c_handle.Init.OwnAddress2 = 0;
-        hardware.i2c_handle.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
-        hardware.i2c_handle.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
-        hardware.i2c_handle.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
-        hal_ret = HAL_I2C_Init(&hardware.i2c_handle);
-        configASSERT(hal_ret == HAL_OK);
-        /** Configure Analogue filter */
-        hal_ret = HAL_I2CEx_ConfigAnalogFilter(&hardware.i2c_handle, I2C_ANALOGFILTER_ENABLE);
-        configASSERT(hal_ret == HAL_OK);
-        /** Configure Digital filter */
-        hal_ret = HAL_I2CEx_ConfigDigitalFilter(&hardware.i2c_handle, 0);
-        configASSERT(hal_ret == HAL_OK);
 
         /** Configure interrupt for ADC Alert pin */
         HAL_NVIC_SetPriority(EXTI15_10_IRQn, 4, 0);
@@ -119,153 +77,6 @@ void thermistor_hardware_init() {
     }
 }
 
-bool thermal_i2c_write_16(uint16_t addr, uint8_t reg, uint16_t val) {
-    const uint16_t bytes_to_send = 2;
-    const TickType_t max_block_time = pdMS_TO_TICKS(100);
-    BaseType_t sem_ret;
-    uint32_t notification_val = 0;
-    HAL_StatusTypeDef hal_ret;
-
-    if(!hardware.initialized) {
-        return false;
-    }
-
-    sem_ret = xSemaphoreTake(hardware.i2c_semaphore, portMAX_DELAY);
-    if(sem_ret != pdTRUE) {
-        return false;
-    }
-
-    // Set up notification info
-    hardware.i2c_task_to_notify = xTaskGetCurrentTaskHandle();
-
-    // Prepare buffer & send it
-    hardware.i2c_buffer[0] = (val >> 8) & 0xFF;
-    hardware.i2c_buffer[1] = (val & 0xFF);
-    hal_ret = HAL_I2C_Mem_Write_IT(&hardware.i2c_handle, addr, (uint16_t)reg,
-                                   REGISTER_ADDR_LEN, hardware.i2c_buffer, 
-                                   bytes_to_send);
-    if(hal_ret == HAL_OK) {
-        // Block on the interrupt for transmit_complete
-        notification_val = ulTaskNotifyTake(pdTRUE, max_block_time);
-    }
-
-    // Ignore return, we would not return an error here even if it fails
-    (void)xSemaphoreGive(hardware.i2c_semaphore);
-
-    return (notification_val == 1) && (hal_ret == HAL_OK);
-}
-
-bool thermal_i2c_read_16(uint16_t addr, uint8_t reg, uint16_t *val) {
-    const uint16_t bytes_to_read = 2;
-    const TickType_t max_block_time = pdMS_TO_TICKS(100);
-    BaseType_t sem_ret;
-    uint32_t notification_val = 0;
-    HAL_StatusTypeDef hal_ret;
-
-    if(!hardware.initialized) {
-        return false;
-    }
-
-    sem_ret = xSemaphoreTake(hardware.i2c_semaphore, portMAX_DELAY);
-    if(sem_ret != pdTRUE) {
-        return false;
-    }
-    
-    // Set up notification info
-    if(hardware.i2c_task_to_notify != NULL) {
-        xSemaphoreGive(hardware.i2c_semaphore);
-        return false;
-    }
-    hardware.i2c_task_to_notify = xTaskGetCurrentTaskHandle();
-    
-    hal_ret = HAL_I2C_Mem_Read_IT(&hardware.i2c_handle, addr, (uint16_t)reg,
-                                  REGISTER_ADDR_LEN, hardware.i2c_buffer,
-                                  bytes_to_read);
-    if(hal_ret == HAL_OK) {
-        // Block on the interrupt for transmit_complete
-        notification_val = ulTaskNotifyTake(pdTRUE, max_block_time);
-        if(notification_val == 1) {
-            // Only write an output value if we succesfully read from the device
-            *val = (((uint16_t)hardware.i2c_buffer[0]) << 8) | ((uint16_t)hardware.i2c_buffer[1]);
-        }
-    }
-
-    // Ignore return, we would not return an error here even if it fails
-    (void)xSemaphoreGive(hardware.i2c_semaphore);
-
-    return (notification_val == 1) && (hal_ret == HAL_OK);
-}
-
-bool thermal_i2c_write_data(uint16_t addr, uint8_t *data, uint16_t len) {
-    const TickType_t max_block_time = pdMS_TO_TICKS(100);
-    HAL_StatusTypeDef hal_ret;
-    uint32_t notification_val = 0;
-    BaseType_t sem_ret;
-
-    if(data == NULL) {
-        return false;
-    }
-
-    sem_ret = xSemaphoreTake(hardware.i2c_semaphore, portMAX_DELAY);
-    if(sem_ret != pdTRUE) {
-        return false;
-    }
-
-    // Set up notification info
-    if(hardware.i2c_task_to_notify != NULL) {
-        xSemaphoreGive(hardware.i2c_semaphore);
-        return false;
-    }
-    hardware.i2c_task_to_notify = xTaskGetCurrentTaskHandle();
-
-    hal_ret = HAL_I2C_Master_Transmit_IT(&hardware.i2c_handle, addr, data, len);
-
-    if(hal_ret == HAL_OK) {
-        // Block on the interrupt for transmit_complete
-        notification_val = ulTaskNotifyTake(pdTRUE, max_block_time);
-    }
-
-    // Ignore return, we would not return an error here even if it fails
-    (void)xSemaphoreGive(hardware.i2c_semaphore);
-
-    return (notification_val == 1) && (hal_ret == HAL_OK);
-}
-
-bool thermal_i2c_read_data(uint16_t addr, uint8_t *data, uint16_t len) {
-    const TickType_t max_block_time = pdMS_TO_TICKS(100);
-    HAL_StatusTypeDef hal_ret;
-    uint32_t notification_val = 0;
-    BaseType_t sem_ret;
-
-    if(data == NULL) {
-        return false;
-    }
-
-    sem_ret = xSemaphoreTake(hardware.i2c_semaphore, portMAX_DELAY);
-    if(sem_ret != pdTRUE) {
-        return false;
-    }
-
-    // Set up notification info
-    if(hardware.i2c_task_to_notify != NULL) {
-        xSemaphoreGive(hardware.i2c_semaphore);
-        return false;
-    }
-    hardware.i2c_task_to_notify = xTaskGetCurrentTaskHandle();
-
-    hal_ret = HAL_I2C_Master_Receive_IT(&hardware.i2c_handle, addr, data, len);
-
-    if(hal_ret == HAL_OK) {
-        // Block on the interrupt for transmit_complete
-        notification_val = ulTaskNotifyTake(pdTRUE, max_block_time);
-    }
-
-    // Ignore return, we would not return an error here even if it fails
-    (void)xSemaphoreGive(hardware.i2c_semaphore);
-    
-    return (notification_val == 1) && (hal_ret == HAL_OK);
-
-}
 
 bool thermal_arm_adc_for_read() {
     hardware.gpio_task_to_notify = xTaskGetCurrentTaskHandle();
@@ -286,114 +97,4 @@ void thermal_adc_ready_callback() {
             portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
         }
     }
-}
-
-// Interrupt handling is the same for every type of transmission
-static void handle_i2c_callback() {
-    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-    if( hardware.i2c_task_to_notify == NULL ) {
-        return;
-    }
-    vTaskNotifyGiveFromISR(hardware.i2c_task_to_notify, 
-                           &xHigherPriorityTaskWoken);
-    hardware.i2c_task_to_notify = NULL;
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
-}
-
-/**
-* @brief I2C MSP Initialization
-* This function configures the hardware resources used in this example
-* @param hi2c: I2C handle pointer
-* @retval None
-*/
-void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c)
-{
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
-    if(hi2c->Instance==I2C2)
-    {
-        ENABLE_I2C_GPIO_CLK();
-        GPIO_InitStruct.Pin = SCL_PIN;
-        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
-        HAL_GPIO_Init(SCL_PORT, &GPIO_InitStruct);
-
-        GPIO_InitStruct.Pin = SDA_PIN;
-        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
-        HAL_GPIO_Init(SDA_PORT, &GPIO_InitStruct);
-
-        /* Peripheral clock enable */
-        __HAL_RCC_I2C2_CLK_ENABLE();
-        /* I2C2 interrupt Init */
-        HAL_NVIC_SetPriority(I2C2_EV_IRQn, 6, 0);
-        HAL_NVIC_EnableIRQ(I2C2_EV_IRQn);
-        HAL_NVIC_SetPriority(I2C2_ER_IRQn, 6, 0);
-        HAL_NVIC_EnableIRQ(I2C2_ER_IRQn);
-    }
-}
-
-/**
-* @brief I2C MSP De-Initialization
-* This function freeze the hardware resources used in this example
-* @param hi2c: I2C handle pointer
-* @retval None
-*/
-void HAL_I2C_MspDeInit(I2C_HandleTypeDef* hi2c)
-{
-    if(hi2c->Instance==I2C2)
-    {
-        /* Peripheral clock disable */
-        __HAL_RCC_I2C2_CLK_DISABLE();
-
-        /**I2C2 GPIO Configuration
-        PC4     ------> I2C2_SCL
-        PA8     ------> I2C2_SDA
-        */
-        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_4);
-
-        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_8);
-
-        /* I2C2 interrupt DeInit */
-        HAL_NVIC_DisableIRQ(I2C2_EV_IRQn);
-        HAL_NVIC_DisableIRQ(I2C2_ER_IRQn);
-    }
-}
-
-/** Overwritten HAL functions */
-
-void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *i2c_handle){
-    handle_i2c_callback();
-}
-
-void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *i2c_handle){
-    handle_i2c_callback();
-}
-
-void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c) {
-    handle_i2c_callback();
-}
-
-void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c) {
-    handle_i2c_callback();
-}
-
-void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *i2c_handle)
-{
-    handle_i2c_callback();
-}
-
-/** Interrupt handlers */
-
-void I2C2_EV_IRQHandler(void)
-{
-    HAL_I2C_EV_IRQHandler(&hardware.i2c_handle);
-}
-
-void I2C2_ER_IRQHandler(void)
-{
-    HAL_I2C_ER_IRQHandler(&hardware.i2c_handle);
 }

--- a/stm32-modules/tempdeck-gen3/firmware/thermistor/thermistor_policy.cpp
+++ b/stm32-modules/tempdeck-gen3/firmware/thermistor/thermistor_policy.cpp
@@ -2,6 +2,7 @@
 #include "firmware/thermistor_policy.hpp"
 
 #include "FreeRTOS.h"
+#include "firmware/i2c_hardware.h"
 #include "firmware/internal_adc_hardware.h"
 #include "firmware/thermistor_hardware.h"
 #include "semphr.h"
@@ -37,14 +38,14 @@ auto ThermistorPolicy::ads1115_arm_for_read() -> bool {
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermistorPolicy::ads1115_i2c_write_16(uint8_t reg, uint16_t data)
     -> bool {
-    return thermal_i2c_write_16(ADC_ADDRESS, reg, data);
+    return i2c_hardware_write_16(I2C_BUS_THERMAL, ADC_ADDRESS, reg, data);
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto ThermistorPolicy::ads1115_i2c_read_16(uint8_t reg)
     -> std::optional<uint16_t> {
     uint16_t data = 0;
-    if (thermal_i2c_read_16(ADC_ADDRESS, reg, &data)) {
+    if (i2c_hardware_read_16(I2C_BUS_THERMAL, ADC_ADDRESS, reg, &data)) {
         return std::optional<uint16_t>(data);
     }
     return std::nullopt;


### PR DESCRIPTION
The I2C code was originally lifted from Thermocycler Gen2, where only one I2C bus is used. In the Tempdeck we are going to have two buses, with one bus dedicated to the LED board to avoid any interference with the thermal I2C bus. This code sets up the framework to allow the second bus to be seamlessly added when bringing up the LED board.

* Moves the I2C code from `thermistor_hardware` to `i2c_hardware`
* Each I2C bus gets its own struct with a unique buffer, semaphore, and task notification for signalling the end of transmission.

Tested on hardware that hooking up a thermistor still shows the correct temperature being polled.