### PR TITLE
fix(thermocycler-gen2): update async error responses

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/errors.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/errors.hpp
@@ -71,4 +71,15 @@ constexpr auto write_into(Input start, Limit end, ErrorCode code) -> Input {
     const char* str = errorstring(code);
     return write_string_to_iterpair(start, end, str);
 }
+
+template <typename Input, typename Limit>
+requires std::forward_iterator<Input> && std::sized_sentinel_for<Limit, Input>
+constexpr auto write_into_async(Input start, Limit end, ErrorCode code)
+    -> Input {
+    constexpr const char* prefix = "async ";
+    auto next = write_string_to_iterpair(start, end, prefix);
+
+    const char* error_str = errorstring(code);
+    return write_string_to_iterpair(next, end, error_str);
+}
 };  // namespace errors

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -266,7 +266,7 @@ class HostCommsTask {
         std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_message(const messages::ErrorMessage& msg, InputIt tx_into,
                        InputLimit tx_limit) -> InputIt {
-        return errors::write_into(tx_into, tx_limit, msg.code);
+        return errors::write_into_async(tx_into, tx_limit, msg.code);
     }
 
     template <typename InputIt, typename InputLimit>

--- a/stm32-modules/thermocycler-gen2/src/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/src/CMakeLists.txt
@@ -41,7 +41,7 @@ set(${TARGET_MODULE_NAME}_VERSION "${VERSION}" CACHE STRING "${TARGET_MODULE_NAM
 
 configure_file(./version.cpp.in ./version.cpp)
 
-option(ALLOW_ASYNC_ERRORS "Select whether asynchronous errors are sent by firmware")
+option(ALLOW_ASYNC_ERRORS "Select whether asynchronous errors are sent by firmware" ON)
 
 if(ALLOW_ASYNC_ERRORS) 
     add_definitions(-DSYSTEM_ALLOW_ASYNC_ERRORS)

--- a/stm32-modules/thermocycler-gen2/src/errors.cpp
+++ b/stm32-modules/thermocycler-gen2/src/errors.cpp
@@ -76,9 +76,9 @@ const char* const THERMAL_TARGET_BAD =
 const char* const THERMAL_DRIFT =
     "ERR408:thermal:Thermal drift of more than 4C\n";
 const char* const LID_MOTOR_BUSY = "ERR501:lid:Lid motor busy\n";
-const char* const LID_MOTOR_FAULT = "EERR502:lid:Lid motor fault\n";
+const char* const LID_MOTOR_FAULT = "ERR502:lid:Lid motor fault\n";
 const char* const SEAL_MOTOR_SPI_ERROR = "ERR503:seal:SPI error\n";
-const char* const SEAL_MOTOR_BUSY = "EERR504:seal:Seal motor busy\n";
+const char* const SEAL_MOTOR_BUSY = "ERR504:seal:Seal motor busy\n";
 const char* const SEAL_MOTOR_FAULT = "ERR505:seal:Seal motor fault\n";
 const char* const SEAL_MOTOR_STALL = "ERR5006:seal:Seal motor stall event\n";
 const char* const LID_CLOSED = "ERR507:lid:Lid must be opened\n";

--- a/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_motor_task.cpp
     test_motor_utils.cpp
     test_eeprom.cpp
+    test_errors.cpp
     # GCode parse tests
     test_m14.cpp
     test_m18.cpp

--- a/stm32-modules/thermocycler-gen2/tests/test_errors.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_errors.cpp
@@ -1,0 +1,41 @@
+#include <array>
+#include <cstring>
+
+#include "catch2/catch.hpp"
+#include "thermocycler-gen2/errors.hpp"
+SCENARIO("testing error writing") {
+    GIVEN("a buffer long enough for an error") {
+        auto buffer = std::string(64, 'c');
+        WHEN("writing an error into it") {
+            auto written =
+                errors::write_into_async(buffer.begin(), buffer.end(),
+                                         errors::ErrorCode::USB_TX_OVERRUN);
+            THEN("the error is written into the buffer") {
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith(
+                                         "async ERR001:tx buffer overrun\n"));
+                AND_THEN("the length was appropriately returned") {
+                    REQUIRE(written ==
+                            buffer.begin() + strlen("async ERR001:tx "
+                                                    "buffer overrun\n"));
+                }
+            }
+        }
+    }
+    GIVEN("a buffer too small for an error") {
+        auto buffer = std::string(2, 'c');
+        WHEN("trying to write an error into it") {
+            auto written = errors::write_into_async(
+                buffer.begin(), buffer.end(),
+                errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            THEN(
+                "the error written into only the space available in the "
+                "buffer") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::Equals(std::string("as")));
+                AND_THEN("the amount written is 0") {
+                    REQUIRE(written == buffer.begin() + 2);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Prepends async error responses with `async`