### PR TITLE
fix(thermocycler-gen2): front button ESD filtering

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/firmware/system_hardware.h
+++ b/stm32-modules/include/thermocycler-gen2/firmware/system_hardware.h
@@ -6,7 +6,8 @@ extern "C" {
 
 #include <stdbool.h>
 
-// Front button can only be pressed at 200ms increments
+// Initial debounce time of 200ms. If the button is released by the time
+// this passes, assume it was an ESD event.
 #define FRONT_BUTTON_DEBOUNCE_MS (200)
 // Front button should be queried at this frequency after debouncing
 #define FRONT_BUTTON_QUERY_RATE_MS (50)

--- a/stm32-modules/include/thermocycler-gen2/firmware/system_hardware.h
+++ b/stm32-modules/include/thermocycler-gen2/firmware/system_hardware.h
@@ -6,9 +6,9 @@ extern "C" {
 
 #include <stdbool.h>
 
-// Initial debounce time of 200ms. If the button is released by the time
+// Initial debounce time of 50ms. If the button is released by the time
 // this passes, assume it was an ESD event.
-#define FRONT_BUTTON_DEBOUNCE_MS (200)
+#define FRONT_BUTTON_DEBOUNCE_MS (50)
 // Front button should be queried at this frequency after debouncing
 #define FRONT_BUTTON_QUERY_RATE_MS (50)
 


### PR DESCRIPTION
ESD testing showed that voltage spikes can generate spurious inputs on the front button GPIO. This PR adds some logic to filter out short spikes such as this, while allowing actual button presses.

- If the button is not pressed after the initial debounce period, we now assume it was a voltage spike rather than a valid press.
- Decreased debounce time to 50ms to avoid filtering out valid presses. This is still a generous debounce period based on testing, and especially will be expected to filter out transient ESD spikes.