### PR TITLE
feat(thermocycler-gen2): optimize seal logic for DVT boards

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/firmware/motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/firmware/motor_policy.hpp
@@ -177,6 +177,16 @@ class MotorPolicy {
     [[nodiscard]] auto seal_read_retraction_switch() const -> bool;
 
     /**
+     * @brief Returns whether the switches for the seal motor use a
+     * shared line for retraction and extension. If they are shared,
+     * it is impossible for firmware to distinguish which switch is
+     * activated at any given time.
+     *
+     * @return true if the switch lines are shared, false otherwise.
+     */
+    [[nodiscard]] auto seal_switches_are_shared() const -> bool;
+
+    /**
      * @brief Call the seal callback function
      *
      */

--- a/stm32-modules/include/thermocycler-gen2/test/test_motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/test/test_motor_policy.hpp
@@ -80,6 +80,8 @@ class TestMotorPolicy : public TestTMC2130Policy {
         return _retraction_switch_triggered;
     }
 
+    auto seal_switches_are_shared() -> bool { return _shared_switch_lines; }
+
     // Test-specific functions
 
     auto tick() -> void {
@@ -116,6 +118,10 @@ class TestMotorPolicy : public TestTMC2130Policy {
 
     auto get_lid_rpm() -> double { return _lid_rpm; }
 
+    auto set_switch_lines_shared(bool shared) -> void {
+        _shared_switch_lines = shared;
+    }
+
   private:
     // Solenoid is engaged when unpowered
     bool _solenoid_engaged = true;
@@ -132,5 +138,7 @@ class TestMotorPolicy : public TestTMC2130Policy {
     bool _extension_switch_armed = false;
     bool _retraction_switch_armed = false;
     double _lid_rpm = 0;
+    // Default to shared switch lines (pre-DVT)
+    bool _shared_switch_lines = true;
     Callback _callback;
 };

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -843,7 +843,7 @@ class MotorTask {
             return error;
         }
         if (extend_switch && retract_switch) {
-            // Both switches retracted means the seal subsystem is somehow
+            // Both switches triggered means the seal subsystem is somehow
             // broken.
             error = errors::ErrorCode::SEAL_MOTOR_SWITCH;
         } else if (retract_switch) {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -84,6 +84,9 @@ concept MotorExecutionPolicy = requires(Policy& p,
     { p.seal_read_extension_switch() } -> std::same_as<bool>;
     // A function to read the seal retraction limit switch
     { p.seal_read_retraction_switch() } -> std::same_as<bool>;
+    // A function to determine whether this thermocycler has shared seal switch
+    // lines. If they're shared, the seal can't be left on the switches.
+    { p.seal_switches_are_shared() } -> std::same_as<bool>;
     // Policy defines a number that provides the number of seal motor ticks
     // in a second
     {std::is_integral_v<decltype(Policy::MotorTickFrequency)>};
@@ -1136,53 +1139,79 @@ class MotorTask {
     template <MotorExecutionPolicy Policy>
     auto handle_lid_state_end(Policy& policy) -> errors::ErrorCode {
         auto error = errors::ErrorCode::NO_ERROR;
+        auto shared_switches = policy.seal_switches_are_shared();
         switch (_state.status) {
-            case LidState::Status::IDLE:
+            case LidState::Status::IDLE: {
                 // Do nothing
                 break;
-            case LidState::Status::OPENING_RETRACT_SEAL:
-                _seal_position = motor_util::SealStepper::Status::BETWEEN;
+            }
+            case LidState::Status::OPENING_RETRACT_SEAL: {
+                _seal_position =
+                    shared_switches
+                        ? motor_util::SealStepper::Status::BETWEEN
+                        : motor_util::SealStepper::Status::RETRACTED;
                 // Start lid motor movement
-                error = handle_lid_state_enter(
-                    LidState::Status::OPENING_RETRACT_SEAL_BACKOFF, policy);
+                auto next_state =
+                    shared_switches
+                        ? LidState::Status::OPENING_RETRACT_SEAL_BACKOFF
+                        : LidState::Status::OPENING_OPEN_HINGE;
+                error = handle_lid_state_enter(next_state, policy);
                 break;
-            case LidState::Status::OPENING_RETRACT_SEAL_BACKOFF:
+            }
+            case LidState::Status::OPENING_RETRACT_SEAL_BACKOFF: {
                 _seal_position = motor_util::SealStepper::Status::RETRACTED;
                 // Start lid motor movement
                 error = handle_lid_state_enter(
                     LidState::Status::OPENING_OPEN_HINGE, policy);
                 break;
-            case LidState::Status::OPENING_OPEN_HINGE:
-                error = handle_lid_state_enter(LidState::Status::IDLE, policy);
+                case LidState::Status::OPENING_OPEN_HINGE:
+                    error =
+                        handle_lid_state_enter(LidState::Status::IDLE, policy);
+                    break;
+            }
+            case LidState::Status::CLOSING_RETRACT_SEAL: {
+                _seal_position =
+                    shared_switches
+                        ? motor_util::SealStepper::Status::BETWEEN
+                        : motor_util::SealStepper::Status::RETRACTED;
+                auto next_state =
+                    shared_switches
+                        ? LidState::Status::CLOSING_RETRACT_SEAL_BACKOFF
+                        : LidState::Status::CLOSING_CLOSE_HINGE;
+                error = handle_lid_state_enter(next_state, policy);
                 break;
-            case LidState::Status::CLOSING_RETRACT_SEAL:
-                _seal_position = motor_util::SealStepper::Status::BETWEEN;
-                error = handle_lid_state_enter(
-                    LidState::Status::CLOSING_RETRACT_SEAL_BACKOFF, policy);
-                break;
-            case LidState::Status::CLOSING_RETRACT_SEAL_BACKOFF:
+            }
+            case LidState::Status::CLOSING_RETRACT_SEAL_BACKOFF: {
                 _seal_position = motor_util::SealStepper::Status::RETRACTED;
                 // Start lid motor movement
                 error = handle_lid_state_enter(
                     LidState::Status::CLOSING_CLOSE_HINGE, policy);
                 break;
-            case LidState::Status::CLOSING_CLOSE_HINGE:
-                error = handle_lid_state_enter(
-                    LidState::Status::CLOSING_EXTEND_SEAL, policy);
+                case LidState::Status::CLOSING_CLOSE_HINGE:
+                    error = handle_lid_state_enter(
+                        LidState::Status::CLOSING_EXTEND_SEAL, policy);
+                    break;
+            }
+            case LidState::Status::CLOSING_EXTEND_SEAL: {
+                _seal_position = shared_switches
+                                     ? motor_util::SealStepper::Status::BETWEEN
+                                     : motor_util::SealStepper::Status::ENGAGED;
+                auto next_state =
+                    shared_switches
+                        ? LidState::Status::CLOSING_EXTEND_SEAL_BACKOFF
+                        : LidState::Status::IDLE;
+                error = handle_lid_state_enter(next_state, policy);
                 break;
-            case LidState::Status::CLOSING_EXTEND_SEAL:
-                _seal_position = motor_util::SealStepper::Status::BETWEEN;
-                error = handle_lid_state_enter(
-                    LidState::Status::CLOSING_EXTEND_SEAL_BACKOFF, policy);
-                break;
-            case LidState::Status::CLOSING_EXTEND_SEAL_BACKOFF:
+            }
+            case LidState::Status::CLOSING_EXTEND_SEAL_BACKOFF: {
                 _seal_position = motor_util::SealStepper::Status::ENGAGED;
-                // Start lid motor movement
                 error = handle_lid_state_enter(LidState::Status::IDLE, policy);
                 break;
-            case LidState::Status::PLATE_LIFTING:
+            }
+            case LidState::Status::PLATE_LIFTING: {
                 error = handle_lid_state_enter(LidState::Status::IDLE, policy);
                 break;
+            }
         }
         if (error != errors::ErrorCode::NO_ERROR) {
             // Clear the lid status no matter what

--- a/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_policy.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_policy.cpp
@@ -147,3 +147,8 @@ auto MotorPolicy::seal_switch_set_disarmed() -> void {
     }
     return motor_hardware_seal_retraction_switch_triggered();
 }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+[[nodiscard]] auto MotorPolicy::seal_switches_are_shared() const -> bool {
+    return _shared_seal_switch_lines;
+}

--- a/stm32-modules/thermocycler-gen2/simulator/motor_thread.cpp
+++ b/stm32-modules/thermocycler-gen2/simulator/motor_thread.cpp
@@ -117,6 +117,8 @@ class SimMotorPolicy : public SimTMC2130Policy {
 
     auto seal_read_retraction_switch() -> bool { return false; }
 
+    auto seal_switches_are_shared() -> bool { return false; }
+
   private:
     // Lowest position the lid can move before stalling
     static constexpr uint32_t min_lid_steps =


### PR DESCRIPTION
Closes RET-1209 and RET-1228

The seal motor has two limit switches on the EVT units, but those switches share a single GPIO. On DVT and later thermocyclers, there are independent lines for each switch. This means that the control logic for the seal motor during lid open/close movements can be simplified.

- When given an open/close lid command, check whether both switches are triggered and return an error if so.
- When the next step is retracting or extending the seal, skip the step if the correct limit switch is already triggered
- When the next step is a "backoff" from the limit switch at the end of a movement, skip the step if we are on a board with multiple GPIO for the seal switches.

Tested that the lid still works as expected on an EVT unit (and still won't move when the seal limit switches are triggered), and tested on a DVT unit that the motor task uses the new logic and that the behavior works as expected.