### PR TITLE
fix(startup): fully reset STM32G4 after sysmem bootloader

### DIFF
--- a/stm32-modules/common/STM32G491/startup_hal.c
+++ b/stm32-modules/common/STM32G491/startup_hal.c
@@ -7,6 +7,7 @@
 
 void startup_flash_init() {
     __HAL_RCC_FLASH_CLK_ENABLE();
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_SR_ERRORS);
 }
 
 // Each target has a different method to set the page for erasing

--- a/stm32-modules/common/STM32G491/startup_system_stm32g4xx.c
+++ b/stm32-modules/common/STM32G491/startup_system_stm32g4xx.c
@@ -206,6 +206,7 @@ void SystemCoreClockUpdate(void) {
 }
 
 void HardwareInit(void) {
+    HAL_DeInit();
     HAL_Init();
     SystemClock_Config();
     SystemCoreClockUpdate();


### PR DESCRIPTION
When an STM32G491-based module (i.e. Thermocycler-Gen2 or Tempdeck-Gen3) exits the DFU bootloader, the startup program would jump straight to the main application without overwriting the backup slot. This would cause the _next_ module restart to take a long time while the startup app overwrites the backup slot, which is much less intuitive than the delay happening right after ISP.

Debugging the startup app showed that the Flash Status Register populates with multiple error bits set when the DFU bootloader exits. Clearing these bits before performing any flash operations fixes the issue, but only if `HAL_DeInit` is also called before configuring the clock.

After this PR, sending a new firmware image over DFU and then sending the DFU `:leave`command results in the startup app immediately ovewriting the backup slot. The next time the module is restarted, the main application starts up instantly, and sending `M115` gives back the correct version information.

_This issue does not affect STM32F303 modules (i.e. Heater-Shaker)._