### PR TITLE
fix(thermocycler-gen2): throttle simulator periodic data

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/simulator/periodic_data_thread.hpp
+++ b/stm32-modules/include/thermocycler-gen2/simulator/periodic_data_thread.hpp
@@ -47,6 +47,11 @@ class PeriodicDataThread {
     // Should be initiated in its own jthread
     auto run(std::stop_token& st) -> void;
 
+    // Thread safe method to signal that lid thread processed data
+    auto signal_lid_thread_ready() -> void;
+    // Thread safe method to signal that lid thread processed data
+    auto signal_plate_thread_ready() -> void;
+
   private:
     // The further from room temperature an element is, the stronger
     // the draw back to room temp will be.
@@ -72,6 +77,10 @@ class PeriodicDataThread {
     // This really wants to be an std::latch, but that isn't available
     // in gcc10. Bummer :(
     std::atomic_bool _init_latch;
+    // If one of these flags is set, wait until the respective thread signals
+    // that it read the temperature update
+    std::atomic_bool _waiting_for_lid_thread{false};
+    std::atomic_bool _waiting_for_plate_thread{false};
 };
 
 auto build(bool realtime) -> std::pair<std::unique_ptr<std::jthread>,

--- a/stm32-modules/include/thermocycler-gen2/simulator/periodic_data_thread.hpp
+++ b/stm32-modules/include/thermocycler-gen2/simulator/periodic_data_thread.hpp
@@ -61,8 +61,8 @@ class PeriodicDataThread {
     // reading
     auto scaled_gain_effect(double gain, double power,
                             std::chrono::milliseconds delta) -> double;
-    auto update_heat_pad() -> void;
-    auto update_peltiers() -> void;
+    auto update_heat_pad() -> bool;
+    auto update_peltiers() -> bool;
     auto run_motor() -> void;
 
     Power _heat_pad_power;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
@@ -112,6 +112,10 @@ class LidHeaterTask {
         _task_registry = other_tasks;
     }
 
+    [[nodiscard]] auto get_last_temp_update() const -> Milliseconds {
+        return _last_update;
+    }
+
     /**
      * run_once() runs one spin of the task. This means it
      * - Waits for a message, either a thermistor update or

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -226,6 +226,10 @@ class ThermalPlateTask {
         _task_registry = other_tasks;
     }
 
+    [[nodiscard]] auto get_last_temp_update() const -> Milliseconds {
+        return _last_update;
+    }
+
     /**
      * run_once() runs one spin of the task. This means it
      * - Waits for a message, either a thermistor update or

--- a/stm32-modules/thermocycler-gen2/simulator/lid_heater_thread.cpp
+++ b/stm32-modules/thermocycler-gen2/simulator/lid_heater_thread.cpp
@@ -47,10 +47,16 @@ auto run(
     auto policy = SimLidHeaterPolicy(periodic_data);
     tcb->queue.set_stop_token(st);
     while (!st.stop_requested()) {
+        auto last_update_before = tcb->task.get_last_temp_update();
         try {
             tcb->task.run_once(policy);
         } catch (const SimLidHeaterTask::Queue::StopDuringMsgWait sdmw) {
             return;
+        }
+        if (last_update_before != tcb->task.get_last_temp_update()) {
+            // The temperature was updated, so let the periodic data thread
+            // know it can send another update
+            periodic_data->signal_lid_thread_ready();
         }
     }
 }


### PR DESCRIPTION
When running the TC Gen2 simulator in opentrons emulation, errors would bubble up indicating message queue overflow. This seems to be due to the periodic data thread running too fast for its own good and filling the other task's queues with tons of temperature update messages.

This PR adds atomic flags for the periodic data thread to track when it sends a temperature update to another thread. The lid and plate threads will clear their respective flags whenever a temperature conversion message is consumed.

Tested on my machine that the simulator still lets you set a temperature target and simulates the temperature reaching that target on both the lid and plate. 