### PR TITLE
feat(tests): add code coverage tracking

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+
+comment:
+  # add flags to `layout` configuration to show up in the PR comment
+  layout: 'reach, diff, flags, files'
+
+flag_management:
+  default_rules:
+    carryforward: true

--- a/.github/workflows/stm32-codecov.yaml
+++ b/.github/workflows/stm32-codecov.yaml
@@ -1,0 +1,45 @@
+name: 'STM32 Common Code build/test'
+on:
+  pull_request
+  workflow_dispatch
+
+
+defaults:
+  run:
+    shell: bash
+
+
+jobs:
+  generate-coverage:
+    name: 'Generate-Coverage'
+    runs-on: 'ubuntu-20.04'
+    timeout-minutes: 10
+    env:
+      CC: gcc-10
+      CXX: g++-10
+    steps:
+      - run: |
+          sudo apt update
+          sudo apt install gcc-10 g++-10 lcov
+      - uses: 'actions/checkout@v2'
+        with:
+          fetch-depth: 0
+      - uses: 'actions/cache@v2'
+        with:
+          path: './stm32-tools'
+          key: stm32-host-${{ secrets.MODULES_STM32_CACHE_VERSION }}-${{ hashFiles('cmake/*') }}
+          restore-keys: stm32-host-${{ secrets.MODULES_STM32_CACHE_VERSION }}-
+      - name: 'Configure'
+        run: cmake --preset=stm32-host -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug
+      - name: 'Run all stm32 tests'
+        run: |
+          cmake --build --preset host --target common-build-and-test
+          cmake --build --preset host --target thermocycler-gen2-build-and-test
+          cmake --build --preset host --target heater-shaker-build-and-test
+          cmake --build --preset host --target tempdeck-gen3-build-and-test
+      - name: 'Generate coverage'
+        run: cmake --build --preset host --target lcov-geninfo
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: build-stm32-host/lcov/data/capture/common-core.info

--- a/.github/workflows/stm32-codecov.yaml
+++ b/.github/workflows/stm32-codecov.yaml
@@ -1,4 +1,4 @@
-name: 'STM32 Common Code build/test'
+name: 'Code Coverage'
 on: [pull_request, workflow_dispatch]
 
 
@@ -25,8 +25,8 @@ jobs:
       - uses: 'actions/cache@v2'
         with:
           path: './stm32-tools'
-          key: stm32-host-${{ secrets.MODULES_STM32_CACHE_VERSION }}-${{ hashFiles('cmake/*') }}
-          restore-keys: stm32-host-${{ secrets.MODULES_STM32_CACHE_VERSION }}-
+          key: stm32-host-codecov-${{ secrets.MODULES_STM32_CACHE_VERSION }}-${{ hashFiles('cmake/*') }}
+          restore-keys: stm32-host-codecov-${{ secrets.MODULES_STM32_CACHE_VERSION }}-
       - name: 'Configure'
         run: cmake --preset=stm32-host -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug
       - name: 'Run all stm32 tests'

--- a/.github/workflows/stm32-codecov.yaml
+++ b/.github/workflows/stm32-codecov.yaml
@@ -40,4 +40,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          file: build-stm32-host/lcov/data/capture/common-core.info
+          files: build-stm32-host/lcov/data/capture/common-core.info
+          name: codecov-stm32-modules
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/stm32-codecov.yaml
+++ b/.github/workflows/stm32-codecov.yaml
@@ -25,8 +25,8 @@ jobs:
       - uses: 'actions/cache@v2'
         with:
           path: './stm32-tools'
-          key: stm32-host-codecov-${{ secrets.MODULES_STM32_CACHE_VERSION }}-${{ hashFiles('cmake/*') }}
-          restore-keys: stm32-host-codecov-${{ secrets.MODULES_STM32_CACHE_VERSION }}-
+          key: stm32-host-${{ secrets.MODULES_STM32_CACHE_VERSION }}-${{ hashFiles('cmake/*') }}
+          restore-keys: stm32-host-${{ secrets.MODULES_STM32_CACHE_VERSION }}-
       - name: 'Configure'
         run: cmake --preset=stm32-host -DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug
       - name: 'Run all stm32 tests'

--- a/.github/workflows/stm32-codecov.yaml
+++ b/.github/workflows/stm32-codecov.yaml
@@ -1,7 +1,5 @@
 name: 'STM32 Common Code build/test'
-on:
-  pull_request
-  workflow_dispatch
+on: [pull_request, workflow_dispatch]
 
 
 defaults:

--- a/.github/workflows/stm32-codecov.yaml
+++ b/.github/workflows/stm32-codecov.yaml
@@ -19,6 +19,11 @@ jobs:
       - run: |
           sudo apt update
           sudo apt install gcc-10 g++-10 lcov
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+      - name: 'Install lcov_cobertura module'
+        run: pip install lcov_cobertura
       - uses: 'actions/checkout@v2'
         with:
           fetch-depth: 0
@@ -37,10 +42,11 @@ jobs:
           cmake --build --preset host --target tempdeck-gen3-build-and-test
       - name: 'Generate coverage'
         run: cmake --build --preset host --target lcov-geninfo
+      - name: 'Convert coverage to xml'
+        run: lcov_cobertura build-stm32-host/lcov/data/capture/all_targets.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: build-stm32-host/lcov/data/capture/common-core.info
+          files: ./coverage.xml
           name: codecov-stm32-modules
           fail_ci_if_error: true
-          verbose: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,10 @@ project("OpentronsModules"
   LANGUAGES CXX C ASM
   DESCRIPTION "Firmware for Opentrons modules")
 
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH 
+      "${PROJECT_SOURCE_DIR}/cmake" 
+      "${PROJECT_SOURCE_DIR}/cmake/codecov/cmake" 
+      ${CMAKE_MODULE_PATH})
 if (NOT ${CMAKE_CROSSCOMPILING})
   enable_testing()
   add_custom_target(build-and-test)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ You can change to a different compiler, like an installed upstream clang/llvm, b
 
 This isn't the default `stm32-host` because it requires specifying the compiler by version to actually work on OSX, where `gcc` and `g++` unqualified by version are... aliased to system clang. Setting the default to `gcc-10` and `g++-10` then might have problems on other platforms if someone update their gcc and g++ or on CI.
 
+## code coverage
+
+This repository is configured to generate code coverage from the tests.
+
+To enable code coverage, configure the host toolchain for tests with the options `-DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug`. _In order for code coverage to be accurate, you must run the build-and-test target for a module_. After running every build-and-test target, the target `lcov` will generate an HTMl report of the code coverage from the tests.
+
+In general, do not enable code coverage unless you need it. Test execution will be far slower.
 
 ### Custom Configuration
 

--- a/stm32-modules/CMakeLists.txt
+++ b/stm32-modules/CMakeLists.txt
@@ -13,8 +13,20 @@ if (${CMAKE_CROSSCOMPILING})
         add_definitions(-DASSERTIONS_ENABLED)
     endif()
 
+    function(add_coverage TARGET)
+    endfunction()
+
+    function(coverage_evaluate)
+    endfunction()
 else()
     find_package(Boost 1.71.0)
+    find_package(codecov)
+
+    # We can safely ignore test code and stm32-tools imports
+    list(APPEND LCOV_REMOVE_PATTERNS 
+        "'${PROJECT_SOURCE_DIR}/stm32-tools/*'"
+        "'${PROJECT_SOURCE_DIR}/**/tests/*.cpp'"
+        "'${PROJECT_SOURCE_DIR}/*/putchar.c'")
 endif()
 
 find_package(Clang)
@@ -24,3 +36,5 @@ add_subdirectory(common)
 add_subdirectory(heater-shaker)
 add_subdirectory(thermocycler-gen2)
 add_subdirectory(tempdeck-gen3)
+
+coverage_evaluate()

--- a/stm32-modules/common/src/CMakeLists.txt
+++ b/stm32-modules/common/src/CMakeLists.txt
@@ -93,3 +93,5 @@ if (${CMAKE_CROSSCOMPILING})
   
   
 endif()
+
+add_coverage(${TARGET_MODULE_NAME}-core)

--- a/stm32-modules/common/tests/CMakeLists.txt
+++ b/stm32-modules/common/tests/CMakeLists.txt
@@ -47,3 +47,5 @@ target_link_libraries(${TARGET_MODULE_NAME}
 
 catch_discover_tests(${TARGET_MODULE_NAME} )
 add_build_and_test_target(${TARGET_MODULE_NAME} )
+
+add_coverage(${TARGET_MODULE_NAME})

--- a/stm32-modules/common/tests/test_at24c0xc.cpp
+++ b/stm32-modules/common/tests/test_at24c0xc.cpp
@@ -18,7 +18,8 @@ TEST_CASE("TestAT24C0XCPolicy functionality") {
                 }
             }
             AND_WHEN("reading a full page") {
-                std::array<uint8_t, 8> readback = {0};
+                std::array<uint8_t, 8> readback = {0, 0, 0, 0, 0, 0, 0, 0};
+                policy.i2c_write(0, 0);
                 policy.i2c_read(0, readback.begin(), readback.size());
                 THEN("the returned buffer does not match what was written") {
                     for (int i = 0; i < 8; ++i) {

--- a/stm32-modules/heater-shaker/src/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/src/CMakeLists.txt
@@ -80,3 +80,5 @@ target_compile_options(heater-shaker-core
   $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
   $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
   )
+
+  add_coverage(heater-shaker-core)

--- a/stm32-modules/heater-shaker/tests/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/tests/CMakeLists.txt
@@ -65,3 +65,5 @@ target_link_libraries(heater-shaker
 
 catch_discover_tests(heater-shaker)
 add_build_and_test_target(heater-shaker)
+
+add_coverage(heater-shaker)

--- a/stm32-modules/include/common/test/test_at24c0xc_policy.hpp
+++ b/stm32-modules/include/common/test/test_at24c0xc_policy.hpp
@@ -20,8 +20,8 @@ class TestAT24C0XCPolicy {
     using Buffer = std::array<uint8_t, PAGES * PAGE_LENGTH>;
 
     TestAT24C0XCPolicy() : _buffer(), _data_pointer(0), _write_protect(true) {
-        for (auto& itr : _buffer) {
-            itr = 0;
+        for (size_t i = 0; i < _buffer.size(); ++i) {
+            _buffer[i] = 0;
         }
     }
 

--- a/stm32-modules/include/common/test/test_at24c0xc_policy.hpp
+++ b/stm32-modules/include/common/test/test_at24c0xc_policy.hpp
@@ -19,8 +19,11 @@ class TestAT24C0XCPolicy {
     static constexpr const size_t PAGE_LENGTH = at24c0xc::PAGE_LENGTH;
     using Buffer = std::array<uint8_t, PAGES * PAGE_LENGTH>;
 
-    TestAT24C0XCPolicy()
-        : _buffer({0}), _data_pointer(0), _write_protect(true) {}
+    TestAT24C0XCPolicy() : _buffer(), _data_pointer(0), _write_protect(true) {
+        for (auto& itr : _buffer) {
+            itr = 0;
+        }
+    }
 
     // --- Policy fulfillment -----------
 

--- a/stm32-modules/tempdeck-gen3/src/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/src/CMakeLists.txt
@@ -90,3 +90,5 @@ target_compile_options(${TARGET_MODULE_NAME}-core
   $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
   $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
   )
+
+add_coverage(${TARGET_MODULE_NAME}-core)

--- a/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/tests/CMakeLists.txt
@@ -56,3 +56,5 @@ target_link_libraries(${TARGET_MODULE_NAME}
 
 catch_discover_tests(${TARGET_MODULE_NAME} )
 add_build_and_test_target(${TARGET_MODULE_NAME} )
+
+add_coverage(${TARGET_MODULE_NAME})

--- a/stm32-modules/thermocycler-gen2/src/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/src/CMakeLists.txt
@@ -94,3 +94,5 @@ target_compile_options(${TARGET_MODULE_NAME}-core
   $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
   $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
   )
+
+add_coverage(${TARGET_MODULE_NAME}-core)

--- a/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
@@ -84,3 +84,5 @@ target_link_libraries(${TARGET_MODULE_NAME}
 
 catch_discover_tests(${TARGET_MODULE_NAME} )
 add_build_and_test_target(${TARGET_MODULE_NAME} )
+
+add_coverage(${TARGET_MODULE_NAME})


### PR DESCRIPTION
This PR adds support to generate code coverage information for the firmware.

* This takes advantage of a cmake module that easily sets up a target to generate `lcov`  coverage info
* The lcov output is converted to an xml file with a python module to be compatible with `codecov`
* The resulting code coverage XML is pushed to codecov and displayed as a message with the PR

This PR also addresses an issue with a failing unit test that had not been failing in CI before. Weird!