### PR TITLE
fix(thermocycler-gen2): always disable if thermistors are bad

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
@@ -160,7 +160,8 @@ class LidHeaterTask {
         auto old_error_bitmap = _state.error_bitmap;
         auto current_time = Milliseconds(msg.timestamp_ms);
         handle_temperature_conversion(msg.lid_temp, _thermistor);
-        if (old_error_bitmap != _state.error_bitmap) {
+        if ((old_error_bitmap != _state.error_bitmap) ||
+            (_state.error_bitmap != 0)) {
             if (_state.error_bitmap != 0) {
                 // We entered an error state. Disable power output.
                 _state.system_status = State::ERROR;
@@ -297,6 +298,7 @@ class LidHeaterTask {
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
 
         if (_state.system_status == State::ERROR && !msg.from_system) {
+            std::ignore = policy.set_heater_power(0.0F);
             response.with_error = most_relevant_error();
             static_cast<void>(
                 _task_registry->comms->get_message_queue().try_send(response));
@@ -328,7 +330,9 @@ class LidHeaterTask {
             messages::DeactivateAllResponse{.responding_to_id = msg.id};
 
         static_cast<void>(policy.set_heater_power(0.0F));
-        _state.system_status = State::IDLE;
+        if(_state.system_status != State::ERROR) {
+            _state.system_status = State::IDLE;
+        }
 
         static_cast<void>(
             _task_registry->comms->get_message_queue().try_send(response));

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
@@ -330,7 +330,7 @@ class LidHeaterTask {
             messages::DeactivateAllResponse{.responding_to_id = msg.id};
 
         static_cast<void>(policy.set_heater_power(0.0F));
-        if(_state.system_status != State::ERROR) {
+        if (_state.system_status != State::ERROR) {
             _state.system_status = State::IDLE;
         }
 

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -590,8 +590,9 @@ class ThermalPlateTask {
             messages::DeactivateAllResponse{.responding_to_id = msg.id};
 
         policy.set_enabled(false);
-        _state.system_status = State::IDLE;
-
+        if (_state.system_status != State::ERROR) {
+            _state.system_status = State::IDLE;
+        }
         static_cast<void>(
             _task_registry->comms->get_message_queue().try_send(response));
     }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -313,7 +313,8 @@ class ThermalPlateTask {
             }
         }
 
-        if (old_error_bitmap != _state.error_bitmap) {
+        if ((old_error_bitmap != _state.error_bitmap) ||
+            (_state.error_bitmap != 0)) {
             if (_state.error_bitmap != 0) {
                 // We entered an error state. Disable power output.
                 _state.system_status = State::ERROR;


### PR DESCRIPTION
The TC2 firmware includes protection against shorted & disconnected thermistors. The status of each thermistor is stored as a bit flag for both the Thermal Plate and Lid Thermistor tasks. When a flag goes from 0 to 1, the firmware detects it and makes sure to disable any related hardware to prevent a dangerous thermal error case.

Unfortunately, some commands were resetting the task state to IDLE. Because the flags were only checked if they _changed_, the thermal tasks would then happily let users set a target temperature. If a thermistor is broken, the thermal control will probably lead to a runaway overheat situation.

Steps to reproduce:
* Turn on TC with a faulty  resistor (e.g. put a 2.2Ω resistor in place)
* Send M140 to set the lid on or M104 to set plate on --> get an error back
* Send M18 to deactivate everything
* Send M140 or M104 again --> this time, the lid or plate will start heating

After this PR, the last step will return an error and NOT control the temperature.