### PR TITLE
feat(thermocycler-gen2): ignore thermistor uniformity checks below 7.5 degrees

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -103,9 +103,8 @@ class PlateControl {
     /**
      * When performing the thermistor drift check, this is the max point
      * below which errors are ignored. This is added to prevent unnecesary
-     * error messages during long incubations below 8º where temperature may
-     * drift more than our normal spec BUT will not affect the samples on the
-     * Thermocycler.
+     * error messages during long periods below 8º where temperature may
+     * drift more than our normal spec BUT will not affect the samples.
      */
     static constexpr double DRIFT_CHECK_IGNORE_MAX_TEMP = 7.5;
 

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -100,6 +100,14 @@ class PlateControl {
     static constexpr double TARGET_ADJUST_FOR_COLD_TARGET = -5.0F;
     /** Extra factor to multiply the proportioal band by */
     static constexpr double PROPORTIONAL_BAND_EXTRA_FACTOR = 2.0F;
+    /**
+     * When performing the thermistor drift check, this is the max point
+     * below which errors are ignored. This is added to prevent unnecesary
+     * error messages during long incubations below 8º where temperature may
+     * drift more than our normal spec BUT will not affect the samples on the
+     * Thermocycler.
+     */
+    static constexpr double DRIFT_CHECK_IGNORE_MAX_TEMP = 7.5;
 
     PlateControl() = delete;
     /**

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -304,7 +304,8 @@ auto PlateControl::reset_control(thermal_general::HeatsinkFan &fan) -> void {
         min = std::min(temperature, min);
         max = std::max(temperature, max);
     }
-    return std::abs(max - min) <= THERMISTOR_DRIFT_MAX_C;
+    return (std::abs(max - min) <= THERMISTOR_DRIFT_MAX_C) ||
+           (max <= DRIFT_CHECK_IGNORE_MAX_TEMP);
 }
 
 [[nodiscard]] auto PlateControl::get_peltier_temps() const

--- a/stm32-modules/thermocycler-gen2/tests/test_plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_plate_control.cpp
@@ -201,6 +201,28 @@ TEST_CASE("PlateControl drift error check") {
                 THEN("the result is false") { REQUIRE(result == false); }
             }
         }
+        GIVEN("uniform cold temperature across thermistors") {
+            constexpr double target = 4;
+            set_temp(thermistors, target);
+            WHEN("checking for thermistor drift") {
+                auto result = plateControl.thermistor_drift_check();
+                THEN("the result is true") { REQUIRE(result == true); }
+            }
+            AND_GIVEN("thermistors out of spec BUT under 7.5") {
+                thermistors.at(THERM_BACK_LEFT).temp_c = 0.5;
+                thermistors.at(THERM_BACK_RIGHT).temp_c = 7;
+                THEN("thermistor drift error does not occur") {
+                    REQUIRE(plateControl.thermistor_drift_check());
+                }
+            }
+            AND_GIVEN("thermistors out of spec and a resistor exceeds 7.5") {
+                thermistors.at(THERM_BACK_LEFT).temp_c = 0.5;
+                thermistors.at(THERM_BACK_RIGHT).temp_c = 8;
+                THEN("thermistor drift error occurs") {
+                    REQUIRE(!plateControl.thermistor_drift_check());
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
A potential use case of the thermocycler is holding for an extremely long time (multiple days) at 4 degrees at the end of an experiment. There are some cases where condensation from the well plate can result in skewed thermistor readings over this long time period, and the thermocycler may fail the thermistor uniformity check and disable itself. As long as all temperatures are below 8º, it is preferable for the TC to continue holding rather than stop itself due to the error. 

After discussions with the hardware team, we settled on a threshold of 7.5 degrees to ensure that, if thermistors in a column are diverging (but holding their average to 4º), the TC will shut off before the lower value reaches sub-zero temperatures.