### PR TITLE
fix(github-actions): run codecov on edge pushes

### DIFF
--- a/.github/workflows/stm32-codecov.yaml
+++ b/.github/workflows/stm32-codecov.yaml
@@ -1,6 +1,10 @@
 name: 'Code Coverage'
-on: [pull_request, workflow_dispatch]
-
+on:
+  pull_request:
+  push:
+    branches:
+      - 'edge'
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/stm32-common.yaml
+++ b/.github/workflows/stm32-common.yaml
@@ -1,18 +1,6 @@
 name: 'STM32 Common Code build/test'
 on:
   pull_request:
-    paths:
-      - 'stm32-modules/common/**/*'
-      - 'stm32-modules/include/common/**/*'
-      - 'cmake/**/*'
-      - 'CMakeLists.txt'
-      - 'stm32-modules/CMakeLists.txt'
-      - 'CMakePresets.json'
-      - '.clang-format'
-      - '.clang-tidy'
-      - 'cpp-utils/**/*'
-    paths_ignore:
-      - 'cmake/Arduino*'
   push:
     paths:
       - 'stm32-modules/common/**/*'


### PR DESCRIPTION
Codecov wasn't generating any reports for edge.

- Added configuration to run codecov generation on every edge push
- Added configuration to run stm32-common checks on every PR so that the repo settings don't try to block merging if no CI is running