### PR TITLE
fix(thermocycler-gen2 script): fix order of thermistor data

### DIFF
--- a/stm32-modules/thermocycler-gen2/scripts/hold_temp.py
+++ b/stm32-modules/thermocycler-gen2/scripts/hold_temp.py
@@ -56,7 +56,7 @@ class Thermocycler():
         bl: float # back left
         
         def __str__(self):
-            return f'{self.hs},{self.fr},{self.fc},{self.fl},{self.br},{self.bc},{self.bl}'
+            return f'{self.hs},{self.fr},{self.fl},{self.fc},{self.br},{self.bl},{self.bc}'
         
     @dataclass
     class Power:


### PR DESCRIPTION
The script `hold_temp.py` prints out a csv header, and then was printing out the actual data in a different order. This PR just swaps the order of the data to match the header.