### PR TITLE
feat(thermocycler-gen2): add filtering to peltier output

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/peltier_filter.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/peltier_filter.hpp
@@ -1,0 +1,59 @@
+/**
+ * @file peltier_filter.hpp
+ * @brief Implements a simple filter on the output power of a peltier to
+ * enforce a maximum ∆power/sec limit.
+ */
+
+#pragma once
+
+#include "systemwide.h"
+
+namespace peltier_filter {
+
+using PowerPerSec = double;
+
+/** Number of seconds in 100ms */
+static constexpr double ONE_HUNDRED_MS = 0.1;
+/**
+ * Maximum rate of change - 0% to 100% in one hundred milliseconds.
+ * This effectively means that changing from max cooling to max heating
+ * will take 200ms (-100% to 100%)
+ */
+static constexpr PowerPerSec MAX_DELTA = (1.0 / ONE_HUNDRED_MS);
+
+/**
+ * Provides a simple filter on Peltier power values to ease the stress on
+ * on the peltiers over their lifetime.
+ */
+class PeltierFilter {
+  public:
+    /**
+     * @brief Reset the filter. This should be called whenever a peltier is
+     * disabled.
+     */
+    auto reset() -> void;
+
+    /**
+     * @brief Set a new peltier power value and filter it based on the
+     * last value that was set.
+     *
+     * @param setting The desired power, in the range [-1.0, 1.0]
+     * @param delta_sec The number of seconds that have elapsed since the
+     * last setting.
+     * @return The power that should be set on the peltier.
+     */
+    [[nodiscard]] auto set_filtered(double setting, double delta_sec) -> double;
+
+    /**
+     * @brief Get the last filtered setting for this peltier.
+     *
+     * @return The most recent filtered setting
+     */
+    [[nodiscard]] auto get_last() const -> double;
+
+  private:
+    /** The last setting for this peltier.*/
+    double _last = 0.0;
+};
+
+}  // namespace peltier_filter

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/peltier_filter.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/peltier_filter.hpp
@@ -19,7 +19,7 @@ static constexpr double ONE_HUNDRED_MS = 0.1;
  * This effectively means that changing from max cooling to max heating
  * will take 200ms (-100% to 100%)
  */
-static constexpr PowerPerSec MAX_DELTA = (1.0 / ONE_HUNDRED_MS);
+static constexpr PowerPerSec MAX_DELTA = (2.0 / ONE_HUNDRED_MS);
 
 /**
  * Provides a simple filter on Peltier power values to ease the stress on

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/peltier_filter.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/peltier_filter.hpp
@@ -19,7 +19,7 @@ static constexpr double ONE_HUNDRED_MS = 0.1;
  * This effectively means that changing from max cooling to max heating
  * will take 200ms (-100% to 100%)
  */
-static constexpr PowerPerSec MAX_DELTA = (2.0 / ONE_HUNDRED_MS);
+static constexpr PowerPerSec MAX_DELTA = (1.0 / ONE_HUNDRED_MS);
 
 /**
  * Provides a simple filter on Peltier power values to ease the stress on

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/peltier_filter.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/peltier_filter.hpp
@@ -15,9 +15,9 @@ using PowerPerSec = double;
 /** Number of seconds in 100ms */
 static constexpr double ONE_HUNDRED_MS = 0.1;
 /**
- * Maximum rate of change - 0% to 100% in one hundred milliseconds.
+ * Maximum rate of change is -100% to 100% in one hundred milliseconds.
  * This effectively means that changing from max cooling to max heating
- * will take 200ms (-100% to 100%)
+ * will take 100ms.
  */
 static constexpr PowerPerSec MAX_DELTA = (2.0 / ONE_HUNDRED_MS);
 

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_general.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_general.hpp
@@ -10,6 +10,7 @@
 #include "core/thermistor_conversion.hpp"
 #include "systemwide.h"
 #include "thermocycler-gen2/errors.hpp"
+#include "thermocycler-gen2/peltier_filter.hpp"
 
 namespace thermal_general {
 
@@ -60,6 +61,8 @@ struct Peltier {
     ThermistorPair thermistors;  // Links to the front & back thermistors
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     PID pid;  // Current PID loop
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    peltier_filter::PeltierFilter filter = peltier_filter::PeltierFilter();
 
     /** Get the current temperature of this peltier.*/
     [[nodiscard]] auto current_temp() const -> double {

--- a/stm32-modules/thermocycler-gen2/src/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/src/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 set(CORE_LINTABLE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/errors.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/plate_control.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/peltier_filter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/board_revision.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/colors.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/motor_utils.cpp)

--- a/stm32-modules/thermocycler-gen2/src/peltier_filter.cpp
+++ b/stm32-modules/thermocycler-gen2/src/peltier_filter.cpp
@@ -1,5 +1,6 @@
 #include "thermocycler-gen2/peltier_filter.hpp"
 
+#include <algorithm>
 #include <cstdlib>
 
 using namespace peltier_filter;
@@ -8,6 +9,7 @@ auto PeltierFilter::reset() -> void { _last = 0.0F; }
 
 [[nodiscard]] auto PeltierFilter::set_filtered(double setting, double delta_sec)
     -> double {
+    setting = std::clamp(setting, -1.0, 1.0);
     const auto max_change = delta_sec * MAX_DELTA;
     if (std::abs(setting - _last) > max_change) {
         // Just change by the max change for this tick

--- a/stm32-modules/thermocycler-gen2/src/peltier_filter.cpp
+++ b/stm32-modules/thermocycler-gen2/src/peltier_filter.cpp
@@ -1,0 +1,21 @@
+#include "thermocycler-gen2/peltier_filter.hpp"
+
+#include <cstdlib>
+
+using namespace peltier_filter;
+
+auto PeltierFilter::reset() -> void { _last = 0.0F; }
+
+[[nodiscard]] auto PeltierFilter::set_filtered(double setting, double delta_sec)
+    -> double {
+    const auto max_change = delta_sec * MAX_DELTA;
+    if (std::abs(setting - _last) > max_change) {
+        // Just change by the max change for this tick
+        auto change = (setting > _last) ? max_change : -max_change;
+        setting = _last + change;
+    }
+    _last = setting;
+    return _last;
+}
+
+[[nodiscard]] auto PeltierFilter::get_last() const -> double { return _last; }

--- a/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_system_pulse.cpp
     test_thermal_plate_task.cpp
     test_plate_control.cpp
+    test_peltier_filter.cpp
     test_tmc2130.cpp
     test_board_revision_hardware.cpp
     test_board_revision.cpp

--- a/stm32-modules/thermocycler-gen2/tests/test_peltier_filter.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_peltier_filter.cpp
@@ -1,4 +1,6 @@
 
+#include <vector>
+
 #include "catch2/catch.hpp"
 #include "thermocycler-gen2/peltier_filter.hpp"
 
@@ -7,7 +9,7 @@ TEST_CASE("peltier filter functionality") {
     auto subject = PeltierFilter();
     REQUIRE(subject.get_last() == 0.0F);
     WHEN("setting power outside of the filter limits") {
-        const auto TIME_DELTA = GENERATE(0.01, 0.05);
+        const auto TIME_DELTA = GENERATE(0.01, 0.02);
         const auto SETTING = GENERATE(1.0, -1.0);
 
         auto result = subject.set_filtered(SETTING, TIME_DELTA);
@@ -32,6 +34,17 @@ TEST_CASE("peltier filter functionality") {
         auto result = subject.set_filtered(SETTING, TIME_DELTA);
         THEN("the result is not filtered at all") {
             REQUIRE_THAT(result, Catch::Matchers::WithinAbs(SETTING, 0.01));
+        }
+    }
+    WHEN("setting power at 10ms intervals") {
+        const auto TIME_DELTA = 0.01;
+        THEN("it increments as expected") {
+            std::vector<double> expected = {0.2, 0.4, 0.6, 0.8, 1.0, 1.0};
+            std::vector<double> result;
+            for (auto i = 0; i < 6; ++i) {
+                result.push_back(subject.set_filtered(1.0, TIME_DELTA));
+            }
+            REQUIRE_THAT(result, Catch::Matchers::Approx(expected));
         }
     }
 }

--- a/stm32-modules/thermocycler-gen2/tests/test_peltier_filter.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_peltier_filter.cpp
@@ -1,0 +1,37 @@
+
+#include "catch2/catch.hpp"
+#include "thermocycler-gen2/peltier_filter.hpp"
+
+TEST_CASE("peltier filter functionality") {
+    using namespace peltier_filter;
+    auto subject = PeltierFilter();
+    REQUIRE(subject.get_last() == 0.0F);
+    WHEN("setting power outside of the filter limits") {
+        const auto TIME_DELTA = GENERATE(0.01, 0.05);
+        const auto SETTING = GENERATE(1.0, -1.0);
+
+        auto result = subject.set_filtered(SETTING, TIME_DELTA);
+        THEN("the result is filtered") {
+            auto expected = MAX_DELTA * TIME_DELTA * (SETTING > 0 ? 1 : -1);
+            REQUIRE_THAT(result, Catch::Matchers::WithinAbs(expected, 0.01));
+            AND_WHEN("doing it again") {
+                result = subject.set_filtered(SETTING, TIME_DELTA);
+                THEN("the result is doubled") {
+                    REQUIRE_THAT(
+                        result, Catch::Matchers::WithinAbs(expected * 2, 0.01));
+                }
+            }
+        }
+        THEN("getting the last result matches expected") {
+            REQUIRE(subject.get_last() == result);
+        }
+    }
+    WHEN("setting power within filter limits") {
+        const auto TIME_DELTA = GENERATE(0.1, 0.5, 1.0);
+        const auto SETTING = GENERATE(1.0, -1.0, -0.245, 0.64);
+        auto result = subject.set_filtered(SETTING, TIME_DELTA);
+        THEN("the result is not filtered at all") {
+            REQUIRE_THAT(result, Catch::Matchers::WithinAbs(SETTING, 0.01));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a slight amount of filtering to the output of the peltiers for the TC Gen2 plate control.

Transitioning immediately from full cooling to full heating (or vice-versa) may put undue stress on the peltier elements due to the thermal shock. Having a small amount of "dead time" is recommended to lessen that thermal shock when transitioning between directions; in this implementation, adding a constraint on the maximum power delta (such that the total transition time between full cooling and full heating takes a few control cycles) is intended to add a transition period to help provide a transition period.

Closed loop thermal performance will be verified through hardware testing before merging in order to ensure that this filtering will not affect the performance of the thermal control.