### PR TITLE
fix(heater-shaker): bifurcated homing speed

### DIFF
--- a/stm32-modules/heater-shaker/firmware/CMakeLists.txt
+++ b/stm32-modules/heater-shaker/firmware/CMakeLists.txt
@@ -52,7 +52,8 @@ set(HS_FW_LINTABLE_SRCS
   ${MOTOR_DIR}/freertos_motor_task.cpp
   ${MOTOR_DIR}/motor_policy.cpp
   ${COMMS_DIR}/freertos_comms_task.cpp
-  ${SYSTEM_DIR}/freertos_idle_timer_task.cpp)
+  ${SYSTEM_DIR}/freertos_idle_timer_task.cpp
+  ${SYSTEM_DIR}/serial.cpp)
 
 # Add source files that should NOT be checked by clang-tidy here
 set(HS_FW_NONLINTABLE_SRCS

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.cpp
@@ -126,3 +126,8 @@ auto MotorPolicy::set_pid_constants(double kp, double ki, double kd) -> void {
     PID_SetKI(hw_handles->mct[0]->pPIDSpeed,
               static_cast<int16_t>(ki / SPEED_UNIT_CONVERSION_SPC));
 }
+
+auto MotorPolicy::get_serial_number(void)
+    -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> {
+    return _serial.get_serial_number();
+}

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.hpp
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_policy.hpp
@@ -2,7 +2,9 @@
 
 #include <cstdint>
 
+#include "firmware/serial.hpp"
 #include "heater-shaker/errors.hpp"
+#include "systemwide.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wvolatile"
@@ -10,9 +12,15 @@
 #include "mc_interface.h"
 #include "motor_hardware.h"
 #include "stm32f3xx_hal.h"
+#include "system_serial_number.h"
 #pragma GCC diagnostic pop
 
 class MotorPolicy {
+  private:
+    static constexpr std::size_t SYSTEM_SERIAL_NUMBER_LENGTH =
+        SYSTEM_WIDE_SERIAL_NUMBER_LENGTH;
+    Serial _serial{};
+
   public:
     static constexpr int32_t DEFAULT_RAMP_RATE_RPM_PER_S = 1000;
     static constexpr int32_t MAX_RAMP_RATE_RPM_PER_S = 20000;
@@ -36,6 +44,8 @@ class MotorPolicy {
     auto plate_lock_brake() -> void;
     auto plate_lock_open_sensor_read() -> bool;
     auto plate_lock_closed_sensor_read() -> bool;
+    auto get_serial_number(void)
+        -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH>;
 
   private:
     static constexpr uint16_t MAX_SOLENOID_CURRENT_MA = 330;

--- a/stm32-modules/heater-shaker/firmware/system/serial.cpp
+++ b/stm32-modules/heater-shaker/firmware/system/serial.cpp
@@ -1,0 +1,43 @@
+#include <iterator>
+#include <ranges>
+
+#include "firmware/serial.hpp"
+
+auto Serial::set_serial_number(
+    std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> system_serial_number)
+    -> errors::ErrorCode {
+    writable_serial to_write_struct;
+    // convert bytes to uint64_t for system_set_serial_number
+    // write to 8 chars to each of first 3 addresses on last page of flash
+    for (uint8_t address = 0; address < ADDRESSES; address++) {
+        auto input = system_serial_number.begin() + (address * ADDRESS_LENGTH);
+        auto limit = input + ADDRESS_LENGTH;
+        uint64_t to_write = 0;
+        for (ssize_t byte_index = sizeof(to_write) - 1;
+             input != limit && byte_index >= 0; input++, byte_index--) {
+            to_write |= (static_cast<uint64_t>(*input) << (byte_index * 8));
+        }
+        to_write_struct.contents[address] = to_write;
+    }
+    if (!system_set_serial_number(&to_write_struct)) {
+        return errors::ErrorCode::SYSTEM_SERIAL_NUMBER_HAL_ERROR;
+    }
+    return errors::ErrorCode::NO_ERROR;
+}
+
+auto Serial::get_serial_number(void)
+    -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> {
+    std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> serial_number_array = {
+        "EMPTYSN"};
+    for (uint8_t address = 0; address < ADDRESSES; address++) {
+        uint64_t written_serial_number = system_get_serial_number(address);
+        // int to bytes
+        auto output = serial_number_array.begin() + (address * ADDRESS_LENGTH);
+        auto limit = output + ADDRESS_LENGTH;
+        for (ssize_t iter = sizeof(written_serial_number) - 1;
+             iter >= 0 && output != limit; iter--, output++) {
+            *output = (written_serial_number >> (iter * 8));
+        }
+    }
+    return serial_number_array;
+}

--- a/stm32-modules/heater-shaker/firmware/system/serial.cpp
+++ b/stm32-modules/heater-shaker/firmware/system/serial.cpp
@@ -1,7 +1,7 @@
+#include "firmware/serial.hpp"
+
 #include <iterator>
 #include <ranges>
-
-#include "firmware/serial.hpp"
 
 auto Serial::set_serial_number(
     std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> system_serial_number)

--- a/stm32-modules/heater-shaker/firmware/system/system_policy.cpp
+++ b/stm32-modules/heater-shaker/firmware/system/system_policy.cpp
@@ -7,7 +7,6 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wvolatile"
 #include "system_hardware.h"
-#include "system_serial_number.h"
 #pragma GCC diagnostic pop
 
 #include "heater-shaker/errors.hpp"
@@ -21,40 +20,12 @@ auto SystemPolicy::enter_bootloader() -> void {
 auto SystemPolicy::set_serial_number(
     std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> system_serial_number)
     -> errors::ErrorCode {
-    writable_serial to_write_struct;
-    // convert bytes to uint64_t for system_set_serial_number
-    // write to 8 chars to each of first 3 addresses on last page of flash
-    for (uint8_t address = 0; address < ADDRESSES; address++) {
-        auto input = system_serial_number.begin() + (address * ADDRESS_LENGTH);
-        auto limit = input + ADDRESS_LENGTH;
-        uint64_t to_write = 0;
-        for (ssize_t byte_index = sizeof(to_write) - 1;
-             input != limit && byte_index >= 0; input++, byte_index--) {
-            to_write |= (static_cast<uint64_t>(*input) << (byte_index * 8));
-        }
-        to_write_struct.contents[address] = to_write;
-    }
-    if (!system_set_serial_number(&to_write_struct)) {
-        return errors::ErrorCode::SYSTEM_SERIAL_NUMBER_HAL_ERROR;
-    }
-    return errors::ErrorCode::NO_ERROR;
+    return _serial.set_serial_number(system_serial_number);
 }
 
 auto SystemPolicy::get_serial_number(void)
     -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> {
-    std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> serial_number_array = {
-        "EMPTYSN"};
-    for (uint8_t address = 0; address < ADDRESSES; address++) {
-        uint64_t written_serial_number = system_get_serial_number(address);
-        // int to bytes
-        auto output = serial_number_array.begin() + (address * ADDRESS_LENGTH);
-        auto limit = output + ADDRESS_LENGTH;
-        for (ssize_t iter = sizeof(written_serial_number) - 1;
-             iter >= 0 && output != limit; iter--, output++) {
-            *output = (written_serial_number >> (iter * 8));
-        }
-    }
-    return serial_number_array;
+    return _serial.get_serial_number();
 }
 
 auto SystemPolicy::start_set_led(LED_COLOR color, uint8_t pwm_setting)

--- a/stm32-modules/heater-shaker/simulator/motor_thread.cpp
+++ b/stm32-modules/heater-shaker/simulator/motor_thread.cpp
@@ -8,10 +8,19 @@
 #include "heater-shaker/errors.hpp"
 #include "heater-shaker/motor_task.hpp"
 #include "heater-shaker/tasks.hpp"
+#include "systemwide.h"
 
 using namespace motor_thread;
 
 struct SimMotorPolicy {
+  private:
+    bool serial_number_set = false;
+    static constexpr std::size_t SYSTEM_SERIAL_NUMBER_LENGTH =
+        SYSTEM_WIDE_SERIAL_NUMBER_LENGTH;
+    std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> system_serial_number = {};
+    errors::ErrorCode set_serial_number_return = errors::ErrorCode::NO_ERROR;
+
+  public:
     static constexpr int32_t DEFAULT_RAMP_RATE_RPM_PER_S = 1000;
     static constexpr int32_t MAX_RAMP_RATE_RPM_PER_S = 20000;
     static constexpr int32_t MIN_RAMP_RATE_RPM_PER_S = 1;
@@ -86,6 +95,17 @@ struct SimMotorPolicy {
             return false;
         } else {
             return sim_plate_lock_power > 0.0 ? true : false;
+        }
+    }
+
+    auto get_serial_number(void)
+        -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> {
+        if (serial_number_set) {
+            return system_serial_number;
+        } else {
+            std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> empty_serial_number =
+                {"EMPTYSN"};
+            return empty_serial_number;
         }
     }
 

--- a/stm32-modules/heater-shaker/tests/test_motor_policy.cpp
+++ b/stm32-modules/heater-shaker/tests/test_motor_policy.cpp
@@ -135,3 +135,14 @@ auto TestMotorPolicy::test_get_overridden_ki() const -> double {
 auto TestMotorPolicy::test_get_overridden_kd() const -> double {
     return overridden_kd;
 }
+
+auto TestMotorPolicy::get_serial_number(void)
+    -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> {
+    if (serial_number_set) {
+        return system_serial_number;
+    } else {
+        std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> empty_serial_number = {
+            "EMPTYSN"};
+        return empty_serial_number;
+    }
+}

--- a/stm32-modules/heater-shaker/tests/test_motor_policy.cpp
+++ b/stm32-modules/heater-shaker/tests/test_motor_policy.cpp
@@ -136,6 +136,18 @@ auto TestMotorPolicy::test_get_overridden_kd() const -> double {
     return overridden_kd;
 }
 
+auto TestMotorPolicy::set_serial_number(
+    std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> new_system_serial_number)
+    -> errors::ErrorCode {
+    // copy to system_serial_number
+    auto copy_start = new_system_serial_number.begin();
+    auto copy_length = static_cast<int>(new_system_serial_number.size());
+    std::copy(copy_start, (copy_start + copy_length),
+              system_serial_number.begin());
+    serial_number_set = true;
+    return set_serial_number_return;
+}
+
 auto TestMotorPolicy::get_serial_number(void)
     -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> {
     if (serial_number_set) {

--- a/stm32-modules/heater-shaker/tests/test_motor_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_motor_task.cpp
@@ -728,10 +728,10 @@ SCENARIO("motor task homing", "[motor][homing]") {
         tasks->get_motor_task().run_once(tasks->get_motor_policy());
         CHECK(tasks->get_motor_policy().get_target_rpm() >
               std::remove_cvref_t<decltype(tasks->get_motor_task())>::
-                  HOMING_ROTATION_LIMIT_LOW_RPM);
+                  HOMING_ROTATION_LIMIT_LOW_OLD_RPM);
         CHECK(tasks->get_motor_policy().get_target_rpm() <
               std::remove_cvref_t<decltype(tasks->get_motor_task())>::
-                  HOMING_ROTATION_LIMIT_HIGH_RPM);
+                  HOMING_ROTATION_LIMIT_HIGH_OLD_RPM);
         CHECK(tasks->get_motor_task().get_state() ==
               motor_task::State::HOMING_MOVING_TO_HOME_SPEED);
         CHECK(std::holds_alternative<messages::CheckHomingStatusMessage>(
@@ -740,9 +740,9 @@ SCENARIO("motor task homing", "[motor][homing]") {
             "checking the homing status while in the appropriate speed range") {
             tasks->get_motor_policy().test_set_current_rpm(
                 (std::remove_cvref_t<decltype(tasks->get_motor_task())>::
-                     HOMING_ROTATION_LIMIT_HIGH_RPM +
+                     HOMING_ROTATION_LIMIT_HIGH_OLD_RPM +
                  std::remove_cvref_t<decltype(tasks->get_motor_task())>::
-                     HOMING_ROTATION_LIMIT_LOW_RPM) /
+                     HOMING_ROTATION_LIMIT_LOW_OLD_RPM) /
                 2);
             tasks->get_motor_task().run_once(tasks->get_motor_policy());
             THEN("the task goes to coasting and engages the solenoid") {
@@ -759,7 +759,7 @@ SCENARIO("motor task homing", "[motor][homing]") {
             "range") {
             tasks->get_motor_policy().test_set_current_rpm(
                 std::remove_cvref_t<decltype(tasks->get_motor_task())>::
-                    HOMING_ROTATION_LIMIT_HIGH_RPM *
+                    HOMING_ROTATION_LIMIT_HIGH_OLD_RPM *
                 1.1);
             tasks->get_motor_task().run_once(tasks->get_motor_policy());
             THEN("the task remains in moving-to-speed and waits for the rpm") {

--- a/stm32-modules/heater-shaker/tests/test_motor_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_motor_task.cpp
@@ -602,7 +602,8 @@ SCENARIO("motor task homing", "[motor][homing]") {
             }
         }
         WHEN("starting a home sequence with an old solenoid serial number") {
-            std::array<char, SYSTEM_WIDE_SERIAL_NUMBER_LENGTH> serial_number = {"HSV012022113007"};
+            std::array<char, SYSTEM_WIDE_SERIAL_NUMBER_LENGTH> serial_number = {
+                "HSV012022113007"};
             tasks->get_motor_policy().set_serial_number(serial_number);
             auto home_message = messages::BeginHomingMessage{.id = 123};
             tasks->get_motor_queue().backing_deque.push_back(
@@ -615,7 +616,8 @@ SCENARIO("motor task homing", "[motor][homing]") {
             }
         }
         WHEN("starting a home sequence with a new solenoid serial number") {
-            std::array<char, SYSTEM_WIDE_SERIAL_NUMBER_LENGTH> serial_number = {"HSV012022113008"};
+            std::array<char, SYSTEM_WIDE_SERIAL_NUMBER_LENGTH> serial_number = {
+                "HSV012022113008"};
             tasks->get_motor_policy().set_serial_number(serial_number);
             auto home_message = messages::BeginHomingMessage{.id = 123};
             tasks->get_motor_queue().backing_deque.push_back(
@@ -628,7 +630,8 @@ SCENARIO("motor task homing", "[motor][homing]") {
             }
         }
         WHEN("starting a home sequence with an invalid serial number") {
-            std::array<char, SYSTEM_WIDE_SERIAL_NUMBER_LENGTH> serial_number = {"HSV01XX"};
+            std::array<char, SYSTEM_WIDE_SERIAL_NUMBER_LENGTH> serial_number = {
+                "HSV01XX"};
             tasks->get_motor_policy().set_serial_number(serial_number);
             auto home_message = messages::BeginHomingMessage{.id = 123};
             tasks->get_motor_queue().backing_deque.push_back(

--- a/stm32-modules/include/heater-shaker/firmware/serial.hpp
+++ b/stm32-modules/include/heater-shaker/firmware/serial.hpp
@@ -2,33 +2,26 @@
 
 #include <array>
 
-#include "firmware/serial.hpp"
 #include "heater-shaker/errors.hpp"
 #include "systemwide.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wvolatile"
-#include "system_hardware.h"
+#include "system_serial_number.h"
 #pragma GCC diagnostic pop
 
-class SystemPolicy {
+class Serial {
   private:
     static constexpr std::size_t SYSTEM_SERIAL_NUMBER_LENGTH =
         SYSTEM_WIDE_SERIAL_NUMBER_LENGTH;
     static constexpr uint8_t ADDRESS_LENGTH = 8;
     static constexpr uint8_t ADDRESSES =
         SYSTEM_SERIAL_NUMBER_LENGTH / ADDRESS_LENGTH;
-    Serial _serial{};
 
   public:
-    auto enter_bootloader() -> void;
     auto set_serial_number(
         std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> system_serial_number)
         -> errors::ErrorCode;
     auto get_serial_number(void)
         -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH>;
-    auto start_set_led(LED_COLOR color, uint8_t pwm_setting)
-        -> errors::ErrorCode;
-    auto check_I2C_ready(void) -> bool;
-    auto delay_time_ms(uint16_t time_ms) -> void;
 };

--- a/stm32-modules/include/heater-shaker/test/test_motor_policy.hpp
+++ b/stm32-modules/include/heater-shaker/test/test_motor_policy.hpp
@@ -1,9 +1,19 @@
 #pragma once
 #include <cstdint>
+#include <array>
+
+#include "systemwide.h"
 
 #include "heater-shaker/errors.hpp"
 
 class TestMotorPolicy {
+  private:
+    bool serial_number_set = false;
+    static constexpr std::size_t SYSTEM_SERIAL_NUMBER_LENGTH =
+        SYSTEM_WIDE_SERIAL_NUMBER_LENGTH;
+    std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> system_serial_number = {};
+    errors::ErrorCode set_serial_number_return = errors::ErrorCode::NO_ERROR;
+
   public:
     TestMotorPolicy();
     TestMotorPolicy(int16_t initial_rpm, int16_t initial_target_rpm,
@@ -45,6 +55,9 @@ class TestMotorPolicy {
     [[nodiscard]] auto test_get_overridden_ki() const -> double;
     [[nodiscard]] auto test_get_overridden_kp() const -> double;
     [[nodiscard]] auto test_get_overridden_kd() const -> double;
+
+    auto get_serial_number(void)
+        -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH>;
 
   private:
     int16_t target_rpm;

--- a/stm32-modules/include/heater-shaker/test/test_motor_policy.hpp
+++ b/stm32-modules/include/heater-shaker/test/test_motor_policy.hpp
@@ -55,6 +55,9 @@ class TestMotorPolicy {
     [[nodiscard]] auto test_get_overridden_kp() const -> double;
     [[nodiscard]] auto test_get_overridden_kd() const -> double;
 
+    auto set_serial_number(
+        std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH> new_system_serial_number)
+        -> errors::ErrorCode;
     auto get_serial_number(void)
         -> std::array<char, SYSTEM_SERIAL_NUMBER_LENGTH>;
 

--- a/stm32-modules/include/heater-shaker/test/test_motor_policy.hpp
+++ b/stm32-modules/include/heater-shaker/test/test_motor_policy.hpp
@@ -1,10 +1,9 @@
 #pragma once
-#include <cstdint>
 #include <array>
-
-#include "systemwide.h"
+#include <cstdint>
 
 #include "heater-shaker/errors.hpp"
+#include "systemwide.h"
 
 class TestMotorPolicy {
   private:


### PR DESCRIPTION
# Overview

This bifurcates final homing speed for units with old and new solenoids. We've seen repetitive stress failures of the old solenoid, so this reduces the speed of the main motor during homing from 300rpm to 225 for those units. Bifurcation is determined by serial number, with new solenoids in units made after the 2022-11-30 7th unit.

To ensure homing doesn't fail to start due to static friction, the main motor spins at 300rpm for 1 second before shifting to its final homing speed and the solenoid engages.

# Test Plan

- [x] Verify homing speed 300rpm with serial numbers after 2022-11-30_07
- [x] Verify homing speed 225rpm with serial numbers before 2022-11-30_07
- [x] Verify homing speed 225rpm with invalid serial numbers

# Changelog


# Review requests


# Risk assessment

Low, final homing speed determination via serial number fails safely, and kickstart process has been thoroughly tested previously.