### PR TITLE
feat(tempdeck-gen3): support pcb rev2

### DIFF
--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -498,7 +498,7 @@ class ThermalTask {
     Queue& _message_queue;
     Aggregator* _task_registry;
     ThermalReadings _readings;
-    thermistor_conversion::Conversion<lookups::NXFT15XV103FA2B030> _converter;
+    thermistor_conversion::Conversion<lookups::KS103J2G> _converter;
     Fan _fan;
     Peltier _peltier;
     ot_utils::pid::PID _pid;

--- a/stm32-modules/tempdeck-gen3/firmware/system/i2c_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/system/i2c_hardware.c
@@ -24,9 +24,9 @@
 /** Size of register address: 1 byte.*/
 #define REGISTER_ADDR_LEN (1)
 
-#define SDA_PIN (GPIO_PIN_8)
-#define SDA_PORT (GPIOA)
-#define SCL_PIN (GPIO_PIN_9)
+#define SDA_PIN (GPIO_PIN_7)
+#define SDA_PORT (GPIOB)
+#define SCL_PIN (GPIO_PIN_15)
 #define SCL_PORT (GPIOA)
 
 /** Private typedef */
@@ -55,7 +55,7 @@ typedef struct {
 static I2C_Hardware i2c_hardware = {
     .i2c = { 
         {
-            .instance = I2C2,
+            .instance = I2C1,
             .handle = {},
             .task_to_notify = NULL,
             .semaphore = NULL,
@@ -353,51 +353,52 @@ static inline I2C_Instance*
 void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c)
 {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
-    if(hi2c->Instance==I2C2)
+    if(hi2c->Instance==I2C1)
     {
         __HAL_RCC_GPIOA_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
         GPIO_InitStruct.Pin = SCL_PIN;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
+        GPIO_InitStruct.Alternate = GPIO_AF4_I2C1;
         HAL_GPIO_Init(SCL_PORT, &GPIO_InitStruct);
 
         GPIO_InitStruct.Pin = SDA_PIN;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
+        GPIO_InitStruct.Alternate = GPIO_AF4_I2C1;
         HAL_GPIO_Init(SDA_PORT, &GPIO_InitStruct);
 
         /* Peripheral clock enable */
-        __HAL_RCC_I2C2_CLK_ENABLE();
+        __HAL_RCC_I2C1_CLK_ENABLE();
         /* I2C2 interrupt Init */
-        HAL_NVIC_SetPriority(I2C2_EV_IRQn, 6, 0);
-        HAL_NVIC_EnableIRQ(I2C2_EV_IRQn);
-        HAL_NVIC_SetPriority(I2C2_ER_IRQn, 6, 0);
-        HAL_NVIC_EnableIRQ(I2C2_ER_IRQn);
+        HAL_NVIC_SetPriority(I2C1_EV_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(I2C1_EV_IRQn);
+        HAL_NVIC_SetPriority(I2C1_ER_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(I2C1_ER_IRQn);
     }
 }
 
 void HAL_I2C_MspDeInit(I2C_HandleTypeDef* hi2c)
 {
-    if(hi2c->Instance==I2C2)
+    if(hi2c->Instance==I2C1)
     {
         /* Peripheral clock disable */
-        __HAL_RCC_I2C2_CLK_DISABLE();
+        __HAL_RCC_I2C1_CLK_DISABLE();
 
         /**I2C2 GPIO Configuration
-        PC4     ------> I2C2_SCL
-        PA8     ------> I2C2_SDA
+        PA15    ------> I2C1_SCL
+        PB7     ------> I2C1_SDA
         */
-        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_4);
+        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_15);
 
-        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_8);
+        HAL_GPIO_DeInit(GPIOB, GPIO_PIN_7);
 
         /* I2C2 interrupt DeInit */
-        HAL_NVIC_DisableIRQ(I2C2_EV_IRQn);
-        HAL_NVIC_DisableIRQ(I2C2_ER_IRQn);
+        HAL_NVIC_DisableIRQ(I2C1_EV_IRQn);
+        HAL_NVIC_DisableIRQ(I2C1_ER_IRQn);
     }
 }
 
@@ -426,12 +427,12 @@ void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *i2c_handle)
 
 /** Interrupt handlers */
 
-void I2C2_EV_IRQHandler(void)
+void I2C1_EV_IRQHandler(void)
 {
     HAL_I2C_EV_IRQHandler(&i2c_hardware.i2c[I2C_BUS_THERMAL].handle);
 }
 
-void I2C2_ER_IRQHandler(void)
+void I2C1_ER_IRQHandler(void)
 {
     HAL_I2C_ER_IRQHandler(&i2c_hardware.i2c[I2C_BUS_THERMAL].handle);
 }

--- a/stm32-modules/tempdeck-gen3/firmware/system/stm32g4xx_hal_msp.c
+++ b/stm32-modules/tempdeck-gen3/firmware/system/stm32g4xx_hal_msp.c
@@ -71,19 +71,19 @@ void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* htim_base)
 
 void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef* htim_pwm)
 {
-    if(htim_pwm->Instance==TIM1)
+    if(htim_pwm->Instance==TIM2)
     {
         /* Peripheral clock enable */
-        __HAL_RCC_TIM1_CLK_ENABLE();
+        __HAL_RCC_TIM2_CLK_ENABLE();
     }
 }
 
 void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef* htim_pwm)
 {
-    if(htim_pwm->Instance==TIM1)
+    if(htim_pwm->Instance==TIM2)
     {
         /* Peripheral clock disable */
-        __HAL_RCC_TIM1_CLK_DISABLE();
+        __HAL_RCC_TIM2_CLK_DISABLE();
     }
 
 }

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/tachometer_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/tachometer_hardware.c
@@ -44,15 +44,15 @@
 /** Private definitions */
 
 // Timer handle for tachometer
-#define TACH_TIMER (TIM15)
+#define TACH_TIMER (TIM17)
 // Input channel for tachometer
 #define TACH_CHANNEL (TIM_CHANNEL_1)
 // Port for tachometer
 #define TACH_GPIO_PORT (GPIOA)
 // Pin for tachometer
-#define TACH_GPIO_PIN  (GPIO_PIN_2)
+#define TACH_GPIO_PIN  (GPIO_PIN_7)
 // Interrupt vector for tach
-#define TACH_IRQ (TIM1_BRK_TIM15_IRQn)
+#define TACH_IRQ (TIM1_TRG_COM_TIM17_IRQn)
 
 // Tachometer timer reload frequency
 #define TIMER_CLOCK_FREQ (170000000)
@@ -162,7 +162,7 @@ static void init_tach_timer(TIM_HandleTypeDef *handle) {
 
 // This interrupt does NOT go through the HAL system because that overhead is
 // not required for this application.
-void TIM1_BRK_TIM15_IRQHandler(void) {
+void TIM1_TRG_COM_TIM17_IRQHandler(void) {
     if(__HAL_TIM_GET_FLAG(&hardware.timer, TIM_IT_CC1)) {
         // New pulse input
         __HAL_TIM_CLEAR_IT(&hardware.timer, TIM_IT_CC1);
@@ -194,7 +194,7 @@ void HAL_TIM_IC_MspInit(TIM_HandleTypeDef* htim_ic)
     if(htim_ic->Instance==TACH_TIMER)
     {
         /* Peripheral clock enable */
-        __HAL_RCC_TIM15_CLK_ENABLE();
+        __HAL_RCC_TIM17_CLK_ENABLE();
         __HAL_RCC_GPIOA_CLK_ENABLE();
 
         /* CC1 input init */
@@ -202,7 +202,7 @@ void HAL_TIM_IC_MspInit(TIM_HandleTypeDef* htim_ic)
         GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        GPIO_InitStruct.Alternate = GPIO_AF9_TIM15;
+        GPIO_InitStruct.Alternate = GPIO_AF1_TIM17;
         HAL_GPIO_Init(TACH_GPIO_PORT, &GPIO_InitStruct);
 
         /* Timer interrupt Init */

--- a/stm32-modules/tempdeck-gen3/firmware/thermistor/internal_adc_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermistor/internal_adc_hardware.c
@@ -19,7 +19,7 @@
 // Local defines
 
 // Which ADC Peripheral we are initializing
-#define ADC_INSTANCE (ADC2)
+#define ADC_INSTANCE (ADC1)
 
 // Local typedefs
 
@@ -51,9 +51,9 @@ static adc_hardware_t adc_hardware = {
 
 // Configuration for the Current Measurement ADC Channel
 static const adc_channel_init_t imeas_channel_conf = {
-    .channel = ADC_CHANNEL_2,
-    .pin = GPIO_PIN_1,
-    .port = GPIOA
+    .channel = ADC_CHANNEL_5,
+    .pin = GPIO_PIN_14,
+    .port = GPIOB
 };
 
 static const uint32_t adc_ranks[] = {
@@ -139,7 +139,7 @@ static void init_adc_hardware(ADC_HandleTypeDef *handle) {
     HAL_StatusTypeDef ret = HAL_ERROR;
     ADC_ChannelConfTypeDef channel_config = {0};
 
-    handle->Instance = ADC2;
+    handle->Instance = ADC_INSTANCE;
     handle->Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV2;
     handle->Init.Resolution = ADC_RESOLUTION_12B;
     handle->Init.DataAlign = ADC_DATAALIGN_RIGHT;
@@ -218,17 +218,17 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)
         /* Peripheral clock enable */
         __HAL_RCC_ADC12_CLK_ENABLE();
 
-        __HAL_RCC_GPIOA_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
         
         GPIO_InitStruct.Pin = imeas_channel_conf.pin;
         GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         HAL_GPIO_Init(imeas_channel_conf.port, &GPIO_InitStruct);
 
-        /* ADC2 DMA Init */
-        /* ADC2 Init */
+        /* ADC1 DMA Init */
+        /* ADC1 Init */
         adc_hardware.dma.Instance = DMA1_Channel1;
-        adc_hardware.dma.Init.Request = DMA_REQUEST_ADC2;
+        adc_hardware.dma.Init.Request = DMA_REQUEST_ADC1;
         adc_hardware.dma.Init.Direction = DMA_PERIPH_TO_MEMORY;
         adc_hardware.dma.Init.PeriphInc = DMA_PINC_DISABLE;
         adc_hardware.dma.Init.MemInc = DMA_MINC_ENABLE;
@@ -243,7 +243,7 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)
 
         __HAL_LINKDMA(hadc,DMA_Handle,adc_hardware.dma);
 
-        /* ADC2 interrupt Init */
+        /* ADC1 interrupt Init */
         HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
         HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
     }
@@ -262,14 +262,14 @@ void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
         /* Peripheral clock disable */
         __HAL_RCC_ADC12_CLK_DISABLE();
 
-        /**ADC2 GPIO Configuration
-        PA1     ------> ADC2_IN2
+        /**ADC1 GPIO Configuration
+        PB14     ------> ADC1_IN5
         */
-        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_1);
+        HAL_GPIO_DeInit(imeas_channel_conf.port, imeas_channel_conf.pin);
 
         HAL_DMA_DeInit(hadc->DMA_Handle);
 
-        /* ADC2 interrupt DeInit */
+        /* ADC1 interrupt DeInit */
         HAL_NVIC_DisableIRQ(ADC1_2_IRQn);
     }
 }

--- a/stm32-modules/tempdeck-gen3/firmware/thermistor/thermistor_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermistor/thermistor_hardware.c
@@ -17,8 +17,8 @@
 
 /** Private definitions */
 
-#define ADC_ALERT_PIN  (GPIO_PIN_11)
-#define ADC_ALERT_PORT (GPIOB)
+#define ADC_ALERT_PIN  (GPIO_PIN_12)
+#define ADC_ALERT_PORT (GPIOC)
 
 /** Private typedef */
 
@@ -44,7 +44,7 @@ void thermistor_hardware_init() {
 
     // Enforce that only one task may initialize the I2C
     if(atomic_exchange(&hardware.initialization_started, true) == false) {
-        __HAL_RCC_GPIOB_CLK_ENABLE();
+        __HAL_RCC_GPIOC_CLK_ENABLE();
         __HAL_RCC_GPIOA_CLK_ENABLE();
 
         /* Configure the ADC Alert pin*/

--- a/stm32-modules/tempdeck-gen3/firmware/ui/ui_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/ui/ui_hardware.c
@@ -7,8 +7,8 @@
 
 /** Local defines */
 
-#define HEARTBEAT_LED_PORT (GPIOB)
-#define HEARTBEAT_LED_PIN  (GPIO_PIN_12)
+#define HEARTBEAT_LED_PORT (GPIOA)
+#define HEARTBEAT_LED_PIN  (GPIO_PIN_3)
 
 /** Hardware static data struct */
 
@@ -30,7 +30,7 @@ void ui_hardware_initialize() {
         .Alternate = 0
     };
     //NOLINTNEXTLINE(performance-no-int-to-ptr)
-    __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOA_CLK_ENABLE();
     //NOLINTNEXTLINE(performance-no-int-to-ptr)
     HAL_GPIO_Init(HEARTBEAT_LED_PORT, &init);
     ui_hardware.initialized = true;

--- a/stm32-modules/tempdeck-gen3/src/CMakeLists.txt
+++ b/stm32-modules/tempdeck-gen3/src/CMakeLists.txt
@@ -14,10 +14,10 @@ add_custom_command(
   COMMAND Python::Interpreter ${COMMON_SRC_DIR}/generate_thermistor_table.py
     ${CMAKE_CURRENT_BINARY_DIR}/thermistor_lookups.hpp
     ${CMAKE_CURRENT_BINARY_DIR}/thermistor_lookups.cpp
-    --nxffile
-    ${COMMON_SRC_DIR}/nxft15xv103fa2b030.csv
+    --ksfile
+    ${COMMON_SRC_DIR}/ks103j2.csv
   DEPENDS ${COMMON_SRC_DIR}/generate_thermistor_table.py
-          ${COMMON_SRC_DIR}/nxft15xv103fa2b030.csv
+          ${COMMON_SRC_DIR}/ks103j2.csv
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/thermistor_lookups.hpp
          ${CMAKE_CURRENT_BINARY_DIR}/thermistor_lookups.cpp
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
@@ -29,7 +29,7 @@ TEST_CASE("peltier current conversions") {
 TEST_CASE("thermal task message handling") {
     auto *tasks = tasks::BuildTasks();
     TestThermalPolicy policy;
-    thermistor_conversion::Conversion<lookups::NXFT15XV103FA2B030> converter(
+    thermistor_conversion::Conversion<lookups::KS103J2G> converter(
         decltype(tasks->_thermal_task)::THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM,
         decltype(tasks->_thermal_task)::ADC_BIT_MAX, false);
     WHEN("new thermistor readings are received") {
@@ -58,9 +58,9 @@ TEST_CASE("thermal task message handling") {
             REQUIRE(readings.plate_temp.has_value());
             REQUIRE(readings.heatsink_temp.has_value());
             REQUIRE_THAT(readings.plate_temp.value(),
-                         Catch::Matchers::WithinAbs(25.00, 0.01));
+                         Catch::Matchers::WithinAbs(25.00, 0.02));
             REQUIRE_THAT(readings.heatsink_temp.value(),
-                         Catch::Matchers::WithinAbs(50.00, 0.01));
+                         Catch::Matchers::WithinAbs(50.00, 0.02));
         }
         AND_WHEN("a GetTempDebug message is received") {
             tasks->_thermal_queue.backing_deque.push_back(
@@ -77,9 +77,9 @@ TEST_CASE("thermal task message handling") {
                     tasks->_comms_queue.backing_deque.front());
                 REQUIRE(response.responding_to_id == 123);
                 REQUIRE_THAT(response.plate_temp,
-                             Catch::Matchers::WithinAbs(25.00, 0.01));
+                             Catch::Matchers::WithinAbs(25.00, 0.02));
                 REQUIRE_THAT(response.heatsink_temp,
-                             Catch::Matchers::WithinAbs(50.00, 0.01));
+                             Catch::Matchers::WithinAbs(50.00, 0.02));
                 REQUIRE(response.plate_adc == plate_count);
                 REQUIRE(response.heatsink_adc == hs_count);
             }
@@ -400,7 +400,7 @@ TEST_CASE("thermal task set temperature command") {
 TEST_CASE("closed loop thermal control") {
     auto *tasks = tasks::BuildTasks();
     TestThermalPolicy policy;
-    thermistor_conversion::Conversion<lookups::NXFT15XV103FA2B030> converter(
+    thermistor_conversion::Conversion<lookups::KS103J2G> converter(
         decltype(tasks->_thermal_task)::THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM,
         decltype(tasks->_thermal_task)::ADC_BIT_MAX, false);
 
@@ -574,7 +574,7 @@ TEST_CASE("thermal task power debug functionality") {
     auto current_adc =
         thermal_task::PeltierReadback::milliamps_to_adc(peltier_current);
     const double temp = 25.0F;
-    thermistor_conversion::Conversion<lookups::NXFT15XV103FA2B030> converter(
+    thermistor_conversion::Conversion<lookups::KS103J2G> converter(
         decltype(tasks->_thermal_task)::THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM,
         decltype(tasks->_thermal_task)::ADC_BIT_MAX, false);
     auto temp_adc = converter.backconvert(temp);


### PR DESCRIPTION
This PR makes hardware configuration changes to port the Tempdeck Gen3 firmware to the Revision 2 board. For the sake of expediency, there is __no backwards compatibility__ to the non-form-factor board.

The following changes were made:
- Moved from I2C2 to I2C1 for ADC/EEPROM
- Moved ADC alert pin to C12
- Moved tachometer input to TIM17 CH1
- Moved TEC PWM output to TIM2 CH3 and CH4
- Moved EEPROM Write Protect to C11
- Moved Current Sense input from ADC2 CH2 to ADC1 CH5 on pin B14
- Moved Heartbeat LED to A3
- Updated the thermistor model to the model that will be used on the final TD3, the same as the Thermocycler Gen2

Tested on hardware that:
* The ADC still reads the thermistors, and connecting the new thermistor model correctly reads ambient temperature
* Heating/cooling the peltiers goes in the right direction
* Fan can be controlled with power %, and the tachometer data is updated as the fan speeds up/slows down
* Heartbeat still works
* Current sense responds to peltier power changes - _the transfer function is not updated yet!_
* USB comms still work fine
* Tried uploading firmware using the third ADC channel to make sure that works correctly as well (will be the heatsink thermistor)

Followup PR(s) will also:
- Modify control to use two plate thermistors instead of one
- Update the transfer function for current measurement based on the updated schematic