### PR TITLE
feat(thermocycler-gen2): add plate lift wiggling

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -118,7 +118,7 @@ struct LidStepperState {
         motor_util::LidStepper::angle_to_microsteps(-30);
     // Velocity for plate lift actions. This provides a smoother lifting
     // action than the default open/close velocity.
-    constexpr static double PLATE_LIFT_VELOCITY_RPM = 80.0F;
+    constexpr static double PLATE_LIFT_VELOCITY_RPM = 10.0F;
     // Velocity for all lid movements other than plate lift
     constexpr static double LID_DEFAULT_VELOCITY_RPM = 125.0F;
     // States for lid stepper
@@ -1284,6 +1284,8 @@ class MotorTask {
             case LidStepperState::Status::LIFT_RAISE:
                 // Lower the plate lift mechanism and move the lid far enough
                 // that it will go PAST the switch.
+                std::ignore = policy.lid_stepper_set_rpm(
+                    LidStepperState::LID_DEFAULT_VELOCITY_RPM);
                 policy.lid_stepper_start(
                     LidStepperState::PLATE_LIFT_LOWER_DEGREES, true);
                 _lid_stepper_state.status = LidStepperState::Status::LIFT_LOWER;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -112,10 +112,12 @@ struct LidStepperState {
     // for this movement.
     constexpr static double CLOSE_OVERDRIVE_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(-5);
+    constexpr static double PLATE_LIFT_NUDGE_DEGREES = 
+        motor_util::LidStepper::angle_to_microsteps(10);
     constexpr static double PLATE_LIFT_RAISE_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(20);
     constexpr static double PLATE_LIFT_LOWER_DEGREES =
-        motor_util::LidStepper::angle_to_microsteps(-30);
+        motor_util::LidStepper::angle_to_microsteps(-23);
     // Velocity for plate lift actions. This provides a smoother lifting
     // action than the default open/close velocity.
     constexpr static double PLATE_LIFT_VELOCITY_RPM = 10.0F;
@@ -129,6 +131,8 @@ struct LidStepperState {
         OPEN_OVERDRIVE,  /**< Close from switch back to 90º position.*/
         CLOSE_TO_SWITCH, /**< Close lid until it hits the switch.*/
         CLOSE_OVERDRIVE, /**< Close lid a few degrees into the switch.*/
+        LIFT_NUDGE,      /**< Nudge the plate up with one pin.*/
+        LIFT_NUDGE_DOWN, /**< Move back to the "open" position after nudging.*/
         LIFT_RAISE,      /**< Open lid to raise the plate lift.*/
         LIFT_LOWER,      /**< Close lid to lower the plate lift.*/
     };
@@ -997,10 +1001,10 @@ class MotorTask {
             LidStepperState::PLATE_LIFT_VELOCITY_RPM);
         // Now start a lid motor movement to closed position
         policy.lid_stepper_set_dac(LID_STEPPER_RUN_CURRENT);
-        policy.lid_stepper_start(LidStepperState::PLATE_LIFT_RAISE_DEGREES,
+        policy.lid_stepper_start(LidStepperState::PLATE_LIFT_NUDGE_DEGREES,
                                  true);
         // Store the new state, as well as the response ID
-        _lid_stepper_state.status = LidStepperState::Status::LIFT_RAISE;
+        _lid_stepper_state.status = LidStepperState::Status::LIFT_NUDGE;
         _lid_stepper_state.position = motor_util::LidStepper::Position::BETWEEN;
         _lid_stepper_state.response_id = response_id;
         return true;
@@ -1280,6 +1284,16 @@ class MotorTask {
                 error = handle_lid_state_end(policy);
                 // TODO(Frank, Mar-7-2022) check if the lid didn't make it in
                 // all the way
+                break;
+            case LidStepperState::Status::LIFT_NUDGE:
+                policy.lid_stepper_start(
+                    -1 * LidStepperState::PLATE_LIFT_NUDGE_DEGREES, true);
+                _lid_stepper_state.status = LidStepperState::Status::LIFT_NUDGE_DOWN;
+                break;
+            case LidStepperState::Status::LIFT_NUDGE_DOWN:
+                policy.lid_stepper_start(
+                    LidStepperState::PLATE_LIFT_RAISE_DEGREES, true);
+                _lid_stepper_state.status = LidStepperState::Status::LIFT_RAISE;
                 break;
             case LidStepperState::Status::LIFT_RAISE:
                 // Lower the plate lift mechanism and move the lid far enough

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1293,8 +1293,6 @@ class MotorTask {
                 // all the way
                 break;
             case LidStepperState::Status::LIFT_NUDGE:
-                // std::ignore = policy.lid_stepper_set_rpm(
-                //    LidStepperState::LID_DEFAULT_VELOCITY_RPM);
                 policy.lid_stepper_start(
                     -1 * LidStepperState::PLATE_LIFT_RETURN_DEGREES, true);
                 _lid_stepper_state.status =

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -113,20 +113,20 @@ struct LidStepperState {
     constexpr static double CLOSE_OVERDRIVE_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(-5);
     constexpr static double PLATE_LIFT_NUDGE_START_DEGREES =
-        motor_util::LidStepper::angle_to_microsteps(10.5);
+        motor_util::LidStepper::angle_to_microsteps(11);
     constexpr static double PLATE_LIFT_NUDGE_FINAL_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(15);
     constexpr static double PLATE_LIFT_NUDGE_INCREMENT =
         motor_util::LidStepper::angle_to_microsteps(0.5);
     constexpr static double PLATE_LIFT_RETURN_DEGREES =
-        motor_util::LidStepper::angle_to_microsteps(3);
+        motor_util::LidStepper::angle_to_microsteps(5);
     constexpr static double PLATE_LIFT_RAISE_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(20);
     constexpr static double PLATE_LIFT_LOWER_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(-23);
     // Velocity for plate lift actions. This provides a smoother lifting
     // action than the default open/close velocity.
-    constexpr static double PLATE_LIFT_VELOCITY_RPM = 20.0F;
+    constexpr static double PLATE_LIFT_VELOCITY_RPM = 40.0F;
     // Velocity for all lid movements other than plate lift
     constexpr static double LID_DEFAULT_VELOCITY_RPM = 125.0F;
     // States for lid stepper
@@ -1314,7 +1314,7 @@ class MotorTask {
                         LidStepperState::Status::LIFT_NUDGE;
                 } else {
                     policy.lid_stepper_start(
-                        LidStepperState::PLATE_LIFT_RAISE_DEGREES - _nudge_degrees, true);
+                        LidStepperState::PLATE_LIFT_RAISE_DEGREES + LidStepperState::PLATE_LIFT_RETURN_DEGREES - _nudge_degrees, true);
                     _lid_stepper_state.status =
                         LidStepperState::Status::LIFT_RAISE;
                 }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -118,13 +118,15 @@ struct LidStepperState {
         motor_util::LidStepper::angle_to_microsteps(15);
     constexpr static double PLATE_LIFT_NUDGE_INCREMENT =
         motor_util::LidStepper::angle_to_microsteps(0.5);
+    constexpr static double PLATE_LIFT_RETURN_DEGREES =
+        motor_util::LidStepper::angle_to_microsteps(3);
     constexpr static double PLATE_LIFT_RAISE_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(20);
     constexpr static double PLATE_LIFT_LOWER_DEGREES =
         motor_util::LidStepper::angle_to_microsteps(-23);
     // Velocity for plate lift actions. This provides a smoother lifting
     // action than the default open/close velocity.
-    constexpr static double PLATE_LIFT_VELOCITY_RPM = 50.0F;
+    constexpr static double PLATE_LIFT_VELOCITY_RPM = 20.0F;
     // Velocity for all lid movements other than plate lift
     constexpr static double LID_DEFAULT_VELOCITY_RPM = 125.0F;
     // States for lid stepper
@@ -1291,9 +1293,9 @@ class MotorTask {
                 // all the way
                 break;
             case LidStepperState::Status::LIFT_NUDGE:
-                std::ignore = policy.lid_stepper_set_rpm(
-                    LidStepperState::LID_DEFAULT_VELOCITY_RPM);
-                policy.lid_stepper_start(-1 * _nudge_degrees, true);
+                //std::ignore = policy.lid_stepper_set_rpm(
+                //    LidStepperState::LID_DEFAULT_VELOCITY_RPM);
+                policy.lid_stepper_start(-1 * LidStepperState::PLATE_LIFT_RETURN_DEGREES, true);
                 _lid_stepper_state.status =
                     LidStepperState::Status::LIFT_NUDGE_DOWN;
                 break;
@@ -1305,12 +1307,14 @@ class MotorTask {
                     LidStepperState::PLATE_LIFT_NUDGE_FINAL_DEGREES) {
                     _nudge_degrees +=
                         LidStepperState::PLATE_LIFT_NUDGE_INCREMENT;
-                    policy.lid_stepper_start(_nudge_degrees, true);
+                    policy.lid_stepper_start(
+                        LidStepperState::PLATE_LIFT_RETURN_DEGREES + 
+                        LidStepperState::PLATE_LIFT_NUDGE_INCREMENT, true);
                     _lid_stepper_state.status =
                         LidStepperState::Status::LIFT_NUDGE;
                 } else {
                     policy.lid_stepper_start(
-                        LidStepperState::PLATE_LIFT_RAISE_DEGREES, true);
+                        LidStepperState::PLATE_LIFT_RAISE_DEGREES - _nudge_degrees, true);
                     _lid_stepper_state.status =
                         LidStepperState::Status::LIFT_RAISE;
                 }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1293,9 +1293,10 @@ class MotorTask {
                 // all the way
                 break;
             case LidStepperState::Status::LIFT_NUDGE:
-                //std::ignore = policy.lid_stepper_set_rpm(
+                // std::ignore = policy.lid_stepper_set_rpm(
                 //    LidStepperState::LID_DEFAULT_VELOCITY_RPM);
-                policy.lid_stepper_start(-1 * LidStepperState::PLATE_LIFT_RETURN_DEGREES, true);
+                policy.lid_stepper_start(
+                    -1 * LidStepperState::PLATE_LIFT_RETURN_DEGREES, true);
                 _lid_stepper_state.status =
                     LidStepperState::Status::LIFT_NUDGE_DOWN;
                 break;
@@ -1308,13 +1309,17 @@ class MotorTask {
                     _nudge_degrees +=
                         LidStepperState::PLATE_LIFT_NUDGE_INCREMENT;
                     policy.lid_stepper_start(
-                        LidStepperState::PLATE_LIFT_RETURN_DEGREES + 
-                        LidStepperState::PLATE_LIFT_NUDGE_INCREMENT, true);
+                        LidStepperState::PLATE_LIFT_RETURN_DEGREES +
+                            LidStepperState::PLATE_LIFT_NUDGE_INCREMENT,
+                        true);
                     _lid_stepper_state.status =
                         LidStepperState::Status::LIFT_NUDGE;
                 } else {
                     policy.lid_stepper_start(
-                        LidStepperState::PLATE_LIFT_RAISE_DEGREES + LidStepperState::PLATE_LIFT_RETURN_DEGREES - _nudge_degrees, true);
+                        LidStepperState::PLATE_LIFT_RAISE_DEGREES +
+                            LidStepperState::PLATE_LIFT_RETURN_DEGREES -
+                            _nudge_degrees,
+                        true);
                     _lid_stepper_state.status =
                         LidStepperState::Status::LIFT_RAISE;
                 }

--- a/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_hardware.c
@@ -104,7 +104,7 @@ extern "C" {
 /** Above this speed, will get skipping */
 #define LID_RPM_MAX (125)
 /** Below this speed reduces torque */
-#define LID_RPM_MIN (75)
+#define LID_RPM_MIN (10)
 
 // ----------------------------------------------------------------------------
 // Local typedefs

--- a/stm32-modules/thermocycler-gen2/scripts/start_dfu.py
+++ b/stm32-modules/thermocycler-gen2/scripts/start_dfu.py
@@ -1,0 +1,7 @@
+from test_utils import *
+
+
+if __name__ == '__main__':
+    ser = build_serial()
+    ser.write('dfu\n'.encode())
+    exit(0)


### PR DESCRIPTION
This adds a "wiggling" motion to the Thermocycler plate lift action in order to dislodge plates more gently.

* The speed for plate lift is decreased a bit to reduce the sudden force on the plate
* The plate lift moves up a little bit, retreats a bit, and then moves up a little more; it does this a few times until the plate is certainly dislodged
* The lifter runs to its limit and goes back to the normal "open" position as usual

The issue that this addresses does not happen on _every_ thermocycler. On affected units, the original plate lifter implementation would "pop" the plate very suddenly, potentially spilling liquid.

With the new implementation, you can leave a thermocycler closed for a long time, cycle temperatures, open the lid, and run a plate lift and the popping is gone (or, in the worst cases, very highly dampened)