### PR TITLE
feat(tempdeck-gen3): support new eeprom

### DIFF
--- a/stm32-modules/common/tests/CMakeLists.txt
+++ b/stm32-modules/common/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_fixed_point.cpp
     test_gcode_parse.cpp 
     test_generic_timer.cpp
+    test_m24128.cpp
     test_pid.cpp
     test_queue_aggregator.cpp
     test_thermistor_conversions.cpp

--- a/stm32-modules/common/tests/test_m24128.cpp
+++ b/stm32-modules/common/tests/test_m24128.cpp
@@ -1,0 +1,107 @@
+#include "catch2/catch.hpp"
+#include "core/m24128.hpp"
+#include "test/test_m24128_policy.hpp"
+
+using namespace m24128_test_policy;
+
+TEST_CASE("TestM24128Policy functionality") {
+    GIVEN("a test policy") {
+        auto policy = TestM24128Policy();
+        WHEN("writing 8 bytes") {
+            std::array<uint8_t, 10> buffer = {0, 0, 0, 1, 2, 3, 4, 5, 6, 7};
+            REQUIRE(policy.i2c_write(0, buffer.begin(), buffer.size()));
+            THEN("the internal buffer does not match what was written") {
+                for (int i = 0; i < 8; ++i) {
+                    DYNAMIC_SECTION(std::string("Buffer index ") << i) {
+                        REQUIRE(policy._buffer[i] == 0);
+                    }
+                }
+            }
+            AND_WHEN("reading 8 bytes") {
+                std::array<uint8_t, 8> readback = {0, 0, 0, 0, 0, 0, 0, 0};
+                policy.i2c_write(0, readback.begin(), 2);
+                policy.i2c_read(0, readback.begin(), readback.size());
+                THEN("the returned buffer does not match what was written") {
+                    for (int i = 0; i < 8; ++i) {
+                        DYNAMIC_SECTION(std::string("Buffer index ") << i) {
+                            REQUIRE(readback[i] == 0);
+                        }
+                    }
+                }
+            }
+        }
+        GIVEN("write protect disabled") {
+            policy.set_write_protect(false);
+            WHEN("writing 8 bytes") {
+                std::array<uint8_t, 10> buffer = {0, 0, 0, 1, 2, 3, 4, 5, 6, 7};
+                REQUIRE(policy.i2c_write(0, buffer.begin(), buffer.size()));
+                THEN("the internal buffer matches what was written") {
+                    for (int i = 0; i < 8; ++i) {
+                        DYNAMIC_SECTION(std::string("Buffer index ") << i) {
+                            REQUIRE(policy._buffer[i] == buffer[i + 2]);
+                        }
+                    }
+                }
+                AND_WHEN("reading bytes back") {
+                    std::array<uint8_t, 8> readback = {0};
+                    policy.i2c_write(0, readback.begin(), 2);
+                    policy.i2c_read(0, readback.begin(), readback.size());
+                    THEN("the returned buffer matches what was written") {
+                        for (int i = 0; i < 8; ++i) {
+                            DYNAMIC_SECTION(std::string("Buffer index ") << i) {
+                                REQUIRE(readback[i] == buffer[i + 2]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct TwoFloats {
+    float a, b;
+};
+
+TEST_CASE("M24128 class functionality") {
+    using namespace m24128;
+    constexpr const uint8_t address = 0b1010100;
+    GIVEN("an M24128") {
+        auto policy = TestM24128Policy();
+        auto eeprom = M24128<address>();
+        WHEN("writing a float to page 0") {
+            float value = 10.0;
+            eeprom.write_value(0, value, policy);
+            AND_WHEN("reading back the stored value") {
+                auto readback = eeprom.read_value<float>(0, policy);
+                THEN("the same number is returned") {
+                    REQUIRE(readback.has_value());
+                    REQUIRE(readback.value() == value);
+                }
+            }
+            AND_WHEN("reading back the stored value as a double") {
+                auto readback = eeprom.read_value<double>(0, policy);
+                THEN("the returned number is wrong") {
+                    REQUIRE(readback.has_value());
+                    REQUIRE(readback.value() != value);
+                }
+            }
+        }
+        WHEN("writing a struct to page 4") {
+            TwoFloats value = {.a = 1.0, .b = 2.0};
+            eeprom.write_value(4, value, policy);
+            AND_WHEN("reading back the stored value") {
+                auto readback = eeprom.read_value<TwoFloats>(4, policy);
+                THEN("the same number is returned") {
+                    REQUIRE(readback.has_value());
+                    REQUIRE(readback.value().a == value.a);
+                    REQUIRE(readback.value().b == value.b);
+                }
+            }
+        }
+        WHEN("reading from page 200") {
+            auto ret = eeprom.read_value<double>(200, policy);
+            THEN("nothing is read") { REQUIRE(!ret.has_value()); }
+        }
+    }
+}

--- a/stm32-modules/include/common/core/m24128.hpp
+++ b/stm32-modules/include/common/core/m24128.hpp
@@ -98,9 +98,9 @@ class M24128 {
         uint16_t start_addr = page * PAGE_LENGTH;
         // MSB is first, followed by LSB
 
-        //NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         _buffer.at(0) = static_cast<uint8_t>((start_addr & 0xFF00) >> 8);
-        //NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         _buffer.at(1) = static_cast<uint8_t>((start_addr)&0xFF);
 
         return true;

--- a/stm32-modules/include/common/core/m24128.hpp
+++ b/stm32-modules/include/common/core/m24128.hpp
@@ -1,0 +1,109 @@
+/**
+ * @file m24128.hpp
+ * @brief Implements a generic driver for M24128 EEPROM IC
+ *
+ */
+
+#pragma once
+
+#include <array>
+#include <concepts>
+#include <cstring>
+
+#include "core/bit_utils.hpp"
+
+namespace m24128 {
+
+static constexpr const size_t PAGE_LENGTH = 64;
+
+template <typename Policy>
+concept M24128_Policy = requires(Policy &policy, uint8_t addr,
+                                 std::array<uint8_t, PAGE_LENGTH> array) {
+    // Function to write a page.
+    // Accepts I2C address, uint8_t iterator, and a length
+    {
+        policy.i2c_write(addr, array.begin(), array.size())
+        } -> std::same_as<bool>;
+    // Function to read a page (8 bytes).
+    // Accepts I2C address, uint8_t iterator, and a length
+    {
+        policy.i2c_read(addr, array.begin(), array.size())
+        } -> std::same_as<bool>;
+    // Function to enable or disable protection.
+    // True turns on protection, false disables it.
+    { policy.set_write_protect(true) } -> std::same_as<void>;
+};
+
+template <uint8_t ADDRESS>
+class M24128 {
+  private:
+    static constexpr size_t ADDRESS_BYTES = 2;
+    // I2C address of the EEPROM, shifted 1 bit left from the
+    // datasheet.
+    static constexpr const uint8_t _address = ADDRESS << 1;
+
+  public:
+    static const constexpr uint16_t PAGES = 128;
+
+    template <typename T, M24128_Policy Policy>
+    requires std::is_trivially_copyable_v<T>
+    auto write_value(uint8_t page, T value, Policy &policy) -> bool {
+        // The type to be written must be serializable in a single buffer
+        static_assert(sizeof(T) <= PAGE_LENGTH, "Type T must be max 64 bytes.");
+        constexpr size_t Length = sizeof(T) + ADDRESS_BYTES;
+
+        if (!populate_address(page)) {
+            return false;
+        }
+        // Because T must be trivially copyable, this is not a dangerous copy
+        std::memcpy(&(_buffer[ADDRESS_BYTES]), &value, sizeof(value));
+
+        policy.set_write_protect(false);
+        auto ret = policy.i2c_write(_address, _buffer.begin(), Length);
+        policy.set_write_protect(true);
+
+        return ret;
+    }
+
+    template <typename T, M24128_Policy Policy>
+    requires std::is_trivially_copyable_v<T>
+    [[nodiscard]] auto read_value(uint8_t page, Policy &policy)
+        -> std::optional<T> {
+        using RT = std::optional<T>;
+
+        static_assert(sizeof(T) <= PAGE_LENGTH, "Type T must be max 64 bytes.");
+
+        if (!populate_address(page)) {
+            return std::nullopt;
+        }
+
+        // Must write the address before reading everything else
+        if (!policy.i2c_write(_address, _buffer.begin(), ADDRESS_BYTES)) {
+            return std::nullopt;
+        }
+
+        if (!policy.i2c_read(_address, _buffer.begin(), PAGE_LENGTH)) {
+            return std::nullopt;
+        }
+        T value;
+        memcpy(&value, &_buffer[0], sizeof(value));
+        return RT(value);
+    }
+
+  private:
+    auto populate_address(uint8_t page) -> bool {
+        if (page > PAGES) {
+            return false;
+        }
+        uint16_t start_addr = page * PAGE_LENGTH;
+        // MSB then LSB
+        _buffer.at(0) = static_cast<uint8_t>((start_addr & 0xFF00) >> 8);
+        _buffer.at(1) = static_cast<uint8_t>((start_addr)&0xFF);
+        return true;
+    }
+
+    using Buffer = std::array<uint8_t, PAGE_LENGTH + 2>;
+    Buffer _buffer;  // Keep a static buffer to avoid reallocating on the stack
+};
+
+}  // namespace m24128

--- a/stm32-modules/include/common/core/m24128.hpp
+++ b/stm32-modules/include/common/core/m24128.hpp
@@ -85,7 +85,7 @@ class M24128 {
         if (!policy.i2c_read(_address, _buffer.begin(), PAGE_LENGTH)) {
             return std::nullopt;
         }
-        T value;
+        T value{};
         memcpy(&value, &_buffer[0], sizeof(value));
         return RT(value);
     }
@@ -96,9 +96,13 @@ class M24128 {
             return false;
         }
         uint16_t start_addr = page * PAGE_LENGTH;
-        // MSB then LSB
+        // MSB is first, followed by LSB
+
+        //NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         _buffer.at(0) = static_cast<uint8_t>((start_addr & 0xFF00) >> 8);
+        //NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         _buffer.at(1) = static_cast<uint8_t>((start_addr)&0xFF);
+
         return true;
     }
 

--- a/stm32-modules/include/common/test/test_m24128_policy.hpp
+++ b/stm32-modules/include/common/test/test_m24128_policy.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <array>
+#include <iterator>
+
+#include "core/m24128.hpp"
+
+namespace m24128_test_policy {
+
+template <typename Iter>
+concept ByteIterator = requires {
+    {std::forward_iterator<Iter>};
+    {std::is_same_v<std::iter_value_t<Iter>, uint8_t>};
+};
+
+class TestM24128Policy {
+  public:
+    static constexpr const size_t PAGE_LENGTH = m24128::PAGE_LENGTH;
+    using Buffer = std::array<uint8_t, 128 * PAGE_LENGTH>;
+
+    TestM24128Policy() : _buffer(), _data_pointer(0), _write_protect(true) {
+        for (size_t i = 0; i < _buffer.size(); ++i) {
+            _buffer[i] = 0;
+        }
+    }
+
+    // --- Policy fulfillment -----------
+
+    template <ByteIterator Input>
+    auto i2c_write(uint8_t addr, Input data, size_t len) -> bool {
+        // Ignore address for test purposes
+        static_cast<void>(addr);
+
+        if (len >= 2) {
+            _data_pointer = (*data) << 8;
+            ++data;
+            _data_pointer |= (*data);
+            ++data;
+            len -= 2;
+        } else {
+            return true;
+        }
+
+        if (_data_pointer >= _buffer.size()) {
+            // Out of bounds write attempt
+            return false;
+        }
+
+        while (!_write_protect && len > 0) {
+            _buffer[_data_pointer++] = *data;
+            ++data;
+            len--;
+            // If data pointer is at a page boundary, wraparound
+            if ((_data_pointer % PAGE_LENGTH) == 0) {
+                _data_pointer -= PAGE_LENGTH;
+            }
+        }
+
+        return true;
+    }
+
+    template <ByteIterator Input>
+    auto i2c_read(uint8_t addr, Input data, size_t len) -> bool {
+        // Ignore address for test purposes
+        static_cast<void>(addr);
+        // Data pointer is held over from the last transaction
+        for (size_t i = 0; i < len; ++i, ++data) {
+            *data = _buffer[_data_pointer++];
+            // Wraparound is at memory limit instead of page boundary
+            if (_data_pointer == _buffer.size()) {
+                _data_pointer = 0;
+            }
+        }
+        return true;
+    }
+
+    auto set_write_protect(bool write_protect) -> void {
+        _write_protect = write_protect;
+    }
+
+    Buffer _buffer;
+    size_t _data_pointer;
+    bool _write_protect;
+};
+
+}  // namespace m24128_test_policy

--- a/stm32-modules/include/tempdeck-gen3/simulator/sim_thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/simulator/sim_thermal_policy.hpp
@@ -3,9 +3,9 @@
 #include <cmath>
 #include <cstdint>
 
-#include "simulator/sim_at24c0xc_policy.hpp"
+#include "test/test_m24128_policy.hpp"
 
-struct SimThermalPolicy : public at24c0xc_sim_policy::SimAT24C0XCPolicy<32> {
+struct SimThermalPolicy : public m24128_test_policy::TestM24128Policy {
     auto enable_peltier() -> void { _enabled = true; }
 
     auto disable_peltier() -> void { _enabled = false; }

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/eeprom.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/eeprom.hpp
@@ -77,6 +77,8 @@ class Eeprom {
             }
         }
 
+        _initialized = true;
+
         return ret;
     }
 

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/eeprom.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/eeprom.hpp
@@ -30,9 +30,14 @@ namespace eeprom {
  * if any, is included with the EEPROM constant values.
  *
  */
-struct OffsetConstants {
+struct __attribute__((packed)) OffsetConstants {
     // Constant A is the same for each channel
     double a, b, c;
+};
+
+struct __attribute__((packed)) PageContent {
+    uint8_t constant_flag;
+    OffsetConstants constants;
 };
 
 /**
@@ -59,14 +64,19 @@ class Eeprom {
                                             Policy& policy) -> OffsetConstants {
         OffsetConstants ret = defaults;
         // Read the constants
-        auto flag = read_const_flag(policy);
+        auto readback = _eeprom.template read_value<PageContent>(
+            static_cast<uint8_t>(EEPROMPageMap::CONSTANTS), policy);
 
-        if (flag == EEPROMFlag::CONSTANTS_WRITTEN) {
-            ret.a = read_const(EEPROMPageMap::CONST_A, policy);
-            ret.b = read_const(EEPROMPageMap::CONST_B, policy);
-            ret.c = read_const(EEPROMPageMap::CONST_C, policy);
+        if (readback.has_value()) {
+            auto& values = readback.value();
+            if (values.constant_flag ==
+                static_cast<uint8_t>(EEPROMFlag::CONSTANTS_WRITTEN)) {
+                ret.a = values.constants.a;
+                ret.b = values.constants.b;
+                ret.c = values.constants.c;
+            }
         }
-        _initialized = true;
+
         return ret;
     }
 
@@ -83,29 +93,16 @@ class Eeprom {
     auto write_offset_constants(OffsetConstants constants, Policy& policy)
         -> bool {
         // Write the constants
+        auto to_write = PageContent{.constant_flag = static_cast<uint8_t>(
+                                        EEPROMFlag::CONSTANTS_WRITTEN),
+                                    .constants = constants};
         auto ret = _eeprom.template write_value(
-            static_cast<uint8_t>(EEPROMPageMap::CONST_A), constants.a, policy);
-        if (ret) {
-            ret = _eeprom.template write_value(
-                static_cast<uint8_t>(EEPROMPageMap::CONST_B), constants.b,
-                policy);
-        }
-        if (ret) {
-            ret = _eeprom.template write_value(
-                static_cast<uint8_t>(EEPROMPageMap::CONST_C), constants.c,
-                policy);
-        }
-        if (ret) {
-            // Flag that the constants are good
-            ret = _eeprom.template write_value(
-                static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG),
-                static_cast<uint32_t>(EEPROMFlag::CONSTANTS_WRITTEN), policy);
-        }
-        if (!ret && false) {
+            static_cast<uint8_t>(EEPROMPageMap::CONSTANTS), to_write, policy);
+        if (!ret) {
             // Attempt to flag that the constants are not valid
             static_cast<void>(_eeprom.template write_value(
-                static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG),
-                static_cast<uint32_t>(EEPROMFlag::INVALID), policy));
+                static_cast<uint8_t>(EEPROMPageMap::CONSTANTS),
+                static_cast<uint8_t>(EEPROMFlag::INVALID), policy));
         }
         return ret;
     }
@@ -119,15 +116,10 @@ class Eeprom {
 
   private:
     // Enumeration of memory locations to be used on the EEPROM
-    enum class EEPROMPageMap : uint8_t {
-        CONST_FLAG,
-        CONST_A,
-        CONST_B,
-        CONST_C
-    };
+    enum class EEPROMPageMap : uint8_t { CONSTANTS };
 
     // Enumeration of the EEPROM_CONST_FLAG values
-    enum class EEPROMFlag {
+    enum class EEPROMFlag : uint8_t {
         CONSTANTS_WRITTEN = 1,  // Values of all constants are written
         INVALID = 0xFF          // No values are written
     };
@@ -137,49 +129,6 @@ class Eeprom {
 
     /** Default value for all constants.*/
     static constexpr double OFFSET_DEFAULT_CONST = 0.0F;
-
-    /**
-     * @brief Read one of the constants on the device
-     *
-     * @tparam Policy class for reading from the eeprom
-     * @param page Which page to read. Must be a valid page
-     * @param policy Instance of Policy for reading
-     * @return double containing the constant
-     */
-    template <m24128::M24128_Policy Policy>
-    [[nodiscard]] auto read_const(EEPROMPageMap page, Policy& policy)
-        -> double {
-        if (page != EEPROMPageMap::CONST_FLAG) {
-            auto val = _eeprom.template read_value<double>(
-                static_cast<uint8_t>(page), policy);
-            if (val.has_value()) {
-                return val.value();
-            }
-        }
-        return OFFSET_DEFAULT_CONST;
-    }
-
-    /**
-     * @brief Read the Constants Flag in the EEPROM. This flag provides the
-     * validity of the constants in memory.
-     *
-     * @tparam Policy class for reading from the eeprom
-     * @param policy Instance of Policy for reading
-     * @return EEPROMFlag containing the state of the constants in EEPROM
-     */
-    template <m24128::M24128_Policy Policy>
-    [[nodiscard]] auto read_const_flag(Policy& policy) -> EEPROMFlag {
-        auto val = _eeprom.template read_value<uint32_t>(
-            static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG), policy);
-        if (val.has_value()) {
-            auto flag = val.value();
-            if (flag == static_cast<uint32_t>(EEPROMFlag::CONSTANTS_WRITTEN)) {
-                return EEPROMFlag::CONSTANTS_WRITTEN;
-            }
-        }
-        // Default
-        return EEPROMFlag::INVALID;
-    }
 
     // Handle for the actual EEPROM IC
     m24128::M24128<ADDRESS> _eeprom;

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/eeprom.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/eeprom.hpp
@@ -9,7 +9,7 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "core/at24c0xc.hpp"
+#include "core/m24128.hpp"
 
 namespace eeprom {
 
@@ -39,7 +39,7 @@ struct OffsetConstants {
  * @brief Encapsulates interactions with the EEPROM on the Thermocycler
  * mainboard. Allows reading and writing the thermal offset constants.
  */
-template <size_t PAGES, uint8_t ADDRESS>
+template <uint8_t ADDRESS>
 class Eeprom {
   public:
     Eeprom() : _eeprom() {}
@@ -54,7 +54,7 @@ class Eeprom {
      * @return OffsetConstants containing the A, B and C constants, or the
      * default values if the EEPROM doesn't have programmed values.
      */
-    template <at24c0xc::AT24C0xC_Policy Policy>
+    template <m24128::M24128_Policy Policy>
     [[nodiscard]] auto get_offset_constants(const OffsetConstants& defaults,
                                             Policy& policy) -> OffsetConstants {
         OffsetConstants ret = defaults;
@@ -79,7 +79,7 @@ class Eeprom {
      * @param policy Instance of Policy
      * @return True if the constants were written, false otherwise
      */
-    template <at24c0xc::AT24C0xC_Policy Policy>
+    template <m24128::M24128_Policy Policy>
     auto write_offset_constants(OffsetConstants constants, Policy& policy)
         -> bool {
         // Write the constants
@@ -101,7 +101,7 @@ class Eeprom {
                 static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG),
                 static_cast<uint32_t>(EEPROMFlag::CONSTANTS_WRITTEN), policy);
         }
-        if (!ret) {
+        if (!ret && false) {
             // Attempt to flag that the constants are not valid
             static_cast<void>(_eeprom.template write_value(
                 static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG),
@@ -146,7 +146,7 @@ class Eeprom {
      * @param policy Instance of Policy for reading
      * @return double containing the constant
      */
-    template <at24c0xc::AT24C0xC_Policy Policy>
+    template <m24128::M24128_Policy Policy>
     [[nodiscard]] auto read_const(EEPROMPageMap page, Policy& policy)
         -> double {
         if (page != EEPROMPageMap::CONST_FLAG) {
@@ -167,7 +167,7 @@ class Eeprom {
      * @param policy Instance of Policy for reading
      * @return EEPROMFlag containing the state of the constants in EEPROM
      */
-    template <at24c0xc::AT24C0xC_Policy Policy>
+    template <m24128::M24128_Policy Policy>
     [[nodiscard]] auto read_const_flag(Policy& policy) -> EEPROMFlag {
         auto val = _eeprom.template read_value<uint32_t>(
             static_cast<uint8_t>(EEPROMPageMap::CONST_FLAG), policy);
@@ -182,7 +182,7 @@ class Eeprom {
     }
 
     // Handle for the actual EEPROM IC
-    at24c0xc::AT24C0xC<PAGES, ADDRESS> _eeprom;
+    m24128::M24128<ADDRESS> _eeprom;
     // Whether the constants have been read from the EEPROM since startup.
     // Even if the EEPROM is empty, this flag is set after attempting
     // to read so that the firmware doesn't try to keep making redundant

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -21,7 +21,7 @@ concept ThermalPolicy = requires(Policy& p) {
     { p.set_fan_power(1.0) } -> std::same_as<bool>;
     { p.get_fan_rpm() } -> std::same_as<double>;
 }
-&&at24c0xc::AT24C0xC_Policy<Policy>;
+&&m24128::M24128_Policy<Policy>;
 
 using Message = messages::ThermalMessage;
 
@@ -122,8 +122,7 @@ class ThermalTask {
 
     static constexpr double MILLISECONDS_TO_SECONDS = 0.001F;
 
-    static constexpr size_t EEPROM_PAGES = 32;
-    static constexpr uint8_t EEPROM_ADDRESS = 0b1010010;
+    static constexpr uint8_t EEPROM_ADDRESS = 0x50;
 
     static constexpr const double OFFSET_DEFAULT_CONST_A = 0.0F;
     static constexpr const double OFFSET_DEFAULT_CONST_B = 0.0F;
@@ -428,7 +427,7 @@ class ThermalTask {
     auto visit_message(const messages::GetOffsetConstantsMessage& message,
                        Policy& policy) -> void {
         _offset_constants =
-            _eeprom.get_offset_constants(_offset_constants, policy);
+            _eeprom.get_offset_constants(eeprom::OffsetConstants{.a=0,.b=0,.c=0}, policy);
 
         auto response =
             messages::GetOffsetConstantsResponse{.responding_to_id = message.id,
@@ -539,7 +538,7 @@ class ThermalTask {
     Fan _fan;
     Peltier _peltier;
     ot_utils::pid::PID _pid;
-    eeprom::Eeprom<EEPROM_PAGES, EEPROM_ADDRESS> _eeprom;
+    eeprom::Eeprom<EEPROM_ADDRESS> _eeprom;
     eeprom::OffsetConstants _offset_constants;
 };
 

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -426,9 +426,8 @@ class ThermalTask {
     template <ThermalPolicy Policy>
     auto visit_message(const messages::GetOffsetConstantsMessage& message,
                        Policy& policy) -> void {
-        _offset_constants =
-            _eeprom.get_offset_constants(eeprom::OffsetConstants{.a=0,.b=0,.c=0}, policy);
-
+        std::ignore = policy;
+        // Don't readback from EEPROM - values were updated on startup.
         auto response =
             messages::GetOffsetConstantsResponse{.responding_to_id = message.id,
                                                  .a = _offset_constants.a,

--- a/stm32-modules/include/tempdeck-gen3/test/test_thermal_policy.hpp
+++ b/stm32-modules/include/tempdeck-gen3/test/test_thermal_policy.hpp
@@ -3,9 +3,9 @@
 #include <cmath>
 #include <cstdint>
 
-#include "test/test_at24c0xc_policy.hpp"
+#include "test/test_m24128_policy.hpp"
 
-struct TestThermalPolicy : public at24c0xc_test_policy::TestAT24C0XCPolicy<32> {
+struct TestThermalPolicy : public m24128_test_policy::TestM24128Policy {
     auto enable_peltier() -> void { _enabled = true; }
 
     auto disable_peltier() -> void {

--- a/stm32-modules/tempdeck-gen3/firmware/README.md
+++ b/stm32-modules/tempdeck-gen3/firmware/README.md
@@ -4,7 +4,7 @@ This section provides a general overview of the firmware architecture for the Te
 ## Drivers
 Hardware peripherals attached to the STM32 are classified into drivers. These drivers are not given their own tasks, but are rather utilized _by_ the software tasks. Lower level hardware control, such as simple access to internal peripherals, is covered by 'Hardware Policy' code. Drivers are distinct in that they maintain their own state.
 
-- __EEPROM Driver__ - Provides functionality to read and write the EEPROM on the system over I2C. See `../../include/common/core/at24c0xc.hpp`
+- __EEPROM Driver__ - Provides functionality to read and write the EEPROM on the system over I2C. See `../../include/common/core/m24128.hpp`
 - __LED Driver__ - Provides functionality to write to the LED's on the system. Uses I2C.
 - __PID Driver__ - Provides a unified interface to calculate Proportional Integral Derivative control. See `../../include/common/core/pid.hpp`
 - __ADS1115 Driver__ - Provides an interface to control the ADS1115 ADC IC on the main board. See `../../include/common/core/ads1115.hpp`

--- a/stm32-modules/tempdeck-gen3/scripts/test_utils.py
+++ b/stm32-modules/tempdeck-gen3/scripts/test_utils.py
@@ -279,11 +279,11 @@ class Tempdeck():
         NONE), they will not be written.
         '''
         msg = 'M116'
-        if a:
+        if a is not None:
             msg += f' A{a}'
-        if b:
+        if b is not None:
             msg += f' B{b}'
-        if c:
+        if c is not None:
             msg += f' C{c}'
         msg += '\n'
         self._send_and_recv(msg, 'M116 OK')

--- a/stm32-modules/tempdeck-gen3/tests/test_eeprom.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_eeprom.cpp
@@ -1,16 +1,16 @@
 #include "catch2/catch.hpp"
 #include "tempdeck-gen3/eeprom.hpp"
-#include "test/test_at24c0xc_policy.hpp"
+#include "test/test_m24128_policy.hpp"
 
-using namespace at24c0xc_test_policy;
+using namespace m24128_test_policy;
 using namespace eeprom;
 
 static auto _default = OffsetConstants{.a = 68, .b = 5, .c = 9};
 
 TEST_CASE("eeprom class initialization tracking") {
     GIVEN("an EEPROM") {
-        auto policy = TestAT24C0XCPolicy<32>();
-        auto eeprom = Eeprom<32, 0x10>();
+        auto policy = TestM24128Policy();
+        auto eeprom = Eeprom<0x10>();
         THEN("it starts as noninitialized") { REQUIRE(!eeprom.initialized()); }
         WHEN("reading from the EEPROM") {
             auto defaults = _default;
@@ -24,8 +24,8 @@ TEST_CASE("eeprom class initialization tracking") {
 
 TEST_CASE("blank eeprom reading") {
     GIVEN("an EEPROM") {
-        auto policy = TestAT24C0XCPolicy<32>();
-        auto eeprom = Eeprom<32, 0x10>();
+        auto policy = TestM24128Policy();
+        auto eeprom = Eeprom<0x10>();
         WHEN("reading before writing anything") {
             auto defaults = _default;
             auto readback = eeprom.get_offset_constants(defaults, policy);
@@ -43,8 +43,8 @@ TEST_CASE("blank eeprom reading") {
 
 TEST_CASE("eeprom reading and writing") {
     GIVEN("an EEPROM and constants A= -3.5, B = 10 and C = -12") {
-        auto policy = TestAT24C0XCPolicy<32>();
-        auto eeprom = Eeprom<32, 0x10>();
+        auto policy = TestM24128Policy();
+        auto eeprom = Eeprom<0x10>();
         OffsetConstants constants = {.a = 32, .b = -33, .c = -44};
         WHEN("writing the constants") {
             REQUIRE(eeprom.write_offset_constants(constants, policy));

--- a/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
@@ -493,8 +493,7 @@ TEST_CASE("closed loop thermal control") {
 TEST_CASE("thermal task offset constants message handling") {
     auto *tasks = tasks::BuildTasks();
     TestThermalPolicy policy;
-    eeprom::Eeprom<decltype(tasks->_thermal_task)::EEPROM_ADDRESS>
-        eeprom;
+    eeprom::Eeprom<decltype(tasks->_thermal_task)::EEPROM_ADDRESS> eeprom;
 
     WHEN("getting the offset constants") {
         auto get_msg = messages::GetOffsetConstantsMessage{.id = 1};

--- a/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
+++ b/stm32-modules/tempdeck-gen3/tests/test_thermal_task.cpp
@@ -493,8 +493,7 @@ TEST_CASE("closed loop thermal control") {
 TEST_CASE("thermal task offset constants message handling") {
     auto *tasks = tasks::BuildTasks();
     TestThermalPolicy policy;
-    eeprom::Eeprom<decltype(tasks->_thermal_task)::EEPROM_PAGES,
-                   decltype(tasks->_thermal_task)::EEPROM_ADDRESS>
+    eeprom::Eeprom<decltype(tasks->_thermal_task)::EEPROM_ADDRESS>
         eeprom;
 
     WHEN("getting the offset constants") {


### PR DESCRIPTION
Closes RET-1224

The Rev 3 version of the Tempdeck-Gen3 PCB uses a different eeprom than the previous revisions. The new EEPROM, STMicroelectronics' `M24128`, uses 64-byte pages instead of the previous model's 8-byte pages. Therefore, we are able to store the entirety of the offset data in a single page, reserving the rest of the space for potential future data.

This PR makes the following changes:
* The EEPROM model is updated to a new `M24128` class
* The EEPROM contents have been compressed into a single `__packed` struct that fits into a 64-byte page
* The offset values are not read back from the EEPROM after the first initialization
* Fixed a bug that the python driver wouldn't send offset calibration values of `0`

Tested on a Tempdeck-Gen3 Revision 3 PCB. Tried setting the value for each constant to a nonzero number, and then reset the board by removing power. After powerup, the constants could be read out over USB with the same values. Repeating the same test with different numbers was successful.

Given that the EEPROM was unpopulated on all prior revisions anyways, this PR does _not_ attempt to maintain backwards compatibility.

Also note that the offset constants aren't actually _used_ for anything yet. That will be a future PR for a different ticket.