### PR TITLE
feat(tempdeck-gen3): include thermal calibration offsets when calculating temperature

### DIFF
--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -400,8 +400,8 @@ class ThermalTask {
         }
 
         _offset_constants = constants;
-        //auto ret = _eeprom.write_offset_constants(constants, policy);
-        //if (ret) {
+        // auto ret = _eeprom.write_offset_constants(constants, policy);
+        // if (ret) {
         //    // Succesful, so overwrite the task's constants
         //    _offset_constants = constants;
         //} else {

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -412,13 +412,14 @@ class ThermalTask {
             constants.c = message.c.value();
         }
 
-        auto ret = _eeprom.write_offset_constants(constants, policy);
-        if (ret) {
-            // Succesful, so overwrite the task's constants
-            _offset_constants = constants;
-        } else {
-            response.with_error = errors::ErrorCode::SYSTEM_EEPROM_ERROR;
-        }
+        _offset_constants = constants;
+        //auto ret = _eeprom.write_offset_constants(constants, policy);
+        //if (ret) {
+        //    // Succesful, so overwrite the task's constants
+        //    _offset_constants = constants;
+        //} else {
+        //    response.with_error = errors::ErrorCode::SYSTEM_EEPROM_ERROR;
+        //}
 
         static_cast<void>(
             _task_registry->send_to_address(response, Queues::HostAddress));
@@ -427,8 +428,8 @@ class ThermalTask {
     template <ThermalPolicy Policy>
     auto visit_message(const messages::GetOffsetConstantsMessage& message,
                        Policy& policy) -> void {
-        _offset_constants =
-            _eeprom.get_offset_constants(_offset_constants, policy);
+        //_offset_constants =
+        //    _eeprom.get_offset_constants(_offset_constants, policy);
 
         auto response =
             messages::GetOffsetConstantsResponse{.responding_to_id = message.id,

--- a/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
+++ b/stm32-modules/include/tempdeck-gen3/tempdeck-gen3/thermal_task.hpp
@@ -399,13 +399,13 @@ class ThermalTask {
         }
 
         _offset_constants = constants;
-        // auto ret = _eeprom.write_offset_constants(constants, policy);
-        // if (ret) {
-        //    // Succesful, so overwrite the task's constants
-        //    _offset_constants = constants;
-        //} else {
-        //    response.with_error = errors::ErrorCode::SYSTEM_EEPROM_ERROR;
-        //}
+        auto ret = _eeprom.write_offset_constants(constants, policy);
+        if (ret) {
+            // Succesful, so overwrite the task's constants
+            _offset_constants = constants;
+        } else {
+            response.with_error = errors::ErrorCode::SYSTEM_EEPROM_ERROR;
+        }
 
         static_cast<void>(
             _task_registry->send_to_address(response, Queues::HostAddress));


### PR DESCRIPTION
This PR adds functionality for the TD3 to include the calibration values when calculating temperature for the thermistors.

The algorithm is the same as most of our other thermal-control modules: `temp = (A * heatsink temp) + ((B+1)*plate temp) + C`

Tested setting the offsets on a board, reading back the temperatures, and verifying that the temperatures in fact changed.