### PR TITLE
feature(flex-stacker): bring up host comms task

### DIFF
--- a/stm32-modules/flex-stacker/firmware/CMakeLists.txt
+++ b/stm32-modules/flex-stacker/firmware/CMakeLists.txt
@@ -17,13 +17,13 @@ set(GDBINIT_PATH "${CMAKE_CURRENT_BINARY_DIR}/../../common/STM32G491/gdbinit")
 # Add source files that should be checked by clang-tidy here
 set(${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+    ${COMMS_DIR}/freertos_comms_task.cpp
     ${SYSTEM_DIR}/freertos_idle_timer_task.cpp
     ${UI_DIR}/freertos_ui_task.cpp
     ${MOTOR_CONTROL_DIR}/freertos_motor_task.cpp
     ${MOTOR_CONTROL_DIR}/freertos_motor_driver_task.cpp
     ${MOTOR_CONTROL_DIR}/motor_driver_policy.cpp
     ${MOTOR_CONTROL_DIR}/motor_policy.cpp
-    ${COMMS_DIR}/freertos_comms_task.cpp
     )
 
 # Add source files that should NOT be checked by clang-tidy here

--- a/stm32-modules/flex-stacker/firmware/CMakeLists.txt
+++ b/stm32-modules/flex-stacker/firmware/CMakeLists.txt
@@ -59,6 +59,7 @@ set_target_properties(${TARGET_MODULE_NAME}
 target_include_directories(${TARGET_MODULE_NAME}
         PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../include/${TARGET_MODULE_NAME}
         PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../../cpp-utils/include/
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../../stm32-tools/printf/
         )
 
 target_compile_options(${TARGET_MODULE_NAME}

--- a/stm32-modules/flex-stacker/firmware/CMakeLists.txt
+++ b/stm32-modules/flex-stacker/firmware/CMakeLists.txt
@@ -23,6 +23,7 @@ set(${TARGET_MODULE_NAME}_FW_LINTABLE_SRCS
     ${MOTOR_CONTROL_DIR}/freertos_motor_driver_task.cpp
     ${MOTOR_CONTROL_DIR}/motor_driver_policy.cpp
     ${MOTOR_CONTROL_DIR}/motor_policy.cpp
+    ${COMMS_DIR}/freertos_comms_task.cpp
     )
 
 # Add source files that should NOT be checked by clang-tidy here

--- a/stm32-modules/flex-stacker/firmware/CMakeLists.txt
+++ b/stm32-modules/flex-stacker/firmware/CMakeLists.txt
@@ -107,7 +107,7 @@ set_target_properties(
 
 
 find_program(ARM_GDB
-        arm-none-eabi-gdb-py
+        arm-none-eabi-gdb-py3
         PATHS "${CrossGCC_BINDIR}"
         NO_DEFAULT_PATH
         REQUIRED)

--- a/stm32-modules/flex-stacker/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/stm32-modules/flex-stacker/firmware/host_comms_task/freertos_comms_task.cpp
@@ -1,0 +1,166 @@
+/*
+ * firmware-specific functions, data, and hooks for host comms control
+ */
+#include "firmware/freertos_comms_task.hpp"
+
+#include <array>
+#include <functional>
+#include <utility>
+
+#include "FreeRTOS.h"
+#include "firmware/firmware_tasks.hpp"
+#include "firmware/freertos_message_queue.hpp"
+#include "firmware/usb_hardware.h"
+#include "flex-stacker/host_comms_task.hpp"
+#include "flex-stacker/messages.hpp"
+#include "hal/double_buffer.hpp"
+#include "task.h"
+
+/** Sadly this must be manually duplicated from usbd_cdc.h */
+constexpr size_t CDC_BUFFER_SIZE = 512U;
+
+// Store any static data for USB comms
+struct CommsTaskFreeRTOS {
+    double_buffer::DoubleBuffer<char, CDC_BUFFER_SIZE * 4> rx_buf;
+    double_buffer::DoubleBuffer<char, CDC_BUFFER_SIZE * 4> tx_buf;
+    char *committed_rx_buf_ptr;
+};
+
+static auto cdc_init_handler() -> uint8_t *;
+static auto cdc_deinit_handler() -> void;
+// NOLINTNEXTLINE(readability-named-parameter)
+static auto cdc_rx_handler(uint8_t *, uint32_t *) -> uint8_t *;
+
+namespace host_comms_control_task {
+
+enum class Notifications : uint8_t {
+    INCOMING_MESSAGE = 1,
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static tasks::FirmwareTasks::HostCommsQueue
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    _comms_queue(static_cast<uint8_t>(Notifications::INCOMING_MESSAGE),
+                 "Comms Queue");
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static CommsTaskFreeRTOS _local_task = {
+    .rx_buf = {}, .tx_buf = {}, .committed_rx_buf_ptr = nullptr};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto _top_task = host_comms_task::HostCommsTask(_comms_queue, nullptr);
+
+auto run(tasks::FirmwareTasks::QueueAggregator *aggregator) -> void {
+    auto *local_task = &_local_task;
+    auto *top_task = &_top_task;
+
+    auto *handle = xTaskGetCurrentTaskHandle();
+
+    _comms_queue.provide_handle(handle);
+    top_task->provide_aggregator(aggregator);
+    aggregator->register_queue(_comms_queue);
+
+    usb_hw_init(&cdc_rx_handler, &cdc_init_handler, &cdc_deinit_handler);
+    usb_hw_start();
+    local_task->committed_rx_buf_ptr = local_task->rx_buf.committed()->data();
+    while (true) {
+        char *tx_end =
+            top_task->run_once(local_task->tx_buf.accessible()->begin(),
+                               local_task->tx_buf.accessible()->end());
+        if (!top_task->may_connect()) {
+            usb_hw_stop();
+        } else if (tx_end != local_task->tx_buf.accessible()->data()) {
+            local_task->tx_buf.swap();
+            usb_hw_send(
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                reinterpret_cast<uint8_t *>(
+                    local_task->tx_buf.committed()->data()),
+                tx_end - local_task->tx_buf.committed()->data());
+        }
+    }
+}
+
+}  // namespace host_comms_control_task
+
+static auto cdc_init_handler() -> uint8_t * {
+    using namespace host_comms_control_task;
+    _local_task.committed_rx_buf_ptr = _local_task.rx_buf.committed()->data();
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<uint8_t *>(_local_task.committed_rx_buf_ptr);
+}
+
+static auto cdc_deinit_handler() -> void {
+    using namespace host_comms_control_task;
+    _local_task.committed_rx_buf_ptr = _local_task.rx_buf.committed()->data();
+}
+
+/*
+** CDC_Receive is a callback hook invoked from the CDC class internals in an
+**
+** interrupt context. Buf points to the pre-provided rx buf, into which the data
+** from the hardware-isolated USB packet memory area has been copied; Len is a
+** pointer to the length of data.
+**
+** Because the host may send any number of characters in one USB packet - for
+** instance, a host that is using programmatic access to the serial device may
+** send an entire message, while a host that is someone typing into a serial
+** terminal may send one character per packet - we have to accumulate characters
+** somewhere until a full message is assembled. To avoid excessive copying, we
+** do this by changing the exact location of the rx buffer we give the
+** USB infrastructure. The rules are
+**
+** - We always start after a buffer swap with the beginning of the committed
+**   buffer
+** - When we receive a message
+**   - if there's a newline (indicating a complete message), we swap the buffers
+**     and  send the one that just got swapped out to the task for parsing
+**   - if there's not a newline,
+**     - if, after the message we just received, there is not enough space for
+**       an entire packet in the buffer, we swap the buffers and send the
+**       swapped-out one to the task, where it will probably be ignored
+**     - if, after the message we just received, there's enough space in the
+**       buffer, we don't swap the buffers, but advance our read pointer to just
+**       after the message we received
+**
+** Just about every line of this function has a NOLINT annotation. This is bad.
+** But the goal is that this is one of a very few functions like this, and
+** changes to this function require extra scrutiny and testing.
+*/
+
+// NOLINTNEXTLINE(readability-non-const-parameter)
+static auto cdc_rx_handler(uint8_t *Buf, uint32_t *Len) -> uint8_t * {
+    using namespace host_comms_control_task;
+    ssize_t remaining_buffer_count =
+        (_local_task.rx_buf.committed()->data()
+         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+         + _local_task.rx_buf.committed()->size()) -
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic,cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<char *>(Buf + *Len);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    if ((std::find_if(Buf, Buf + *Len,
+                      [](auto ch) { return ch == '\n' || ch == '\r'; }) !=
+         (Buf +  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+          *Len)) ||
+        remaining_buffer_count < static_cast<ssize_t>(CDC_BUFFER_SIZE)) {
+        // there was a newline in this message, can pass on
+        auto message =
+            messages::HostCommsMessage(messages::IncomingMessageFromHost{
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                .buffer = reinterpret_cast<const char *>(
+                    _local_task.rx_buf.committed()->data()),
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                .limit = reinterpret_cast<const char *>(
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                    Buf + *Len)});
+        static_cast<void>(_comms_queue.try_send_from_isr(message));
+        _local_task.rx_buf.swap();
+        _local_task.committed_rx_buf_ptr =
+            _local_task.rx_buf.committed()->data();
+    } else {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        _local_task.committed_rx_buf_ptr += *Len;
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<uint8_t *>(_local_task.committed_rx_buf_ptr);
+}

--- a/stm32-modules/flex-stacker/firmware/main.cpp
+++ b/stm32-modules/flex-stacker/firmware/main.cpp
@@ -10,10 +10,16 @@ using EntryPoint = std::function<void(tasks::FirmwareTasks::QueueAggregator *)>;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto motor_driver_task_entry = EntryPoint(motor_driver_task::run);
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto motor_task_entry = EntryPoint(motor_control_task::run);
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto ui_task_entry = EntryPoint(ui_control_task::run);
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto host_comms_entry = EntryPoint(host_comms_control_task::run);
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto aggregator = tasks::FirmwareTasks::QueueAggregator();
 
@@ -21,10 +27,17 @@ static auto aggregator = tasks::FirmwareTasks::QueueAggregator();
 static auto driver_task =
     ot_utils::freertos_task::FreeRTOSTask<tasks::MOTOR_DRIVER_STACK_SIZE,
                                           EntryPoint>(motor_driver_task_entry);
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto motor_task =
     ot_utils::freertos_task::FreeRTOSTask<tasks::MOTOR_STACK_SIZE, EntryPoint>(
         motor_task_entry);
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static auto host_comms_task =
+    ot_utils::freertos_task::FreeRTOSTask<tasks::COMMS_STACK_SIZE, EntryPoint>(
+        host_comms_entry);
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto ui_task =
     ot_utils::freertos_task::FreeRTOSTask<tasks::UI_STACK_SIZE, EntryPoint>(
@@ -36,6 +49,8 @@ auto main() -> int {
     driver_task.start(tasks::MOTOR_DRIVER_TASK_PRIORITY, "Motor Driver",
                       &aggregator);
     motor_task.start(tasks::MOTOR_TASK_PRIORITY, "Motor", &aggregator);
+
+    host_comms_task.start(tasks::COMMS_TASK_PRIORITY, "Comms", &aggregator);
 
     ui_task.start(tasks::UI_TASK_PRIORITY, "UI", &aggregator);
     vTaskStartScheduler();

--- a/stm32-modules/flex-stacker/src/errors.cpp
+++ b/stm32-modules/flex-stacker/src/errors.cpp
@@ -15,6 +15,7 @@ const char* const SYSTEM_SERIAL_NUMBER_HAL_ERROR =
     "ERR302:system:HAL error, busy, or timeout\n";
 const char* const SYSTEM_EEPROM_ERROR =
     "ERR303:system:EEPROM communication error\n";
+const char* const TMC2160_READ_ERROR = "ERR901:TMC2160 driver read error\n";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
@@ -34,6 +35,7 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(SYSTEM_SERIAL_NUMBER_INVALID);
         HANDLE_CASE(SYSTEM_SERIAL_NUMBER_HAL_ERROR);
         HANDLE_CASE(SYSTEM_EEPROM_ERROR);
+        HANDLE_CASE(TMC2160_READ_ERROR);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/flex-stacker/src/errors.cpp
+++ b/stm32-modules/flex-stacker/src/errors.cpp
@@ -9,6 +9,12 @@ const char* const UNHANDLED_GCODE = "ERR003:unhandled gcode\n";
 const char* const GCODE_CACHE_FULL = "ERR004:gcode cache full\n";
 const char* const BAD_MESSAGE_ACKNOWLEDGEMENT =
     "ERR005:bad message acknowledgement\n";
+const char* const SYSTEM_SERIAL_NUMBER_INVALID =
+    "ERR301:system:serial number invalid format\n";
+const char* const SYSTEM_SERIAL_NUMBER_HAL_ERROR =
+    "ERR302:system:HAL error, busy, or timeout\n";
+const char* const SYSTEM_EEPROM_ERROR =
+    "ERR303:system:EEPROM communication error\n";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
@@ -25,6 +31,9 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(UNHANDLED_GCODE);
         HANDLE_CASE(GCODE_CACHE_FULL);
         HANDLE_CASE(BAD_MESSAGE_ACKNOWLEDGEMENT);
+        HANDLE_CASE(SYSTEM_SERIAL_NUMBER_INVALID);
+        HANDLE_CASE(SYSTEM_SERIAL_NUMBER_HAL_ERROR);
+        HANDLE_CASE(SYSTEM_EEPROM_ERROR);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/include/flex-stacker/firmware/firmware_tasks.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/firmware_tasks.hpp
@@ -18,6 +18,9 @@ constexpr uint8_t HOST_TASK_PRIORITY = 1;
 constexpr size_t SYSTEM_STACK_SIZE = 256;
 constexpr uint8_t SYSTEM_TASK_PRIORITY = 1;
 
+constexpr size_t COMMS_STACK_SIZE = 256;
+constexpr uint8_t COMMS_TASK_PRIORITY = 1;
+
 constexpr size_t MOTOR_STACK_SIZE = 256;
 constexpr uint8_t MOTOR_TASK_PRIORITY = 1;
 

--- a/stm32-modules/include/flex-stacker/firmware/freertos_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/freertos_comms_task.hpp
@@ -1,0 +1,15 @@
+/*
+ * Interface for the firmware-specifc parts of the host comms task
+ */
+#pragma once
+
+#include "FreeRTOS.h"
+#include "firmware/firmware_tasks.hpp"
+#include "firmware/freertos_message_queue.hpp"
+#include "task.h"
+
+namespace host_comms_control_task {
+
+// Actual function that runs in the task
+auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void;
+}  // namespace host_comms_control_task

--- a/stm32-modules/include/flex-stacker/firmware/freertos_tasks.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/freertos_tasks.hpp
@@ -24,3 +24,8 @@ namespace ui_control_task {
 // Actual function that runs in the task
 auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void;
 }  // namespace ui_control_task
+
+namespace host_comms_control_task {
+// Actual function that runs in the task
+auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void;
+}  // namespace host_comms_control_task

--- a/stm32-modules/include/flex-stacker/flex-stacker/errors.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/errors.hpp
@@ -31,7 +31,6 @@ constexpr auto write_into(Input start, Limit end, ErrorCode code) -> Input {
     return write_string_to_iterpair(start, end, str);
 }
 
-
 template <typename Input, typename Limit>
 requires std::forward_iterator<Input> && std::sized_sentinel_for<Limit, Input>
 constexpr auto write_into_async(Input start, Limit end, ErrorCode code)

--- a/stm32-modules/include/flex-stacker/flex-stacker/errors.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/errors.hpp
@@ -14,6 +14,10 @@ enum class ErrorCode {
     UNHANDLED_GCODE = 3,
     GCODE_CACHE_FULL = 4,
     BAD_MESSAGE_ACKNOWLEDGEMENT = 5,
+    // 3xx - System General
+    SYSTEM_SERIAL_NUMBER_INVALID = 301,
+    SYSTEM_SERIAL_NUMBER_HAL_ERROR = 302,
+    SYSTEM_EEPROM_ERROR = 303,
 };
 
 auto errorstring(ErrorCode code) -> const char*;
@@ -23,5 +27,17 @@ requires std::forward_iterator<Input> && std::sized_sentinel_for<Limit, Input>
 constexpr auto write_into(Input start, Limit end, ErrorCode code) -> Input {
     const char* str = errorstring(code);
     return write_string_to_iterpair(start, end, str);
+}
+
+
+template <typename Input, typename Limit>
+requires std::forward_iterator<Input> && std::sized_sentinel_for<Limit, Input>
+constexpr auto write_into_async(Input start, Limit end, ErrorCode code)
+    -> Input {
+    constexpr const char* prefix = "async ";
+    auto next = write_string_to_iterpair(start, end, prefix);
+
+    const char* error_str = errorstring(code);
+    return write_string_to_iterpair(next, end, error_str);
 }
 };  // namespace errors

--- a/stm32-modules/include/flex-stacker/flex-stacker/errors.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/errors.hpp
@@ -18,6 +18,8 @@ enum class ErrorCode {
     SYSTEM_SERIAL_NUMBER_INVALID = 301,
     SYSTEM_SERIAL_NUMBER_HAL_ERROR = 302,
     SYSTEM_EEPROM_ERROR = 303,
+    // 9xx - TMC2160
+    TMC2160_READ_ERROR = 901,
 };
 
 auto errorstring(ErrorCode code) -> const char*;

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
@@ -1,0 +1,237 @@
+/*
+** Definitions of valid gcodes understood by the flex-stacker; intended to work
+*with
+** the gcode parser in gcode_parser.hpp
+*/
+
+#pragma once
+
+#include <printf.h>  // Non-malloc printf
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <concepts>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+#include <optional>
+#include <utility>
+
+#include "core/gcode_parser.hpp"
+#include "core/utility.hpp"
+#include "systemwide.h"
+#include "flex-stacker/errors.hpp"
+
+namespace gcode {
+
+struct EnterBootloader {
+    /**
+     * EnterBootloader uses the command string "dfu" instead of a gcode to be
+     * more like other modules. There are no arguments and in the happy path
+     * there is no response (because we reboot into the bootloader).
+     * */
+    using ParseResult = std::optional<EnterBootloader>;
+    static constexpr auto prefix = std::array{'d', 'f', 'u'};
+    static constexpr const char* response = "dfu OK\n";
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(EnterBootloader()), working);
+    }
+};
+
+struct GetSystemInfo {
+    /**
+     * GetSystemInfo keys off gcode M115 and returns hardware and
+     * software versions and serial number
+     * */
+    using ParseResult = std::optional<GetSystemInfo>;
+    static constexpr auto prefix = std::array{'M', '1', '1', '5'};
+    static constexpr std::size_t SERIAL_NUMBER_LENGTH =
+        SYSTEM_WIDE_SERIAL_NUMBER_LENGTH;
+    // If no SN is provided, this is the default rather than an empty string
+    static constexpr const char* DEFAULT_SN = "EMPTYSN";
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(
+        InputIt write_to_buf, InLimit write_to_limit,
+        std::array<char, SERIAL_NUMBER_LENGTH> serial_number,
+        const char* fw_version, const char* hw_version) -> InputIt {
+        static constexpr const char* prefix = "M115 FW:";
+        auto written =
+            write_string_to_iterpair(write_to_buf, write_to_limit, prefix);
+        if (written == write_to_limit) {
+            return written;
+        }
+        written = write_string_to_iterpair(written, write_to_limit, fw_version);
+        if (written == write_to_limit) {
+            return written;
+        }
+        static constexpr const char* hw_prefix = " HW:";
+        written = write_string_to_iterpair(written, write_to_limit, hw_prefix);
+        if (written == write_to_limit) {
+            return written;
+        }
+        written = write_string_to_iterpair(written, write_to_limit, hw_version);
+        if (written == write_to_limit) {
+            return written;
+        }
+        static constexpr const char* sn_prefix = " SerialNo:";
+        written = write_string_to_iterpair(written, write_to_limit, sn_prefix);
+        if (written == write_to_limit) {
+            return written;
+        }
+
+        // If the serial number is unwritten, it will contain 0xFF which is
+        // an illegal character that will confuse the host side. Replace the
+        // first instance of it with a null terminator for safety.
+        constexpr uint8_t invalid_ascii_mask = 0x80;
+        auto serial_len = strnlen(serial_number.begin(), serial_number.size());
+        auto invalid_char = std::find_if(
+            serial_number.begin(), serial_number.end(), [](auto c) {
+                return static_cast<uint8_t>(c) & invalid_ascii_mask;
+            });
+        if (invalid_char != serial_number.end()) {
+            serial_len = std::min(serial_len,
+                                  static_cast<size_t>(std::abs(std::distance(
+                                      serial_number.begin(), invalid_char))));
+        }
+
+        if (serial_len > 0) {
+            written =
+                copy_min_range(written, write_to_limit, serial_number.begin(),
+                               std::next(serial_number.begin(),
+                                         static_cast<signed int>(serial_len)));
+        } else {
+            written =
+                write_string_to_iterpair(written, write_to_limit, DEFAULT_SN);
+        }
+
+        if (written == write_to_limit) {
+            return written;
+        }
+        static constexpr const char* suffix = " OK\n";
+        return write_string_to_iterpair(written, write_to_limit, suffix);
+    }
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(GetSystemInfo()), working);
+    }
+};
+
+struct SetSerialNumber {
+    /*
+    ** Set Serial Number uses a random gcode, M996, adjacent to the firmware
+    *update gcode, 997
+    ** Format: M996 <SN>
+    ** Example: M996 HSM02071521A4 sets serial number to HSM02071521A4
+    */
+    using ParseResult = std::optional<SetSerialNumber>;
+    static constexpr auto prefix = std::array{'M', '9', '9', '6', ' '};
+    static constexpr const char* response = "M996 OK\n";
+    static constexpr std::size_t SERIAL_NUMBER_LENGTH =
+        SYSTEM_WIDE_SERIAL_NUMBER_LENGTH;
+    std::array<char, SERIAL_NUMBER_LENGTH> serial_number = {};
+    errors::ErrorCode with_error = errors::ErrorCode::NO_ERROR;
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    static auto write_response_into(InputIt buf, InputLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+
+        auto after = working;
+        bool found = false;
+        for (auto index = working; index != limit && (!found); index++) {
+            if (std::isspace(*index) || (*index == '\0')) {
+                after = index;
+                found = true;
+            }
+        }
+        if ((after != working) && (std::distance(working, after) <
+                                   static_cast<int>(SERIAL_NUMBER_LENGTH))) {
+            std::array<char, SERIAL_NUMBER_LENGTH> serial_number_res = {};
+            std::copy(working, after, serial_number_res.begin());
+            return std::make_pair(ParseResult(SetSerialNumber{
+                                      .serial_number = serial_number_res}),
+                                  after);
+        }
+        if (std::distance(working, after) >
+            static_cast<int>(SERIAL_NUMBER_LENGTH)) {
+            return std::make_pair(
+                ParseResult(SetSerialNumber{
+                    .with_error =
+                        errors::ErrorCode::SYSTEM_SERIAL_NUMBER_INVALID}),
+                input);
+        }
+        return std::make_pair(ParseResult(), input);
+    }
+};
+
+struct GetBoardRevision {
+    using ParseResult = std::optional<GetBoardRevision>;
+    static constexpr auto prefix = std::array{'M', '9', '0', '0', '.', 'D'};
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(GetBoardRevision()), working);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit, int revision)
+        -> InputIt {
+        int res = 0;
+        res = snprintf(&*buf, (limit - buf), "M900.D C:%i OK\n", revision);
+        if (res <= 0) {
+            return buf;
+        }
+        return buf + res;
+    }
+};
+
+}  // namespace gcode

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
@@ -22,6 +22,10 @@
 
 namespace gcode {
 
+auto motor_id_to_char(MotorID motor_id) -> const char* {
+    return (motor_id == MotorID::MOTOR_X ? "X" : motor_id == MotorID::MOTOR_Z ? "Z" : "L");
+}
+
 struct EnterBootloader {
     /**
      * EnterBootloader uses the command string "dfu" instead of a gcode to be
@@ -283,8 +287,7 @@ struct GetTMCRegister {
                                     MotorID motor_id, uint8_t reg,
                                     uint32_t data
     ) -> InputIt {
-        const char* hw_prefix = motor_id == MotorID::MOTOR_X ? "X" : motor_id == MotorID::MOTOR_Z ? "Z" : "L";
-        auto res = snprintf(&*buf, (limit - buf), "M920 %s%u %lu OK\n", hw_prefix, reg, data);
+        auto res = snprintf(&*buf, (limit - buf), "M920 %s%u %lu OK\n", motor_id_to_char(motor_id), reg, data);
         if (res <= 0) {
             return buf;
         }

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -263,7 +263,7 @@ class HostCommsTask {
                         errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
                 } else {
                     return cache_element.write_response_into(
-                        tx_into, tx_limit);
+                        tx_into, tx_limit, response.motor_id, response.reg, response.data);
                 }
             },
             cache_entry);

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -118,11 +118,15 @@ struct GetMotorDriverRegisterResponse {
     uint8_t reg;
     uint32_t data;
 };
-
+/*
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
                    GetMotorDriverRegisterResponse>;
+*/
+using HostCommsMessage =
+    ::std::variant<std::monostate, IncomingMessageFromHost>;
+
 using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,
                    SetSerialNumberMessage, EnterBootloaderMessage>;

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -118,14 +118,11 @@ struct GetMotorDriverRegisterResponse {
     uint8_t reg;
     uint32_t data;
 };
-/*
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
                    GetMotorDriverRegisterResponse>;
-*/
-using HostCommsMessage =
-    ::std::variant<std::monostate, IncomingMessageFromHost>;
 
 using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -129,9 +129,8 @@ using SystemMessage =
                    SetSerialNumberMessage, EnterBootloaderMessage>;
 
 using MotorDriverMessage =
-    ::std::variant<std::monostate, SetTMCRegisterMessage,
-                   GetTMCRegisterMessage, PollTMCRegisterMessage,
-                   StopPollTMCRegisterMessage>;
+    ::std::variant<std::monostate, SetTMCRegisterMessage, GetTMCRegisterMessage,
+                   PollTMCRegisterMessage, StopPollTMCRegisterMessage>;
 using MotorMessage = ::std::variant<std::monostate>;
 
 };  // namespace messages

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -89,30 +89,30 @@ struct ForceUSBDisconnect {
     size_t return_address;
 };
 
-struct SetMotorDriverRegister {
+struct SetTMCRegisterMessage {
     uint32_t id;
     MotorID motor_id;
     uint8_t reg;
     uint32_t data;
 };
 
-struct GetMotorDriverRegister {
+struct GetTMCRegisterMessage {
     uint32_t id;
     MotorID motor_id;
     uint8_t reg;
 };
 
-struct PollMotorDriverRegister {
+struct PollTMCRegisterMessage {
     uint32_t id;
     MotorID motor_id;
     uint8_t reg;
 };
 
-struct StopPollingMotorDriverRegister {
+struct StopPollTMCRegisterMessage {
     uint32_t id;
 };
 
-struct GetMotorDriverRegisterResponse {
+struct GetTMCRegisterResponse {
     uint32_t responding_to_id;
     MotorID motor_id;
     uint8_t reg;
@@ -122,16 +122,16 @@ struct GetMotorDriverRegisterResponse {
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
-                   GetMotorDriverRegisterResponse>;
+                   GetTMCRegisterResponse>;
 
 using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,
                    SetSerialNumberMessage, EnterBootloaderMessage>;
 
 using MotorDriverMessage =
-    ::std::variant<std::monostate, SetMotorDriverRegister,
-                   GetMotorDriverRegister, PollMotorDriverRegister,
-                   StopPollingMotorDriverRegister>;
+    ::std::variant<std::monostate, SetTMCRegisterMessage,
+                   GetTMCRegisterMessage, PollTMCRegisterMessage,
+                   StopPollTMCRegisterMessage>;
 using MotorMessage = ::std::variant<std::monostate>;
 
 };  // namespace messages

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -12,6 +12,7 @@
 #include "core/version.hpp"
 #include "firmware/motor_policy.hpp"
 #include "flex-stacker/messages.hpp"
+#include "flex-stacker/errors.hpp"
 #include "flex-stacker/tasks.hpp"
 #include "flex-stacker/tmc2160.hpp"
 #include "flex-stacker/tmc2160_interface.hpp"
@@ -131,8 +132,8 @@ class MotorDriverTask {
         if (!_task_registry) {
             return;
         }
+        auto tmc2160_interface = tmc2160::TMC2160Interface<Policy>(policy);
         if (!_initialized) {
-            static tmc2160::TMC2160Interface<Policy> tmc2160_interface(policy);
             if (!_tmc2160.initialize_config(motor_x_config, tmc2160_interface,
                                             MotorID::MOTOR_X)) {
                 return;
@@ -151,35 +152,58 @@ class MotorDriverTask {
         auto message = Message(std::monostate());
 
         _message_queue.recv(&message);
-        auto visit_helper = [this](auto& message) -> void {
-            this->visit_message(message);
+        auto visit_helper = [this, &tmc2160_interface](auto& message) -> void {
+            this->visit_message(message, tmc2160_interface);
         };
         std::visit(visit_helper, message);
     }
 
   private:
-    auto visit_message(const std::monostate& message) -> void {
-        static_cast<void>(message);
+    template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto visit_message(const std::monostate& m, tmc2160::TMC2160Interface<Policy>& tmc2160_interface) -> void {
+        static_cast<void>(m);
+        static_cast<void>(tmc2160_interface);
     }
 
-    auto visit_message(const messages::SetMotorDriverRegister& message)
+    template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto visit_message(const messages::SetTMCRegisterMessage& m, tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
-        static_cast<void>(message);
+        static_cast<void>(m);
+        static_cast<void>(tmc2160_interface);
     }
 
-    auto visit_message(const messages::GetMotorDriverRegister& message)
+    template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto visit_message(const messages::GetTMCRegisterMessage& m,  tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
-        static_cast<void>(message);
+        messages::HostCommsMessage response;
+        if (tmc2160::is_valid_address(m.reg)) {
+            auto data = tmc2160_interface.read(tmc2160::Registers(m.reg), m.motor_id);
+            if (!data.has_value()) {
+                response = messages::ErrorMessage{
+                    .code = errors::ErrorCode::TMC2160_READ_ERROR};
+            } else {
+                response = messages::GetTMCRegisterResponse{
+                    .responding_to_id = m.id,
+                    .motor_id = m.motor_id,
+                    .reg = m.reg,
+                    .data = data.value()};
+            }
+
+            static_cast<void>(
+                _task_registry->send_to_address(response, Queues::HostCommsAddress));
+        }
     }
 
-    auto visit_message(const messages::PollMotorDriverRegister& message)
+    template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto visit_message(const messages::PollTMCRegisterMessage& m, tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
-        static_cast<void>(message);
+        static_cast<void>(m);
     }
 
-    auto visit_message(const messages::StopPollingMotorDriverRegister& message)
+    template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto visit_message(const messages::StopPollTMCRegisterMessage& m, tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
-        static_cast<void>(message);
+        static_cast<void>(m);
     }
 
     Queue& _message_queue;

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -11,8 +11,8 @@
 #include "core/queue_aggregator.hpp"
 #include "core/version.hpp"
 #include "firmware/motor_policy.hpp"
-#include "flex-stacker/messages.hpp"
 #include "flex-stacker/errors.hpp"
+#include "flex-stacker/messages.hpp"
 #include "flex-stacker/tasks.hpp"
 #include "flex-stacker/tmc2160.hpp"
 #include "flex-stacker/tmc2160_interface.hpp"
@@ -160,50 +160,59 @@ class MotorDriverTask {
 
   private:
     template <tmc2160::TMC2160InterfacePolicy Policy>
-    auto visit_message(const std::monostate& m, tmc2160::TMC2160Interface<Policy>& tmc2160_interface) -> void {
-        static_cast<void>(m);
-        static_cast<void>(tmc2160_interface);
-    }
-
-    template <tmc2160::TMC2160InterfacePolicy Policy>
-    auto visit_message(const messages::SetTMCRegisterMessage& m, tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
+    auto visit_message(const std::monostate& m,
+                       tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
         static_cast<void>(m);
         static_cast<void>(tmc2160_interface);
     }
 
     template <tmc2160::TMC2160InterfacePolicy Policy>
-    auto visit_message(const messages::GetTMCRegisterMessage& m,  tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
+    auto visit_message(const messages::SetTMCRegisterMessage& m,
+                       tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
+        -> void {
+        static_cast<void>(m);
+        static_cast<void>(tmc2160_interface);
+    }
+
+    template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto visit_message(const messages::GetTMCRegisterMessage& m,
+                       tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
         messages::HostCommsMessage response;
         if (tmc2160::is_valid_address(m.reg)) {
-            auto data = tmc2160_interface.read(tmc2160::Registers(m.reg), m.motor_id);
+            auto data =
+                tmc2160_interface.read(tmc2160::Registers(m.reg), m.motor_id);
             if (!data.has_value()) {
                 response = messages::ErrorMessage{
                     .code = errors::ErrorCode::TMC2160_READ_ERROR};
             } else {
-                response = messages::GetTMCRegisterResponse{
-                    .responding_to_id = m.id,
-                    .motor_id = m.motor_id,
-                    .reg = m.reg,
-                    .data = data.value()};
+                response =
+                    messages::GetTMCRegisterResponse{.responding_to_id = m.id,
+                                                     .motor_id = m.motor_id,
+                                                     .reg = m.reg,
+                                                     .data = data.value()};
             }
 
-            static_cast<void>(
-                _task_registry->send_to_address(response, Queues::HostCommsAddress));
+            static_cast<void>(_task_registry->send_to_address(
+                response, Queues::HostCommsAddress));
         }
     }
 
     template <tmc2160::TMC2160InterfacePolicy Policy>
-    auto visit_message(const messages::PollTMCRegisterMessage& m, tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
+    auto visit_message(const messages::PollTMCRegisterMessage& m,
+                       tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
         static_cast<void>(m);
+        static_cast<void>(tmc2160_interface);
     }
 
     template <tmc2160::TMC2160InterfacePolicy Policy>
-    auto visit_message(const messages::StopPollTMCRegisterMessage& m, tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
+    auto visit_message(const messages::StopPollTMCRegisterMessage& m,
+                       tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
         static_cast<void>(m);
+        static_cast<void>(tmc2160_interface);
     }
 
     Queue& _message_queue;

--- a/stm32-modules/include/flex-stacker/flex-stacker/tasks.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tasks.hpp
@@ -15,16 +15,19 @@ struct Tasks {
     using MotorDriverQueue = QueueImpl<messages::MotorDriverMessage>;
     // Message queue for motor control task
     using MotorQueue = QueueImpl<messages::MotorMessage>;
-
+    using HostCommsQueue = QueueImpl<messages::HostCommsMessage>;
     // Central aggregator
     using QueueAggregator =
-        queue_aggregator::QueueAggregator<MotorDriverQueue, MotorQueue>;
+        queue_aggregator::QueueAggregator<MotorDriverQueue, MotorQueue,
+                                          HostCommsQueue>;
 
     // Addresses
     static constexpr size_t MotorDriverAddress =
         QueueAggregator::template get_queue_idx<MotorDriverQueue>();
     static constexpr size_t MotorAddress =
         QueueAggregator::template get_queue_idx<MotorQueue>();
+    static constexpr size_t HostCommsAddress =
+        QueueAggregator::template get_queue_idx<HostCommsQueue>();
 };
 
 };  // namespace tasks


### PR DESCRIPTION
This PR sets up the host comms task for the stacker. You can now send a GCode to read from a register of one of the motor drivers. 
```
Tx ==> M920 X0
Rx <== M920 X0 1 OK
```

, where X is the axis [X | Z | L] and 0 is the register address in decimal and 1 is the data read from the register (decimal).

closes PLAT-427