### PR TITLE
feat(flex-stacker): add motor interrupt handlers

### DIFF
--- a/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_task.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_task.cpp
@@ -12,13 +12,16 @@ namespace motor_control_task {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto x_motor_interrupt =
-    motor_interrupt_controller::MotorInterruptController(MotorID::MOTOR_X);
+    motor_interrupt_controller::MotorInterruptController(MotorID::MOTOR_X,
+                                                         nullptr);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto z_motor_interrupt =
-    motor_interrupt_controller::MotorInterruptController(MotorID::MOTOR_Z);
+    motor_interrupt_controller::MotorInterruptController(MotorID::MOTOR_Z,
+                                                         nullptr);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto l_motor_interrupt =
-    motor_interrupt_controller::MotorInterruptController(MotorID::MOTOR_L);
+    motor_interrupt_controller::MotorInterruptController(MotorID::MOTOR_L,
+                                                         nullptr);
 
 enum class Notifications : uint8_t {
     INCOMING_MESSAGE = 1,

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_policy.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_policy.cpp
@@ -16,3 +16,8 @@ auto MotorPolicy::disable_motor(MotorID motor_id) -> bool {
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto MotorPolicy::step(MotorID motor_id) -> void { step_motor(motor_id); }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto MotorPolicy::set_direction(MotorID motor_id, bool direction) -> void {
+    hw_set_direction(motor_id, direction);
+}

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_policy.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_policy.cpp
@@ -15,9 +15,14 @@ auto MotorPolicy::disable_motor(MotorID motor_id) -> bool {
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-auto MotorPolicy::step(MotorID motor_id) -> void { step_motor(motor_id); }
+auto MotorPolicy::step(MotorID motor_id) -> void { hw_step_motor(motor_id); }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto MotorPolicy::set_direction(MotorID motor_id, bool direction) -> void {
     hw_set_direction(motor_id, direction);
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto MotorPolicy::check_limit_switch(MotorID motor_id, bool direction) -> bool {
+    return hw_read_limit_switch(motor_id, direction);
 }

--- a/stm32-modules/flex-stacker/src/CMakeLists.txt
+++ b/stm32-modules/flex-stacker/src/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 # Configure lintable/nonlintable sources here
 set(CORE_LINTABLE_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/errors.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/motor_utils.cpp
         )
 set(CORE_LINTABLE_SOURCES
         ${CORE_LINTABLE_SOURCES}

--- a/stm32-modules/flex-stacker/src/motor_utils.cpp
+++ b/stm32-modules/flex-stacker/src/motor_utils.cpp
@@ -75,3 +75,8 @@ auto MovementProfile::tick() -> TickReturn {
 [[nodiscard]] auto MovementProfile::current_distance() const -> ticks {
     return _current_distance;
 }
+
+/** Returns the movement type.*/
+[[nodiscard]] auto MovementProfile::movement_type() const -> MovementType {
+    return _type;
+}

--- a/stm32-modules/include/common/core/linear_motion_system.hpp
+++ b/stm32-modules/include/common/core/linear_motion_system.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <concepts>
+#include <numbers>
+
+namespace lms {
+
+struct BeltConfig {
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    float pulley_diameter;  // mm
+    [[nodiscard]] constexpr auto get_mm_per_rev() const -> float {
+        return static_cast<float>(pulley_diameter * std::numbers::pi);
+    }
+};
+
+struct LeadScrewConfig {
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    float lead_screw_pitch;      // mm/rev
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    float gear_reduction_ratio;  // large teeth / small teeth
+    [[nodiscard]] constexpr auto get_mm_per_rev() const -> float {
+        return lead_screw_pitch / gear_reduction_ratio;
+    }
+};
+
+struct GearBoxConfig {
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    float gear_diameter;         // mm
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    float gear_reduction_ratio;  // large teeth / small teeth
+    [[nodiscard]] constexpr auto get_mm_per_rev() const -> float {
+        return static_cast<float>((gear_diameter * std::numbers::pi) /
+                                  gear_reduction_ratio);
+    }
+};
+
+template <typename MC>
+concept MotorMechanicalConfig = requires {
+                                    std::is_same_v<MC, BeltConfig> || std::is_same_v<MC, LeadScrewConfig> ||
+                                        std::is_same_v<MC, GearBoxConfig>;
+                                };
+
+template <MotorMechanicalConfig MEConfig>
+struct LinearMotionSystemConfig {
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    MEConfig mech_config{};
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    float steps_per_rev{};
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    float microstep{};
+    [[nodiscard]] constexpr auto get_usteps_per_mm() const -> float {
+        return (steps_per_rev * microstep) / (mech_config.get_mm_per_rev());
+    }
+    [[nodiscard]] constexpr auto get_usteps_per_um() const -> float {
+        return (steps_per_rev * microstep) /
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+               (mech_config.get_mm_per_rev() * 1000.0);
+    }
+    [[nodiscard]] constexpr auto get_um_per_step() const -> float {
+        return (mech_config.get_mm_per_rev()) / (steps_per_rev * microstep) *
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+               1000;
+    }
+};
+
+}  // namespace lms

--- a/stm32-modules/include/common/core/linear_motion_system.hpp
+++ b/stm32-modules/include/common/core/linear_motion_system.hpp
@@ -15,7 +15,7 @@ struct BeltConfig {
 
 struct LeadScrewConfig {
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-    float lead_screw_pitch;      // mm/rev
+    float lead_screw_pitch;  // mm/rev
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     float gear_reduction_ratio;  // large teeth / small teeth
     [[nodiscard]] constexpr auto get_mm_per_rev() const -> float {
@@ -25,7 +25,7 @@ struct LeadScrewConfig {
 
 struct GearBoxConfig {
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-    float gear_diameter;         // mm
+    float gear_diameter;  // mm
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     float gear_reduction_ratio;  // large teeth / small teeth
     [[nodiscard]] constexpr auto get_mm_per_rev() const -> float {
@@ -36,9 +36,9 @@ struct GearBoxConfig {
 
 template <typename MC>
 concept MotorMechanicalConfig = requires {
-                                    std::is_same_v<MC, BeltConfig> || std::is_same_v<MC, LeadScrewConfig> ||
-                                        std::is_same_v<MC, GearBoxConfig>;
-                                };
+    std::is_same_v<MC, BeltConfig> || std::is_same_v<MC, LeadScrewConfig> ||
+        std::is_same_v<MC, GearBoxConfig>;
+};
 
 template <MotorMechanicalConfig MEConfig>
 struct LinearMotionSystemConfig {
@@ -53,12 +53,12 @@ struct LinearMotionSystemConfig {
     }
     [[nodiscard]] constexpr auto get_usteps_per_um() const -> float {
         return (steps_per_rev * microstep) /
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+               // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
                (mech_config.get_mm_per_rev() * 1000.0);
     }
     [[nodiscard]] constexpr auto get_um_per_step() const -> float {
         return (mech_config.get_mm_per_rev()) / (steps_per_rev * microstep) *
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+               // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
                1000;
     }
 };

--- a/stm32-modules/include/flex-stacker/firmware/motor_hardware.h
+++ b/stm32-modules/include/flex-stacker/firmware/motor_hardware.h
@@ -15,10 +15,11 @@ void spi_hardware_init(void);
 bool motor_spi_sendreceive(MotorID motor_id, uint8_t *tx_data, uint8_t *rx_data,
                            uint16_t len);
 
-void step_motor(MotorID motor_id);
+void hw_step_motor(MotorID motor_id);
 bool hw_enable_motor(MotorID motor_id);
 bool hw_disable_motor(MotorID motor_id);
 void hw_set_direction(MotorID, bool direction);
+bool hw_read_limit_switch(MotorID motor_id, bool direction);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <atomic>
 
 #include "firmware/motor_hardware.h"
 #include "firmware/motor_policy.hpp"
@@ -17,19 +18,24 @@ static constexpr double DEFAULT_ACCEL = 50000;     // steps per second^2
 
 class MotorInterruptController {
   public:
-    MotorInterruptController(MotorID id, MotorPolicy* policy)
+    explicit MotorInterruptController(MotorID id, MotorPolicy* policy)
         : _id(id),
           _policy(policy),
           _initialized(false),
           _profile(TIMER_FREQ, 0, 0, 0, motor_util::MovementType::OpenLoop, 0) {
     }
+    MotorInterruptController(MotorInterruptController const&) = delete;
+    void operator=(MotorInterruptController const&) = delete;
+    MotorInterruptController(MotorInterruptController const&&) = delete;
+    void operator=(MotorInterruptController const&&) = delete;
+    ~MotorInterruptController() = default;
 
     auto tick() -> bool {
         if (!_initialized) {
             return false;
         }
         auto ret = _profile.tick();
-        if (ret.step) {
+        if (ret.step && !stop_condition_met()) {
             _policy->step(_id);
         }
         if (ret.done) {
@@ -38,7 +44,10 @@ class MotorInterruptController {
         return ret.done;
     }
     auto set_freq(uint32_t freq) -> void { step_freq = freq; }
-    auto initialize(MotorPolicy* policy) -> void { _policy = policy; }
+    auto initialize(MotorPolicy* policy) -> void {
+        _policy = policy;
+        _initialized = true;
+    }
     auto start_movement(uint32_t id, long steps, uint32_t frequency) -> void {
         _profile = motor_util::MovementProfile(
             TIMER_FREQ, 0, frequency, 0,
@@ -48,20 +57,30 @@ class MotorInterruptController {
     }
     auto set_direction(bool direction) -> void {
         _policy->set_direction(_id, direction);
+        _direction = direction;
     }
-
+    auto limit_switch_triggered() -> bool {
+        return _policy->check_limit_switch(_id, _direction);
+    }
     [[nodiscard]] auto get_response_id() const -> uint32_t {
         return _response_id;
+    }
+    auto stop_condition_met() -> bool {
+        if (_profile.movement_type() == motor_util::MovementType::OpenLoop) {
+            return limit_switch_triggered();
+        }
+        return false;
     }
 
   private:
     MotorID _id;
     MotorPolicy* _policy;
-    bool _initialized;
+    std::atomic_bool _initialized;
     motor_util::MovementProfile _profile;
     uint32_t step_count = 0;
     uint32_t step_freq = DEFAULT_MOTOR_FREQ;
     uint32_t _response_id = 0;
+    bool _direction = false;
 };
 
 }  // namespace motor_interrupt_controller

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -1,26 +1,35 @@
 #pragma once
 
 #include "firmware/motor_hardware.h"
+#include "firmware/motor_policy.hpp"
 #include "systemwide.h"
 
 namespace motor_interrupt_controller {
+
+using MotorPolicy = motor_policy::MotorPolicy;
 
 static constexpr int TIMER_FREQ = 100000;
 static constexpr int DEFAULT_MOTOR_FREQ = 50;
 
 class MotorInterruptController {
   public:
-    MotorInterruptController(MotorID m_id) : m_id(m_id) {}
+    MotorInterruptController(MotorID id, MotorPolicy* policy)
+        : _id(id), _policy(policy), _initialized(false) {}
     auto tick() -> void {
         step_count = (step_count + 1) % (TIMER_FREQ / step_freq);
         if (step_count == 0) {
-            step_motor(m_id);
+            _policy->step(_id);
         }
     }
     auto set_freq(uint32_t freq) -> void { step_freq = freq; }
+    auto initialize(MotorPolicy* policy) -> void {
+        _policy = policy;
+    }
 
   private:
-    MotorID m_id;
+    MotorID _id;
+    MotorPolicy* _policy;
+    bool _initialized;
     uint32_t step_count = 0;
     uint32_t step_freq = DEFAULT_MOTOR_FREQ;
 };

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -2,6 +2,7 @@
 
 #include "firmware/motor_hardware.h"
 #include "firmware/motor_policy.hpp"
+#include "flex-stacker/motor_utils.hpp"
 #include "systemwide.h"
 
 namespace motor_interrupt_controller {
@@ -10,11 +11,18 @@ using MotorPolicy = motor_policy::MotorPolicy;
 
 static constexpr int TIMER_FREQ = 100000;
 static constexpr int DEFAULT_MOTOR_FREQ = 50;
+static constexpr double DEFAULT_VELOCITY = 200000;
+static constexpr double DEFAULT_ACCEL = 50000;
 
 class MotorInterruptController {
   public:
     MotorInterruptController(MotorID id, MotorPolicy* policy)
-        : _id(id), _policy(policy), _initialized(false) {}
+        : _id(id),
+          _policy(policy),
+          _initialized(false),
+          _profile(TIMER_FREQ, 0, DEFAULT_VELOCITY, DEFAULT_ACCEL,
+                   motor_util::MovementType::OpenLoop, 0) {}
+
     auto tick() -> void {
         step_count = (step_count + 1) % (TIMER_FREQ / step_freq);
         if (step_count == 0) {
@@ -22,14 +30,13 @@ class MotorInterruptController {
         }
     }
     auto set_freq(uint32_t freq) -> void { step_freq = freq; }
-    auto initialize(MotorPolicy* policy) -> void {
-        _policy = policy;
-    }
+    auto initialize(MotorPolicy* policy) -> void { _policy = policy; }
 
   private:
     MotorID _id;
     MotorPolicy* _policy;
     bool _initialized;
+    motor_util::MovementProfile _profile;
     uint32_t step_count = 0;
     uint32_t step_freq = DEFAULT_MOTOR_FREQ;
 };

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -48,12 +48,14 @@ class MotorInterruptController {
         _policy = policy;
         _initialized = true;
     }
-    auto start_movement(uint32_t id, long steps, uint32_t frequency) -> void {
+    auto start_movement(uint32_t move_id, bool direction, long steps,
+                        uint32_t frequency) -> void {
+        set_direction(direction);
         _profile = motor_util::MovementProfile(
             TIMER_FREQ, 0, frequency, 0,
             motor_util::MovementType::FixedDistance, steps);
         _policy->enable_motor(_id);
-        _response_id = id;
+        _response_id = move_id;
     }
     auto set_direction(bool direction) -> void {
         _policy->set_direction(_id, direction);

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -11,8 +11,9 @@ using MotorPolicy = motor_policy::MotorPolicy;
 
 static constexpr int TIMER_FREQ = 100000;
 static constexpr int DEFAULT_MOTOR_FREQ = 50;
-static constexpr double DEFAULT_VELOCITY = 200000;
-static constexpr double DEFAULT_ACCEL = 50000;
+
+static constexpr double DEFAULT_VELOCITY = 64000;  // steps per second
+static constexpr double DEFAULT_ACCEL = 50000;     // steps per second^2
 
 class MotorInterruptController {
   public:
@@ -20,17 +21,38 @@ class MotorInterruptController {
         : _id(id),
           _policy(policy),
           _initialized(false),
-          _profile(TIMER_FREQ, 0, DEFAULT_VELOCITY, DEFAULT_ACCEL,
-                   motor_util::MovementType::OpenLoop, 0) {}
+          _profile(TIMER_FREQ, 0, 0, 0, motor_util::MovementType::OpenLoop, 0) {
+    }
 
-    auto tick() -> void {
-        step_count = (step_count + 1) % (TIMER_FREQ / step_freq);
-        if (step_count == 0) {
+    auto tick() -> bool {
+        if (!_initialized) {
+            return false;
+        }
+        auto ret = _profile.tick();
+        if (ret.step) {
             _policy->step(_id);
         }
+        if (ret.done) {
+            _policy->disable_motor(_id);
+        }
+        return ret.done;
     }
     auto set_freq(uint32_t freq) -> void { step_freq = freq; }
     auto initialize(MotorPolicy* policy) -> void { _policy = policy; }
+    auto start_movement(uint32_t id, long steps, uint32_t frequency) -> void {
+        _profile = motor_util::MovementProfile(
+            TIMER_FREQ, 0, frequency, 0,
+            motor_util::MovementType::FixedDistance, steps);
+        _policy->enable_motor(_id);
+        _response_id = id;
+    }
+    auto set_direction(bool direction) -> void {
+        _policy->set_direction(_id, direction);
+    }
+
+    [[nodiscard]] auto get_response_id() const -> uint32_t {
+        return _response_id;
+    }
 
   private:
     MotorID _id;
@@ -39,6 +61,7 @@ class MotorInterruptController {
     motor_util::MovementProfile _profile;
     uint32_t step_count = 0;
     uint32_t step_freq = DEFAULT_MOTOR_FREQ;
+    uint32_t _response_id = 0;
 };
 
 }  // namespace motor_interrupt_controller

--- a/stm32-modules/include/flex-stacker/firmware/motor_policy.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_policy.hpp
@@ -12,6 +12,7 @@ class MotorPolicy {
     auto disable_motor(MotorID motor_id) -> bool;
     auto step(MotorID motor_id) -> void;
     auto set_direction(MotorID motor_id, bool direction) -> void;
+    auto check_limit_switch(MotorID motor_id, bool direction) -> bool;
 };
 
 }  // namespace motor_policy

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -134,6 +134,10 @@ struct MoveMotorAtFrequencyMessage {
     uint32_t frequency;
 };
 
+struct MoveCompleteMessage {
+    MotorID motor_id;
+};
+
 struct StopMotorMessage {
     uint32_t id;
 };
@@ -151,8 +155,8 @@ using MotorDriverMessage =
     ::std::variant<std::monostate, SetTMCRegisterMessage, GetTMCRegisterMessage,
                    PollTMCRegisterMessage, StopPollTMCRegisterMessage>;
 
-using MotorMessage =
-    ::std::variant<std::monostate, MotorEnableMessage,
-                   MoveMotorAtFrequencyMessage, StopMotorMessage>;
+using MotorMessage = ::std::variant<std::monostate, MotorEnableMessage,
+                                    MoveMotorAtFrequencyMessage,
+                                    StopMotorMessage, MoveCompleteMessage>;
 
 };  // namespace messages

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -144,9 +144,10 @@ class MotorTask {
     auto visit_message(const messages::MoveMotorAtFrequencyMessage& m,
                        Policy& policy) -> void {
         static_cast<void>(policy);
-//        auto controller = controller_from_id(m.motor_id);
+        //        auto controller = controller_from_id(m.motor_id);
         controller_from_id(m.motor_id).set_direction(m.direction);
-        controller_from_id(m.motor_id).start_movement(m.id, m.steps, m.frequency);
+        controller_from_id(m.motor_id)
+            .start_movement(m.id, m.steps, m.frequency);
     }
 
     template <MotorControlPolicy Policy>
@@ -161,7 +162,8 @@ class MotorTask {
         -> void {
         static_cast<void>(policy);
         auto response = messages::AcknowledgePrevious{
-            .responding_to_id = controller_from_id(m.motor_id).get_response_id()};
+            .responding_to_id =
+                controller_from_id(m.motor_id).get_response_id()};
         static_cast<void>(_task_registry->send_to_address(
             response, Queues::HostCommsAddress));
     }

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -144,9 +144,8 @@ class MotorTask {
     auto visit_message(const messages::MoveMotorAtFrequencyMessage& m,
                        Policy& policy) -> void {
         static_cast<void>(policy);
-        controller_from_id(m.motor_id).set_direction(m.direction);
         controller_from_id(m.motor_id)
-            .start_movement(m.id, m.steps, m.frequency);
+            .start_movement(m.id, m.direction, m.steps, m.frequency);
     }
 
     template <MotorControlPolicy Policy>

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -144,9 +144,9 @@ class MotorTask {
     auto visit_message(const messages::MoveMotorAtFrequencyMessage& m,
                        Policy& policy) -> void {
         static_cast<void>(policy);
-        auto controller = controller_from_id(m.motor_id);
-        controller.set_direction(m.direction);
-        controller.start_movement(m.id, m.steps, m.frequency);
+//        auto controller = controller_from_id(m.motor_id);
+        controller_from_id(m.motor_id).set_direction(m.direction);
+        controller_from_id(m.motor_id).start_movement(m.id, m.steps, m.frequency);
     }
 
     template <MotorControlPolicy Policy>
@@ -160,9 +160,8 @@ class MotorTask {
     auto visit_message(const messages::MoveCompleteMessage& m, Policy& policy)
         -> void {
         static_cast<void>(policy);
-        auto controller = controller_from_id(m.motor_id);
         auto response = messages::AcknowledgePrevious{
-            .responding_to_id = controller.get_response_id()};
+            .responding_to_id = controller_from_id(m.motor_id).get_response_id()};
         static_cast<void>(_task_registry->send_to_address(
             response, Queues::HostCommsAddress));
     }

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "core/ack_cache.hpp"
+#include "core/linear_motion_system.hpp"
 #include "core/queue_aggregator.hpp"
 #include "core/version.hpp"
 #include "firmware/motor_interrupt.hpp"
@@ -26,6 +27,25 @@ concept MotorControlPolicy = requires(P p, MotorID motor_id) {
 
 using Message = messages::MotorMessage;
 using Controller = motor_interrupt_controller::MotorInterruptController;
+
+static constexpr struct lms::LinearMotionSystemConfig<lms::LeadScrewConfig>
+    motor_x_config = {
+    .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 9.7536,
+                                        .gear_reduction_ratio = 1.0},
+    .steps_per_rev = 200, .microstep = 16,
+};
+static constexpr struct lms::LinearMotionSystemConfig<lms::LeadScrewConfig>
+    motor_z_config = {
+    .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 9.7536,
+                                        .gear_reduction_ratio = 1.0},
+    .steps_per_rev = 200, .microstep = 16,
+};
+static constexpr struct lms::LinearMotionSystemConfig<lms::GearBoxConfig>
+    motor_l_config = {
+    .mech_config = lms::GearBoxConfig{.gear_diameter = 16.0,
+                                      .gear_reduction_ratio = 16.0 / 30.0},
+    .steps_per_rev = 200, .microstep = 16,
+};
 
 template <template <class> class QueueImpl>
 requires MessageQueue<QueueImpl<Message>, Message>

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -144,7 +144,6 @@ class MotorTask {
     auto visit_message(const messages::MoveMotorAtFrequencyMessage& m,
                        Policy& policy) -> void {
         static_cast<void>(policy);
-        //        auto controller = controller_from_id(m.motor_id);
         controller_from_id(m.motor_id).set_direction(m.direction);
         controller_from_id(m.motor_id)
             .start_movement(m.id, m.steps, m.frequency);

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -82,6 +82,13 @@ class MotorTask {
 
         auto message = Message(std::monostate());
 
+        if (!_initialized) {
+            _x_controller.initialize(&policy);
+            _z_controller.initialize(&policy);
+            _l_controller.initialize(&policy);
+            _initialized = true;
+        }
+
         _message_queue.recv(&message);
         auto visit_helper = [this, &policy](auto& message) -> void {
             this->visit_message(message, policy);

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_utils.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_utils.hpp
@@ -91,6 +91,9 @@ class MovementProfile {
     /** Returns the number of ticks that have been taken.*/
     [[nodiscard]] auto current_distance() const -> ticks;
 
+    /** Returns the movement type.*/
+    [[nodiscard]] auto movement_type() const -> MovementType;
+
   private:
     uint32_t _ticks_per_second;           // Tick frequency
     steps_per_tick _velocity = 0;         // Current velocity


### PR DESCRIPTION
This PR implements Movement Profile in the motor interrupt handlers to allow the motors to move at specified frequency (microsteps/sec) and for a fixed distance (microsteps). 
