### PR TITLE
feat(flex-stacker): update gcode params for motion and current-control 

### DIFF
--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -54,21 +54,22 @@ class MotorInterruptController {
         _initialized = true;
     }
     auto start_fixed_movement(uint32_t move_id, bool direction, long steps,
+                              uint32_t steps_per_sec_discont,
                               uint32_t steps_per_sec, uint32_t step_per_sec_sq)
         -> void {
         set_direction(direction);
         _profile = motor_util::MovementProfile(
-            TIMER_FREQ, 0, steps_per_sec, step_per_sec_sq,
+            TIMER_FREQ, steps_per_sec_discont, steps_per_sec, step_per_sec_sq,
             motor_util::MovementType::FixedDistance, steps);
         _policy->enable_motor(_id);
         _response_id = move_id;
     }
     auto start_movement(uint32_t move_id, bool direction,
-                        uint32_t steps_per_sec, uint32_t step_per_sec_sq)
-        -> void {
+                        uint32_t steps_per_sec_discont, uint32_t steps_per_sec,
+                        uint32_t step_per_sec_sq) -> void {
         set_direction(direction);
         _profile = motor_util::MovementProfile(
-            TIMER_FREQ, 0, steps_per_sec, step_per_sec_sq,
+            TIMER_FREQ, steps_per_sec_discont, steps_per_sec, step_per_sec_sq,
             motor_util::MovementType::OpenLoop, 0);
         _policy->enable_motor(_id);
         _response_id = move_id;

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -174,7 +174,7 @@ struct ArgL {
 
 struct SetRunCurrent {
     MotorID motor_id;
-    float current;
+    uint32_t current;
 
     using ParseResult = std::optional<SetRunCurrent>;
     static constexpr auto prefix = std::array{'M', '9', '0', '6', ' '};
@@ -184,19 +184,19 @@ struct SetRunCurrent {
         static constexpr auto prefix = std::array{'X'};
         static constexpr bool required = false;
         bool present = false;
-        float value = 0;
+        uint32_t value = 0;
     };
     struct ZArg {
         static constexpr auto prefix = std::array{'Z'};
         static constexpr bool required = false;
         bool present = false;
-        float value = 0;
+        uint32_t value = 0;
     };
     struct LArg {
         static constexpr auto prefix = std::array{'L'};
         static constexpr bool required = false;
         bool present = false;
-        float value = 0;
+        uint32_t value = 0;
     };
 
     template <typename InputIt, typename Limit>
@@ -211,7 +211,7 @@ struct SetRunCurrent {
         }
         auto ret = SetRunCurrent{
             .motor_id = MotorID::MOTOR_X,
-            .current = 0.0,
+            .current = 0,
         };
 
         auto arguments = res.first.value();
@@ -239,7 +239,7 @@ struct SetRunCurrent {
 
 struct SetHoldCurrent {
     MotorID motor_id;
-    float current;
+    uint32_t current;
 
     using ParseResult = std::optional<SetHoldCurrent>;
     static constexpr auto prefix = std::array{'M', '9', '0', '7', ' '};
@@ -249,19 +249,19 @@ struct SetHoldCurrent {
         static constexpr auto prefix = std::array{'X'};
         static constexpr bool required = false;
         bool present = false;
-        float value = 0;
+        uint32_t value = 0;
     };
     struct ZArg {
         static constexpr auto prefix = std::array{'Z'};
         static constexpr bool required = false;
         bool present = false;
-        float value = 0;
+        uint32_t value = 0;
     };
     struct LArg {
         static constexpr auto prefix = std::array{'L'};
         static constexpr bool required = false;
         bool present = false;
-        float value = 0;
+        uint32_t value = 0;
     };
 
     template <typename InputIt, typename Limit>
@@ -276,7 +276,7 @@ struct SetHoldCurrent {
         }
         auto ret = SetHoldCurrent{
             .motor_id = MotorID::MOTOR_X,
-            .current = 0.0,
+            .current = 0,
         };
 
         auto arguments = res.first.value();

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -458,7 +458,8 @@ class HostCommsTask {
             .motor_id = gcode.motor_id,
             .mm = gcode.mm,
             .mm_per_second = gcode.mm_per_second,
-            .mm_per_second_sq = gcode.mm_per_second_sq};
+            .mm_per_second_sq = gcode.mm_per_second_sq,
+            .mm_per_second_discont = gcode.mm_per_second_discont};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
@@ -484,7 +485,8 @@ class HostCommsTask {
             .motor_id = gcode.motor_id,
             .direction = gcode.direction,
             .mm_per_second = gcode.mm_per_second,
-            .mm_per_second_sq = gcode.mm_per_second_sq};
+            .mm_per_second_sq = gcode.mm_per_second_sq,
+            .mm_per_second_discont = gcode.mm_per_second_discont};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -389,7 +389,7 @@ class HostCommsTask {
             messages::SetMotorCurrentMessage{.id = id,
                                              .motor_id = gcode.motor_id,
                                              .run_current = gcode.current,
-                                             .hold_current = 0.0};
+                                             .hold_current = 0};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
@@ -413,7 +413,7 @@ class HostCommsTask {
         auto message =
             messages::SetMotorCurrentMessage{.id = id,
                                              .motor_id = gcode.motor_id,
-                                             .run_current = 0.0,
+                                             .run_current = 0,
                                              .hold_current = gcode.current};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -92,8 +92,8 @@ struct ForceUSBDisconnect {
 struct SetMotorCurrentMessage {
     uint32_t id;
     MotorID motor_id;
-    float run_current;
-    float hold_current;
+    uint32_t run_current;
+    uint32_t hold_current;
 };
 
 struct SetTMCRegisterMessage {

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -89,6 +89,13 @@ struct ForceUSBDisconnect {
     size_t return_address;
 };
 
+struct SetMotorCurrentMessage {
+    uint32_t id;
+    MotorID motor_id;
+    float run_current;
+    float hold_current;
+};
+
 struct SetTMCRegisterMessage {
     uint32_t id;
     MotorID motor_id;
@@ -192,7 +199,8 @@ using SystemMessage =
 
 using MotorDriverMessage =
     ::std::variant<std::monostate, SetTMCRegisterMessage, GetTMCRegisterMessage,
-                   PollTMCRegisterMessage, StopPollTMCRegisterMessage>;
+                   PollTMCRegisterMessage, StopPollTMCRegisterMessage,
+                   SetMotorCurrentMessage>;
 
 using MotorMessage =
     ::std::variant<std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -140,6 +140,7 @@ struct MoveMotorInMmMessage {
     int32_t mm;
     uint32_t mm_per_second;
     uint32_t mm_per_second_sq;
+    uint32_t mm_per_second_discont;
 };
 
 struct MoveToLimitSwitchMessage {
@@ -148,6 +149,7 @@ struct MoveToLimitSwitchMessage {
     bool direction;
     uint32_t mm_per_second;
     uint32_t mm_per_second_sq;
+    uint32_t mm_per_second_discont;
 };
 
 struct GetLimitSwitchesMessage {

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -244,11 +244,11 @@ class MotorDriverTask {
                        tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
         auto response = messages::AcknowledgePrevious{.responding_to_id = m.id};
-        if (m.hold_current != 0.0) {
+        if (m.hold_current != 0) {
             driver_conf_from_id(m.motor_id).ihold_irun.hold_current =
                 get_current_value(m.motor_id, m.hold_current);
         };
-        if (m.run_current != 0.0) {
+        if (m.run_current != 0) {
             driver_conf_from_id(m.motor_id).ihold_irun.run_current =
                 get_current_value(m.motor_id, m.run_current);
         }

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "core/ack_cache.hpp"
+#include "core/fixed_point.hpp"
 #include "core/queue_aggregator.hpp"
 #include "core/version.hpp"
 #include "firmware/motor_policy.hpp"
@@ -127,6 +128,19 @@ class MotorDriverTask {
         _task_registry = aggregator;
     }
 
+    auto driver_conf_from_id(MotorID motor_id) -> tmc2160::TMC2160RegisterMap& {
+        switch (motor_id) {
+            case MotorID::MOTOR_X:
+                return _x_config;
+            case MotorID::MOTOR_Z:
+                return _z_config;
+            case MotorID::MOTOR_L:
+                return _l_config;
+            default:
+                return _x_config;
+        }
+    }
+
     template <tmc2160::TMC2160InterfacePolicy Policy>
     auto run_once(Policy& policy) -> void {
         if (!_task_registry) {
@@ -225,10 +239,45 @@ class MotorDriverTask {
         static_cast<void>(tmc2160_interface);
     }
 
+    template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto visit_message(const messages::SetMotorCurrentMessage& m,
+                       tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
+        -> void {
+        auto response = messages::AcknowledgePrevious{.responding_to_id = m.id};
+        if (m.hold_current != 0.0) {
+            driver_conf_from_id(m.motor_id).ihold_irun.hold_current =
+                get_current_value(m.motor_id, m.hold_current);
+        };
+        if (m.run_current != 0.0) {
+            driver_conf_from_id(m.motor_id).ihold_irun.run_current =
+                get_current_value(m.motor_id, m.run_current);
+        }
+        if (!_tmc2160.update_current(driver_conf_from_id(m.motor_id),
+                                     tmc2160_interface, m.motor_id)) {
+            response.with_error = errors::ErrorCode::TMC2160_WRITE_ERROR;
+        };
+        static_cast<void>(_task_registry->send_to_address(
+            response, Queues::HostCommsAddress));
+    }
+
+    auto get_current_value(MotorID motor_id, float current) -> uint32_t {
+        return _tmc2160.convert_peak_current_to_tmc2160_value(
+            current, driver_conf_from_id(motor_id).glob_scale,
+            _motor_current_config);
+    }
+
     Queue& _message_queue;
     Aggregator* _task_registry;
     bool _initialized;
 
     tmc2160::TMC2160 _tmc2160{};
+    // same motor current config for all three motors
+    const tmc2160::TMC2160MotorCurrentConfig _motor_current_config{
+        .r_sense = 0.22,
+        .v_sf = 0.325,
+    };
+    tmc2160::TMC2160RegisterMap _x_config = motor_x_config;
+    tmc2160::TMC2160RegisterMap _z_config = motor_z_config;
+    tmc2160::TMC2160RegisterMap _l_config = motor_l_config;
 };
 };  // namespace motor_driver_task

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -160,7 +160,7 @@ class MotorTask {
         static_cast<void>(policy);
         auto direction = m.steps > 0;
         controller_from_id(m.motor_id)
-            .start_fixed_movement(m.id, direction, std::abs(m.steps),
+            .start_fixed_movement(m.id, direction, std::abs(m.steps), 0,
                                   m.steps_per_second, m.steps_per_second_sq);
     }
 
@@ -172,6 +172,7 @@ class MotorTask {
         auto s_per_m = steps_per_mm(m.motor_id);
         controller_from_id(m.motor_id)
             .start_fixed_movement(m.id, direction, std::abs(m.mm * s_per_m),
+                                  m.mm_per_second_discont * s_per_m,
                                   m.mm_per_second * s_per_m,
                                   m.mm_per_second_sq * s_per_m * s_per_m);
     }
@@ -182,7 +183,9 @@ class MotorTask {
         static_cast<void>(policy);
         auto s_per_m = steps_per_mm(m.motor_id);
         controller_from_id(m.motor_id)
-            .start_movement(m.id, m.direction, m.mm_per_second * s_per_m,
+            .start_movement(m.id, m.direction,
+                            m.mm_per_second_discont * s_per_m,
+                            m.mm_per_second * s_per_m,
                             m.mm_per_second_sq * s_per_m * s_per_m);
     }
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
@@ -139,7 +139,7 @@ class TMC2160 {
 
     // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     [[nodiscard]] auto convert_peak_current_to_tmc2160_value(
-        float peak_c, const GlobalScaler& glob_scale,
+        uint32_t peak_c, const GlobalScaler& glob_scale,
         const TMC2160MotorCurrentConfig& current_config) const -> uint32_t {
         /*
          * This function allows us to calculate the current scaling value (rms)
@@ -157,8 +157,11 @@ class TMC2160 {
         auto VOLTAGE_INV = current_config.r_sense / current_config.v_sf;
         auto RMS_CURRENT_CONSTANT =
             globale_scaler_inv * CS_SCALER * VOLTAGE_INV;
-        auto shifted_current_cs = static_cast<uint64_t>(
-            RMS_CURRENT_CONSTANT * peak_c * static_cast<float>(1LL << 32));
+        auto fixed_point_constant = static_cast<uint32_t>(
+            RMS_CURRENT_CONSTANT * static_cast<float>(1LL << 16));
+        uint64_t shifted_current_cs =
+            static_cast<uint64_t>(fixed_point_constant) *
+            static_cast<uint64_t>(peak_c);
         auto current_cs = static_cast<uint32_t>(shifted_current_cs >> 32);
         if (current_cs > 32) {
             current_cs = 32;

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
@@ -74,6 +74,14 @@ class TMC2160 {
         return true;
     }
 
+    template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto update_current(const TMC2160RegisterMap& registers,
+                        tmc2160::TMC2160Interface<Policy>& policy,
+                        MotorID motor_id) -> bool {
+        return set_register(verify_ihold_irun(registers.ihold_irun), policy,
+                            motor_id);
+    }
+
     static auto verify_gconf(GConfig reg) -> GConfig {
         reg.test_mode = 0;
         return reg;
@@ -127,6 +135,35 @@ class TMC2160 {
     static auto verify_glob_scaler(GlobalScaler reg) -> GlobalScaler {
         reg.clamp_value();
         return reg;
+    }
+
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    [[nodiscard]] auto convert_peak_current_to_tmc2160_value(
+        float peak_c, const GlobalScaler& glob_scale,
+        const TMC2160MotorCurrentConfig& current_config) const -> uint32_t {
+        /*
+         * This function allows us to calculate the current scaling value (rms)
+         * from the desired peak current in mA to send to the motor driver
+         * register
+         */
+        static constexpr float CS_SCALER = 32.0;
+        static constexpr float GLOBAL_SCALER = 256.0;
+
+        auto globale_scaler_inv = 1.0;
+        if (glob_scale.global_scaler != 0U) {
+            globale_scaler_inv =
+                GLOBAL_SCALER / static_cast<float>(glob_scale.global_scaler);
+        }
+        auto VOLTAGE_INV = current_config.r_sense / current_config.v_sf;
+        auto RMS_CURRENT_CONSTANT =
+            globale_scaler_inv * CS_SCALER * VOLTAGE_INV;
+        auto shifted_current_cs = static_cast<uint64_t>(
+            RMS_CURRENT_CONSTANT * peak_c * static_cast<float>(1LL << 32));
+        auto current_cs = static_cast<uint32_t>(shifted_current_cs >> 32);
+        if (current_cs > 32) {
+            current_cs = 32;
+        }
+        return current_cs - 1;
     }
 
   private:

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160_registers.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160_registers.hpp
@@ -582,6 +582,11 @@ struct __attribute__((packed, __may_alias__)) StealthChop {
     uint32_t pwm_lim : 4 = 0;
 };
 
+struct TMC2160MotorCurrentConfig {
+    float r_sense;
+    float v_sf;
+};
+
 // Encapsulates all of the registers that should be configured by software
 struct TMC2160RegisterMap {
     GConfig gconfig = {};


### PR DESCRIPTION
This PR does two things:
1. Add max speed discontinuity as part of the params for move messages, so you can now set the initial velocity for the move
2. Add gcodes to set the peak run current and hold current for each axis