### PR TITLE
fix(flex-stacker): increase comms task stack size

### DIFF
--- a/stm32-modules/include/flex-stacker/firmware/firmware_tasks.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/firmware_tasks.hpp
@@ -12,14 +12,11 @@ namespace tasks {
 
 using FirmwareTasks = Tasks<FreeRTOSMessageQueue>;
 
-constexpr size_t HOST_STACK_SIZE = 2048;
-constexpr uint8_t HOST_TASK_PRIORITY = 1;
+constexpr size_t COMMS_STACK_SIZE = 2048;
+constexpr uint8_t COMMS_TASK_PRIORITY = 1;
 
 constexpr size_t SYSTEM_STACK_SIZE = 256;
 constexpr uint8_t SYSTEM_TASK_PRIORITY = 1;
-
-constexpr size_t COMMS_STACK_SIZE = 512;
-constexpr uint8_t COMMS_TASK_PRIORITY = 1;
 
 constexpr size_t MOTOR_STACK_SIZE = 256;
 constexpr uint8_t MOTOR_TASK_PRIORITY = 1;

--- a/stm32-modules/include/flex-stacker/firmware/firmware_tasks.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/firmware_tasks.hpp
@@ -18,7 +18,7 @@ constexpr uint8_t HOST_TASK_PRIORITY = 1;
 constexpr size_t SYSTEM_STACK_SIZE = 256;
 constexpr uint8_t SYSTEM_TASK_PRIORITY = 1;
 
-constexpr size_t COMMS_STACK_SIZE = 256;
+constexpr size_t COMMS_STACK_SIZE = 512;
 constexpr uint8_t COMMS_TASK_PRIORITY = 1;
 
 constexpr size_t MOTOR_STACK_SIZE = 256;

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -479,10 +479,10 @@ struct MoveMotorInSteps {
 
 struct MoveMotorInMm {
     MotorID motor_id;
-    int32_t mm;
-    uint32_t mm_per_second;
-    uint32_t mm_per_second_sq;
-    uint32_t mm_per_second_discont;
+    float mm;
+    float mm_per_second;
+    float mm_per_second_sq;
+    float mm_per_second_discont;
 
     using ParseResult = std::optional<MoveMotorInMm>;
     static constexpr auto prefix = std::array{'G', '0', ' '};
@@ -492,39 +492,39 @@ struct MoveMotorInMm {
         static constexpr auto prefix = std::array{'X'};
         static constexpr bool required = false;
         bool present = false;
-        int32_t value = 0;
+        float value = 0;
     };
     struct ZArg {
         static constexpr auto prefix = std::array{'Z'};
         static constexpr bool required = false;
         bool present = false;
-        int32_t value = 0;
+        float value = 0;
     };
     struct LArg {
         static constexpr auto prefix = std::array{'L'};
         static constexpr bool required = false;
         bool present = false;
-        int32_t value = 0;
+        float value = 0;
     };
     struct VelArg {
         static constexpr auto prefix = std::array{'V'};
         static constexpr bool required = true;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
 
     struct AccelArg {
         static constexpr auto prefix = std::array{'A'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
 
     struct DiscontArg {
         static constexpr auto prefix = std::array{'D'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
 
     template <typename InputIt, typename Limit>
@@ -540,10 +540,10 @@ struct MoveMotorInMm {
         }
         auto ret = MoveMotorInMm{
             .motor_id = MotorID::MOTOR_X,
-            .mm = 0,
-            .mm_per_second = 0,
-            .mm_per_second_sq = 0,
-            .mm_per_second_discont = 0,
+            .mm = 0.0,
+            .mm_per_second = 0.0,
+            .mm_per_second_sq = 0.0,
+            .mm_per_second_discont = 0.0,
         };
 
         auto arguments = res.first.value();

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -587,9 +587,9 @@ struct MoveMotorInMm {
 struct MoveToLimitSwitch {
     MotorID motor_id;
     bool direction;
-    uint32_t mm_per_second;
-    uint32_t mm_per_second_sq;
-    uint32_t mm_per_second_discont;
+    float mm_per_second;
+    float mm_per_second_sq;
+    float mm_per_second_discont;
 
     using ParseResult = std::optional<MoveToLimitSwitch>;
     static constexpr auto prefix = std::array{'G', '5', ' '};
@@ -617,19 +617,19 @@ struct MoveToLimitSwitch {
         static constexpr auto prefix = std::array{'V'};
         static constexpr bool required = true;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
     struct AccelArg {
         static constexpr auto prefix = std::array{'A'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
     struct DiscontArg {
         static constexpr auto prefix = std::array{'D'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
 
     template <typename InputIt, typename Limit>
@@ -646,9 +646,9 @@ struct MoveToLimitSwitch {
         auto ret = MoveToLimitSwitch{
             .motor_id = MotorID::MOTOR_X,
             .direction = false,
-            .mm_per_second = 0,
-            .mm_per_second_sq = 0,
-            .mm_per_second_discont = 0,
+            .mm_per_second = 0.0,
+            .mm_per_second_sq = 0.0,
+            .mm_per_second_discont = 0.0,
         };
 
         auto arguments = res.first.value();

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -174,7 +174,7 @@ struct ArgL {
 
 struct SetRunCurrent {
     MotorID motor_id;
-    uint32_t current;
+    float current;
 
     using ParseResult = std::optional<SetRunCurrent>;
     static constexpr auto prefix = std::array{'M', '9', '0', '6', ' '};
@@ -184,19 +184,19 @@ struct SetRunCurrent {
         static constexpr auto prefix = std::array{'X'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
     struct ZArg {
         static constexpr auto prefix = std::array{'Z'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
     struct LArg {
         static constexpr auto prefix = std::array{'L'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
 
     template <typename InputIt, typename Limit>
@@ -211,7 +211,7 @@ struct SetRunCurrent {
         }
         auto ret = SetRunCurrent{
             .motor_id = MotorID::MOTOR_X,
-            .current = 0,
+            .current = 0.0,
         };
 
         auto arguments = res.first.value();
@@ -239,7 +239,7 @@ struct SetRunCurrent {
 
 struct SetHoldCurrent {
     MotorID motor_id;
-    uint32_t current;
+    float current;
 
     using ParseResult = std::optional<SetHoldCurrent>;
     static constexpr auto prefix = std::array{'M', '9', '0', '7', ' '};
@@ -249,19 +249,19 @@ struct SetHoldCurrent {
         static constexpr auto prefix = std::array{'X'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
     struct ZArg {
         static constexpr auto prefix = std::array{'Z'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
     struct LArg {
         static constexpr auto prefix = std::array{'L'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
 
     template <typename InputIt, typename Limit>
@@ -276,7 +276,7 @@ struct SetHoldCurrent {
         }
         auto ret = SetHoldCurrent{
             .motor_id = MotorID::MOTOR_X,
-            .current = 0,
+            .current = 0.0,
         };
 
         auto arguments = res.first.value();

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -389,7 +389,7 @@ class HostCommsTask {
             messages::SetMotorCurrentMessage{.id = id,
                                              .motor_id = gcode.motor_id,
                                              .run_current = gcode.current,
-                                             .hold_current = 0};
+                                             .hold_current = 0.0};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
@@ -413,7 +413,7 @@ class HostCommsTask {
         auto message =
             messages::SetMotorCurrentMessage{.id = id,
                                              .motor_id = gcode.motor_id,
-                                             .run_current = 0,
+                                             .run_current = 0.0,
                                              .hold_current = gcode.current};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -154,9 +154,9 @@ struct MoveToLimitSwitchMessage {
     uint32_t id;
     MotorID motor_id;
     bool direction;
-    uint32_t mm_per_second;
-    uint32_t mm_per_second_sq;
-    uint32_t mm_per_second_discont;
+    float mm_per_second;
+    float mm_per_second_sq;
+    float mm_per_second_discont;
 };
 
 struct GetLimitSwitchesMessage {

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -92,8 +92,8 @@ struct ForceUSBDisconnect {
 struct SetMotorCurrentMessage {
     uint32_t id;
     MotorID motor_id;
-    uint32_t run_current;
-    uint32_t hold_current;
+    float run_current;
+    float hold_current;
 };
 
 struct SetTMCRegisterMessage {

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -144,10 +144,10 @@ struct MoveMotorInStepsMessage {
 struct MoveMotorInMmMessage {
     uint32_t id;
     MotorID motor_id;
-    int32_t mm;
-    uint32_t mm_per_second;
-    uint32_t mm_per_second_sq;
-    uint32_t mm_per_second_discont;
+    float mm;
+    float mm_per_second;
+    float mm_per_second_sq;
+    float mm_per_second_discont;
 };
 
 struct MoveToLimitSwitchMessage {

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -244,11 +244,11 @@ class MotorDriverTask {
                        tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
         auto response = messages::AcknowledgePrevious{.responding_to_id = m.id};
-        if (m.hold_current != 0) {
+        if (m.hold_current != 0.0) {
             driver_conf_from_id(m.motor_id).ihold_irun.hold_current =
                 get_current_value(m.motor_id, m.hold_current);
         };
-        if (m.run_current != 0) {
+        if (m.run_current != 0.0) {
             driver_conf_from_id(m.motor_id).ihold_irun.run_current =
                 get_current_value(m.motor_id, m.run_current);
         }

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
@@ -139,7 +139,7 @@ class TMC2160 {
 
     // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     [[nodiscard]] auto convert_peak_current_to_tmc2160_value(
-        uint32_t peak_c, const GlobalScaler& glob_scale,
+        float peak_c, const GlobalScaler& glob_scale,
         const TMC2160MotorCurrentConfig& current_config) const -> uint32_t {
         /*
          * This function allows us to calculate the current scaling value (rms)
@@ -157,11 +157,8 @@ class TMC2160 {
         auto VOLTAGE_INV = current_config.r_sense / current_config.v_sf;
         auto RMS_CURRENT_CONSTANT =
             globale_scaler_inv * CS_SCALER * VOLTAGE_INV;
-        auto fixed_point_constant = static_cast<uint32_t>(
-            RMS_CURRENT_CONSTANT * static_cast<float>(1LL << 16));
-        uint64_t shifted_current_cs =
-            static_cast<uint64_t>(fixed_point_constant) *
-            static_cast<uint64_t>(peak_c);
+        auto shifted_current_cs = static_cast<uint64_t>(
+            RMS_CURRENT_CONSTANT * peak_c * static_cast<float>(1LL << 32));
         auto current_cs = static_cast<uint32_t>(shifted_current_cs >> 32);
         if (current_cs > 32) {
             current_cs = 32;


### PR DESCRIPTION
As it turns out, we were using the wrong variable for setting the stack size of the comms task. Now that it has increased from 256 to 2048, we are finally able to use floats in gcodes. 
 