### PR TITLE
feat(flex-stacker): make move params persist

### DIFF
--- a/stm32-modules/include/flex-stacker/firmware/firmware_tasks.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/firmware_tasks.hpp
@@ -12,14 +12,11 @@ namespace tasks {
 
 using FirmwareTasks = Tasks<FreeRTOSMessageQueue>;
 
-constexpr size_t HOST_STACK_SIZE = 2048;
-constexpr uint8_t HOST_TASK_PRIORITY = 1;
+constexpr size_t COMMS_STACK_SIZE = 2048;
+constexpr uint8_t COMMS_TASK_PRIORITY = 1;
 
 constexpr size_t SYSTEM_STACK_SIZE = 256;
 constexpr uint8_t SYSTEM_TASK_PRIORITY = 1;
-
-constexpr size_t COMMS_STACK_SIZE = 512;
-constexpr uint8_t COMMS_TASK_PRIORITY = 1;
 
 constexpr size_t MOTOR_STACK_SIZE = 256;
 constexpr uint8_t MOTOR_TASK_PRIORITY = 1;

--- a/stm32-modules/include/flex-stacker/firmware/firmware_tasks.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/firmware_tasks.hpp
@@ -18,7 +18,7 @@ constexpr uint8_t HOST_TASK_PRIORITY = 1;
 constexpr size_t SYSTEM_STACK_SIZE = 256;
 constexpr uint8_t SYSTEM_TASK_PRIORITY = 1;
 
-constexpr size_t COMMS_STACK_SIZE = 256;
+constexpr size_t COMMS_STACK_SIZE = 512;
 constexpr uint8_t COMMS_TASK_PRIORITY = 1;
 
 constexpr size_t MOTOR_STACK_SIZE = 256;

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -480,9 +480,7 @@ struct MoveMotorInSteps {
 struct MoveMotorInMm {
     MotorID motor_id;
     float mm;
-    float mm_per_second;
-    float mm_per_second_sq;
-    float mm_per_second_discont;
+    std::optional<float> mm_per_second, mm_per_second_sq, mm_per_second_discont;
 
     using ParseResult = std::optional<MoveMotorInMm>;
     static constexpr auto prefix = std::array{'G', '0', ' '};
@@ -508,7 +506,7 @@ struct MoveMotorInMm {
     };
     struct VelArg {
         static constexpr auto prefix = std::array{'V'};
-        static constexpr bool required = true;
+        static constexpr bool required = false;
         bool present = false;
         float value = 0;
     };
@@ -541,9 +539,9 @@ struct MoveMotorInMm {
         auto ret = MoveMotorInMm{
             .motor_id = MotorID::MOTOR_X,
             .mm = 0.0,
-            .mm_per_second = 0.0,
-            .mm_per_second_sq = 0.0,
-            .mm_per_second_discont = 0.0,
+            .mm_per_second = std::nullopt,
+            .mm_per_second_sq = std::nullopt,
+            .mm_per_second_discont = std::nullopt,
         };
 
         auto arguments = res.first.value();
@@ -561,8 +559,6 @@ struct MoveMotorInMm {
 
         if (std::get<3>(arguments).present) {
             ret.mm_per_second = std::get<3>(arguments).value;
-        } else {
-            return std::make_pair(ParseResult(), input);
         }
 
         if (std::get<4>(arguments).present) {
@@ -587,9 +583,7 @@ struct MoveMotorInMm {
 struct MoveToLimitSwitch {
     MotorID motor_id;
     bool direction;
-    float mm_per_second;
-    float mm_per_second_sq;
-    float mm_per_second_discont;
+    std::optional<float> mm_per_second, mm_per_second_sq, mm_per_second_discont;
 
     using ParseResult = std::optional<MoveToLimitSwitch>;
     static constexpr auto prefix = std::array{'G', '5', ' '};
@@ -646,9 +640,9 @@ struct MoveToLimitSwitch {
         auto ret = MoveToLimitSwitch{
             .motor_id = MotorID::MOTOR_X,
             .direction = false,
-            .mm_per_second = 0.0,
-            .mm_per_second_sq = 0.0,
-            .mm_per_second_discont = 0.0,
+            .mm_per_second = std::nullopt,
+            .mm_per_second_sq = std::nullopt,
+            .mm_per_second_discont = std::nullopt,
         };
 
         auto arguments = res.first.value();

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -479,10 +479,10 @@ struct MoveMotorInSteps {
 
 struct MoveMotorInMm {
     MotorID motor_id;
-    int32_t mm;
-    uint32_t mm_per_second;
-    uint32_t mm_per_second_sq;
-    uint32_t mm_per_second_discont;
+    float mm;
+    float mm_per_second;
+    float mm_per_second_sq;
+    float mm_per_second_discont;
 
     using ParseResult = std::optional<MoveMotorInMm>;
     static constexpr auto prefix = std::array{'G', '0', ' '};
@@ -492,39 +492,39 @@ struct MoveMotorInMm {
         static constexpr auto prefix = std::array{'X'};
         static constexpr bool required = false;
         bool present = false;
-        int32_t value = 0;
+        float value = 0;
     };
     struct ZArg {
         static constexpr auto prefix = std::array{'Z'};
         static constexpr bool required = false;
         bool present = false;
-        int32_t value = 0;
+        float value = 0;
     };
     struct LArg {
         static constexpr auto prefix = std::array{'L'};
         static constexpr bool required = false;
         bool present = false;
-        int32_t value = 0;
+        float value = 0;
     };
     struct VelArg {
         static constexpr auto prefix = std::array{'V'};
         static constexpr bool required = true;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
 
     struct AccelArg {
         static constexpr auto prefix = std::array{'A'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
 
     struct DiscontArg {
         static constexpr auto prefix = std::array{'D'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
 
     template <typename InputIt, typename Limit>
@@ -540,10 +540,10 @@ struct MoveMotorInMm {
         }
         auto ret = MoveMotorInMm{
             .motor_id = MotorID::MOTOR_X,
-            .mm = 0,
-            .mm_per_second = 0,
-            .mm_per_second_sq = 0,
-            .mm_per_second_discont = 0,
+            .mm = 0.0,
+            .mm_per_second = 0.0,
+            .mm_per_second_sq = 0.0,
+            .mm_per_second_discont = 0.0,
         };
 
         auto arguments = res.first.value();

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -87,6 +87,61 @@ struct GetTMCRegister {
     }
 };
 
+struct SetMicrosteps {
+    MotorID motor_id;
+    uint8_t microsteps_power;
+
+    using ParseResult = std::optional<SetMicrosteps>;
+    static constexpr auto prefix = std::array{'M', '9', '0', '9', ' '};
+    static constexpr const char* response = "M909 OK\n";
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        MotorID motor_id_val = MotorID::MOTOR_X;
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        switch (*working) {
+            case 'X':
+                motor_id_val = MotorID::MOTOR_X;
+                break;
+            case 'Z':
+                motor_id_val = MotorID::MOTOR_Z;
+                break;
+            case 'L':
+                motor_id_val = MotorID::MOTOR_L;
+                break;
+            default:
+                return std::make_pair(ParseResult(), input);
+        }
+        std::advance(working, 1);
+        if (working == limit) {
+            return std::make_pair(ParseResult(), input);
+        }
+
+        auto ustep_res = gcode::parse_value<uint8_t>(working, limit);
+        if (!ustep_res.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+
+        return std::make_pair(
+            ParseResult(SetMicrosteps{.motor_id = motor_id_val,
+                                       .microsteps_power = ustep_res.first.value()}),
+            ustep_res.second);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+};
+
 struct SetTMCRegister {
     MotorID motor_id;
     uint8_t reg;
@@ -97,8 +152,8 @@ struct SetTMCRegister {
     static constexpr const char* response = "M921 OK\n";
 
     template <typename InputIt, typename Limit>
-    requires std::forward_iterator<InputIt> &&
-        std::sized_sentinel_for<Limit, InputIt>
+        requires std::forward_iterator<InputIt> &&
+                 std::sized_sentinel_for<Limit, InputIt>
     static auto parse(const InputIt& input, Limit limit)
         -> std::pair<ParseResult, InputIt> {
         MotorID motor_id_val = MotorID::MOTOR_X;
@@ -147,8 +202,8 @@ struct SetTMCRegister {
     }
 
     template <typename InputIt, typename InLimit>
-    requires std::forward_iterator<InputIt> &&
-        std::sized_sentinel_for<InputIt, InLimit>
+        requires std::forward_iterator<InputIt> &&
+                 std::sized_sentinel_for<InputIt, InLimit>
     static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
         return write_string_to_iterpair(buf, limit, response);
     }

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -128,10 +128,10 @@ struct SetMicrosteps {
             return std::make_pair(ParseResult(), input);
         }
 
-        return std::make_pair(
-            ParseResult(SetMicrosteps{.motor_id = motor_id_val,
-                                       .microsteps_power = ustep_res.first.value()}),
-            ustep_res.second);
+        return std::make_pair(ParseResult(SetMicrosteps{
+                                  .motor_id = motor_id_val,
+                                  .microsteps_power = ustep_res.first.value()}),
+                              ustep_res.second);
     }
 
     template <typename InputIt, typename InLimit>
@@ -152,8 +152,8 @@ struct SetTMCRegister {
     static constexpr const char* response = "M921 OK\n";
 
     template <typename InputIt, typename Limit>
-        requires std::forward_iterator<InputIt> &&
-                 std::sized_sentinel_for<Limit, InputIt>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
     static auto parse(const InputIt& input, Limit limit)
         -> std::pair<ParseResult, InputIt> {
         MotorID motor_id_val = MotorID::MOTOR_X;
@@ -202,8 +202,8 @@ struct SetTMCRegister {
     }
 
     template <typename InputIt, typename InLimit>
-        requires std::forward_iterator<InputIt> &&
-                 std::sized_sentinel_for<InputIt, InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
     static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
         return write_string_to_iterpair(buf, limit, response);
     }

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -587,9 +587,9 @@ struct MoveMotorInMm {
 struct MoveToLimitSwitch {
     MotorID motor_id;
     bool direction;
-    uint32_t mm_per_second;
-    uint32_t mm_per_second_sq;
-    uint32_t mm_per_second_discont;
+    float mm_per_second;
+    float mm_per_second_sq;
+    float mm_per_second_discont;
 
     using ParseResult = std::optional<MoveToLimitSwitch>;
     static constexpr auto prefix = std::array{'G', '5', ' '};
@@ -617,19 +617,19 @@ struct MoveToLimitSwitch {
         static constexpr auto prefix = std::array{'V'};
         static constexpr bool required = true;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
     struct AccelArg {
         static constexpr auto prefix = std::array{'A'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
     struct DiscontArg {
         static constexpr auto prefix = std::array{'D'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
 
     template <typename InputIt, typename Limit>
@@ -646,9 +646,9 @@ struct MoveToLimitSwitch {
         auto ret = MoveToLimitSwitch{
             .motor_id = MotorID::MOTOR_X,
             .direction = false,
-            .mm_per_second = 0,
-            .mm_per_second_sq = 0,
-            .mm_per_second_discont = 0,
+            .mm_per_second = 0.0,
+            .mm_per_second_sq = 0.0,
+            .mm_per_second_discont = 0.0,
         };
 
         auto arguments = res.first.value();

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -174,7 +174,7 @@ struct ArgL {
 
 struct SetRunCurrent {
     MotorID motor_id;
-    uint32_t current;
+    float current;
 
     using ParseResult = std::optional<SetRunCurrent>;
     static constexpr auto prefix = std::array{'M', '9', '0', '6', ' '};
@@ -184,19 +184,19 @@ struct SetRunCurrent {
         static constexpr auto prefix = std::array{'X'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
     struct ZArg {
         static constexpr auto prefix = std::array{'Z'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
     struct LArg {
         static constexpr auto prefix = std::array{'L'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
 
     template <typename InputIt, typename Limit>
@@ -211,7 +211,7 @@ struct SetRunCurrent {
         }
         auto ret = SetRunCurrent{
             .motor_id = MotorID::MOTOR_X,
-            .current = 0,
+            .current = 0.0,
         };
 
         auto arguments = res.first.value();
@@ -239,7 +239,7 @@ struct SetRunCurrent {
 
 struct SetHoldCurrent {
     MotorID motor_id;
-    uint32_t current;
+    float current;
 
     using ParseResult = std::optional<SetHoldCurrent>;
     static constexpr auto prefix = std::array{'M', '9', '0', '7', ' '};
@@ -249,19 +249,19 @@ struct SetHoldCurrent {
         static constexpr auto prefix = std::array{'X'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
     struct ZArg {
         static constexpr auto prefix = std::array{'Z'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
     struct LArg {
         static constexpr auto prefix = std::array{'L'};
         static constexpr bool required = false;
         bool present = false;
-        uint32_t value = 0;
+        float value = 0;
     };
 
     template <typename InputIt, typename Limit>
@@ -276,7 +276,7 @@ struct SetHoldCurrent {
         }
         auto ret = SetHoldCurrent{
             .motor_id = MotorID::MOTOR_X,
-            .current = 0,
+            .current = 0.0,
         };
 
         auto arguments = res.first.value();

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -389,7 +389,7 @@ class HostCommsTask {
             messages::SetMotorCurrentMessage{.id = id,
                                              .motor_id = gcode.motor_id,
                                              .run_current = gcode.current,
-                                             .hold_current = 0};
+                                             .hold_current = 0.0};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
@@ -413,7 +413,7 @@ class HostCommsTask {
         auto message =
             messages::SetMotorCurrentMessage{.id = id,
                                              .motor_id = gcode.motor_id,
-                                             .run_current = 0,
+                                             .run_current = 0.0,
                                              .hold_current = gcode.current};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -42,7 +42,7 @@ class HostCommsTask {
         gcode::GetTMCRegister, gcode::SetTMCRegister, gcode::SetRunCurrent,
         gcode::SetHoldCurrent, gcode::EnableMotor, gcode::DisableMotor,
         gcode::MoveMotorInSteps, gcode::MoveToLimitSwitch, gcode::MoveMotorInMm,
-        gcode::GetLimitSwitches, gcode::SetMicrosteps>;
+        gcode::GetLimitSwitches, gcode::SetMicrosteps, gcode::GetMoveParams>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::SetTMCRegister, gcode::SetRunCurrent,
@@ -52,6 +52,7 @@ class HostCommsTask {
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetTMCRegisterCache = AckCache<8, gcode::GetTMCRegister>;
     using GetLimitSwitchesCache = AckCache<8, gcode::GetLimitSwitches>;
+    using GetMoveParamsCache = AckCache<8, gcode::GetMoveParams>;
 
   public:
     static constexpr size_t TICKS_TO_WAIT_ON_SEND = 10;
@@ -66,7 +67,9 @@ class HostCommsTask {
           // NOLINTNEXTLINE(readability-redundant-member-init)
           get_tmc_register_cache(),
           // NOLINTNEXTLINE(readability-redundant-member-init)
-          get_limit_switches_cache() {}
+          get_limit_switches_cache(),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
+          get_move_params_cache() {}
     HostCommsTask(const HostCommsTask& other) = delete;
     auto operator=(const HostCommsTask& other) -> HostCommsTask& = delete;
     HostCommsTask(HostCommsTask&& other) noexcept = delete;
@@ -311,6 +314,29 @@ class HostCommsTask {
                         response.x_retract_triggered,
                         response.l_released_triggered,
                         response.l_held_triggered);
+                }
+            },
+            cache_entry);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(const messages::GetMoveParamsResponse& response,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto cache_entry =
+            get_move_params_cache.remove_if_present(response.responding_to_id);
+        return std::visit(
+            [tx_into, tx_limit, response](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (std::is_same_v<std::monostate, T>) {
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                } else {
+                    return cache_element.write_response_into(
+                        tx_into, tx_limit, response.motor_id, response.velocity,
+                        response.acceleration, response.velocity_discont);
                 }
             },
             cache_entry);
@@ -640,6 +666,28 @@ class HostCommsTask {
         return std::make_pair(true, tx_into);
     }
 
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::GetMoveParams& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = get_move_params_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::GetMoveParamsMessage{
+            .id = id, .motor_id = gcode.motor_id};
+        if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            get_move_params_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
     // Our error handler just writes an error and bails
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
@@ -658,6 +706,7 @@ class HostCommsTask {
     GetSystemInfoCache get_system_info_cache;
     GetTMCRegisterCache get_tmc_register_cache;
     GetLimitSwitchesCache get_limit_switches_cache;
+    GetMoveParamsCache get_move_params_cache;
     bool may_connect_latch = true;
 };
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -194,10 +194,24 @@ struct StopMotorMessage {
     uint32_t id;
 };
 
+struct GetMoveParamsMessage {
+    uint32_t id;
+    MotorID motor_id;
+};
+
+struct GetMoveParamsResponse {
+    uint32_t responding_to_id;
+    MotorID motor_id;
+    float velocity;
+    float acceleration;
+    float velocity_discont;
+};
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
-                   GetTMCRegisterResponse, GetLimitSwitchesResponses>;
+                   GetTMCRegisterResponse, GetLimitSwitchesResponses,
+                   GetMoveParamsResponse>;
 
 using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,
@@ -212,6 +226,7 @@ using MotorMessage =
     ::std::variant<std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,
                    MoveToLimitSwitchMessage, StopMotorMessage,
                    MoveCompleteMessage, GetLimitSwitchesMessage,
-                   MoveMotorInMmMessage, SetMicrostepsMessage>;
+                   MoveMotorInMmMessage, SetMicrostepsMessage,
+                   GetMoveParamsMessage>;
 
 };  // namespace messages

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -142,21 +142,21 @@ struct MoveMotorInStepsMessage {
 };
 
 struct MoveMotorInMmMessage {
-    uint32_t id;
-    MotorID motor_id;
-    float mm;
-    float mm_per_second;
-    float mm_per_second_sq;
-    float mm_per_second_discont;
+    uint32_t id = 0;
+    MotorID motor_id = MotorID::MOTOR_X;
+    float mm = 0;
+    std::optional<float> mm_per_second = std::nullopt;
+    std::optional<float> mm_per_second_sq = std::nullopt;
+    std::optional<float> mm_per_second_discont = std::nullopt;
 };
 
 struct MoveToLimitSwitchMessage {
-    uint32_t id;
-    MotorID motor_id;
-    bool direction;
-    float mm_per_second;
-    float mm_per_second_sq;
-    float mm_per_second_discont;
+    uint32_t id = 0;
+    MotorID motor_id = MotorID::MOTOR_X;
+    bool direction = false;
+    std::optional<float> mm_per_second = std::nullopt;
+    std::optional<float> mm_per_second_sq = std::nullopt;
+    std::optional<float> mm_per_second_discont = std::nullopt;
 };
 
 struct GetLimitSwitchesMessage {

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -154,9 +154,9 @@ struct MoveToLimitSwitchMessage {
     uint32_t id;
     MotorID motor_id;
     bool direction;
-    uint32_t mm_per_second;
-    uint32_t mm_per_second_sq;
-    uint32_t mm_per_second_discont;
+    float mm_per_second;
+    float mm_per_second_sq;
+    float mm_per_second_discont;
 };
 
 struct GetLimitSwitchesMessage {

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -96,6 +96,12 @@ struct SetMotorCurrentMessage {
     float hold_current;
 };
 
+struct SetMicrostepsMessage {
+    uint32_t id;
+    MotorID motor_id;
+    uint8_t microsteps_power;
+};
+
 struct SetTMCRegisterMessage {
     uint32_t id;
     MotorID motor_id;
@@ -200,12 +206,12 @@ using SystemMessage =
 using MotorDriverMessage =
     ::std::variant<std::monostate, SetTMCRegisterMessage, GetTMCRegisterMessage,
                    PollTMCRegisterMessage, StopPollTMCRegisterMessage,
-                   SetMotorCurrentMessage>;
+                   SetMotorCurrentMessage, SetMicrostepsMessage>;
 
 using MotorMessage =
     ::std::variant<std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,
                    MoveToLimitSwitchMessage, StopMotorMessage,
                    MoveCompleteMessage, GetLimitSwitchesMessage,
-                   MoveMotorInMmMessage>;
+                   MoveMotorInMmMessage, SetMicrostepsMessage>;
 
 };  // namespace messages

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -92,8 +92,8 @@ struct ForceUSBDisconnect {
 struct SetMotorCurrentMessage {
     uint32_t id;
     MotorID motor_id;
-    uint32_t run_current;
-    uint32_t hold_current;
+    float run_current;
+    float hold_current;
 };
 
 struct SetTMCRegisterMessage {

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -144,10 +144,10 @@ struct MoveMotorInStepsMessage {
 struct MoveMotorInMmMessage {
     uint32_t id;
     MotorID motor_id;
-    int32_t mm;
-    uint32_t mm_per_second;
-    uint32_t mm_per_second_sq;
-    uint32_t mm_per_second_discont;
+    float mm;
+    float mm_per_second;
+    float mm_per_second_sq;
+    float mm_per_second_discont;
 };
 
 struct MoveToLimitSwitchMessage {

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -244,11 +244,11 @@ class MotorDriverTask {
                        tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
         auto response = messages::AcknowledgePrevious{.responding_to_id = m.id};
-        if (m.hold_current != 0) {
+        if (m.hold_current != 0.0) {
             driver_conf_from_id(m.motor_id).ihold_irun.hold_current =
                 get_current_value(m.motor_id, m.hold_current);
         };
-        if (m.run_current != 0) {
+        if (m.run_current != 0.0) {
             driver_conf_from_id(m.motor_id).ihold_irun.run_current =
                 get_current_value(m.motor_id, m.run_current);
         }

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -245,7 +245,7 @@ class MotorDriverTask {
         -> void {
         driver_conf_from_id(m.motor_id).chopconf.mres = m.microsteps_power;
         if (!_tmc2160.update_chopconf(driver_conf_from_id(m.motor_id),
-                                     tmc2160_interface, m.motor_id)) {
+                                      tmc2160_interface, m.motor_id)) {
             auto response = messages::AcknowledgePrevious{
                 .responding_to_id = m.id,
                 .with_error = errors::ErrorCode::TMC2160_WRITE_ERROR};
@@ -253,8 +253,8 @@ class MotorDriverTask {
                 response, Queues::HostCommsAddress));
             return;
         };
-        static_cast<void>(_task_registry->send_to_address(
-            m, Queues::MotorAddress));
+        static_cast<void>(
+            _task_registry->send_to_address(m, Queues::MotorAddress));
     }
 
     template <tmc2160::TMC2160InterfacePolicy Policy>

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -321,6 +321,22 @@ class MotorTask {
             response, Queues::HostCommsAddress));
     }
 
+    template <MotorControlPolicy Policy>
+    auto visit_message(const messages::GetMoveParamsMessage& m, Policy& policy)
+        -> void {
+        static_cast<void>(policy);
+        auto response = messages::GetMoveParamsResponse{
+            .responding_to_id = m.id,
+            .motor_id = m.motor_id,
+            .velocity = motor_state(m.motor_id).speed_mm_per_sec,
+            .acceleration = motor_state(m.motor_id).accel_mm_per_sec_sq,
+            .velocity_discont =
+                motor_state(m.motor_id).speed_mm_per_sec_discont,
+        };
+        static_cast<void>(_task_registry->send_to_address(
+            response, Queues::HostCommsAddress));
+    }
+
     Queue& _message_queue;
     Aggregator* _task_registry;
     Controller& _x_controller;

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -57,10 +57,18 @@ struct MotorState {
     float accel_mm_per_sec_sq;
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     float speed_mm_per_sec_discont;
-    [[nodiscard]] auto get_speed() const -> float { return speed_mm_per_sec * steps_per_mm; }
-    [[nodiscard]] auto get_accel() const -> float { return accel_mm_per_sec_sq * steps_per_mm * steps_per_mm; }
-    [[nodiscard]] auto get_speed_discont() const -> float { return speed_mm_per_sec_discont * steps_per_mm; }
-    [[nodiscard]] auto get_distance(float mm) const -> float { return mm * steps_per_mm; }
+    [[nodiscard]] auto get_speed() const -> float {
+        return speed_mm_per_sec * steps_per_mm;
+    }
+    [[nodiscard]] auto get_accel() const -> float {
+        return accel_mm_per_sec_sq * steps_per_mm * steps_per_mm;
+    }
+    [[nodiscard]] auto get_speed_discont() const -> float {
+        return speed_mm_per_sec_discont * steps_per_mm;
+    }
+    [[nodiscard]] auto get_distance(float mm) const -> float {
+        return mm * steps_per_mm;
+    }
 };
 
 struct XState {
@@ -205,13 +213,16 @@ class MotorTask {
             motor_state(m.motor_id).speed_mm_per_sec = m.mm_per_second.value();
         }
         if (m.mm_per_second_sq.has_value()) {
-            motor_state(m.motor_id).accel_mm_per_sec_sq = m.mm_per_second_sq.value();
+            motor_state(m.motor_id).accel_mm_per_sec_sq =
+                m.mm_per_second_sq.value();
         }
         if (m.mm_per_second_discont.has_value()) {
-            motor_state(m.motor_id).speed_mm_per_sec_discont = m.mm_per_second_discont.value();
+            motor_state(m.motor_id).speed_mm_per_sec_discont =
+                m.mm_per_second_discont.value();
         }
         controller_from_id(m.motor_id)
-            .start_fixed_movement(m.id, direction, motor_state(m.motor_id).get_distance(m.mm),
+            .start_fixed_movement(m.id, direction,
+                                  motor_state(m.motor_id).get_distance(m.mm),
                                   motor_state(m.motor_id).get_speed_discont(),
                                   motor_state(m.motor_id).get_speed(),
                                   motor_state(m.motor_id).get_accel());
@@ -225,10 +236,12 @@ class MotorTask {
             motor_state(m.motor_id).speed_mm_per_sec = m.mm_per_second.value();
         }
         if (m.mm_per_second_sq.has_value()) {
-            motor_state(m.motor_id).accel_mm_per_sec_sq = m.mm_per_second_sq.value();
+            motor_state(m.motor_id).accel_mm_per_sec_sq =
+                m.mm_per_second_sq.value();
         }
         if (m.mm_per_second_discont.has_value()) {
-            motor_state(m.motor_id).speed_mm_per_sec_discont = m.mm_per_second_discont.value();
+            motor_state(m.motor_id).speed_mm_per_sec_discont =
+                m.mm_per_second_discont.value();
         }
         controller_from_id(m.motor_id)
             .start_movement(m.id, m.direction,
@@ -281,23 +294,27 @@ class MotorTask {
     auto visit_message(const messages::SetMicrostepsMessage& m, Policy& policy)
         -> void {
         static_cast<void>(policy);
-        // sent from the driver task so we know we've written to driver successfully
+        // sent from the driver task so we know we've written to driver
+        // successfully
         switch (m.motor_id) {
             case MotorID::MOTOR_X:
-                _x_mech_conf.microstep = static_cast<float>(pow(2, m.microsteps_power));
+                _x_mech_conf.microstep =
+                    static_cast<float>(pow(2, m.microsteps_power));
                 _x_state.steps_per_mm = _x_mech_conf.get_usteps_per_mm();
                 break;
             case MotorID::MOTOR_Z:
-                _z_mech_conf.microstep = static_cast<float>(pow(2, m.microsteps_power));
+                _z_mech_conf.microstep =
+                    static_cast<float>(pow(2, m.microsteps_power));
                 _z_state.steps_per_mm = _z_mech_conf.get_usteps_per_mm();
                 break;
             case MotorID::MOTOR_L:
-                _l_mech_conf.microstep = static_cast<float>(pow(2, m.microsteps_power));
+                _l_mech_conf.microstep =
+                    static_cast<float>(pow(2, m.microsteps_power));
                 _l_state.steps_per_mm = _l_mech_conf.get_usteps_per_mm();
                 break;
             default:
                 break;
-            }
+        }
         auto response = messages::AcknowledgePrevious{.responding_to_id = m.id};
         static_cast<void>(_task_registry->send_to_address(
             response, Queues::HostCommsAddress));
@@ -309,9 +326,12 @@ class MotorTask {
     Controller& _z_controller;
     Controller& _l_controller;
     bool _initialized;
-    lms::LinearMotionSystemConfig<lms::LeadScrewConfig> _x_mech_conf = motor_x_config;
-    lms::LinearMotionSystemConfig<lms::LeadScrewConfig> _z_mech_conf = motor_z_config;
-    lms::LinearMotionSystemConfig<lms::GearBoxConfig> _l_mech_conf = motor_l_config;
+    lms::LinearMotionSystemConfig<lms::LeadScrewConfig> _x_mech_conf =
+        motor_x_config;
+    lms::LinearMotionSystemConfig<lms::LeadScrewConfig> _z_mech_conf =
+        motor_z_config;
+    lms::LinearMotionSystemConfig<lms::GearBoxConfig> _l_mech_conf =
+        motor_l_config;
     MotorState _x_state{
         .steps_per_mm = motor_x_config.get_usteps_per_mm(),
         .speed_mm_per_sec = XState::DEFAULT_SPEED,

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -221,11 +221,12 @@ class MotorTask {
                 m.mm_per_second_discont.value();
         }
         controller_from_id(m.motor_id)
-            .start_fixed_movement(m.id, direction,
-                                  motor_state(m.motor_id).get_distance(m.mm),
-                                  motor_state(m.motor_id).get_speed_discont(),
-                                  motor_state(m.motor_id).get_speed(),
-                                  motor_state(m.motor_id).get_accel());
+            .start_fixed_movement(
+                m.id, direction,
+                motor_state(m.motor_id).get_distance(std::abs(m.mm)),
+                motor_state(m.motor_id).get_speed_discont(),
+                motor_state(m.motor_id).get_speed(),
+                motor_state(m.motor_id).get_accel());
     }
 
     template <MotorControlPolicy Policy>

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
@@ -82,6 +82,14 @@ class TMC2160 {
                             motor_id);
     }
 
+    template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto update_chopconf(const TMC2160RegisterMap& registers,
+                        tmc2160::TMC2160Interface<Policy>& policy,
+                        MotorID motor_id) -> bool {
+        return set_register(verify_chopconf(registers.chopconf), policy,
+                            motor_id);
+    }
+
     static auto verify_gconf(GConfig reg) -> GConfig {
         reg.test_mode = 0;
         return reg;

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
@@ -139,7 +139,7 @@ class TMC2160 {
 
     // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     [[nodiscard]] auto convert_peak_current_to_tmc2160_value(
-        uint32_t peak_c, const GlobalScaler& glob_scale,
+        float peak_c, const GlobalScaler& glob_scale,
         const TMC2160MotorCurrentConfig& current_config) const -> uint32_t {
         /*
          * This function allows us to calculate the current scaling value (rms)
@@ -157,11 +157,8 @@ class TMC2160 {
         auto VOLTAGE_INV = current_config.r_sense / current_config.v_sf;
         auto RMS_CURRENT_CONSTANT =
             globale_scaler_inv * CS_SCALER * VOLTAGE_INV;
-        auto fixed_point_constant = static_cast<uint32_t>(
-            RMS_CURRENT_CONSTANT * static_cast<float>(1LL << 16));
-        uint64_t shifted_current_cs =
-            static_cast<uint64_t>(fixed_point_constant) *
-            static_cast<uint64_t>(peak_c);
+        auto shifted_current_cs = static_cast<uint64_t>(
+            RMS_CURRENT_CONSTANT * peak_c * static_cast<float>(1LL << 32));
         auto current_cs = static_cast<uint32_t>(shifted_current_cs >> 32);
         if (current_cs > 32) {
             current_cs = 32;

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
@@ -84,8 +84,8 @@ class TMC2160 {
 
     template <tmc2160::TMC2160InterfacePolicy Policy>
     auto update_chopconf(const TMC2160RegisterMap& registers,
-                        tmc2160::TMC2160Interface<Policy>& policy,
-                        MotorID motor_id) -> bool {
+                         tmc2160::TMC2160Interface<Policy>& policy,
+                         MotorID motor_id) -> bool {
         return set_register(verify_chopconf(registers.chopconf), policy,
                             motor_id);
     }


### PR DESCRIPTION
This PR does the following:
1. Add gcode that sets the microstep resolution for the motors - after motor driver task finishes, it passes the message down the motor task, before sending the ack back to the comms task 
2. Make move params optional and persist between moves