### PR TITLE
feat(flex-stacker): add deceleration phase in motor interrupt handler

### DIFF
--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -61,7 +61,7 @@ struct MotorState {
         return speed_mm_per_sec * steps_per_mm;
     }
     [[nodiscard]] auto get_accel() const -> float {
-        return accel_mm_per_sec_sq * steps_per_mm * steps_per_mm;
+        return accel_mm_per_sec_sq * steps_per_mm;
     }
     [[nodiscard]] auto get_speed_discont() const -> float {
         return speed_mm_per_sec_discont * steps_per_mm;

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_utils.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_utils.hpp
@@ -94,6 +94,8 @@ class MovementProfile {
     /** Returns the movement type.*/
     [[nodiscard]] auto movement_type() const -> MovementType;
 
+    [[nodiscard]] auto remaining_distance() const -> ticks;
+
   private:
     uint32_t _ticks_per_second;           // Tick frequency
     steps_per_tick _velocity = 0;         // Current velocity
@@ -104,6 +106,7 @@ class MovementProfile {
     ticks _target_distance;               // Distance for the movement
     ticks _current_distance = 0;          // Distance this movement has reached
     q31_31 _tick_tracker = 0;             // Running tracker for the tick motion
+    ticks _accel_distance = 0;  // Distance covered during acceleration phase
 
     // When incrementing position tracker, if this bit changes then
     // a step should take place.

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_utils.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_utils.hpp
@@ -82,6 +82,8 @@ class MovementProfile {
      */
     auto tick() -> TickReturn __attribute__((optimize(3)));
 
+    auto fixed_distance_tick() -> void;
+
     /** Returns the current motor velocity in steps_per_tick.*/
     [[nodiscard]] auto current_velocity() const -> steps_per_tick;
 


### PR DESCRIPTION
This PR does the following:
1. fix the acceleration conversion mistake (accidentally multiply `steps_per_mm` twice) 
2. add deceleration phase in motor interrupt handler!

Please sanity check my calculations.
