### PR TITLE
feat(flex-stacker): add the motor stallguard functionality and gcodes.

### DIFF
--- a/stm32-modules/flex-stacker/firmware/main.cpp
+++ b/stm32-modules/flex-stacker/firmware/main.cpp
@@ -54,7 +54,6 @@ static auto ui_task =
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
     switch (GPIO_Pin) {
         case MOTOR_DIAG0_PIN:
-            // vTaskSuspendAll();
             static_cast<void>(aggregator.send_from_isr(
                 messages::GPIOInterruptMessage{.pin = GPIO_Pin}));
             break;

--- a/stm32-modules/flex-stacker/firmware/main.cpp
+++ b/stm32-modules/flex-stacker/firmware/main.cpp
@@ -1,10 +1,18 @@
 #include "FreeRTOS.h"
 #include "firmware/firmware_tasks.hpp"
 #include "firmware/freertos_tasks.hpp"
+#include "firmware/motor_hardware.h"
 #include "firmware/system_stm32g4xx.h"
+#include "flex-stacker/messages.hpp"
 #include "ot_utils/freertos/freertos_task.hpp"
 #include "systemwide.h"
 #include "task.h"
+
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
+#include "stm32g4xx_hal.h"
+#pragma GCC diagnostic pop
 
 using EntryPoint = std::function<void(tasks::FirmwareTasks::QueueAggregator *)>;
 
@@ -42,6 +50,18 @@ static auto host_comms_task =
 static auto ui_task =
     ot_utils::freertos_task::FreeRTOSTask<tasks::UI_STACK_SIZE, EntryPoint>(
         ui_task_entry);
+
+extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
+    switch (GPIO_Pin) {
+        case MOTOR_DIAG0_PIN:
+            // vTaskSuspendAll();
+            static_cast<void>(aggregator.send_from_isr(
+                messages::GPIOInterruptMessage{.pin = GPIO_Pin}));
+            break;
+        default:
+            break;
+    }
+}
 
 auto main() -> int {
     HardwareInit();

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
@@ -1,77 +1,15 @@
-
 #include "stm32g4xx_hal.h"
 #include "stm32g4xx_it.h"
+#include "motor_hardware.h"
 #include "systemwide.h"
 #include "FreeRTOS.h"
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
-
-/******************* Motor Z *******************/
-/** Motor hardware **/
-#define Z_STEP_PIN (GPIO_PIN_2)
-#define Z_STEP_PORT (GPIOC)
-#define Z_DIR_PIN (GPIO_PIN_1)
-#define Z_DIR_PORT (GPIOC)
-#define Z_EN_PIN (GPIO_PIN_3)
-#define Z_EN_PORT (GPIOA)
-#define Z_N_BRAKE_PIN (GPIO_PIN_7)
-#define Z_N_BRAKE_PORT (GPIOB)
-
-/** Limit switches **/
-/* Note: Photointerrupters limit switches */
-#define Z_MINUS_LIMIT_PIN (GPIO_PIN_3)
-#define Z_MINUS_LIMIT_PORT (GPIOC)
-#define Z_PLUS_LIMIT_PIN (GPIO_PIN_0)
-#define Z_PLUS_LIMIT_PORT (GPIOA)
-
-
-/******************* Motor X *******************/
-
-/** Motor hardware **/
-#define X_STEP_PIN (GPIO_PIN_7)
-#define X_STEP_PORT (GPIOA)
-#define X_DIR_PIN (GPIO_PIN_6)
-#define X_DIR_PORT (GPIOA)
-#define X_EN_PIN (GPIO_PIN_4)
-#define X_EN_PORT (GPIOA)
-#define X_N_BRAKE_PIN (GPIO_PIN_9)
-#define X_N_BRAKE_PORT (GPIOB)
-
-
-/** Limit switches **/
-/* Note: Photointerrupters limit switches */
-#define X_MINUS_LIMIT_PIN (GPIO_PIN_1)
-#define X_MINUS_LIMIT_PORT (GPIOA)
-#define X_PLUS_LIMIT_PIN (GPIO_PIN_2)
-#define X_PLUS_LIMIT_PORT (GPIOA)
-
-
-/******************* Motor L *******************/
-
-/** Motor hardware **/
-#define L_STEP_PIN (GPIO_PIN_1)
-#define L_STEP_PORT (GPIOB)
-#define L_DIR_PIN (GPIO_PIN_0)
-#define L_DIR_PORT (GPIOB)
-#define L_EN_PIN (GPIO_PIN_5)
-#define L_EN_PORT (GPIOC)
-
-
-/** Limit switches **/
-/* Note: Mechanical limit switches */
-#define L_N_HELD_PIN (GPIO_PIN_5)
-#define L_N_HELD_PORT (GPIOB)
-#define L_N_RELEASED_PIN (GPIO_PIN_11)
-#define L_N_RELEASED_PORT (GPIOC)
-
-/**************** COMMON ********************/
-#define ESTOP_PIN GPIO_PIN_6
-#define ESTOP_PORT GPIOB
-
 
 // Frequency of the motor interrupt callbacks is 300kHz, providing some extra
 // overhead over the velocities used by this application.
@@ -101,6 +39,7 @@ typedef struct stepper_hardware_struct {
     PinConfig limit_switch_minus;
     PinConfig limit_switch_plus;
     PinConfig ebrake;
+    PinConfig diag0;
 } stepper_hardware_t;
 
 typedef struct motor_hardware_struct {
@@ -120,6 +59,7 @@ static motor_hardware_t _motor_hardware = {
         .step = {X_STEP_PORT, X_STEP_PIN, GPIO_PIN_SET},
         .limit_switch_minus = {X_MINUS_LIMIT_PORT, X_MINUS_LIMIT_PIN, GPIO_PIN_SET},
         .limit_switch_plus = {X_PLUS_LIMIT_PORT, X_PLUS_LIMIT_PIN, GPIO_PIN_SET},
+        .diag0 = {MOTOR_DIAG0_PORT, MOTOR_DIAG0_PIN, GPIO_PIN_SET},
         .ebrake = {0},
     },
     .motor_z = {
@@ -129,6 +69,7 @@ static motor_hardware_t _motor_hardware = {
         .step = {Z_STEP_PORT, Z_STEP_PIN, GPIO_PIN_SET},
         .limit_switch_minus = {Z_MINUS_LIMIT_PORT, Z_MINUS_LIMIT_PIN, GPIO_PIN_SET},
         .limit_switch_plus = {Z_PLUS_LIMIT_PORT, Z_PLUS_LIMIT_PIN, GPIO_PIN_SET},
+        .diag0 = {MOTOR_DIAG0_PORT, MOTOR_DIAG0_PIN, GPIO_PIN_SET},
         .ebrake = {Z_N_BRAKE_PORT, Z_N_BRAKE_PIN, GPIO_PIN_RESET},
     },
     .motor_l = {
@@ -138,10 +79,10 @@ static motor_hardware_t _motor_hardware = {
         .step = {L_STEP_PORT, L_STEP_PIN, GPIO_PIN_SET},
         .limit_switch_minus = {L_N_HELD_PORT, L_N_HELD_PIN, GPIO_PIN_RESET},
         .limit_switch_plus = {L_N_RELEASED_PORT, L_N_RELEASED_PIN, GPIO_PIN_RESET},
+        .diag0 = {MOTOR_DIAG0_PORT, MOTOR_DIAG0_PIN, GPIO_PIN_SET},
         .ebrake = {0},
     }
 };
-
 
 void motor_hardware_gpio_init(void){
 
@@ -168,8 +109,11 @@ void motor_hardware_gpio_init(void){
     init.Pin = Z_N_BRAKE_PIN;
     HAL_GPIO_Init(Z_N_BRAKE_PORT, &init);
 
-    init.Pin  = Z_STEP_PIN;
+    init.Pin = Z_STEP_PIN;
     HAL_GPIO_Init(Z_STEP_PORT, &init);
+
+    init.Pin = MOTOR_DIAG0_PIN;
+    HAL_GPIO_Init(MOTOR_DIAG0_PORT, &init);
 
     // X MOTOR
     init.Pin = X_EN_PIN;
@@ -193,6 +137,8 @@ void motor_hardware_gpio_init(void){
 
     /*Configure GPIO pins : INPUTS */
     init.Mode = GPIO_MODE_INPUT;
+    init.Pull = GPIO_NOPULL;
+    init.Speed = GPIO_SPEED_FREQ_LOW;
 
     // Z MOTOR
     init.Pin = Z_MINUS_LIMIT_PIN;
@@ -217,6 +163,16 @@ void motor_hardware_gpio_init(void){
 
     init.Pin = ESTOP_PIN;
     HAL_GPIO_Init(ESTOP_PORT, &init);
+
+    /*Configure GPIO pins : INPUTs IRQ */
+    init.Mode = GPIO_MODE_IT_FALLING;
+    init.Pull = GPIO_PULLUP;
+    init.Speed = GPIO_SPEED_FREQ_LOW;
+
+    init.Pin = MOTOR_DIAG0_PIN;
+    HAL_GPIO_Init(MOTOR_DIAG0_PORT, &init);
+    HAL_NVIC_SetPriority(EXTI15_10_IRQn, 6, 0);
+    HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
 }
 
 // X motor timer
@@ -330,6 +286,7 @@ void motor_hardware_init(void){
         tim17_init(&_motor_hardware.motor_x.timer);
         tim20_init(&_motor_hardware.motor_z.timer);
         tim3_init(&_motor_hardware.motor_l.timer);
+
     }
     _motor_hardware.initialized = true;
 }
@@ -344,23 +301,15 @@ void hw_enable_ebrake(MotorID motor_id, bool enable) {
 
 stepper_hardware_t get_motor(MotorID motor_id) {
     switch (motor_id) {
-        case MOTOR_Z:
-            return _motor_hardware.motor_z;
-        case MOTOR_X:
-            return _motor_hardware.motor_x;
-        case MOTOR_L:
-            return _motor_hardware.motor_l;
-        default:
-            return (stepper_hardware_t){0};
+        case MOTOR_Z: return _motor_hardware.motor_z;
+        case MOTOR_X: return _motor_hardware.motor_x;
+        case MOTOR_L: return _motor_hardware.motor_l;
+        default: return (stepper_hardware_t){0};
     }
 }
 
 static uint8_t invert_gpio_value(uint8_t setting) {
-    if (setting == GPIO_PIN_SET) {
-        return GPIO_PIN_RESET;
-    } else {
-        return GPIO_PIN_SET;
-    }
+    return setting == GPIO_PIN_SET ? GPIO_PIN_RESET : GPIO_PIN_SET;
 }
 
 void set_pin(PinConfig config) {

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
@@ -172,7 +172,6 @@ void motor_hardware_gpio_init(void){
     init.Pin = MOTOR_DIAG0_PIN;
     HAL_GPIO_Init(MOTOR_DIAG0_PORT, &init);
     HAL_NVIC_SetPriority(EXTI15_10_IRQn, 6, 0);
-    HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
 }
 
 // X motor timer
@@ -364,6 +363,12 @@ bool hw_read_limit_switch(MotorID motor_id, bool direction) {
         return HAL_GPIO_ReadPin(motor.limit_switch_minus.port,
                                 motor.limit_switch_minus.pin) ==
            motor.limit_switch_minus.active_setting;
+}
+
+void hw_set_diag0_irq(bool enable) {
+    enable ?
+        HAL_NVIC_EnableIRQ(EXTI15_10_IRQn) :
+        HAL_NVIC_DisableIRQ(EXTI15_10_IRQn);
 }
 
 void TIM3_IRQHandler(void)

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_policy.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_policy.cpp
@@ -31,3 +31,8 @@ auto MotorPolicy::set_direction(MotorID motor_id, bool direction) -> void {
 auto MotorPolicy::check_limit_switch(MotorID motor_id, bool direction) -> bool {
     return hw_read_limit_switch(motor_id, direction);
 }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto MotorPolicy::set_diag0_irq(bool enable) -> void {
+    hw_set_diag0_irq(enable);
+}

--- a/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.c
+++ b/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.c
@@ -121,3 +121,11 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 void initialize_callbacks(motor_interrupt_callback callback_glue) {
     interrupt_callback = callback_glue;
 }
+
+// MOTOR_DIAG0_PIN interrupt
+void EXTI15_10_IRQHandler(void) {
+    if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_12)) {
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_12);
+    }
+}
+

--- a/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.h
+++ b/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.h
@@ -34,6 +34,7 @@ void UsageFault_Handler(void);
 void DebugMon_Handler(void);
 // void SysTick_Handler(void);
 void RCC_IRQHandler(void);
+void EXTI15_10_IRQHandler(void);
 // void DMA1_Channel1_IRQHandler(void);
 // void DMA1_Channel2_IRQHandler(void);
 

--- a/stm32-modules/flex-stacker/src/errors.cpp
+++ b/stm32-modules/flex-stacker/src/errors.cpp
@@ -18,9 +18,11 @@ const char* const SYSTEM_EEPROM_ERROR =
 const char* const TMC2160_READ_ERROR = "ERR901:TMC2160 driver read error\n";
 const char* const TMC2160_WRITE_ERROR = "ERR902:TMC2160 driver write error\n";
 const char* const TMC2160_INVALID_ADDRESS = "ERR903:TMC2160 invalid address\n";
+const char* const TMC2160_INVALID_VALUE = "ERR904:TMC2160 invalid value\n";
 
 const char* const MOTOR_ENABLE_FAILED = "ERR401:motor enable error\n";
-const char* const MOTOR_DISABLE_FAILED = "ERR401:motor disable error\n";
+const char* const MOTOR_DISABLE_FAILED = "ERR402:motor disable error\n";
+const char* const MOTOR_STALL_DETECTED = "ERR403:motor stall error\n";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
@@ -43,8 +45,10 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(TMC2160_READ_ERROR);
         HANDLE_CASE(TMC2160_WRITE_ERROR);
         HANDLE_CASE(TMC2160_INVALID_ADDRESS);
+        HANDLE_CASE(TMC2160_INVALID_VALUE);
         HANDLE_CASE(MOTOR_ENABLE_FAILED);
         HANDLE_CASE(MOTOR_DISABLE_FAILED);
+        HANDLE_CASE(MOTOR_STALL_DETECTED);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/include/flex-stacker/firmware/motor_hardware.h
+++ b/stm32-modules/include/flex-stacker/firmware/motor_hardware.h
@@ -10,7 +10,6 @@ extern "C" {
 #include "systemwide.h"
 
 void motor_hardware_init(void);
-
 void spi_hardware_init(void);
 bool motor_spi_sendreceive(MotorID motor_id, uint8_t *tx_data, uint8_t *rx_data,
                            uint16_t len);
@@ -26,3 +25,68 @@ bool hw_read_limit_switch(MotorID motor_id, bool direction);
 }  // extern "C"
 #endif  // __cplusplus
 #endif  // __MOTOR_HARDWARE_H
+
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic pop
+
+/******************* Motor Z *******************/
+/** Motor hardware **/
+#define Z_STEP_PIN (GPIO_PIN_2)
+#define Z_STEP_PORT (GPIOC)
+#define Z_DIR_PIN (GPIO_PIN_1)
+#define Z_DIR_PORT (GPIOC)
+#define Z_EN_PIN (GPIO_PIN_3)
+#define Z_EN_PORT (GPIOA)
+#define Z_N_BRAKE_PIN (GPIO_PIN_7)
+#define Z_N_BRAKE_PORT (GPIOB)
+
+/** Limit switches **/
+/* Note: Photointerrupters limit switches */
+#define Z_MINUS_LIMIT_PIN (GPIO_PIN_3)
+#define Z_MINUS_LIMIT_PORT (GPIOC)
+#define Z_PLUS_LIMIT_PIN (GPIO_PIN_0)
+#define Z_PLUS_LIMIT_PORT (GPIOA)
+
+/******************* Motor X *******************/
+
+/** Motor hardware **/
+#define X_STEP_PIN (GPIO_PIN_7)
+#define X_STEP_PORT (GPIOA)
+#define X_DIR_PIN (GPIO_PIN_6)
+#define X_DIR_PORT (GPIOA)
+#define X_EN_PIN (GPIO_PIN_4)
+#define X_EN_PORT (GPIOA)
+#define X_N_BRAKE_PIN (GPIO_PIN_9)
+#define X_N_BRAKE_PORT (GPIOB)
+
+/** Limit switches **/
+/* Note: Photointerrupters limit switches */
+#define X_MINUS_LIMIT_PIN (GPIO_PIN_1)
+#define X_MINUS_LIMIT_PORT (GPIOA)
+#define X_PLUS_LIMIT_PIN (GPIO_PIN_2)
+#define X_PLUS_LIMIT_PORT (GPIOA)
+
+/******************* Motor L *******************/
+
+/** Motor hardware **/
+#define L_STEP_PIN (GPIO_PIN_1)
+#define L_STEP_PORT (GPIOB)
+#define L_DIR_PIN (GPIO_PIN_0)
+#define L_DIR_PORT (GPIOB)
+#define L_EN_PIN (GPIO_PIN_5)
+#define L_EN_PORT (GPIOC)
+
+/** Limit switches **/
+/* Note: Mechanical limit switches */
+#define L_N_HELD_PIN (GPIO_PIN_5)
+#define L_N_HELD_PORT (GPIOB)
+#define L_N_RELEASED_PIN (GPIO_PIN_11)
+#define L_N_RELEASED_PORT (GPIOC)
+
+/**************** COMMON ********************/
+#define ESTOP_PIN (GPIO_PIN_6)
+#define ESTOP_PORT (GPIOB)
+#define MOTOR_DIAG0_PIN (GPIO_PIN_12)
+#define MOTOR_DIAG0_PORT (GPIOB)

--- a/stm32-modules/include/flex-stacker/firmware/motor_hardware.h
+++ b/stm32-modules/include/flex-stacker/firmware/motor_hardware.h
@@ -20,6 +20,7 @@ bool hw_disable_motor(MotorID motor_id);
 bool hw_stop_motor(MotorID motor_id);
 void hw_set_direction(MotorID, bool direction);
 bool hw_read_limit_switch(MotorID motor_id, bool direction);
+void hw_set_diag0_irq(bool enable);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -101,6 +101,8 @@ class MotorInterruptController {
         return false;
     }
 
+    auto set_diag0_irq(bool enable) -> void { _policy->set_diag0_irq(enable); }
+
   private:
     MotorID _id;
     MotorPolicy* _policy;

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -94,7 +94,9 @@ class MotorInterruptController {
         return _response_id;
     }
     auto stop_condition_met() -> bool {
-        if (_stop) return true;
+        if (_stop) {
+            return true;
+        }
         if (_profile.movement_type() == motor_util::MovementType::OpenLoop) {
             return limit_switch_triggered();
         }

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -57,6 +57,7 @@ class MotorInterruptController {
                               uint32_t steps_per_sec_discont,
                               uint32_t steps_per_sec, uint32_t step_per_sec_sq)
         -> void {
+        _stop = false;
         set_direction(direction);
         _profile = motor_util::MovementProfile(
             TIMER_FREQ, steps_per_sec_discont, steps_per_sec, step_per_sec_sq,
@@ -67,11 +68,17 @@ class MotorInterruptController {
     auto start_movement(uint32_t move_id, bool direction,
                         uint32_t steps_per_sec_discont, uint32_t steps_per_sec,
                         uint32_t step_per_sec_sq) -> void {
+        _stop = false;
         set_direction(direction);
         _profile = motor_util::MovementProfile(
             TIMER_FREQ, steps_per_sec_discont, steps_per_sec, step_per_sec_sq,
             motor_util::MovementType::OpenLoop, 0);
         _policy->enable_motor(_id);
+        _response_id = move_id;
+    }
+    auto stop_movement(uint32_t move_id) -> void {
+        _stop = true;
+        _policy->disable_motor(_id);
         _response_id = move_id;
     }
 
@@ -86,6 +93,7 @@ class MotorInterruptController {
         return _response_id;
     }
     auto stop_condition_met() -> bool {
+        if (_stop) return true;
         if (_profile.movement_type() == motor_util::MovementType::OpenLoop) {
             return limit_switch_triggered();
         }
@@ -101,6 +109,7 @@ class MotorInterruptController {
     uint32_t step_freq = DEFAULT_MOTOR_FREQ;
     uint32_t _response_id = 0;
     bool _direction = false;
+    bool _stop = false;
 };
 
 }  // namespace motor_interrupt_controller

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <atomic>
+#include <cstdint>
 
 #include "firmware/motor_hardware.h"
 #include "firmware/motor_policy.hpp"
@@ -76,9 +77,9 @@ class MotorInterruptController {
         _policy->enable_motor(_id);
         _response_id = move_id;
     }
-    auto stop_movement(uint32_t move_id) -> void {
+    auto stop_movement(uint32_t move_id, bool disable_motor) -> void {
         _stop = true;
-        _policy->disable_motor(_id);
+        disable_motor ? _policy->disable_motor(_id) : _policy->stop_motor(_id);
         _response_id = move_id;
     }
 

--- a/stm32-modules/include/flex-stacker/firmware/motor_policy.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_policy.hpp
@@ -14,6 +14,7 @@ class MotorPolicy {
     auto step(MotorID motor_id) -> void;
     auto set_direction(MotorID motor_id, bool direction) -> void;
     auto check_limit_switch(MotorID motor_id, bool direction) -> bool;
+    auto set_diag0_irq(bool enable) -> void;
 };
 
 }  // namespace motor_policy

--- a/stm32-modules/include/flex-stacker/flex-stacker/errors.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/errors.hpp
@@ -22,9 +22,11 @@ enum class ErrorCode {
     TMC2160_READ_ERROR = 901,
     TMC2160_WRITE_ERROR = 902,
     TMC2160_INVALID_ADDRESS = 903,
+    TMC2160_INVALID_VALUE = 904,
     // 4xx - Motor Errors
     MOTOR_ENABLE_FAILED = 401,
     MOTOR_DISABLE_FAILED = 402,
+    MOTOR_STALL_DETECTED = 403
 };
 
 auto errorstring(ErrorCode code) -> const char*;

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -765,33 +765,6 @@ class HostCommsTask {
             cache_entry);
     }
 
-    /*
-
-    template <typename InputIt, typename InputLimit>
-    requires std::forward_iterator<InputIt> &&
-        std::sized_sentinel_for<InputLimit, InputIt>
-    auto visit_message(const messages::GetMoveParamsResponse& response,
-                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
-        auto cache_entry =
-            get_move_params_cache.remove_if_present(response.responding_to_id);
-        return std::visit(
-            [tx_into, tx_limit, response](auto cache_element) {
-                using T = std::decay_t<decltype(cache_element)>;
-                if constexpr (std::is_same_v<std::monostate, T>) {
-                    return errors::write_into(
-                        tx_into, tx_limit,
-                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
-                } else {
-                    return cache_element.write_response_into(
-                        tx_into, tx_limit, response.motor_id, response.velocity,
-                        response.acceleration, response.velocity_discont);
-                }
-            },
-            cache_entry);
-    }
-
-    */
-
     // Our error handler just writes an error and bails
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -45,7 +45,7 @@ class HostCommsTask {
         gcode::SetHoldCurrent, gcode::EnableMotor, gcode::DisableMotor,
         gcode::MoveMotorInSteps, gcode::MoveToLimitSwitch, gcode::MoveMotorInMm,
         gcode::GetLimitSwitches, gcode::SetMicrosteps, gcode::GetMoveParams,
-        gcode::SetMotorStallGuard>;
+        gcode::SetMotorStallGuard, gcode::GetMotorStallGuard>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::SetTMCRegister, gcode::SetRunCurrent,
@@ -57,6 +57,7 @@ class HostCommsTask {
     using GetTMCRegisterCache = AckCache<8, gcode::GetTMCRegister>;
     using GetLimitSwitchesCache = AckCache<8, gcode::GetLimitSwitches>;
     using GetMoveParamsCache = AckCache<8, gcode::GetMoveParams>;
+    using GetMotorStallGuardCache = AckCache<8, gcode::GetMotorStallGuard>;
 
   public:
     static constexpr size_t TICKS_TO_WAIT_ON_SEND = 10;
@@ -73,7 +74,9 @@ class HostCommsTask {
           // NOLINTNEXTLINE(readability-redundant-member-init)
           get_limit_switches_cache(),
           // NOLINTNEXTLINE(readability-redundant-member-init)
-          get_move_params_cache() {}
+          get_move_params_cache(),
+          // NOLINTNEXTLINE(readability-redundant-member-init)
+          get_motor_stall_guard_cache() {}
     HostCommsTask(const HostCommsTask& other) = delete;
     auto operator=(const HostCommsTask& other) -> HostCommsTask& = delete;
     HostCommsTask(HostCommsTask&& other) noexcept = delete;
@@ -717,6 +720,78 @@ class HostCommsTask {
         return std::make_pair(true, tx_into);
     }
 
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::GetMotorStallGuard& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = get_motor_stall_guard_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::GetMotorStallGuardMessage{
+            .id = id, .motor_id = gcode.motor_id};
+        if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            get_motor_stall_guard_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(const messages::GetMotorStallGuardResponse& response,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto cache_entry =
+            get_motor_stall_guard_cache.remove_if_present(response.id);
+        return std::visit(
+            [tx_into, tx_limit, response](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (std::is_same_v<std::monostate, T>) {
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                } else {
+                    return cache_element.write_response_into(
+                        tx_into, tx_limit, response.motor_id, response.enabled,
+                        response.sgt);
+                }
+            },
+            cache_entry);
+    }
+
+    /*
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(const messages::GetMoveParamsResponse& response,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto cache_entry =
+            get_move_params_cache.remove_if_present(response.responding_to_id);
+        return std::visit(
+            [tx_into, tx_limit, response](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (std::is_same_v<std::monostate, T>) {
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                } else {
+                    return cache_element.write_response_into(
+                        tx_into, tx_limit, response.motor_id, response.velocity,
+                        response.acceleration, response.velocity_discont);
+                }
+            },
+            cache_entry);
+    }
+
+    */
+
     // Our error handler just writes an error and bails
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
@@ -736,6 +811,7 @@ class HostCommsTask {
     GetTMCRegisterCache get_tmc_register_cache;
     GetLimitSwitchesCache get_limit_switches_cache;
     GetMoveParamsCache get_move_params_cache;
+    GetMotorStallGuardCache get_motor_stall_guard_cache;
     bool may_connect_latch = true;
 };
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -2,6 +2,7 @@
 #include <array>
 #include <concepts>
 #include <cstdint>
+#include <optional>
 #include <variant>
 
 #include "flex-stacker/errors.hpp"
@@ -38,6 +39,14 @@ concept MessageWithReturn = requires(MessageType mt) {
 template <typename ResponseType>
 concept Response = requires(ResponseType rt) {
     { get_responding_to_id(rt) } -> std::same_as<uint32_t>;
+};
+
+/**
+ * A message sent when an external interrupt is triguered
+ */
+struct GPIOInterruptMessage {
+    uint16_t pin;
+    uint8_t state;
 };
 
 /*
@@ -192,6 +201,7 @@ struct MoveMotorMessage {
 
 struct StopMotorMessage {
     uint32_t id;
+    MotorID motor_id;
 };
 
 struct GetMoveParamsMessage {
@@ -207,6 +217,13 @@ struct GetMoveParamsResponse {
     float velocity_discont;
 };
 
+struct SetMotorStallGuardMessage {
+    uint32_t id = 0;
+    MotorID motor_id = MotorID::MOTOR_X;
+    bool enable = false;
+    std::optional<int32_t> sgt = std::nullopt;
+};
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
@@ -220,13 +237,14 @@ using SystemMessage =
 using MotorDriverMessage =
     ::std::variant<std::monostate, SetTMCRegisterMessage, GetTMCRegisterMessage,
                    PollTMCRegisterMessage, StopPollTMCRegisterMessage,
-                   SetMotorCurrentMessage, SetMicrostepsMessage>;
+                   SetMotorCurrentMessage, SetMicrostepsMessage,
+                   SetMotorStallGuardMessage>;
 
 using MotorMessage =
     ::std::variant<std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,
                    MoveToLimitSwitchMessage, StopMotorMessage,
                    MoveCompleteMessage, GetLimitSwitchesMessage,
                    MoveMotorInMmMessage, SetMicrostepsMessage,
-                   GetMoveParamsMessage>;
+                   GetMoveParamsMessage, GPIOInterruptMessage>;
 
 };  // namespace messages

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -41,14 +41,6 @@ concept Response = requires(ResponseType rt) {
     { get_responding_to_id(rt) } -> std::same_as<uint32_t>;
 };
 
-/**
- * A message sent when an external interrupt is triguered
- */
-struct GPIOInterruptMessage {
-    uint16_t pin;
-    uint8_t state;
-};
-
 /*
 ** Message structs initiate actions. These may be changes in physical state, or
 ** a request to send back some data. Each carries an ID, which should be copied
@@ -217,6 +209,17 @@ struct GetMoveParamsResponse {
     float velocity_discont;
 };
 
+// Message to enable/disable the diag0 pin
+struct SetDiag0IRQMessage {
+    bool enable;
+};
+
+// Message sent when there is an irq on the diag0 line
+struct GPIOInterruptMessage {
+    uint16_t pin;
+    uint8_t state;
+};
+
 struct SetMotorStallGuardMessage {
     uint32_t id = 0;
     MotorID motor_id = MotorID::MOTOR_X;
@@ -252,11 +255,10 @@ using MotorDriverMessage =
                    SetMotorCurrentMessage, SetMicrostepsMessage,
                    SetMotorStallGuardMessage, GetMotorStallGuardMessage>;
 
-using MotorMessage =
-    ::std::variant<std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,
-                   MoveToLimitSwitchMessage, StopMotorMessage,
-                   MoveCompleteMessage, GetLimitSwitchesMessage,
-                   MoveMotorInMmMessage, SetMicrostepsMessage,
-                   GetMoveParamsMessage, GPIOInterruptMessage>;
+using MotorMessage = ::std::variant<
+    std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,
+    MoveToLimitSwitchMessage, StopMotorMessage, MoveCompleteMessage,
+    GetLimitSwitchesMessage, MoveMotorInMmMessage, SetMicrostepsMessage,
+    GetMoveParamsMessage, SetDiag0IRQMessage, GPIOInterruptMessage>;
 
 };  // namespace messages

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -224,11 +224,23 @@ struct SetMotorStallGuardMessage {
     std::optional<int32_t> sgt = std::nullopt;
 };
 
+struct GetMotorStallGuardMessage {
+    uint32_t id = 0;
+    MotorID motor_id = MotorID::MOTOR_X;
+};
+
+struct GetMotorStallGuardResponse {
+    uint32_t id;
+    MotorID motor_id;
+    bool enabled;
+    int sgt;
+};
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
                    GetTMCRegisterResponse, GetLimitSwitchesResponses,
-                   GetMoveParamsResponse>;
+                   GetMoveParamsResponse, GetMotorStallGuardResponse>;
 
 using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,
@@ -238,7 +250,7 @@ using MotorDriverMessage =
     ::std::variant<std::monostate, SetTMCRegisterMessage, GetTMCRegisterMessage,
                    PollTMCRegisterMessage, StopPollTMCRegisterMessage,
                    SetMotorCurrentMessage, SetMicrostepsMessage,
-                   SetMotorStallGuardMessage>;
+                   SetMotorStallGuardMessage, GetMotorStallGuardMessage>;
 
 using MotorMessage =
     ::std::variant<std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -316,7 +316,6 @@ class MotorDriverTask {
     auto visit_message(const messages::GetMotorStallGuardMessage& m,
                        tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
-
         bool enabled = static_cast<bool>(
             driver_conf_from_id(m.motor_id).gconfig.diag0_stall);
         int sgt = driver_conf_from_id(m.motor_id).coolconf.sgt;

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -316,6 +316,7 @@ class MotorDriverTask {
     auto visit_message(const messages::GetMotorStallGuardMessage& m,
                        tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
+        static_cast<void>(tmc2160_interface);
         bool enabled = static_cast<bool>(
             driver_conf_from_id(m.motor_id).gconfig.diag0_stall);
         int sgt = driver_conf_from_id(m.motor_id).coolconf.sgt;

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -282,6 +282,7 @@ class MotorDriverTask {
     auto visit_message(const messages::SetMotorStallGuardMessage& m,
                        tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
+        static_cast<void>(tmc2160_interface);
         auto response = messages::AcknowledgePrevious{
             .responding_to_id = m.id,
             .with_error = errors::ErrorCode::NO_ERROR};
@@ -315,6 +316,7 @@ class MotorDriverTask {
     auto visit_message(const messages::GetMotorStallGuardMessage& m,
                        tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
+
         bool enabled = static_cast<bool>(
             driver_conf_from_id(m.motor_id).gconfig.diag0_stall);
         int sgt = driver_conf_from_id(m.motor_id).coolconf.sgt;

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -5,12 +5,11 @@
  */
 #pragma once
 
-#include <optional>
-
 #include "core/ack_cache.hpp"
 #include "core/fixed_point.hpp"
 #include "core/queue_aggregator.hpp"
 #include "core/version.hpp"
+#include "errors.hpp"
 #include "firmware/motor_policy.hpp"
 #include "flex-stacker/errors.hpp"
 #include "flex-stacker/messages.hpp"
@@ -19,6 +18,7 @@
 #include "flex-stacker/tmc2160_interface.hpp"
 #include "flex-stacker/tmc2160_registers.hpp"
 #include "hal/message_queue.hpp"
+#include "messages.hpp"
 #include "systemwide.h"
 
 namespace motor_driver_task {
@@ -26,7 +26,7 @@ namespace motor_driver_task {
 using Message = messages::MotorDriverMessage;
 
 static constexpr tmc2160::TMC2160RegisterMap motor_z_config{
-    .gconfig = {.diag0_error = 1, .diag1_stall = 1},
+    .gconfig = {.diag0_error = 0, .diag0_stall = 0},
     .short_conf = {.s2vs_level = 0x6,
                    .s2g_level = 0x6,
                    .shortfilter = 1,
@@ -36,14 +36,14 @@ static constexpr tmc2160::TMC2160RegisterMap motor_z_config{
                    .run_current = 31,
                    .hold_current_delay = 15},
     .tpwmthrs = {.threshold = 0x80000},
-    .tcoolthrs = {.threshold = 0x81},
+    .tcoolthrs = {.threshold = 0x2FF},
     .thigh = {.threshold = 0x81},
     .chopconf = {.toff = 0b111,
                  .hstrt = 0b100,
                  .hend = 0b11,
                  .tbl = 0b1,
                  .mres = 0b100},
-    .coolconf = {.semin = 0b11, .semax = 0b100},
+    .coolconf = {.semin = 0b11, .semax = 0b100, .sgt = 1},
     .pwmconf = {.pwm_ofs = 0x1F,
                 .pwm_grad = 0x18,
                 .pwm_autoscale = 1,
@@ -53,7 +53,7 @@ static constexpr tmc2160::TMC2160RegisterMap motor_z_config{
 };
 
 static constexpr tmc2160::TMC2160RegisterMap motor_x_config{
-    .gconfig = {.diag0_error = 1, .diag1_stall = 1},
+    .gconfig = {.diag0_error = 0, .diag0_stall = 0},
     .short_conf = {.s2vs_level = 0x6,
                    .s2g_level = 0x6,
                    .shortfilter = 1,
@@ -63,14 +63,14 @@ static constexpr tmc2160::TMC2160RegisterMap motor_x_config{
                    .run_current = 31,
                    .hold_current_delay = 7},
     .tpwmthrs = {.threshold = 0x80000},
-    .tcoolthrs = {.threshold = 0x81},
+    .tcoolthrs = {.threshold = 0x2FF},
     .thigh = {.threshold = 0x81},
     .chopconf = {.toff = 0b111,
                  .hstrt = 0b111,
                  .hend = 0b1001,
                  .tbl = 0b1,
                  .mres = 0b100},
-    .coolconf = {.semin = 0b11, .semax = 0b100},
+    .coolconf = {.semin = 0b11, .semax = 0b100, .sgt = 1},
     .pwmconf = {.pwm_ofs = 0x1F,
                 .pwm_grad = 0x18,
                 .pwm_autoscale = 1,
@@ -80,7 +80,7 @@ static constexpr tmc2160::TMC2160RegisterMap motor_x_config{
 };
 
 static constexpr tmc2160::TMC2160RegisterMap motor_l_config{
-    .gconfig = {.diag0_error = 1, .diag1_stall = 1},
+    .gconfig = {.diag0_error = 0, .diag0_stall = 0},
     .short_conf = {.s2vs_level = 0x6,
                    .s2g_level = 0x6,
                    .shortfilter = 1,
@@ -90,14 +90,14 @@ static constexpr tmc2160::TMC2160RegisterMap motor_l_config{
                    .run_current = 8,
                    .hold_current_delay = 7},
     .tpwmthrs = {.threshold = 0x80000},
-    .tcoolthrs = {.threshold = 0x81},
+    .tcoolthrs = {.threshold = 0x2FF},
     .thigh = {.threshold = 0x81},
     .chopconf = {.toff = 0b111,
                  .hstrt = 0b111,
                  .hend = 0b1001,
                  .tbl = 0b1,
                  .mres = 0b100},
-    .coolconf = {.semin = 0b11, .semax = 0b100},
+    .coolconf = {.semin = 0b11, .semax = 0b100, .sgt = 1},
     .pwmconf = {.pwm_ofs = 0x1F,
                 .pwm_grad = 0x18,
                 .pwm_autoscale = 1,
@@ -271,6 +271,32 @@ class MotorDriverTask {
                 get_current_value(m.motor_id, m.run_current);
         }
         if (!_tmc2160.update_current(driver_conf_from_id(m.motor_id),
+                                     tmc2160_interface, m.motor_id)) {
+            response.with_error = errors::ErrorCode::TMC2160_WRITE_ERROR;
+        };
+        static_cast<void>(_task_registry->send_to_address(
+            response, Queues::HostCommsAddress));
+    }
+
+    template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto visit_message(const messages::SetMotorStallGuardMessage& m,
+                       tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
+        -> void {
+        auto response = messages::AcknowledgePrevious{.responding_to_id = m.id};
+        driver_conf_from_id(m.motor_id).gconfig.diag0_stall =
+            static_cast<int>(m.enable);
+        if (m.sgt.has_value()) {
+            if (m.sgt.value() >= -64 && m.sgt.value() <= 63) {
+                driver_conf_from_id(m.motor_id).coolconf.sgt = m.sgt.value();
+            } else {
+                response.with_error = errors::ErrorCode::TMC2160_INVALID_VALUE;
+            }
+        }
+        if (!_tmc2160.update_coolconf(driver_conf_from_id(m.motor_id),
+                                      tmc2160_interface, m.motor_id)) {
+            response.with_error = errors::ErrorCode::TMC2160_WRITE_ERROR;
+        };
+        if (!_tmc2160.update_gconfig(driver_conf_from_id(m.motor_id),
                                      tmc2160_interface, m.motor_id)) {
             response.with_error = errors::ErrorCode::TMC2160_WRITE_ERROR;
         };

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -304,6 +304,23 @@ class MotorDriverTask {
             response, Queues::HostCommsAddress));
     }
 
+    template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto visit_message(const messages::GetMotorStallGuardMessage& m,
+                       tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
+        -> void {
+        bool enabled = static_cast<bool>(
+            driver_conf_from_id(m.motor_id).gconfig.diag0_stall);
+        int sgt = driver_conf_from_id(m.motor_id).coolconf.sgt;
+        auto response = messages::GetMotorStallGuardResponse{
+            .id = m.id,
+            .motor_id = m.motor_id,
+            .enabled = enabled,
+            .sgt = sgt,
+        };
+        static_cast<void>(_task_registry->send_to_address(
+            response, Queues::HostCommsAddress));
+    }
+
     auto get_current_value(MotorID motor_id, float current) -> uint32_t {
         return _tmc2160.convert_peak_current_to_tmc2160_value(
             current, driver_conf_from_id(motor_id).glob_scale,

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -256,7 +256,7 @@ class MotorTask {
         -> void {
         static_cast<void>(m);
         static_cast<void>(policy);
-        controller_from_id(m.motor_id).stop_movement(m.id);
+        controller_from_id(m.motor_id).stop_movement(m.id, true);
     }
 
     template <MotorControlPolicy Policy>
@@ -342,9 +342,9 @@ class MotorTask {
     auto visit_message(const messages::GPIOInterruptMessage& m, Policy& policy)
         -> void {
         static_cast<void>(policy);
-        _x_controller.stop_movement(0);
-        _z_controller.stop_movement(0);
-        _l_controller.stop_movement(0);
+        _z_controller.stop_movement(0, true);
+        _x_controller.stop_movement(0, false);
+        _l_controller.stop_movement(0, false);
         auto msg = messages::ErrorMessage{
             .code = errors::ErrorCode::MOTOR_STALL_DETECTED};
         static_cast<void>(

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -256,6 +256,7 @@ class MotorTask {
         -> void {
         static_cast<void>(m);
         static_cast<void>(policy);
+        controller_from_id(m.motor_id).stop_movement(m.id);
     }
 
     template <MotorControlPolicy Policy>
@@ -335,6 +336,19 @@ class MotorTask {
         };
         static_cast<void>(_task_registry->send_to_address(
             response, Queues::HostCommsAddress));
+    }
+
+    template <MotorControlPolicy Policy>
+    auto visit_message(const messages::GPIOInterruptMessage& m, Policy& policy)
+        -> void {
+        static_cast<void>(policy);
+        _x_controller.stop_movement(0);
+        _z_controller.stop_movement(0);
+        _l_controller.stop_movement(0);
+        auto msg = messages::ErrorMessage{
+            .code = errors::ErrorCode::MOTOR_STALL_DETECTED};
+        static_cast<void>(
+            _task_registry->send_to_address(msg, Queues::HostCommsAddress));
     }
 
     Queue& _message_queue;

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -17,6 +17,7 @@
 #include "flex-stacker/tasks.hpp"
 #include "flex-stacker/tmc2160_registers.hpp"
 #include "hal/message_queue.hpp"
+#include "messages.hpp"
 
 namespace motor_task {
 
@@ -339,8 +340,17 @@ class MotorTask {
     }
 
     template <MotorControlPolicy Policy>
+    auto visit_message(const messages::SetDiag0IRQMessage& m, Policy& policy)
+        -> void {
+        static_cast<void>(policy);
+        // NOTE: The diag0 pin is shared by all motors.
+        _x_controller.set_diag0_irq(m.enable);
+    }
+
+    template <MotorControlPolicy Policy>
     auto visit_message(const messages::GPIOInterruptMessage& m, Policy& policy)
         -> void {
+        static_cast<void>(m);
         static_cast<void>(policy);
         _z_controller.stop_movement(0, true);
         _x_controller.stop_movement(0, false);

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
@@ -83,6 +83,21 @@ class TMC2160 {
     }
 
     template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto update_gconfig(const TMC2160RegisterMap& registers,
+                        tmc2160::TMC2160Interface<Policy>& policy,
+                        MotorID motor_id) -> bool {
+        return set_register(verify_gconf(registers.gconfig), policy, motor_id);
+    }
+
+    template <tmc2160::TMC2160InterfacePolicy Policy>
+    auto update_coolconf(const TMC2160RegisterMap& registers,
+                         tmc2160::TMC2160Interface<Policy>& policy,
+                         MotorID motor_id) -> bool {
+        return set_register(verify_coolconf(registers.coolconf), policy,
+                            motor_id);
+    }
+
+    template <tmc2160::TMC2160InterfacePolicy Policy>
     auto update_chopconf(const TMC2160RegisterMap& registers,
                          tmc2160::TMC2160Interface<Policy>& policy,
                          MotorID motor_id) -> bool {

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
@@ -160,9 +160,10 @@ class TMC2160 {
         return reg;
     }
 
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     [[nodiscard]] auto verify_sgt_value(std::optional<int> sgt) -> bool {
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if (sgt.has_value()) {
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
             return sgt.value() >= -64 && sgt.value() <= 63;
         }
         return true;

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
@@ -160,9 +160,11 @@ class TMC2160 {
         return reg;
     }
 
-    static auto verify_sgt_value(std::optional<int> sgt) -> bool {
+    [[nodiscard]] auto verify_sgt_value(std::optional<int> sgt) -> bool {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-        if (sgt.has_value()) return sgt.value() >= -64 && sgt.value() <= 63;
+        if (sgt.has_value()) {
+            return sgt.value() >= -64 && sgt.value() <= 63;
+        }
         return true;
     }
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160.hpp
@@ -160,6 +160,12 @@ class TMC2160 {
         return reg;
     }
 
+    static auto verify_sgt_value(std::optional<int> sgt) -> bool {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        if (sgt.has_value()) return sgt.value() >= -64 && sgt.value() <= 63;
+        return true;
+    }
+
     // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     [[nodiscard]] auto convert_peak_current_to_tmc2160_value(
         float peak_c, const GlobalScaler& glob_scale,


### PR DESCRIPTION
# Overview

The Flex Stacker motors do not have encoders on them so we can't use the same method we use for the Flex firmware to detect stalls, fortunately, the TMC2160 motors have a stall detection mechanism called `StallGuard` which uses back EMF to detect load changes. This pull request exposes the stall guard feature and takes advantage of the `diag0` pin to stop the motors in case of a stall. We then also provide a new `M910: SetMotorStallGuard` to enable and set each motor's Stall Guard Threshold (SGT) value to allow hardware testing to tune the values.

Closes: [PLAT-509](https://opentrons.atlassian.net/browse/PLAT-509)

# Changelog

- Enable diag0 pin by changing the `TCOOLTHRS > TSTEP` value to `0x2FF`
- Enable diag0_stall for all motors in the GCONF (0x00) register
- Enable the Stall Guard Threshold sgt value in the COOLCONF (0x6D) register
- Added an interrupt to listen to diag0 pin, which sends a `GPIOInterruptMessage` to the `motor_task`
- Handle the `GIOInterruptMessage` in the `motor_task` which stops the motors from running.
- Add new gcode `M910: SetMotorStallGuard` to enable/disable and set each motor's Stall Guard Threshold (SGT) value
- Add new gcode `M911: GetMotorStallGuard` to get the SGT since the coolconf reg is write-only.

# Testing

- [x] Make sure that the motors do not stop when held if stallguard Is disabled with `M910`
- [x] Make sure that we can change the stallguard sensitivity with `M910` and that the motors stops when held
- [x] Make sure we can get the stallguard threshold with `M911` after setting it with `M910`

# Review Requests

- Makes sense?
- Anything I'm missing?

[PLAT-509]: https://opentrons.atlassian.net/browse/PLAT-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ