### PR TITLE
fix(flex-stacker): g-code message parsing

### DIFF
--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -27,6 +27,21 @@ auto inline motor_id_to_char(MotorID motor_id) -> const char* {
                                                                    : "L");
 }
 
+template<typename ValueType, char... Chars>
+struct Arg {
+    static constexpr auto prefix = std::array{Chars...};
+    static constexpr bool required = false;
+    bool present = false;
+    ValueType value = ValueType{};
+};
+
+template<char... Chars>
+struct ArgNoVal {
+    static constexpr auto prefix = std::array{Chars...};
+    static constexpr bool required = false;
+    bool present = false;
+};
+
 struct GetTMCRegister {
     MotorID motor_id;
     uint8_t reg;


### PR DESCRIPTION
@vegano1 pointed out that the `SetTMCRegister` G-code no longer works. This PR fixes that and refactors the parser by adding argument templates so we don't have to re-write the structs so many times.