### PR TITLE
feat(flex-stacker): stream motor driver stall guard value during move

### DIFF
--- a/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_driver_task.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_driver_task.cpp
@@ -3,6 +3,7 @@
 #include "firmware/motor_driver_policy.hpp"
 #include "firmware/motor_hardware.h"
 #include "flex-stacker/motor_driver_task.hpp"
+#include "flex-stacker/tmc2160_interface.hpp"
 #include "ot_utils/freertos/freertos_timer.hpp"
 
 namespace motor_driver_task {
@@ -29,8 +30,9 @@ auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
     spi_hardware_init();
 
     auto policy = motor_driver_policy::MotorDriverPolicy();
+    auto tmc2160_interface = tmc2160::TMC2160Interface(policy);
     while (true) {
-        _top_task.run_once(policy);
+        _top_task.run_once(tmc2160_interface);
     }
 }
 

--- a/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_driver_task.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_driver_task.cpp
@@ -21,39 +21,43 @@ static tasks::FirmwareTasks::MotorDriverQueue
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _top_task = motor_driver_task::MotorDriverTask(_queue, nullptr);
 
-
 static constexpr uint32_t STREAM_TASK_DEPTH = 200;
 StaticTask_t stream_task_buffer;
-StackType_t stream_task_stack[ STREAM_TASK_DEPTH ];
+StackType_t stream_task_stack[STREAM_TASK_DEPTH];
+static constexpr uint32_t FREQ_MS = 50;
 
 static void run_stallguard_task(void* arg) {
-    auto& interface = *static_cast<tmc2160::TMC2160Interface*>(arg);
+    auto* interface = static_cast<
+        tmc2160::TMC2160Interface<motor_driver_policy::MotorDriverPolicy>*>(
+        arg);
+
     uint32_t ulNotifiedValue;
     MotorID motor_id;
 
-    xTaskNotifyWait(0, 0, &ulNotifiedValue, portMAX_DELAY);
-    switch (ulNotifiedValue) {
-        case 1:
-            motor_id = MotorID::MOTOR_X;
-            break;
-        case 2:
-            motor_id = MotorID::MOTOR_Z;
-            break;
-        case 3:
-            motor_id = MotorID::MOTOR_L;
-            break;
-        default:
-            return;
-    }
+    xTaskNotifyWait(0, 0xffffffff, &ulNotifiedValue, portMAX_DELAY);
+    motor_id = ulNotifiedValue == 1 ? MotorID::MOTOR_X
+               : 2                  ? MotorID::MOTOR_Z
+                                    : MotorID::MOTOR_L;
+    static_cast<void>(interface->read_stallguard(motor_id));
     for (;;) {
-//        auto value = interface.stream_stallguard(motor_id);
-//        if (value.has_value()) {
-//            _queue.send_message(value.value());
-//        }
-        auto msg = messages::StallGuardResultMessage{.data = motor_id};
-        static_cast<void>(_queue.try_send_from_isr(msg));
-        vTaskDelay(pdMS_TO_TICKS(100));
+        if (xTaskNotifyWait(0x00, 0xFFFFFFFF, &ulNotifiedValue, 0) == pdPASS) {
+            // value changed
+            motor_id = (ulNotifiedValue == 1)   ? MotorID::MOTOR_X
+                       : (ulNotifiedValue == 2) ? MotorID::MOTOR_Z
+                                                : MotorID::MOTOR_L;
+            // restart first reading
+            static_cast<void>(interface->read_stallguard(motor_id));
+        } else {
+            auto value = interface->read_stallguard(motor_id);
+            if (value.has_value()) {
+                auto msg =
+                    messages::StallGuardResultMessage{.data = value.value()};
+                static_cast<void>(_queue.try_send_from_isr(msg));
+            }
+        }
+        vTaskDelay(pdMS_TO_TICKS(FREQ_MS));
     }
+
 }
 
 auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
@@ -67,7 +71,9 @@ auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
     auto policy = motor_driver_policy::MotorDriverPolicy();
     auto tmc2160_interface = tmc2160::TMC2160Interface(policy);
 
-    auto* stream_handle = xTaskCreateStatic(run_stallguard_task, "Stallguard Task", STREAM_TASK_DEPTH, (void *)&tmc2160_interface, 1, stream_task_stack, &stream_task_buffer);
+    auto* stream_handle = xTaskCreateStatic(
+        run_stallguard_task, "Stallguard Task", STREAM_TASK_DEPTH,
+        &tmc2160_interface, 1, stream_task_stack, &stream_task_buffer);
     vTaskSuspend(stream_handle);
     _top_task.provide_stallguard_handle(stream_handle);
 

--- a/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_driver_task.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_driver_task.cpp
@@ -46,7 +46,8 @@ static void run_stallguard_task(void* arg) {
                                                 : MotorID::MOTOR_L;
             static_cast<void>(interface->read_stallguard(motor_id));
             for (;;) {
-                if (xTaskNotifyWait(ULONG_MAX, ULONG_MAX, NULL, 0) == pdPASS) {
+                if (xTaskNotifyWait(ULONG_MAX, ULONG_MAX, nullptr, 0) ==
+                    pdPASS) {
                     // Received a notification! This notification should only be
                     // used to break the for loop and the value would not be
                     // read. This, together with the task suspend issued by the

--- a/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_driver_task.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_driver_task.cpp
@@ -21,6 +21,41 @@ static tasks::FirmwareTasks::MotorDriverQueue
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto _top_task = motor_driver_task::MotorDriverTask(_queue, nullptr);
 
+
+static constexpr uint32_t STREAM_TASK_DEPTH = 200;
+StaticTask_t stream_task_buffer;
+StackType_t stream_task_stack[ STREAM_TASK_DEPTH ];
+
+static void run_stallguard_task(void* arg) {
+    auto& interface = *static_cast<tmc2160::TMC2160Interface*>(arg);
+    uint32_t ulNotifiedValue;
+    MotorID motor_id;
+
+    xTaskNotifyWait(0, 0, &ulNotifiedValue, portMAX_DELAY);
+    switch (ulNotifiedValue) {
+        case 1:
+            motor_id = MotorID::MOTOR_X;
+            break;
+        case 2:
+            motor_id = MotorID::MOTOR_Z;
+            break;
+        case 3:
+            motor_id = MotorID::MOTOR_L;
+            break;
+        default:
+            return;
+    }
+    for (;;) {
+//        auto value = interface.stream_stallguard(motor_id);
+//        if (value.has_value()) {
+//            _queue.send_message(value.value());
+//        }
+        auto msg = messages::StallGuardResultMessage{.data = motor_id};
+        static_cast<void>(_queue.try_send_from_isr(msg));
+        vTaskDelay(pdMS_TO_TICKS(100));
+    }
+}
+
 auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
     auto* handle = xTaskGetCurrentTaskHandle();
     _queue.provide_handle(handle);
@@ -31,6 +66,11 @@ auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
 
     auto policy = motor_driver_policy::MotorDriverPolicy();
     auto tmc2160_interface = tmc2160::TMC2160Interface(policy);
+
+    auto* stream_handle = xTaskCreateStatic(run_stallguard_task, "Stallguard Task", STREAM_TASK_DEPTH, (void *)&tmc2160_interface, 1, stream_task_stack, &stream_task_buffer);
+    vTaskSuspend(stream_handle);
+    _top_task.provide_stallguard_handle(stream_handle);
+
     while (true) {
         _top_task.run_once(tmc2160_interface);
     }

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_spi_hardware.c
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_spi_hardware.c
@@ -279,7 +279,7 @@ void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
 bool motor_spi_sendreceive(
     MotorID motor_id, uint8_t *txData, uint8_t *rxData, uint16_t size
 ) {
-    const TickType_t max_block_time = pdMS_TO_TICKS(50);
+    const TickType_t max_block_time = pdMS_TO_TICKS(10);
     uint32_t notification_val = 0;
 
     if (!_spi.initialized || (_spi.task_to_notify != NULL) || (size > MOTOR_MAX_SPI_LEN)) {

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_spi_hardware.c
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_spi_hardware.c
@@ -279,7 +279,7 @@ void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
 bool motor_spi_sendreceive(
     MotorID motor_id, uint8_t *txData, uint8_t *rxData, uint16_t size
 ) {
-    const TickType_t max_block_time = pdMS_TO_TICKS(100);
+    const TickType_t max_block_time = pdMS_TO_TICKS(50);
     uint32_t notification_val = 0;
 
     if (!_spi.initialized || (_spi.task_to_notify != NULL) || (size > MOTOR_MAX_SPI_LEN)) {

--- a/stm32-modules/include/flex-stacker/firmware/firmware_tasks.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/firmware_tasks.hpp
@@ -21,7 +21,7 @@ constexpr uint8_t SYSTEM_TASK_PRIORITY = 1;
 constexpr size_t MOTOR_STACK_SIZE = 256;
 constexpr uint8_t MOTOR_TASK_PRIORITY = 1;
 
-constexpr size_t MOTOR_DRIVER_STACK_SIZE = 256;
+constexpr size_t MOTOR_DRIVER_STACK_SIZE = 512;
 constexpr uint8_t MOTOR_DRIVER_TASK_PRIORITY = 1;
 
 constexpr size_t UI_STACK_SIZE = 256;

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -49,6 +49,37 @@ struct ArgNoPrefix {
     ValueType value = ValueType{};
 };
 
+struct StallGuardResult {
+    uint32_t data;
+
+    using ParseResult = std::optional<StallGuardResult>;
+    static constexpr auto prefix = std::array{'M', '9', '0', '0', ' '};
+
+    template <typename InputIt, typename Limit>
+        requires std::forward_iterator<InputIt> &&
+                 std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(StallGuardResult()), working);
+    }
+
+    template <typename InputIt, typename InLimit>
+        requires std::forward_iterator<InputIt> &&
+                 std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit,
+                                    uint32_t data) -> InputIt {
+        auto res = snprintf(&*buf, (limit - buf), "M900 %lu OK\n", data);
+        if (res <= 0) {
+            return buf;
+        }
+        return buf + res;
+    }
+};
+
 struct GetTMCRegister {
     MotorID motor_id;
     uint8_t reg;

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -56,8 +56,8 @@ struct StallGuardResult {
     static constexpr auto prefix = std::array{'M', '9', '0', '0', ' '};
 
     template <typename InputIt, typename Limit>
-        requires std::forward_iterator<InputIt> &&
-                 std::sized_sentinel_for<Limit, InputIt>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
     static auto parse(const InputIt& input, Limit limit)
         -> std::pair<ParseResult, InputIt> {
         auto working = prefix_matches(input, limit, prefix);
@@ -68,10 +68,10 @@ struct StallGuardResult {
     }
 
     template <typename InputIt, typename InLimit>
-        requires std::forward_iterator<InputIt> &&
-                 std::sized_sentinel_for<InputIt, InLimit>
-    static auto write_response_into(InputIt buf, InLimit limit,
-                                    uint32_t data) -> InputIt {
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit, uint32_t data)
+        -> InputIt {
         auto res = snprintf(&*buf, (limit - buf), "M900 %lu OK\n", data);
         if (res <= 0) {
             return buf;

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -495,7 +495,9 @@ struct MoveMotorInSteps {
             ret.steps_per_second_sq = std::get<4>(arguments).value;
         }
 
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if (std::get<5>(arguments).present) {
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
             ret.stream_stallguard = true;
         }
         return std::make_pair(ret, res.second);
@@ -572,6 +574,7 @@ struct MoveMotorInMm {
             // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
             ret.mm_per_second_discont = std::get<5>(arguments).value;
         }
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if (std::get<6>(arguments).present) {
             // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
             ret.stream_stallguard = true;

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -247,6 +247,15 @@ class HostCommsTask {
     }
 
     template <typename InputIt, typename InputLimit>
+        requires std::forward_iterator<InputIt> &&
+                 std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(const messages::StallGuardResultMessage& response,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        return gcode::StallGuardResult::write_response_into(
+            tx_into, tx_limit, response.data);
+    }
+
+    template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_message(const messages::GetSystemInfoResponse& response,

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -247,12 +247,12 @@ class HostCommsTask {
     }
 
     template <typename InputIt, typename InputLimit>
-        requires std::forward_iterator<InputIt> &&
-                 std::sized_sentinel_for<InputLimit, InputIt>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_message(const messages::StallGuardResultMessage& response,
                        InputIt tx_into, InputLimit tx_limit) -> InputIt {
-        return gcode::StallGuardResult::write_response_into(
-            tx_into, tx_limit, response.data);
+        return gcode::StallGuardResult::write_response_into(tx_into, tx_limit,
+                                                            response.data);
     }
 
     template <typename InputIt, typename InputLimit>

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -545,7 +545,8 @@ class HostCommsTask {
             .motor_id = gcode.motor_id,
             .steps = gcode.steps,
             .steps_per_second = gcode.steps_per_second,
-            .steps_per_second_sq = gcode.steps_per_second_sq};
+            .steps_per_second_sq = gcode.steps_per_second_sq,
+            .stream_stallguard = gcode.stream_stallguard};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
@@ -570,6 +571,7 @@ class HostCommsTask {
             .id = id,
             .motor_id = gcode.motor_id,
             .mm = gcode.mm,
+            .stream_stallguard = gcode.stream_stallguard,
             .mm_per_second = gcode.mm_per_second,
             .mm_per_second_sq = gcode.mm_per_second_sq,
             .mm_per_second_discont = gcode.mm_per_second_discont};
@@ -597,6 +599,7 @@ class HostCommsTask {
             .id = id,
             .motor_id = gcode.motor_id,
             .direction = gcode.direction,
+            .stream_stallguard = gcode.stream_stallguard,
             .mm_per_second = gcode.mm_per_second,
             .mm_per_second_sq = gcode.mm_per_second_sq,
             .mm_per_second_discont = gcode.mm_per_second_discont};
@@ -620,10 +623,12 @@ class HostCommsTask {
                 false, errors::write_into(tx_into, tx_limit,
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
-        auto message = messages::MoveMotorMessage{.id = id,
-                                                  .motor_id = gcode.motor_id,
-                                                  .direction = gcode.direction,
-                                                  .frequency = gcode.frequency};
+        auto message = messages::MoveMotorMessage{
+            .id = id,
+            .motor_id = gcode.motor_id,
+            .direction = gcode.direction,
+            .frequency = gcode.frequency,
+            .stream_stallguard = gcode.stream_stallguard};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -115,15 +115,12 @@ struct GetTMCRegisterMessage {
     uint8_t reg;
 };
 
-struct PollTMCRegisterMessage {
+struct PollStallGuardMessage {
     uint32_t id;
     MotorID motor_id;
-    uint8_t reg;
 };
 
-struct StopPollTMCRegisterMessage {
-    uint32_t id;
-};
+struct StopPollStallGuardMessage {};
 
 struct GetTMCRegisterResponse {
     uint32_t responding_to_id;
@@ -219,7 +216,7 @@ using SystemMessage =
 
 using MotorDriverMessage =
     ::std::variant<std::monostate, SetTMCRegisterMessage, GetTMCRegisterMessage,
-                   PollTMCRegisterMessage, StopPollTMCRegisterMessage,
+                   PollStallGuardMessage, StopPollStallGuardMessage,
                    SetMotorCurrentMessage, SetMicrostepsMessage>;
 
 using MotorMessage =

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -221,7 +221,8 @@ using SystemMessage =
 using MotorDriverMessage =
     ::std::variant<std::monostate, SetTMCRegisterMessage, GetTMCRegisterMessage,
                    PollStallGuardMessage, StopPollStallGuardMessage,
-                   SetMotorCurrentMessage, SetMicrostepsMessage, StallGuardResultMessage>;
+                   SetMotorCurrentMessage, SetMicrostepsMessage,
+                   StallGuardResultMessage>;
 
 using MotorMessage =
     ::std::variant<std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -146,12 +146,14 @@ struct MoveMotorInStepsMessage {
     int32_t steps;
     uint32_t steps_per_second;
     uint32_t steps_per_second_sq;
+    bool stream_stallguard;
 };
 
 struct MoveMotorInMmMessage {
     uint32_t id = 0;
     MotorID motor_id = MotorID::MOTOR_X;
     float mm = 0;
+    bool stream_stallguard = false;
     std::optional<float> mm_per_second = std::nullopt;
     std::optional<float> mm_per_second_sq = std::nullopt;
     std::optional<float> mm_per_second_discont = std::nullopt;
@@ -161,6 +163,7 @@ struct MoveToLimitSwitchMessage {
     uint32_t id = 0;
     MotorID motor_id = MotorID::MOTOR_X;
     bool direction = false;
+    bool stream_stallguard = false;
     std::optional<float> mm_per_second = std::nullopt;
     std::optional<float> mm_per_second_sq = std::nullopt;
     std::optional<float> mm_per_second_discont = std::nullopt;
@@ -189,6 +192,7 @@ struct MoveMotorMessage {
     MotorID motor_id;
     bool direction;
     uint32_t frequency;
+    bool stream_stallguard;
 };
 
 struct StopMotorMessage {

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -120,6 +120,10 @@ struct PollStallGuardMessage {
     MotorID motor_id;
 };
 
+struct StallGuardResultMessage {
+    uint32_t data;
+};
+
 struct StopPollStallGuardMessage {};
 
 struct GetTMCRegisterResponse {
@@ -208,7 +212,7 @@ using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
                    GetTMCRegisterResponse, GetLimitSwitchesResponses,
-                   GetMoveParamsResponse>;
+                   GetMoveParamsResponse, StallGuardResultMessage>;
 
 using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,
@@ -217,7 +221,7 @@ using SystemMessage =
 using MotorDriverMessage =
     ::std::variant<std::monostate, SetTMCRegisterMessage, GetTMCRegisterMessage,
                    PollStallGuardMessage, StopPollStallGuardMessage,
-                   SetMotorCurrentMessage, SetMicrostepsMessage>;
+                   SetMotorCurrentMessage, SetMicrostepsMessage, StallGuardResultMessage>;
 
 using MotorMessage =
     ::std::variant<std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -244,7 +244,8 @@ class MotorDriverTask {
     auto visit_message(const messages::PollStallGuardMessage& m,
                        tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
-        if (_stream_task_handle != NULL) {
+        static_cast<void>(tmc2160_interface);
+        if (_stream_task_handle != nullptr) {
             vTaskResume(_stream_task_handle);
             xTaskNotify(_stream_task_handle, int_from_id(m.motor_id),
                         eSetValueWithoutOverwrite);
@@ -255,7 +256,9 @@ class MotorDriverTask {
     auto visit_message(const messages::StopPollStallGuardMessage& m,
                        tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
-        if (_stream_task_handle != NULL) {
+        static_cast<void>(m);
+        static_cast<void>(tmc2160_interface);
+        if (_stream_task_handle != nullptr) {
             xTaskNotify(_stream_task_handle, 0, eSetValueWithoutOverwrite);
             vTaskSuspend(_stream_task_handle);
         }
@@ -265,6 +268,7 @@ class MotorDriverTask {
     auto visit_message(const messages::StallGuardResultMessage& m,
                        tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
+        static_cast<void>(tmc2160_interface);
         static_cast<void>(
             _task_registry->send_to_address(m, Queues::HostCommsAddress));
     }
@@ -328,6 +332,6 @@ class MotorDriverTask {
     tmc2160::TMC2160RegisterMap _z_config = motor_z_config;
     tmc2160::TMC2160RegisterMap _l_config = motor_l_config;
 
-    TaskHandle_t _stream_task_handle = NULL;
+    TaskHandle_t _stream_task_handle = nullptr;
 };
 };  // namespace motor_driver_task

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -224,7 +224,7 @@ class MotorDriverTask {
     }
 
     template <tmc2160::TMC2160InterfacePolicy Policy>
-    auto visit_message(const messages::PollTMCRegisterMessage& m,
+    auto visit_message(const messages::PollStallGuardMessage& m,
                        tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
         static_cast<void>(m);
@@ -232,7 +232,7 @@ class MotorDriverTask {
     }
 
     template <tmc2160::TMC2160InterfacePolicy Policy>
-    auto visit_message(const messages::StopPollTMCRegisterMessage& m,
+    auto visit_message(const messages::StopPollStallGuardMessage& m,
                        tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
         -> void {
         static_cast<void>(m);

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -142,11 +142,11 @@ class MotorDriverTask {
     }
 
     template <tmc2160::TMC2160InterfacePolicy Policy>
-    auto run_once(Policy& policy) -> void {
+    auto run_once(tmc2160::TMC2160Interface<Policy>& tmc2160_interface)
+        -> void {
         if (!_task_registry) {
             return;
         }
-        auto tmc2160_interface = tmc2160::TMC2160Interface<Policy>(policy);
         if (!_initialized) {
             if (!_tmc2160.initialize_config(motor_x_config, tmc2160_interface,
                                             MotorID::MOTOR_X)) {

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -248,7 +248,7 @@ class MotorDriverTask {
         if (_stream_task_handle != nullptr) {
             vTaskResume(_stream_task_handle);
             xTaskNotify(_stream_task_handle, int_from_id(m.motor_id),
-                        eSetValueWithoutOverwrite);
+                        eSetValueWithOverwrite);
         }
     }
 
@@ -259,7 +259,7 @@ class MotorDriverTask {
         static_cast<void>(m);
         static_cast<void>(tmc2160_interface);
         if (_stream_task_handle != nullptr) {
-            xTaskNotify(_stream_task_handle, 0, eSetValueWithoutOverwrite);
+            xTaskNotify(_stream_task_handle, 0, eSetValueWithOverwrite);
             vTaskSuspend(_stream_task_handle);
         }
     }

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -227,6 +227,11 @@ class MotorTask {
                 motor_state(m.motor_id).get_speed_discont(),
                 motor_state(m.motor_id).get_speed(),
                 motor_state(m.motor_id).get_accel());
+
+        auto driver_message = messages::PollStallGuardMessage{
+            .id = m.id, .motor_id = m.motor_id};
+        static_cast<void>(_task_registry->send_to_address(
+            driver_message, Queues::MotorDriverAddress));
     }
 
     template <MotorControlPolicy Policy>
@@ -289,7 +294,10 @@ class MotorTask {
                 controller_from_id(m.motor_id).get_response_id()};
         static_cast<void>(_task_registry->send_to_address(
             response, Queues::HostCommsAddress));
-    }
+        auto driver_message = messages::StopPollStallGuardMessage{};
+        static_cast<void>(_task_registry->send_to_address(
+            driver_message, Queues::MotorDriverAddress));
+    };
 
     template <MotorControlPolicy Policy>
     auto visit_message(const messages::SetMicrostepsMessage& m, Policy& policy)

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -228,8 +228,8 @@ class MotorTask {
                 motor_state(m.motor_id).get_speed(),
                 motor_state(m.motor_id).get_accel());
 
-        auto driver_message = messages::PollStallGuardMessage{
-            .id = m.id, .motor_id = m.motor_id};
+        auto driver_message =
+            messages::PollStallGuardMessage{.id = m.id, .motor_id = m.motor_id};
         static_cast<void>(_task_registry->send_to_address(
             driver_message, Queues::MotorDriverAddress));
     }

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160_interface.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160_interface.hpp
@@ -114,36 +114,24 @@ class TMC2160Interface {
         return RT(retval);
     }
 
-    auto create_stallguard_message() -> MessageT {
-        return build_message(Registers::DRVSTATUS, WriteFlag::READ, 0).value();
-    }
+//    auto create_stallguard_message() -> MessageT {
+//        build_message(Registers::DRVSTATUS, WriteFlag::READ, 0);
+//    }
 
-    auto stream_stallguard(MotorID motor_id)
+    auto read_stallguard(MotorID motor_id)
         -> std::optional<RegisterSerializedType> {
         using RT = std::optional<RegisterSerializedType>;
-        auto buffer = create_stallguard_message();
-        auto ret = _policy.tmc2160_transmit_receive(motor_id, buffer.value());
+        MessageT buffer = {0x6F, 0x00, 0x00, 0x00, 0x00};
+        auto ret = _policy.tmc2160_transmit_receive(motor_id, buffer);
         if (!ret.has_value()) {
             return RT();
         }
+        auto* iter = ret.value().begin();
+        std::advance(iter, 1);
 
-
-        for (;;) {
-
-            ret = _policy.tmc2160_transmit_receive(motor_id, buffer.value());
-            if (!ret.has_value()) {
-                return RT();
-            }
-            ret = _policy.tmc2160_transmit_receive(motor_id, buffer.value());
-            if (!ret.has_value()) {
-                return RT();
-            }
-            auto* iter = ret.value().begin();
-            std::advance(iter, 1);
-
-            RegisterSerializedType retval = 0;
-            iter = bit_utils::bytes_to_int(iter, ret.value().end(), retval);
-        }
+        RegisterSerializedType retval = 0;
+        iter = bit_utils::bytes_to_int(iter, ret.value().end(), retval);
+        return RT(retval);
     }
 
   private:

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmc2160_interface.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmc2160_interface.hpp
@@ -114,9 +114,9 @@ class TMC2160Interface {
         return RT(retval);
     }
 
-    auto read_stallguard(MotorID motor_id)
-        -> uint32_t {
-        MessageT stallguard_msg = {static_cast<uint8_t>(Registers::DRVSTATUS), 0x00, 0x00, 0x00, 0x00};
+    auto read_stallguard(MotorID motor_id) -> uint32_t {
+        MessageT stallguard_msg = {static_cast<uint8_t>(Registers::DRVSTATUS),
+                                   0x00, 0x00, 0x00, 0x00};
         auto ret = _policy.tmc2160_transmit_receive(motor_id, stallguard_msg);
         if (!ret.has_value()) {
             return 0;


### PR DESCRIPTION
This PR creates a freertos task that handles the streaming of the stall guard value if requested in the move. The stall guard result from the motor driver will be reported via a `M900` message every 10 ms while the motor is in motion.

Any concerns regarding how the freertos task is created/executed?