### PR TITLE
feat(thermocycler): make sure the lid ease off the latch before attempting to open

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/test/test_motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/test/test_motor_policy.hpp
@@ -43,10 +43,9 @@ class TestMotorPolicy : public TestTMC2130Policy {
     auto lid_solenoid_disengage() -> void { _solenoid_engaged = false; }
     auto lid_solenoid_engage() -> void { _solenoid_engaged = true; }
 
-    auto lid_read_closed_switch() -> bool {
-        return _lid_closed_switch; }
+    auto lid_read_closed_switch() -> bool { return _lid_closed_switch; }
 
-    auto lid_read_open_switch() -> bool {return _lid_open_switch; }
+    auto lid_read_open_switch() -> bool { return _lid_open_switch; }
 
     auto seal_stepper_start(Callback cb) -> bool {
         if (_seal_moving) {

--- a/stm32-modules/include/thermocycler-gen2/test/test_motor_policy.hpp
+++ b/stm32-modules/include/thermocycler-gen2/test/test_motor_policy.hpp
@@ -43,9 +43,10 @@ class TestMotorPolicy : public TestTMC2130Policy {
     auto lid_solenoid_disengage() -> void { _solenoid_engaged = false; }
     auto lid_solenoid_engage() -> void { _solenoid_engaged = true; }
 
-    auto lid_read_closed_switch() -> bool { return _lid_closed_switch; }
+    auto lid_read_closed_switch() -> bool {
+        return _lid_closed_switch; }
 
-    auto lid_read_open_switch() -> bool { return _lid_open_switch; }
+    auto lid_read_open_switch() -> bool {return _lid_open_switch; }
 
     auto seal_stepper_start(Callback cb) -> bool {
         if (_seal_moving) {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1319,6 +1319,8 @@ class MotorTask {
                                             policy);
                 break;
             case LidStepperState::Status::LATCH_RELEASE_BACKOFF:
+                // Close the latch
+                policy.lid_solenoid_disengage();
                 if (!policy.lid_read_closed_switch()) {
                     // The latch is not holding the lid down, continue to open
                     policy.lid_stepper_start(LidStepperState::FULL_OPEN_DEGREES,
@@ -1347,9 +1349,6 @@ class MotorTask {
                         _task_registry->comms->get_message_queue().try_send(
                             messages::HostCommsMessage(response)));
                 } else {
-                    // Now that the lid is at the open position,
-                    // the solenoid can be safely turned off
-                    policy.lid_solenoid_disengage();
                     // Overdrive into switch
                     policy.lid_stepper_start(
                         LidStepperState::OPEN_OVERDRIVE_DEGREES, true);

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -984,7 +984,7 @@ class MotorTask {
             LidStepperState::LID_DEFAULT_VELOCITY_RPM);
         // Now start a lid motor movement to the endstop
         policy.lid_stepper_set_dac(LID_STEPPER_RUN_CURRENT);
-        policy.lid_stepper_start(LidStepperState::LATCH_RELEASE_OVERDRIVE_DEGREES, false);
+        policy.lid_stepper_start(LidStepperState::LATCH_RELEASE_OVERDRIVE_DEGREES, true);
         // Store the new state, as well as the response ID
         _lid_stepper_state.status = LidStepperState::Status::LATCH_RELEASE_OVERDRIVE;
         _lid_stepper_state.response_id = response_id;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1309,7 +1309,12 @@ class MotorTask {
                         motor_util::LidStepper::Position::BETWEEN;
                 } else {
                     // The latch is stuck, stop and raise error
-                    error = errors::ErrorCode::LID_MOTOR_FAULT;
+                    handle_lid_movement_error(policy);
+                    auto response = messages::ErrorMessage{
+                        .code = errors::ErrorCode::UNEXPECTED_LID_STATE};
+                    static_cast<void>(
+                        _task_registry->comms->get_message_queue().try_send(
+                            messages::HostCommsMessage(response)));
                 }
                 break;
             case LidStepperState::Status::OPEN_TO_SWITCH:

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1319,6 +1319,15 @@ class MotorTask {
                 error = handle_lid_state_end(policy);
                 break;
             case LidStepperState::Status::CLOSE_TO_SWITCH:
+                if (!policy.lid_read_closed_switch()) {
+                    error = errors::ErrorCode::UNEXPECTED_LID_STATE;
+                    // send error message instead
+                    auto response = messages::ErrorMessage{
+                        .code = errors::ErrorCode::UNEXPECTED_LID_STATE};
+                    static_cast<void>(
+                        _task_registry->comms->get_message_queue().try_send(
+                            messages::HostCommsMessage(response)));
+                }
                 // Overdrive the lid stepper into the switch
                 policy.lid_stepper_start(
                     LidStepperState::CLOSE_OVERDRIVE_DEGREES, true);

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -137,15 +137,16 @@ struct LidStepperState {
     constexpr static double LID_DEFAULT_VELOCITY_RPM = 125.0F;
     // States for lid stepper
     enum Status {
-        IDLE,            /**< Not moving.*/
-        SIMPLE_MOVEMENT, /**< Single stage movement.*/
-        LATCH_RELEASE_OVERDRIVE,   /**< Close lid to ease off latch.*/
-        LATCH_RELEASE_BACKOFF,  /**< Open lid slightly to make sure latch is not stuck before fully opening.*/
-        OPEN_TO_SWITCH,  /**< Open until the open switch is hit.*/
-        OPEN_OVERDRIVE,  /**< Close from switch back to 90º position.*/
-        CLOSE_TO_SWITCH, /**< Close lid until it hits the switch.*/
-        CLOSE_OVERDRIVE, /**< Close lid a few degrees into the switch.*/
-        LIFT_NUDGE,      /**< Nudge the plate up with one pin.*/
+        IDLE,                    /**< Not moving.*/
+        SIMPLE_MOVEMENT,         /**< Single stage movement.*/
+        LATCH_RELEASE_OVERDRIVE, /**< Close lid to ease off latch.*/
+        LATCH_RELEASE_BACKOFF, /**< Open lid slightly to make sure latch is not
+                                  stuck before fully opening.*/
+        OPEN_TO_SWITCH,        /**< Open until the open switch is hit.*/
+        OPEN_OVERDRIVE,        /**< Close from switch back to 90º position.*/
+        CLOSE_TO_SWITCH,       /**< Close lid until it hits the switch.*/
+        CLOSE_OVERDRIVE,       /**< Close lid a few degrees into the switch.*/
+        LIFT_NUDGE,            /**< Nudge the plate up with one pin.*/
         LIFT_NUDGE_DOWN, /**< Move back to the "open" position after nudging.*/
         LIFT_RAISE,      /**< Open lid to raise the plate lift.*/
         LIFT_LOWER,      /**< Close lid to lower the plate lift.*/
@@ -218,11 +219,11 @@ struct LidState {
         OPENING_RETRACT_SEAL,         /**< Retracting seal before opening lid.*/
         OPENING_RETRACT_SEAL_BACKOFF, /**< Extend seal to ease off of the
                                            limit switch.*/
-        OPENING_LID_HINGE,           /**< Opening lid hinge.*/
+        OPENING_LID_HINGE,            /**< Opening lid hinge.*/
         CLOSING_RETRACT_SEAL,         /**< Retracting seal before closing lid.*/
         CLOSING_RETRACT_SEAL_BACKOFF, /**< Extend seal to ease off of the
                                            limit switch.*/
-        CLOSING_LID_HINGE,          /**< Closing lid hinge.*/
+        CLOSING_LID_HINGE,            /**< Closing lid hinge.*/
         CLOSING_EXTEND_SEAL,          /**< Extending seal after closing
                                            lid hinge.*/
         CLOSING_EXTEND_SEAL_BACKOFF,  /**< Retract seal to ease off of the
@@ -920,8 +921,8 @@ class MotorTask {
             error = errors::ErrorCode::SEAL_MOTOR_SWITCH;
         } else if (retract_switch) {
             // Seal is already retracted, so just open the hinge
-            error = handle_lid_state_enter(
-                LidState::Status::CLOSING_LID_HINGE, policy);
+            error = handle_lid_state_enter(LidState::Status::CLOSING_LID_HINGE,
+                                           policy);
         } else {
             // Always retract seal before closing
             error = handle_lid_state_enter(
@@ -978,32 +979,37 @@ class MotorTask {
     }
 
     template <MotorExecutionPolicy Policy>
-    auto start_latch_release_overdrive(uint32_t response_id, Policy& policy) -> bool {
+    auto start_latch_release_overdrive(uint32_t response_id, Policy& policy)
+        -> bool {
         // Update velocity for this movement
         std::ignore = policy.lid_stepper_set_rpm(
             LidStepperState::LID_DEFAULT_VELOCITY_RPM);
         // Now start a lid motor movement to the endstop
         policy.lid_stepper_set_dac(LID_STEPPER_RUN_CURRENT);
-        policy.lid_stepper_start(LidStepperState::LATCH_RELEASE_OVERDRIVE_DEGREES, true);
+        policy.lid_stepper_start(
+            LidStepperState::LATCH_RELEASE_OVERDRIVE_DEGREES, true);
         // Store the new state, as well as the response ID
-        _lid_stepper_state.status = LidStepperState::Status::LATCH_RELEASE_OVERDRIVE;
+        _lid_stepper_state.status =
+            LidStepperState::Status::LATCH_RELEASE_OVERDRIVE;
         _lid_stepper_state.response_id = response_id;
         return true;
     }
 
     template <MotorExecutionPolicy Policy>
-    auto start_latch_release_backoff(uint32_t response_id, Policy& policy) -> bool {
+    auto start_latch_release_backoff(uint32_t response_id, Policy& policy)
+        -> bool {
         // First release the latch
         policy.lid_solenoid_engage();
         std::ignore = policy.lid_stepper_set_rpm(
             LidStepperState::LID_DEFAULT_VELOCITY_RPM);
         // Now start a lid motor movement to the endstop
         policy.lid_stepper_set_dac(LID_STEPPER_RUN_CURRENT);
-        policy.lid_stepper_start(LidStepperState::LATCH_RELEASE_BACKOFF_DEGREES, false);
+        policy.lid_stepper_start(LidStepperState::LATCH_RELEASE_BACKOFF_DEGREES,
+                                 false);
         // Store the new state, as well as the response ID
-        _lid_stepper_state.status = LidStepperState::Status::LATCH_RELEASE_BACKOFF;
-        _lid_stepper_state.position =
-            motor_util::LidStepper::Position::BETWEEN;
+        _lid_stepper_state.status =
+            LidStepperState::Status::LATCH_RELEASE_BACKOFF;
+        _lid_stepper_state.position = motor_util::LidStepper::Position::BETWEEN;
         _lid_stepper_state.response_id = response_id;
         return true;
     }
@@ -1301,9 +1307,7 @@ class MotorTask {
     template <MotorExecutionPolicy Policy>
     auto handle_hinge_state_end(Policy& policy) -> errors::ErrorCode {
         auto error = errors::ErrorCode::NO_ERROR;
-//        switch (_lid_stepper_state.status.load()) {
-        auto _status = _lid_stepper_state.status.load();
-        switch (_status) {
+        switch (_lid_stepper_state.status.load()) {
             case LidStepperState::Status::SIMPLE_MOVEMENT:
                 // Turn off the drive current
                 policy.lid_stepper_set_dac(LID_STEPPER_HOLD_CURRENT);
@@ -1313,14 +1317,17 @@ class MotorTask {
                     motor_util::LidStepper::Position::BETWEEN;
                 break;
             case LidStepperState::Status::LATCH_RELEASE_OVERDRIVE:
-                start_latch_release_backoff(_lid_stepper_state.response_id, policy);
+                start_latch_release_backoff(_lid_stepper_state.response_id,
+                                            policy);
                 break;
             case LidStepperState::Status::LATCH_RELEASE_BACKOFF:
                 if (!policy.lid_read_closed_switch()) {
                     // The latch is not holding the lid down, continue to open
-                    policy.lid_stepper_start(LidStepperState::FULL_OPEN_DEGREES, false);
+                    policy.lid_stepper_start(LidStepperState::FULL_OPEN_DEGREES,
+                                             false);
                     // Store the new state, as well as the response ID
-                    _lid_stepper_state.status = LidStepperState::Status::OPEN_TO_SWITCH;
+                    _lid_stepper_state.status =
+                        LidStepperState::Status::OPEN_TO_SWITCH;
                     _lid_stepper_state.position =
                         motor_util::LidStepper::Position::BETWEEN;
                 } else {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1275,11 +1275,7 @@ class MotorTask {
         _state.status = LidState::Status::IDLE;
         _lid_stepper_state.position = motor_util::LidStepper::Position::UNKNOWN;
 
-        auto error_msg = messages::UpdateTaskErrorState{
-            .task = messages::UpdateTaskErrorState::Tasks::MOTOR,
-            .current_error = most_relevant_error()};
-        static_cast<void>(
-            _task_registry->system->get_message_queue().try_send(error_msg));
+        // TODO: issue an update task error state to system task
     }
 
     /**

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1347,18 +1347,6 @@ class MotorTask {
                 }
                 break;
             case LidStepperState::Status::CLOSE_OVERDRIVE:
-                // Now that the lid is at the closed position,
-                // the solenoid can be safely turned off
-                policy.lid_solenoid_disengage();
-                // Turn off lid stepper current
-                policy.lid_stepper_set_dac(LID_STEPPER_HOLD_CURRENT);
-                // Movement is done
-                _lid_stepper_state.status = LidStepperState::Status::IDLE;
-                _lid_stepper_state.position =
-                    motor_util::LidStepper::Position::CLOSED;
-                // The overall lid state machine can advance now
-                error = handle_lid_state_end(policy);
-                // if the lid isn't actually closed, overwrite error status
                 if (!policy.lid_read_closed_switch()) {
                     handle_movement_error(policy);
                     auto response = messages::ErrorMessage{
@@ -1366,6 +1354,19 @@ class MotorTask {
                     static_cast<void>(
                         _task_registry->comms->get_message_queue().try_send(
                             messages::HostCommsMessage(response)));
+                } else {
+                    // Now that the lid is at the closed position,
+                    // the solenoid can be safely turned off
+                    policy.lid_solenoid_disengage();
+                    // Turn off lid stepper current
+                    policy.lid_stepper_set_dac(LID_STEPPER_HOLD_CURRENT);
+                    // Movement is done
+                    _lid_stepper_state.status = LidStepperState::Status::IDLE;
+                    _lid_stepper_state.position =
+                        motor_util::LidStepper::Position::CLOSED;
+                    // The overall lid state machine can advance now
+                    error = handle_lid_state_end(policy);
+                    // if the lid isn't actually closed, overwrite error status
                 }
                 break;
             case LidStepperState::Status::LIFT_NUDGE:

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1274,6 +1274,12 @@ class MotorTask {
         _lid_stepper_state.status = LidStepperState::Status::IDLE;
         _state.status = LidState::Status::IDLE;
         _lid_stepper_state.position = motor_util::LidStepper::Position::UNKNOWN;
+
+        auto error_msg = messages::UpdateTaskErrorState{
+            .task = messages::UpdateTaskErrorState::Tasks::MOTOR,
+            .current_error = most_relevant_error()};
+        static_cast<void>(
+            _task_registry->system->get_message_queue().try_send(error_msg));
     }
 
     /**

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1265,7 +1265,7 @@ class MotorTask {
     }
 
     template <MotorExecutionPolicy Policy>
-    auto handle_movement_error(Policy& policy) {
+    auto handle_lid_movement_error(Policy& policy) {
         policy.lid_solenoid_disengage();
         // Turn off lid stepper current
         policy.lid_stepper_set_dac(LID_STEPPER_HOLD_CURRENT);
@@ -1311,28 +1311,47 @@ class MotorTask {
                 }
                 break;
             case LidStepperState::Status::OPEN_TO_SWITCH:
-                // Now that the lid is at the open position,
-                // the solenoid can be safely turned off
-                policy.lid_solenoid_disengage();
-                // Overdrive into switch
-                policy.lid_stepper_start(
-                    LidStepperState::OPEN_OVERDRIVE_DEGREES, true);
-                _lid_stepper_state.status =
-                    LidStepperState::Status::OPEN_OVERDRIVE;
+                if (!policy.lid_read_open_switch()) {
+                    handle_lid_movement_error(policy);
+                    auto response = messages::ErrorMessage{
+                        .code = errors::ErrorCode::UNEXPECTED_LID_STATE};
+                    static_cast<void>(
+                        _task_registry->comms->get_message_queue().try_send(
+                            messages::HostCommsMessage(response)));
+                } else {
+                    // Now that the lid is at the open position,
+                    // the solenoid can be safely turned off
+                    policy.lid_solenoid_disengage();
+                    // Overdrive into switch
+                    policy.lid_stepper_start(
+                        LidStepperState::OPEN_OVERDRIVE_DEGREES, true);
+                    _lid_stepper_state.status =
+                        LidStepperState::Status::OPEN_OVERDRIVE;
+                }
                 break;
             case LidStepperState::Status::OPEN_OVERDRIVE:
-                // Turn off lid stepper current
-                policy.lid_stepper_set_dac(LID_STEPPER_HOLD_CURRENT);
-                // Movement is done
-                _lid_stepper_state.status = LidStepperState::Status::IDLE;
-                _lid_stepper_state.position =
-                    motor_util::LidStepper::Position::OPEN;
-                // The overall lid state machine can advance now
-                error = handle_lid_state_end(policy);
+                // lid open switch should no longer be triggered
+                if (policy.lid_read_open_switch()) {
+                    handle_lid_movement_error(policy);
+                    auto response = messages::ErrorMessage{
+                        .code = errors::ErrorCode::UNEXPECTED_LID_STATE};
+                    static_cast<void>(
+                        _task_registry->comms->get_message_queue().try_send(
+                            messages::HostCommsMessage(response)));
+                } else {
+                    // Turn off lid stepper current
+                    policy.lid_stepper_set_dac(LID_STEPPER_HOLD_CURRENT);
+                    // Movement is done
+                    _lid_stepper_state.status = LidStepperState::Status::IDLE;
+                    _lid_stepper_state.position =
+                        motor_util::LidStepper::Position::OPEN;
+                    // The overall lid state machine can advance now
+                    error = handle_lid_state_end(policy);
+                }
                 break;
             case LidStepperState::Status::CLOSE_TO_SWITCH:
                 if (!policy.lid_read_closed_switch()) {
-                    handle_movement_error(policy);
+                    handle_lid_movement_error(policy);
                     auto response = messages::ErrorMessage{
                         .code = errors::ErrorCode::UNEXPECTED_LID_STATE};
                     static_cast<void>(
@@ -1348,7 +1367,7 @@ class MotorTask {
                 break;
             case LidStepperState::Status::CLOSE_OVERDRIVE:
                 if (!policy.lid_read_closed_switch()) {
-                    handle_movement_error(policy);
+                    handle_lid_movement_error(policy);
                     auto response = messages::ErrorMessage{
                         .code = errors::ErrorCode::UNEXPECTED_LID_STATE};
                     static_cast<void>(

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1264,6 +1264,18 @@ class MotorTask {
         return error;
     }
 
+    template <MotorExecutionPolicy Policy>
+    auto handle_movement_error(Policy& policy) {
+        policy.lid_solenoid_disengage();
+        // Turn off lid stepper current
+        policy.lid_stepper_set_dac(LID_STEPPER_HOLD_CURRENT);
+
+        // update status
+        _lid_stepper_state.status = LidStepperState::Status::IDLE;
+        _state.status = LidState::Status::IDLE;
+        _lid_stepper_state.position = motor_util::LidStepper::Position::UNKNOWN;
+    }
+
     /**
      * @brief Handler to transition between lid hinge motor states. Should be
      * called every time a lid motor movement complete callback is triggered.
@@ -1320,19 +1332,19 @@ class MotorTask {
                 break;
             case LidStepperState::Status::CLOSE_TO_SWITCH:
                 if (!policy.lid_read_closed_switch()) {
-                    error = errors::ErrorCode::UNEXPECTED_LID_STATE;
-                    // send error message instead
+                    handle_movement_error(policy);
                     auto response = messages::ErrorMessage{
                         .code = errors::ErrorCode::UNEXPECTED_LID_STATE};
                     static_cast<void>(
                         _task_registry->comms->get_message_queue().try_send(
                             messages::HostCommsMessage(response)));
+                } else {
+                    // Overdrive the lid stepper into the switch
+                    policy.lid_stepper_start(
+                        LidStepperState::CLOSE_OVERDRIVE_DEGREES, true);
+                    _lid_stepper_state.status =
+                        LidStepperState::Status::CLOSE_OVERDRIVE;
                 }
-                // Overdrive the lid stepper into the switch
-                policy.lid_stepper_start(
-                    LidStepperState::CLOSE_OVERDRIVE_DEGREES, true);
-                _lid_stepper_state.status =
-                    LidStepperState::Status::CLOSE_OVERDRIVE;
                 break;
             case LidStepperState::Status::CLOSE_OVERDRIVE:
                 // Now that the lid is at the closed position,
@@ -1348,7 +1360,12 @@ class MotorTask {
                 error = handle_lid_state_end(policy);
                 // if the lid isn't actually closed, overwrite error status
                 if (!policy.lid_read_closed_switch()) {
-                    error = errors::ErrorCode::UNEXPECTED_LID_STATE;
+                    handle_movement_error(policy);
+                    auto response = messages::ErrorMessage{
+                        .code = errors::ErrorCode::UNEXPECTED_LID_STATE};
+                    static_cast<void>(
+                        _task_registry->comms->get_message_queue().try_send(
+                            messages::HostCommsMessage(response)));
                 }
                 break;
             case LidStepperState::Status::LIFT_NUDGE:

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -972,6 +972,8 @@ class MotorTask {
         if (_lid_stepper_state.status != LidStepperState::Status::IDLE) {
             return false;
         }
+        // First release the latch
+        policy.lid_solenoid_engage();
         if (policy.lid_read_closed_switch()) {
             return start_latch_release_overdrive(response_id, policy);
         }
@@ -998,8 +1000,6 @@ class MotorTask {
     template <MotorExecutionPolicy Policy>
     auto start_latch_release_backoff(uint32_t response_id, Policy& policy)
         -> bool {
-        // First release the latch
-        policy.lid_solenoid_engage();
         std::ignore = policy.lid_stepper_set_rpm(
             LidStepperState::LID_DEFAULT_VELOCITY_RPM);
         // Now start a lid motor movement to the endstop
@@ -1019,8 +1019,6 @@ class MotorTask {
         if (_lid_stepper_state.status != LidStepperState::Status::IDLE) {
             return false;
         }
-        // First release the latch
-        policy.lid_solenoid_engage();
         // Update velocity for this movement
         std::ignore = policy.lid_stepper_set_rpm(
             LidStepperState::LID_DEFAULT_VELOCITY_RPM);
@@ -1404,9 +1402,6 @@ class MotorTask {
                         _task_registry->comms->get_message_queue().try_send(
                             messages::HostCommsMessage(response)));
                 } else {
-                    // Now that the lid is at the closed position,
-                    // the solenoid can be safely turned off
-                    policy.lid_solenoid_disengage();
                     // Turn off lid stepper current
                     policy.lid_stepper_set_dac(LID_STEPPER_HOLD_CURRENT);
                     // Movement is done

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1176,10 +1176,10 @@ class MotorTask {
                 error = handle_lid_state_enter(
                     LidState::Status::OPENING_OPEN_HINGE, policy);
                 break;
-                case LidState::Status::OPENING_OPEN_HINGE:
-                    error =
-                        handle_lid_state_enter(LidState::Status::IDLE, policy);
-                    break;
+            }
+            case LidState::Status::OPENING_OPEN_HINGE: {
+                error = handle_lid_state_enter(LidState::Status::IDLE, policy);
+                break;
             }
             case LidState::Status::CLOSING_RETRACT_SEAL: {
                 _seal_position =
@@ -1199,10 +1199,11 @@ class MotorTask {
                 error = handle_lid_state_enter(
                     LidState::Status::CLOSING_CLOSE_HINGE, policy);
                 break;
-                case LidState::Status::CLOSING_CLOSE_HINGE:
-                    error = handle_lid_state_enter(
-                        LidState::Status::CLOSING_EXTEND_SEAL, policy);
-                    break;
+            }
+            case LidState::Status::CLOSING_CLOSE_HINGE: {
+                error = handle_lid_state_enter(
+                    LidState::Status::CLOSING_EXTEND_SEAL, policy);
+                break;
             }
             case LidState::Status::CLOSING_EXTEND_SEAL: {
                 _seal_position = shared_switches

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
@@ -633,6 +633,10 @@ struct MotorStep {
     std::optional<double> lid_rpm = std::nullopt;
     // If true, expect an ack in the host comms task
     std::optional<messages::AcknowledgePrevious> ack = std::nullopt;
+
+    bool lid_open_switch_engaged = false;
+    bool lid_closed_switch_engaged = false;
+    std::optional<int> test_id = std::nullopt;
 };
 
 /**


### PR DESCRIPTION
## Overview
During ABR testing, we found that sometimes the thermocycler lid could get stuck on the latch while opening. 

Hardware advised that we close the lid further, to allow the probes on the lid to ease off the latch plate, before releasing the latch. This should ensure that the latch and probes are not locked up by friction during lid opening. 

## Changelog

- when opening the lid from the closed position:
              - first release the solenoid
              - drive the lid closed 1 degree
              - open the lid the first 10 degrees until the optical switch should be disengaged
              - check that the optical switch was successfully disengaged 
              - open the lid the rest of the way
- after opening the lid all the way, check that the 'lid open' limit switch is triggered and throw an error if it isn't
- after backing off the 'lid open' switch, check that it is no longer engaged
- after closing the lid, check that the 'lid closed' limit switch is triggered and throw an error if it isn't
- after overdriving while closing the lid, check that the 'lid closed' switch is still triggered
- no longer engage/disengage the solenoid during close lid to ensure the prongs have a chance to hook onto the latch
