### PR TITLE
fix(flex-stacker): clear ack message cache when a stall is detected.

### DIFF
--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -215,6 +215,10 @@ class HostCommsTask {
         std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_message(const messages::ErrorMessage& msg, InputIt tx_into,
                        InputLimit tx_limit) -> InputIt {
+        // stall detected, clear the message cache.
+        if (msg.code == errors::ErrorCode::MOTOR_STALL_DETECTED) {
+            ack_only_cache.clear();
+        }
         return errors::write_into_async(tx_into, tx_limit, msg.code);
     }
 


### PR DESCRIPTION
# Overview

This fixes an issue where the ack cache would get full when a stall occurred because the incoming move message was not getting the expected response. So let's clear the ack cache when we get a stall before we send an error message.

# Testing

- [x] Trigger multiple stalls and make sure we no longer get gcode cache full messages