### PR TITLE
feat(flex-stacker): implement home motor sequence

### DIFF
--- a/stm32-modules/flex-stacker/src/errors.cpp
+++ b/stm32-modules/flex-stacker/src/errors.cpp
@@ -25,6 +25,10 @@ const char* const MOTOR_DISABLE_FAILED = "ERR402:motor disable error\n";
 const char* const MOTOR_STALL_DETECTED = "ERR403:motor stall error\n";
 const char* const MOTOR_QUEUE_FULL = "ERR404:motor queue full error\n";
 
+const char* const X_MOTOR_BUSY = "ERR501:X motor busy error\n";
+const char* const Z_MOTOR_BUSY = "ERR502:Z motor busy error\n";
+const char* const L_MOTOR_BUSY = "ERR503:L motor busy error\n";
+
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
@@ -51,6 +55,9 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(MOTOR_DISABLE_FAILED);
         HANDLE_CASE(MOTOR_STALL_DETECTED);
         HANDLE_CASE(MOTOR_QUEUE_FULL);
+        HANDLE_CASE(X_MOTOR_BUSY);
+        HANDLE_CASE(Z_MOTOR_BUSY);
+        HANDLE_CASE(L_MOTOR_BUSY);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/flex-stacker/src/errors.cpp
+++ b/stm32-modules/flex-stacker/src/errors.cpp
@@ -23,6 +23,7 @@ const char* const TMC2160_INVALID_VALUE = "ERR904:TMC2160 invalid value\n";
 const char* const MOTOR_ENABLE_FAILED = "ERR401:motor enable error\n";
 const char* const MOTOR_DISABLE_FAILED = "ERR402:motor disable error\n";
 const char* const MOTOR_STALL_DETECTED = "ERR403:motor stall error\n";
+const char* const MOTOR_QUEUE_FULL = "ERR404:motor queue full error\n";
 
 const char* const UNKNOWN_ERROR = "ERR-1:unknown error code\n";
 
@@ -49,6 +50,7 @@ auto errors::errorstring(ErrorCode code) -> const char* {
         HANDLE_CASE(MOTOR_ENABLE_FAILED);
         HANDLE_CASE(MOTOR_DISABLE_FAILED);
         HANDLE_CASE(MOTOR_STALL_DETECTED);
+        HANDLE_CASE(MOTOR_QUEUE_FULL);
     }
     return UNKNOWN_ERROR;
 }

--- a/stm32-modules/include/common/core/circular_buffer.hpp
+++ b/stm32-modules/include/common/core/circular_buffer.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+namespace circular_buffer {
+
+template <typename T>
+class CircularBuffer {
+  public:
+    explicit CircularBuffer(std::size_t buffer_size, bool allow_overwrite)
+        : _buffer(std::make_unique<T[]>(buffer_size)),
+          _max_size(buffer_size),
+          _overwrite(allow_overwrite) {}
+
+    [[nodiscard]] auto empty() const -> bool { return _count == 0; }
+
+    [[nodiscard]] auto full() const -> bool { return _count == _max_size; }
+
+    [[nodiscard]] auto capacity() const -> std::size_t { return _max_size; }
+
+    [[nodiscard]] auto size() const -> std::size_t { return _count; }
+
+    auto enqueue(T item) -> bool {
+        if (!_overwrite && full()) {
+            return false;
+        }
+
+        _buffer[_tail] = item;
+        _tail = (_tail + 1) % _max_size;
+
+        if (full()) {
+            _head = (_head + 1) % _max_size;
+        } else {
+            _count++;
+        }
+        return true;
+    }
+
+    auto dequeue() -> T {
+        T item = _buffer[_head];
+        _head = (_head + 1) % _max_size;
+        _count--;
+
+        return item;
+    }
+
+  private:
+    std::unique_ptr<T[]> _buffer;
+    const std::size_t _max_size;
+    bool _overwrite;
+    std::size_t _head = 0;
+    std::size_t _tail = 0;
+    std::size_t _count = 0;
+};
+
+}  // namespace circular_buffer

--- a/stm32-modules/include/common/core/circular_buffer.hpp
+++ b/stm32-modules/include/common/core/circular_buffer.hpp
@@ -2,20 +2,18 @@
 
 namespace circular_buffer {
 
-template <typename T>
+template <typename T, std::size_t buffer_size>
 class CircularBuffer {
   public:
-    explicit CircularBuffer(std::size_t buffer_size, bool allow_overwrite = false)
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-        : _buffer(std::make_unique<T[]>(buffer_size)),
-          _max_size(buffer_size),
+    explicit CircularBuffer(bool allow_overwrite = false)
+        : _buffer(std::array<T, buffer_size>()),
           _overwrite(allow_overwrite) {}
 
     [[nodiscard]] auto empty() const -> bool { return _count == 0; }
 
-    [[nodiscard]] auto full() const -> bool { return _count == _max_size; }
+    [[nodiscard]] auto full() const -> bool { return _count == buffer_size; }
 
-    [[nodiscard]] auto capacity() const -> std::size_t { return _max_size; }
+    [[nodiscard]] auto capacity() const -> std::size_t { return buffer_size; }
 
     [[nodiscard]] auto size() const -> std::size_t { return _count; }
 
@@ -25,10 +23,10 @@ class CircularBuffer {
         }
 
         _buffer[_tail] = item;
-        _tail = (_tail + 1) % _max_size;
+        _tail = (_tail + 1) % buffer_size;
 
         if (full()) {
-            _head = (_head + 1) % _max_size;
+            _head = (_head + 1) % buffer_size;
         } else {
             _count++;
         }
@@ -37,7 +35,7 @@ class CircularBuffer {
 
     auto dequeue() -> T {
         T item = _buffer[_head];
-        _head = (_head + 1) % _max_size;
+        _head = (_head + 1) % buffer_size;
         _count--;
 
         return item;
@@ -50,9 +48,7 @@ class CircularBuffer {
     }
 
   private:
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-    std::unique_ptr<T[]> _buffer;
-    const std::size_t _max_size;
+    std::array<T, buffer_size> _buffer;
     bool _overwrite;
     std::size_t _head = 0;
     std::size_t _tail = 0;

--- a/stm32-modules/include/common/core/circular_buffer.hpp
+++ b/stm32-modules/include/common/core/circular_buffer.hpp
@@ -2,17 +2,18 @@
 
 namespace circular_buffer {
 
-template <typename T, std::size_t buffer_size>
+template <typename T, std::size_t MaxSize>
 class CircularBuffer {
   public:
+    using BackingStore = std::array<T, MaxSize>;
     explicit CircularBuffer(bool allow_overwrite = false)
-        : _buffer(std::array<T, buffer_size>()), _overwrite(allow_overwrite) {}
+        : _buffer(std::make_unique<BackingStore>()), _overwrite(allow_overwrite) {}
 
     [[nodiscard]] auto empty() const -> bool { return _count == 0; }
 
-    [[nodiscard]] auto full() const -> bool { return _count == buffer_size; }
+    [[nodiscard]] auto full() const -> bool { return _count == MaxSize; }
 
-    [[nodiscard]] auto capacity() const -> std::size_t { return buffer_size; }
+    [[nodiscard]] auto capacity() const -> std::size_t { return MaxSize; }
 
     [[nodiscard]] auto size() const -> std::size_t { return _count; }
 
@@ -21,33 +22,37 @@ class CircularBuffer {
             return false;
         }
 
-        _buffer.at(_tail) = item;
-        _tail = (_tail + 1) % buffer_size;
+        (*_buffer)[_tail] = item;
+        _tail = (_tail + 1) % MaxSize;
 
-        if (full()) {
-            _head = (_head + 1) % buffer_size;
-        } else {
+        if (full() && _overwrite) {
+            // overwrite the oldest item
+            _head = (_head + 1) % MaxSize;
+        } else if (!full()) {
             _count++;
         }
         return true;
     }
 
-    auto dequeue() -> T {
-        T item = _buffer.at(_head);
-        _head = (_head + 1) % buffer_size;
+    auto dequeue(T& item) -> bool {
+        if (empty()) {
+            return false;
+        }
+        item = (*_buffer)[_head];
+        _head = (_head + 1) % MaxSize;
         _count--;
 
-        return item;
+        return true;
     }
 
     auto reset() -> void {
-        while (!empty()) {
-            static_cast<void>(dequeue());
-        }
+        _head = 0;
+        _tail = 0;
+        _count = 0;
     }
 
   private:
-    std::array<T, buffer_size> _buffer;
+    std::unique_ptr<BackingStore> _buffer;
     bool _overwrite;
     std::size_t _head = 0;
     std::size_t _tail = 0;

--- a/stm32-modules/include/common/core/circular_buffer.hpp
+++ b/stm32-modules/include/common/core/circular_buffer.hpp
@@ -42,6 +42,12 @@ class CircularBuffer {
         return item;
     }
 
+    auto reset() -> void {
+        while (!empty()) {
+            static_cast<void>(dequeue());
+        }
+    }
+
   private:
     std::unique_ptr<T[]> _buffer;
     const std::size_t _max_size;

--- a/stm32-modules/include/common/core/circular_buffer.hpp
+++ b/stm32-modules/include/common/core/circular_buffer.hpp
@@ -2,7 +2,8 @@
 
 namespace circular_buffer {
 
-template <typename T, std::size_t buffer_size> class CircularBuffer {
+template <typename T, std::size_t buffer_size>
+class CircularBuffer {
   public:
     explicit CircularBuffer(bool allow_overwrite = false)
         : _buffer(std::array<T, buffer_size>()), _overwrite(allow_overwrite) {}
@@ -53,4 +54,4 @@ template <typename T, std::size_t buffer_size> class CircularBuffer {
     std::size_t _count = 0;
 };
 
-} // namespace circular_buffer
+}  // namespace circular_buffer

--- a/stm32-modules/include/common/core/circular_buffer.hpp
+++ b/stm32-modules/include/common/core/circular_buffer.hpp
@@ -22,7 +22,7 @@ class CircularBuffer {
             return false;
         }
 
-        _buffer[_tail] = item;
+        _buffer.at(_tail) = item;
         _tail = (_tail + 1) % buffer_size;
 
         if (full()) {
@@ -34,7 +34,7 @@ class CircularBuffer {
     }
 
     auto dequeue() -> T {
-        T item = _buffer[_head];
+        T item = _buffer.at(_head);
         _head = (_head + 1) % buffer_size;
         _count--;
 

--- a/stm32-modules/include/common/core/circular_buffer.hpp
+++ b/stm32-modules/include/common/core/circular_buffer.hpp
@@ -5,7 +5,8 @@ namespace circular_buffer {
 template <typename T>
 class CircularBuffer {
   public:
-    explicit CircularBuffer(std::size_t buffer_size, bool allow_overwrite)
+    explicit CircularBuffer(std::size_t buffer_size, bool allow_overwrite = false)
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
         : _buffer(std::make_unique<T[]>(buffer_size)),
           _max_size(buffer_size),
           _overwrite(allow_overwrite) {}
@@ -49,6 +50,7 @@ class CircularBuffer {
     }
 
   private:
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
     std::unique_ptr<T[]> _buffer;
     const std::size_t _max_size;
     bool _overwrite;

--- a/stm32-modules/include/common/core/circular_buffer.hpp
+++ b/stm32-modules/include/common/core/circular_buffer.hpp
@@ -24,8 +24,7 @@ class CircularBuffer {
             return false;
         }
 
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-        (*_buffer)[_tail] = item;
+        _buffer->at(_tail) = item;
         _tail = (_tail + 1) % MaxSize;
 
         if (full() && _overwrite) {
@@ -41,8 +40,7 @@ class CircularBuffer {
         if (empty()) {
             return false;
         }
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-        item = (*_buffer)[_head];
+        item = _buffer->at(_head);
         _head = (_head + 1) % MaxSize;
         _count--;
 

--- a/stm32-modules/include/common/core/circular_buffer.hpp
+++ b/stm32-modules/include/common/core/circular_buffer.hpp
@@ -8,8 +8,14 @@ class CircularBuffer {
     using BackingStore = std::array<T, MaxSize>;
 
     explicit CircularBuffer(bool allow_overwrite = false)
-        : _buffer(std::make_unique<BackingStore>()),
+        : _buffer(BackingStore()),
           _overwrite(allow_overwrite) {}
+
+    CircularBuffer(CircularBuffer& other) = delete;
+    auto operator=(CircularBuffer& other) -> CircularBuffer& = delete;
+    CircularBuffer(CircularBuffer&& other) noexcept = delete;
+    auto operator=(CircularBuffer&& other) noexcept -> CircularBuffer& = delete;
+    ~CircularBuffer() = default;
 
     [[nodiscard]] auto empty() const -> bool { return _count == 0; }
 
@@ -24,7 +30,7 @@ class CircularBuffer {
             return false;
         }
 
-        _buffer->at(_tail) = item;
+        _buffer.at(_tail) = item;
         _tail = (_tail + 1) % MaxSize;
 
         if (full() && _overwrite) {
@@ -40,7 +46,7 @@ class CircularBuffer {
         if (empty()) {
             return false;
         }
-        item = _buffer->at(_head);
+        item = _buffer.at(_head);
         _head = (_head + 1) % MaxSize;
         _count--;
 
@@ -54,7 +60,7 @@ class CircularBuffer {
     }
 
   private:
-    std::unique_ptr<BackingStore> _buffer;
+    BackingStore _buffer;
     bool _overwrite;
     std::size_t _head = 0;
     std::size_t _tail = 0;

--- a/stm32-modules/include/common/core/circular_buffer.hpp
+++ b/stm32-modules/include/common/core/circular_buffer.hpp
@@ -6,8 +6,10 @@ template <typename T, std::size_t MaxSize>
 class CircularBuffer {
   public:
     using BackingStore = std::array<T, MaxSize>;
+
     explicit CircularBuffer(bool allow_overwrite = false)
-        : _buffer(std::make_unique<BackingStore>()), _overwrite(allow_overwrite) {}
+        : _buffer(std::make_unique<BackingStore>()),
+          _overwrite(allow_overwrite) {}
 
     [[nodiscard]] auto empty() const -> bool { return _count == 0; }
 
@@ -22,6 +24,7 @@ class CircularBuffer {
             return false;
         }
 
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
         (*_buffer)[_tail] = item;
         _tail = (_tail + 1) % MaxSize;
 
@@ -38,6 +41,7 @@ class CircularBuffer {
         if (empty()) {
             return false;
         }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
         item = (*_buffer)[_head];
         _head = (_head + 1) % MaxSize;
         _count--;

--- a/stm32-modules/include/common/core/circular_buffer.hpp
+++ b/stm32-modules/include/common/core/circular_buffer.hpp
@@ -8,8 +8,7 @@ class CircularBuffer {
     using BackingStore = std::array<T, MaxSize>;
 
     explicit CircularBuffer(bool allow_overwrite = false)
-        : _buffer(BackingStore()),
-          _overwrite(allow_overwrite) {}
+        : _buffer(BackingStore()), _overwrite(allow_overwrite) {}
 
     CircularBuffer(CircularBuffer& other) = delete;
     auto operator=(CircularBuffer& other) -> CircularBuffer& = delete;

--- a/stm32-modules/include/common/core/circular_buffer.hpp
+++ b/stm32-modules/include/common/core/circular_buffer.hpp
@@ -2,12 +2,10 @@
 
 namespace circular_buffer {
 
-template <typename T, std::size_t buffer_size>
-class CircularBuffer {
+template <typename T, std::size_t buffer_size> class CircularBuffer {
   public:
     explicit CircularBuffer(bool allow_overwrite = false)
-        : _buffer(std::array<T, buffer_size>()),
-          _overwrite(allow_overwrite) {}
+        : _buffer(std::array<T, buffer_size>()), _overwrite(allow_overwrite) {}
 
     [[nodiscard]] auto empty() const -> bool { return _count == 0; }
 
@@ -55,4 +53,4 @@ class CircularBuffer {
     std::size_t _count = 0;
 };
 
-}  // namespace circular_buffer
+} // namespace circular_buffer

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -56,6 +56,7 @@ class MotorInterruptController {
             if (_id == MotorID::MOTOR_Z) {
                 _policy->disable_motor(_id);
             }
+            _stop = true;
             return true;
         }
         return ret.done;
@@ -128,6 +129,8 @@ class MotorInterruptController {
     }
 
     auto set_diag0_irq(bool enable) -> void { _policy->set_diag0_irq(enable); }
+
+    [[nodiscard]] auto is_moving() const -> bool { return !_stop; }
 
   private:
     MotorID _id;

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -12,10 +12,6 @@ namespace motor_interrupt_controller {
 using MotorPolicy = motor_policy::MotorPolicy;
 
 static constexpr int TIMER_FREQ = 100000;
-static constexpr int DEFAULT_MOTOR_FREQ = 50;
-
-static constexpr double DEFAULT_VELOCITY = 64000;  // steps per second
-static constexpr double DEFAULT_ACCEL = 50000;     // steps per second^2
 
 struct Move {
     MotorID motor_id;
@@ -24,7 +20,7 @@ struct Move {
     float speed;
     float acceleration;
     float speed_discont;
-    long steps;
+    uint64_t steps;
     bool limit_switch;
     bool has_next_move;
 };
@@ -61,8 +57,6 @@ class MotorInterruptController {
         }
         return ret.done;
     }
-
-    auto set_freq(uint32_t freq) -> void { step_freq = freq; }
     auto initialize(MotorPolicy* policy) -> void {
         _policy = policy;
         _initialized = true;
@@ -137,8 +131,6 @@ class MotorInterruptController {
     MotorPolicy* _policy;
     std::atomic_bool _initialized;
     motor_util::MovementProfile _profile;
-    uint32_t step_count = 0;
-    uint32_t step_freq = DEFAULT_MOTOR_FREQ;
     uint32_t _response_id = 0;
     bool _direction = false;
     bool _stop = true;

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -17,6 +17,18 @@ static constexpr int DEFAULT_MOTOR_FREQ = 50;
 static constexpr double DEFAULT_VELOCITY = 64000;  // steps per second
 static constexpr double DEFAULT_ACCEL = 50000;     // steps per second^2
 
+struct Move {
+    MotorID motor_id;
+    uint32_t move_id;
+    bool direction;
+    float speed;
+    float acceleration;
+    float speed_discont;
+    long steps;
+    bool limit_switch;
+    bool has_next_move;
+};
+
 class MotorInterruptController {
   public:
     explicit MotorInterruptController(MotorID id, MotorPolicy* policy)
@@ -66,6 +78,18 @@ class MotorInterruptController {
         _policy->enable_motor(_id);
         _response_id = move_id;
     }
+    auto start_move(Move move) -> void {
+        _stop = false;
+        set_direction(move.direction);
+        _profile = motor_util::MovementProfile(
+            TIMER_FREQ, move.speed_discont, move.speed, move.acceleration,
+            move.limit_switch ? motor_util::MovementType::OpenLoop
+                              : motor_util::MovementType::FixedDistance,
+            move.steps);
+        _policy->enable_motor(move.motor_id);
+        _response_id = move.move_id;
+    }
+
     auto start_movement(uint32_t move_id, bool direction,
                         uint32_t steps_per_sec_discont, uint32_t steps_per_sec,
                         uint32_t step_per_sec_sq) -> void {

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -141,7 +141,7 @@ class MotorInterruptController {
     uint32_t step_freq = DEFAULT_MOTOR_FREQ;
     uint32_t _response_id = 0;
     bool _direction = false;
-    bool _stop = false;
+    bool _stop = true;
 };
 
 }  // namespace motor_interrupt_controller

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -15,12 +15,10 @@ static constexpr int TIMER_FREQ = 100000;
 
 struct Move {
     MotorID motor_id;
+    motor_util::MotorState* motor_state;
     uint32_t move_id;
     bool direction;
-    float speed;
-    float acceleration;
-    float speed_discont;
-    uint64_t steps;
+    float distance;
     bool limit_switch;
     bool has_next_move;
 };
@@ -74,27 +72,18 @@ class MotorInterruptController {
         _response_id = move_id;
     }
     auto start_move(Move move) -> void {
+        motor_util::MotorState* state = move.motor_state;
         _stop = false;
         set_direction(move.direction);
         _profile = motor_util::MovementProfile(
-            TIMER_FREQ, move.speed_discont, move.speed, move.acceleration,
+            TIMER_FREQ, state->get_speed_discont(),
+            move.limit_switch ? state->get_speed_discont() : state->get_speed(),
+            state->get_accel(),
             move.limit_switch ? motor_util::MovementType::OpenLoop
                               : motor_util::MovementType::FixedDistance,
-            move.steps);
-        _policy->enable_motor(move.motor_id);
-        _response_id = move.move_id;
-    }
-
-    auto start_movement(uint32_t move_id, bool direction,
-                        uint32_t steps_per_sec_discont, uint32_t steps_per_sec,
-                        uint32_t step_per_sec_sq) -> void {
-        _stop = false;
-        set_direction(direction);
-        _profile = motor_util::MovementProfile(
-            TIMER_FREQ, steps_per_sec_discont, steps_per_sec, step_per_sec_sq,
-            motor_util::MovementType::OpenLoop, 0);
+            state->get_distance(move.distance));
         _policy->enable_motor(_id);
-        _response_id = move_id;
+        _response_id = move.move_id;
     }
     auto stop_movement(uint32_t move_id, bool disable_motor) -> void {
         _stop = true;

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -77,6 +77,7 @@ class MotorInterruptController {
         set_direction(move.direction);
         _profile = motor_util::MovementProfile(
             TIMER_FREQ, state->get_speed_discont(),
+            // if moving to limit switch, use max speed discont
             move.limit_switch ? state->get_speed_discont() : state->get_speed(),
             state->get_accel(),
             move.limit_switch ? motor_util::MovementType::OpenLoop

--- a/stm32-modules/include/flex-stacker/flex-stacker/errors.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/errors.hpp
@@ -26,7 +26,8 @@ enum class ErrorCode {
     // 4xx - Motor Errors
     MOTOR_ENABLE_FAILED = 401,
     MOTOR_DISABLE_FAILED = 402,
-    MOTOR_STALL_DETECTED = 403
+    MOTOR_STALL_DETECTED = 403,
+    MOTOR_QUEUE_FULL = 404,
 };
 
 auto errorstring(ErrorCode code) -> const char*;

--- a/stm32-modules/include/flex-stacker/flex-stacker/errors.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/errors.hpp
@@ -28,6 +28,9 @@ enum class ErrorCode {
     MOTOR_DISABLE_FAILED = 402,
     MOTOR_STALL_DETECTED = 403,
     MOTOR_QUEUE_FULL = 404,
+    X_MOTOR_BUSY = 501,
+    Z_MOTOR_BUSY = 502,
+    L_MOTOR_BUSY = 503,
 };
 
 auto errorstring(ErrorCode code) -> const char*;

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -726,9 +726,7 @@ struct HomeMotor {
         if (!res.first.has_value()) {
             return std::make_pair(ParseResult(), input);
         }
-        auto ret = HomeMotor{
-            .motor_id = MotorID::MOTOR_X,
-            .direction = false};
+        auto ret = HomeMotor{.motor_id = MotorID::MOTOR_X, .direction = false};
         auto arguments = res.first.value();
         if (std::get<0>(arguments).present) {
             ret.direction = static_cast<bool>(std::get<0>(arguments).value);

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -697,6 +697,54 @@ struct StopMotor {
     }
 };
 
+struct HomeMotor {
+    MotorID motor_id;
+    bool direction;
+
+    using ParseResult = std::optional<HomeMotor>;
+    static constexpr auto prefix = std::array{'G', '2', '8', ' '};
+    static constexpr const char* response = "G28 OK\n";
+
+    using XArg = Arg<int, 'X'>;
+    using ZArg = Arg<int, 'Z'>;
+    using LArg = Arg<int, 'L'>;
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto res = gcode::SingleParser<XArg, ZArg, LArg>::parse_gcode(
+            input, limit, prefix);
+        if (!res.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+        auto ret = HomeMotor{
+            .motor_id = MotorID::MOTOR_X,
+            .direction = false};
+        auto arguments = res.first.value();
+        if (std::get<0>(arguments).present) {
+            ret.direction = static_cast<bool>(std::get<0>(arguments).value);
+        } else if (std::get<1>(arguments).present) {
+            ret.motor_id = MotorID::MOTOR_Z;
+            ret.direction = static_cast<bool>(std::get<1>(arguments).value);
+        } else if (std::get<2>(arguments).present) {
+            ret.motor_id = MotorID::MOTOR_L;
+            ret.direction = static_cast<bool>(std::get<2>(arguments).value);
+        } else {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ret, res.second);
+    }
+};
+
 struct GetLimitSwitches {
     using ParseResult = std::optional<GetLimitSwitches>;
     static constexpr auto prefix = std::array{'M', '1', '1', '9'};

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -701,8 +701,8 @@ class HostCommsTask {
     }
 
     template <typename InputIt, typename InputLimit>
-        requires std::forward_iterator<InputIt> &&
-                 std::sized_sentinel_for<InputLimit, InputIt>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_gcode(const gcode::HomeMotor& gcode, InputIt tx_into,
                      InputLimit tx_limit) -> std::pair<bool, InputIt> {
         auto id = ack_only_cache.add(gcode);
@@ -711,9 +711,8 @@ class HostCommsTask {
                 false, errors::write_into(tx_into, tx_limit,
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
-        auto message = messages::HomeMotorMessage{.id = id,
-                                                  .motor_id = gcode.motor_id,
-                                                  .direction = gcode.direction};
+        auto message = messages::HomeMotorMessage{
+            .id = id, .motor_id = gcode.motor_id, .direction = gcode.direction};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -46,14 +46,14 @@ class HostCommsTask {
         gcode::SetHoldCurrent, gcode::EnableMotor, gcode::DisableMotor,
         gcode::MoveMotorInSteps, gcode::MoveToLimitSwitch, gcode::MoveMotorInMm,
         gcode::GetLimitSwitches, gcode::SetMicrosteps, gcode::GetMoveParams,
-        gcode::SetMotorStallGuard, gcode::GetMotorStallGuard>;
+        gcode::SetMotorStallGuard, gcode::GetMotorStallGuard, gcode::HomeMotor>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::SetTMCRegister, gcode::SetRunCurrent,
                  gcode::SetHoldCurrent, gcode::EnableMotor, gcode::DisableMotor,
                  gcode::MoveMotorInSteps, gcode::MoveToLimitSwitch,
                  gcode::MoveMotorInMm, gcode::SetMicrosteps,
-                 gcode::SetMotorStallGuard>;
+                 gcode::SetMotorStallGuard, gcode::HomeMotor>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetTMCRegisterCache = AckCache<8, gcode::GetTMCRegister>;
     using GetLimitSwitchesCache = AckCache<8, gcode::GetLimitSwitches>;
@@ -691,6 +691,29 @@ class HostCommsTask {
                                                   .motor_id = gcode.motor_id,
                                                   .direction = gcode.direction,
                                                   .frequency = gcode.frequency};
+        if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+        requires std::forward_iterator<InputIt> &&
+                 std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::HomeMotor& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::HomeMotorMessage{.id = id,
+                                                  .motor_id = gcode.motor_id,
+                                                  .direction = gcode.direction};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -239,6 +239,12 @@ struct GetMotorStallGuardResponse {
     int sgt;
 };
 
+struct HomeMotorMessage {
+    uint32_t id;
+    MotorID motor_id;
+    bool direction;
+};
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
@@ -259,6 +265,6 @@ using MotorMessage = ::std::variant<
     std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,
     MoveToLimitSwitchMessage, StopMotorMessage, MoveCompleteMessage,
     GetLimitSwitchesMessage, MoveMotorInMmMessage, SetMicrostepsMessage,
-    GetMoveParamsMessage, SetDiag0IRQMessage, GPIOInterruptMessage>;
+    GetMoveParamsMessage, SetDiag0IRQMessage, GPIOInterruptMessage, HomeMotorMessage>;
 
 };  // namespace messages

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -261,10 +261,12 @@ using MotorDriverMessage =
                    SetMotorCurrentMessage, SetMicrostepsMessage,
                    SetMotorStallGuardMessage, GetMotorStallGuardMessage>;
 
-using MotorMessage = ::std::variant<
-    std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,
-    MoveToLimitSwitchMessage, StopMotorMessage, MoveCompleteMessage,
-    GetLimitSwitchesMessage, MoveMotorInMmMessage, SetMicrostepsMessage,
-    GetMoveParamsMessage, SetDiag0IRQMessage, GPIOInterruptMessage, HomeMotorMessage>;
+using MotorMessage =
+    ::std::variant<std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,
+                   MoveToLimitSwitchMessage, StopMotorMessage,
+                   MoveCompleteMessage, GetLimitSwitchesMessage,
+                   MoveMotorInMmMessage, SetMicrostepsMessage,
+                   GetMoveParamsMessage, SetDiag0IRQMessage,
+                   GPIOInterruptMessage, HomeMotorMessage>;
 
 };  // namespace messages

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -107,8 +107,8 @@ class MotorTask {
     using Queue = QueueImpl<Message>;
     using Aggregator = typename tasks::Tasks<QueueImpl>::QueueAggregator;
     using Queues = typename tasks::Tasks<QueueImpl>;
-    using MoveBuffer = circular_buffer::CircularBuffer<Move>;
     static constexpr size_t MOVE_BUFFER_SIZE = 10;
+    using MoveBuffer = circular_buffer::CircularBuffer<Move, MOVE_BUFFER_SIZE>;
 
   public:
     explicit MotorTask(Queue& q, Aggregator* aggregator, Controller& x_ctrl,
@@ -190,6 +190,7 @@ class MotorTask {
         }
         return Error::NO_ERROR;
     }
+
 
     auto make_move(uint32_t id, MotorID motor_id, bool direction,
                    float distance, bool has_next_move = false) -> Move {
@@ -428,6 +429,10 @@ class MotorTask {
         send_error_message(Error::MOTOR_STALL_DETECTED);
     }
 
+    /**
+     * @brief Move the motor to the limit switch; apply fast moves to XZ motors
+     * whenever possible.
+     */
     template <MotorControlPolicy Policy>
     auto visit_message(const messages::HomeMotorMessage& m, Policy& policy)
         -> void {
@@ -436,7 +441,6 @@ class MotorTask {
             send_ack_message(m.id, error);
             return;
         }
-
         if (policy.check_limit_switch(m.motor_id, m.direction)) {
             // motor is already homed
             send_ack_message(m.id);
@@ -490,7 +494,7 @@ class MotorTask {
         .accel_mm_per_sec_sq = Defaults::L::ACCELERATION,
         .speed_mm_per_sec_discont = Defaults::L::SPEED_DISCONT,
     };
-    MoveBuffer _move_queue{MOVE_BUFFER_SIZE};
+    MoveBuffer _move_queue{};
 };
 
 };  // namespace motor_task

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -177,6 +177,19 @@ class MotorTask {
     }
 
   private:
+    auto all_motors_idle() -> Error {
+        if (_x_controller.is_moving()) {
+            return Error::X_MOTOR_BUSY;
+        }
+        if (_z_controller.is_moving()) {
+            return Error::Z_MOTOR_BUSY;
+        }
+        if (_l_controller.is_moving()) {
+            return Error::L_MOTOR_BUSY;
+        }
+        return Error::NO_ERROR;
+    }
+
     auto make_move(uint32_t id, MotorID motor_id, bool direction,
                    float distance, bool has_next_move = false) -> Move {
         MotorState& state = motor_state(motor_id);
@@ -402,6 +415,12 @@ class MotorTask {
     template <MotorControlPolicy Policy>
     auto visit_message(const messages::HomeMotorMessage& m, Policy& policy)
         -> void {
+        auto error = all_motors_idle();
+        if (error != Error::NO_ERROR) {
+            send_ack_message(m.id, error);
+            return;
+        }
+
         if (policy.check_limit_switch(m.motor_id, m.direction)) {
             // motor is already homed
             send_ack_message(m.id);

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -70,7 +70,8 @@ struct Defaults {
         static constexpr float STEPS_PER_REV = 200;
         static constexpr float MICROSTEP = 16;
 
-        static constexpr float SWITCH_TO_SWITCH_DISTANCE = 202.0;
+        // switch-to-switch: 202.0 mm - 5.0 mm offset
+        static constexpr float FAST_HOME_DISTANCE = 197.0;
     };
 
     struct Z {
@@ -83,7 +84,8 @@ struct Defaults {
         static constexpr float STEPS_PER_REV = 200;
         static constexpr float MICROSTEP = 16;
 
-        static constexpr float SWITCH_TO_SWITCH_DISTANCE = 113.75;
+        // switch-to-switch: 113.75 mm - 5.0 mm offset
+        static constexpr float FAST_HOME_DISTANCE = 108.75;
     };
 
     struct L {
@@ -176,8 +178,7 @@ class MotorTask {
 
   private:
     auto make_move(uint32_t id, MotorID motor_id, bool direction,
-                   float distance = 0.0f, bool limit_switch = true,
-                   bool has_next_move = false) -> Move {
+                   float distance, bool has_next_move = false) -> Move {
         MotorState& state = motor_state(motor_id);
         return Move{.motor_id = motor_id,
                     .move_id = id,
@@ -186,8 +187,28 @@ class MotorTask {
                     .acceleration = state.get_accel(),
                     .speed_discont = state.get_speed_discont(),
                     .steps = state.get_distance(distance),
-                    .limit_switch = limit_switch,
+                    .limit_switch = false,
                     .has_next_move = has_next_move};
+    }
+
+    auto make_home_move(uint32_t id, MotorID motor_id, bool direction,
+                        bool has_next_move = false) -> Move {
+        MotorState& state = motor_state(motor_id);
+        return Move{.motor_id = motor_id,
+                    .move_id = id,
+                    .direction = direction,
+                    // slow speed to reach limit switch
+                    .speed = state.get_speed_discont(),
+                    .acceleration = state.get_accel(),
+                    .speed_discont = state.get_speed_discont(),
+                    .steps = 0,
+                    .limit_switch = true,
+                    .has_next_move = has_next_move};
+    }
+
+    auto schedule_move(Move to_scheduled) -> void {
+        auto scheduled = _move_queue.enqueue(to_scheduled);
+        if (!scheduled) send_error_message(Error::MOTOR_QUEUE_FULL);
     }
 
     auto send_error_message(Error error) -> void {
@@ -206,30 +227,6 @@ class MotorTask {
             static_cast<void>(
                 _task_registry->send_to_address(msg, Queues::HostCommsAddress));
         }
-    }
-
-    template <MotorControlPolicy Policy>
-    auto start_home_motor(uint32_t msg_id, MotorID motor_id, bool direction,
-                          Policy& policy) -> Error {
-        Controller& controller = controller_from_id(motor_id);
-        if (motor_id != MotorID::MOTOR_L &&
-            policy.check_limit_switch(motor_id, !direction)) {
-            // if the opposite limit switch is triggered, we know where we are
-            // and can do a fast homing routine
-            auto fast_move =
-                make_move(msg_id, motor_id, direction, 200.0, false, true);
-            auto slow_move =
-                make_move(msg_id, motor_id, direction, 0.0, true, false);
-            // schedule the slow move
-            static_cast<void>(_move_queue.enqueue(slow_move));
-            // start the fast move now
-            controller.start_move(fast_move);
-        } else {
-            // we don't know where we are, move towards the limit switch slowly
-            auto slow_move = make_move(msg_id, motor_id, direction);
-            controller.start_move(slow_move);
-        }
-        return Error::NO_ERROR;
     }
 
     template <MotorControlPolicy Policy>
@@ -290,8 +287,8 @@ class MotorTask {
         if (m.mm_per_second_discont.has_value()) {
             state.speed_mm_per_sec_discont = m.mm_per_second_discont.value();
         }
-        auto move = make_move(m.id, m.motor_id, direction, std::abs(m.mm),
-                              false, false);
+        auto move =
+            make_move(m.id, m.motor_id, direction, std::abs(m.mm), false);
         controller.start_move(move);
     }
 
@@ -310,7 +307,7 @@ class MotorTask {
         if (m.mm_per_second_discont.has_value()) {
             state.speed_mm_per_sec_discont = m.mm_per_second_discont.value();
         }
-        auto move = make_move(m.id, m.motor_id, m.direction);
+        auto move = make_home_move(m.id, m.motor_id, m.direction);
         controller.start_move(move);
     }
 
@@ -410,11 +407,22 @@ class MotorTask {
             send_ack_message(m.id);
             return;
         }
-        auto error = start_home_motor(m.id, m.motor_id, m.direction, policy);
-        if (error != Error::NO_ERROR) {
-            // failed to start homing
-            send_ack_message(m.id, error);
-        };
+        _move_queue.reset();
+        Move move;
+        if (m.motor_id != MotorID::MOTOR_L &&
+            policy.check_limit_switch(m.motor_id, !m.direction)) {
+            // if the opposite limit switch is triggered, we know where we are
+            // and can do a fast homing routine
+            schedule_move(make_home_move(m.id, m.motor_id, m.direction));
+            auto distance = m.motor_id == MotorID::MOTOR_X
+                                ? Defaults::X::FAST_HOME_DISTANCE
+                                : Defaults::Z::FAST_HOME_DISTANCE;
+            move = make_move(m.id, m.motor_id, m.direction, distance, true);
+        } else {
+            // we don't know where we are, move towards the limit switch slowly
+            move = make_home_move(m.id, m.motor_id, m.direction);
+        }
+        controller_from_id(m.motor_id).start_move(move);
     }
 
     Queue& _message_queue;

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -352,11 +352,7 @@ class MotorTask {
             auto next_move = _move_queue.dequeue();
             controller_from_id(next_move.motor_id).start_move(next_move);
         } else {
-            auto response = messages::AcknowledgePrevious{
-                .responding_to_id =
-                    controller_from_id(m.motor_id).get_response_id()};
-            static_cast<void>(_task_registry->send_to_address(
-                response, Queues::HostCommsAddress));
+            send_ack_message(controller_from_id(m.motor_id).get_response_id());
         }
     }
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -55,7 +55,7 @@ struct MotorState {
         return speed_mm_per_sec_discont * get_usteps_per_mm();
     }
     [[nodiscard]] auto get_distance(float mm) const -> long {
-        return mm * get_usteps_per_mm();
+        return (long)(mm * get_usteps_per_mm());
     }
 };
 
@@ -108,6 +108,7 @@ class MotorTask {
     using Aggregator = typename tasks::Tasks<QueueImpl>::QueueAggregator;
     using Queues = typename tasks::Tasks<QueueImpl>;
     using MoveBuffer = circular_buffer::CircularBuffer<Move>;
+    static constexpr size_t MOVE_BUFFER_SIZE = 10;
 
   public:
     explicit MotorTask(Queue& q, Aggregator* aggregator, Controller& x_ctrl,
@@ -221,7 +222,9 @@ class MotorTask {
 
     auto schedule_move(Move to_scheduled) -> void {
         auto scheduled = _move_queue.enqueue(to_scheduled);
-        if (!scheduled) send_error_message(Error::MOTOR_QUEUE_FULL);
+        if (!scheduled) {
+            send_error_message(Error::MOTOR_QUEUE_FULL);
+        }
     }
 
     auto send_error_message(Error error) -> void {
@@ -251,27 +254,25 @@ class MotorTask {
     template <MotorControlPolicy Policy>
     auto visit_message(const messages::MotorEnableMessage& m, Policy& policy)
         -> void {
-        Error error = Error::NO_ERROR;
-        bool enable_tracker;
-        if (!(motor_enable(MotorID::MOTOR_X, m.x, policy, enable_tracker) &&
-              motor_enable(MotorID::MOTOR_Z, m.z, policy, enable_tracker) &&
-              motor_enable(MotorID::MOTOR_L, m.l, policy, enable_tracker))) {
-            error = enable_tracker ? Error::MOTOR_ENABLE_FAILED
-                                   : Error::MOTOR_DISABLE_FAILED;
-        };
-
-        send_ack_message(m.id, error);
+        motor_enable(MotorID::MOTOR_X, m.x, policy);
+        motor_enable(MotorID::MOTOR_Z, m.z, policy);
+        motor_enable(MotorID::MOTOR_L, m.l, policy);
+        send_ack_message(m.id);
     }
 
     template <MotorControlPolicy Policy>
-    auto motor_enable(MotorID id, std::optional<bool> engage, Policy& policy,
-                      bool& enable_tracker) -> bool {
+    auto motor_enable(MotorID id, std::optional<bool> engage, Policy& policy)
+        -> void {
         if (!engage.has_value()) {
-            return true;
+            return;
         }
-        enable_tracker = engage.value();
-        return enable_tracker ? policy.enable_motor(id)
-                              : policy.disable_motor(id);
+
+        auto result =
+            engage.value() ? policy.enable_motor(id) : policy.disable_motor(id);
+        if (!result) {
+            send_error_message(engage.value() ? Error::MOTOR_ENABLE_FAILED
+                                              : Error::MOTOR_DISABLE_FAILED);
+        }
     }
 
     template <MotorControlPolicy Policy>
@@ -489,7 +490,7 @@ class MotorTask {
         .accel_mm_per_sec_sq = Defaults::L::ACCELERATION,
         .speed_mm_per_sec_discont = Defaults::L::SPEED_DISCONT,
     };
-    MoveBuffer _move_queue{10, false};
+    MoveBuffer _move_queue{MOVE_BUFFER_SIZE};
 };
 
 };  // namespace motor_task

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -346,11 +346,16 @@ class MotorTask {
     auto visit_message(const messages::MoveCompleteMessage& m, Policy& policy)
         -> void {
         static_cast<void>(policy);
-        auto response = messages::AcknowledgePrevious{
-            .responding_to_id =
-                controller_from_id(m.motor_id).get_response_id()};
-        static_cast<void>(_task_registry->send_to_address(
-            response, Queues::HostCommsAddress));
+        if (!_move_queue.empty()) {
+            auto next_move = _move_queue.dequeue();
+            controller_from_id(next_move.motor_id).start_move(next_move);
+        } else {
+            auto response = messages::AcknowledgePrevious{
+                .responding_to_id =
+                    controller_from_id(m.motor_id).get_response_id()};
+            static_cast<void>(_task_registry->send_to_address(
+                response, Queues::HostCommsAddress));
+        }
     }
 
     template <MotorControlPolicy Policy>

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -31,6 +31,7 @@ concept MotorControlPolicy = requires(P p, MotorID motor_id) {
 using Message = messages::MotorMessage;
 using Controller = motor_interrupt_controller::MotorInterruptController;
 using Move = motor_interrupt_controller::Move;
+using Error = errors::ErrorCode;
 
 struct MotorState {
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
@@ -189,7 +190,7 @@ class MotorTask {
                     .has_next_move = has_next_move};
     }
 
-    auto send_error_message(errors::ErrorCode error) -> void {
+    auto send_error_message(Error error) -> void {
         if (_task_registry) {
             auto msg = messages::ErrorMessage{.code = error};
             static_cast<void>(
@@ -197,12 +198,11 @@ class MotorTask {
         }
     }
 
-    auto send_ack_message(uint32_t response_id, errors::ErrorCode error_code =
-                                                    errors::ErrorCode::NO_ERROR)
+    auto send_ack_message(uint32_t response_id, Error error = Error::NO_ERROR)
         -> void {
         if (_task_registry) {
             auto msg = messages::AcknowledgePrevious{
-                .responding_to_id = response_id, .with_error = error_code};
+                .responding_to_id = response_id, .with_error = error};
             static_cast<void>(
                 _task_registry->send_to_address(msg, Queues::HostCommsAddress));
         }
@@ -210,7 +210,7 @@ class MotorTask {
 
     template <MotorControlPolicy Policy>
     auto start_home_motor(uint32_t msg_id, MotorID motor_id, bool direction,
-                          Policy& policy) -> errors::ErrorCode {
+                          Policy& policy) -> Error {
         Controller& controller = controller_from_id(motor_id);
         if (motor_id != MotorID::MOTOR_L &&
             policy.check_limit_switch(motor_id, !direction)) {
@@ -229,7 +229,7 @@ class MotorTask {
             auto slow_move = make_move(msg_id, motor_id, direction);
             controller.start_move(slow_move);
         }
-        return errors::ErrorCode::NO_ERROR;
+        return Error::NO_ERROR;
     }
 
     template <MotorControlPolicy Policy>
@@ -241,24 +241,26 @@ class MotorTask {
     template <MotorControlPolicy Policy>
     auto visit_message(const messages::MotorEnableMessage& m, Policy& policy)
         -> void {
-        auto response = messages::AcknowledgePrevious{.responding_to_id = m.id};
-        if (!(motor_enable(MotorID::MOTOR_X, m.x, policy) &&
-              motor_enable(MotorID::MOTOR_Z, m.z, policy) &&
-              motor_enable(MotorID::MOTOR_L, m.l, policy))) {
-            response.with_error = m.x ? errors::ErrorCode::MOTOR_ENABLE_FAILED
-                                      : errors::ErrorCode::MOTOR_DISABLE_FAILED;
+        Error error = Error::NO_ERROR;
+        bool enable_tracker;
+        if (!(motor_enable(MotorID::MOTOR_X, m.x, policy, enable_tracker) &&
+              motor_enable(MotorID::MOTOR_Z, m.z, policy, enable_tracker) &&
+              motor_enable(MotorID::MOTOR_L, m.l, policy, enable_tracker))) {
+            error = enable_tracker ? Error::MOTOR_ENABLE_FAILED
+                                   : Error::MOTOR_DISABLE_FAILED;
         };
-        static_cast<void>(_task_registry->send_to_address(
-            response, Queues::HostCommsAddress));
+
+        send_ack_message(m.id, error);
     }
 
     template <MotorControlPolicy Policy>
-    auto motor_enable(MotorID id, std::optional<bool> engage, Policy& policy)
-        -> bool {
+    auto motor_enable(MotorID id, std::optional<bool> engage, Policy& policy,
+                      bool& enable_tracker) -> bool {
         if (!engage.has_value()) {
             return true;
         }
-        return engage.value() ? policy.enable_motor(id)
+        enable_tracker = engage.value();
+        return enable_tracker ? policy.enable_motor(id)
                               : policy.disable_motor(id);
     }
 
@@ -401,7 +403,7 @@ class MotorTask {
         _z_controller.stop_movement(0, true);
         _x_controller.stop_movement(0, false);
         _l_controller.stop_movement(0, false);
-        send_error_message(errors::ErrorCode::MOTOR_STALL_DETECTED);
+        send_error_message(Error::MOTOR_STALL_DETECTED);
     }
 
     template <MotorControlPolicy Policy>
@@ -413,7 +415,7 @@ class MotorTask {
             return;
         }
         auto error = start_home_motor(m.id, m.motor_id, m.direction, policy);
-        if (error != errors::ErrorCode::NO_ERROR) {
+        if (error != Error::NO_ERROR) {
             // failed to start homing
             send_ack_message(m.id, error);
         };

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -54,8 +54,8 @@ struct MotorState {
     [[nodiscard]] auto get_speed_discont() const -> float {
         return speed_mm_per_sec_discont * get_usteps_per_mm();
     }
-    [[nodiscard]] auto get_distance(float mm) const -> long {
-        return (long)(mm * get_usteps_per_mm());
+    [[nodiscard]] auto get_distance(float mm) const -> uint64_t {
+        return static_cast<uint64_t>(mm * get_usteps_per_mm());
     }
 };
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -343,8 +343,9 @@ class MotorTask {
     auto visit_message(const messages::MoveCompleteMessage& m, Policy& policy)
         -> void {
         static_cast<void>(policy);
-        if (!_move_queue.empty()) {
-            auto next_move = _move_queue.dequeue();
+        Move next_move;
+        if (_move_queue.dequeue(next_move)) {
+            // if there's a next move in the queue, start it
             controller_from_id(next_move.motor_id).start_move(next_move);
         } else {
             send_ack_message(controller_from_id(m.motor_id).get_response_id());

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -167,32 +167,24 @@ class MotorTask {
         return Error::NO_ERROR;
     }
 
-
     auto make_move(uint32_t id, MotorID motor_id, bool direction,
                    float distance, bool has_next_move = false) -> Move {
-        MotorState& state = motor_state(motor_id);
         return Move{.motor_id = motor_id,
+                    .motor_state = &motor_state(motor_id),
                     .move_id = id,
                     .direction = direction,
-                    .speed = state.get_speed(),
-                    .acceleration = state.get_accel(),
-                    .speed_discont = state.get_speed_discont(),
-                    .steps = state.get_distance(distance),
+                    .distance = distance,
                     .limit_switch = false,
                     .has_next_move = has_next_move};
     }
 
     auto make_home_move(uint32_t id, MotorID motor_id, bool direction,
                         bool has_next_move = false) -> Move {
-        MotorState& state = motor_state(motor_id);
         return Move{.motor_id = motor_id,
+                    .motor_state = &motor_state(motor_id),
                     .move_id = id,
                     .direction = direction,
-                    // slow speed to reach limit switch
-                    .speed = state.get_speed_discont(),
-                    .acceleration = state.get_accel(),
-                    .speed_discont = state.get_speed_discont(),
-                    .steps = 0,
+                    .distance = 0,
                     .limit_switch = true,
                     .has_next_move = has_next_move};
     }
@@ -278,7 +270,6 @@ class MotorTask {
         }
         Controller& controller = controller_from_id(m.motor_id);
         MotorState& state = motor_state(m.motor_id);
-        auto direction = m.mm > 0;
         if (m.mm_per_second.has_value()) {
             state.speed_mm_per_sec = m.mm_per_second.value();
         }
@@ -288,6 +279,7 @@ class MotorTask {
         if (m.mm_per_second_discont.has_value()) {
             state.speed_mm_per_sec_discont = m.mm_per_second_discont.value();
         }
+        auto direction = m.mm > 0;
         auto move =
             make_move(m.id, m.motor_id, direction, std::abs(m.mm), false);
         controller.start_move(move);

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -7,6 +7,7 @@
 #include <cmath>
 
 #include "core/ack_cache.hpp"
+#include "core/circular_buffer.hpp"
 #include "core/linear_motion_system.hpp"
 #include "core/queue_aggregator.hpp"
 #include "core/version.hpp"
@@ -29,6 +30,7 @@ concept MotorControlPolicy = requires(P p, MotorID motor_id) {
 
 using Message = messages::MotorMessage;
 using Controller = motor_interrupt_controller::MotorInterruptController;
+using Move = motor_interrupt_controller::Move;
 
 struct MotorState {
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
@@ -51,7 +53,7 @@ struct MotorState {
     [[nodiscard]] auto get_speed_discont() const -> float {
         return speed_mm_per_sec_discont * get_usteps_per_mm();
     }
-    [[nodiscard]] auto get_distance(float mm) const -> float {
+    [[nodiscard]] auto get_distance(float mm) const -> long {
         return mm * get_usteps_per_mm();
     }
 };
@@ -93,6 +95,7 @@ struct Defaults {
         static constexpr float STEPS_PER_REV = 200;
         static constexpr float MICROSTEP = 16;
     };
+};
 
 template <template <class> class QueueImpl>
 requires MessageQueue<QueueImpl<Message>, Message>
@@ -101,6 +104,7 @@ class MotorTask {
     using Queue = QueueImpl<Message>;
     using Aggregator = typename tasks::Tasks<QueueImpl>::QueueAggregator;
     using Queues = typename tasks::Tasks<QueueImpl>;
+    using MoveBuffer = circular_buffer::CircularBuffer<Move>;
 
   public:
     explicit MotorTask(Queue& q, Aggregator* aggregator, Controller& x_ctrl,
@@ -170,6 +174,21 @@ class MotorTask {
     }
 
   private:
+    auto make_move(uint32_t id, MotorID motor_id, bool direction,
+                   float distance = 0.0f, bool limit_switch = true,
+                   bool has_next_move = false) -> Move {
+        MotorState& state = motor_state(motor_id);
+        return Move{.motor_id = motor_id,
+                    .move_id = id,
+                    .direction = direction,
+                    .speed = state.get_speed(),
+                    .acceleration = state.get_accel(),
+                    .speed_discont = state.get_speed_discont(),
+                    .steps = state.get_distance(distance),
+                    .limit_switch = limit_switch,
+                    .has_next_move = has_next_move};
+    }
+
     auto send_error_message(errors::ErrorCode error) -> void {
         if (_task_registry) {
             auto msg = messages::ErrorMessage{.code = error};
@@ -178,7 +197,9 @@ class MotorTask {
         }
     }
 
-    auto send_ack_message(uint32_t response_id, errors::ErrorCode error_code = errors::ErrorCode::NO_ERROR) -> void {
+    auto send_ack_message(uint32_t response_id, errors::ErrorCode error_code =
+                                                    errors::ErrorCode::NO_ERROR)
+        -> void {
         if (_task_registry) {
             auto msg = messages::AcknowledgePrevious{
                 .responding_to_id = response_id, .with_error = error_code};
@@ -188,21 +209,24 @@ class MotorTask {
     }
 
     template <MotorControlPolicy Policy>
-    auto start_home_motor(uint32_t msg_id, MotorID motor_id, bool direction, Policy& policy) -> errors::ErrorCode {
+    auto start_home_motor(uint32_t msg_id, MotorID motor_id, bool direction,
+                          Policy& policy) -> errors::ErrorCode {
         Controller& controller = controller_from_id(motor_id);
-        MotorState& state = motor_state(motor_id);
-        if (motor_id != MotorID::MOTOR_L && policy.check_limit_switch(motor_id, !direction)) {
+        if (motor_id != MotorID::MOTOR_L &&
+            policy.check_limit_switch(motor_id, !direction)) {
             // if the opposite limit switch is triggered, we know where we are
             // and can do a fast homing routine
-            auto fast_move = controller.create_fixed_move(msg_id, direction, 200.0, state, true);
-            auto slow_move = controller.create_move(msg_id, direction, state, false);
+            auto fast_move =
+                make_move(msg_id, motor_id, direction, 200.0, false, true);
+            auto slow_move =
+                make_move(msg_id, motor_id, direction, 0.0, true, false);
             // schedule the slow move
-            _move_queue.push(ScheduledMove{.motor_id = motor_id, .profile=slow_move});
+            static_cast<void>(_move_queue.enqueue(slow_move));
             // start the fast move now
             controller.start_move(fast_move);
         } else {
             // we don't know where we are, move towards the limit switch slowly
-            auto slow_move = controller.create_move(msg_id, direction, state, false);
+            auto slow_move = make_move(msg_id, motor_id, direction);
             controller.start_move(slow_move);
         }
         return errors::ErrorCode::NO_ERROR;
@@ -259,14 +283,13 @@ class MotorTask {
             state.speed_mm_per_sec = m.mm_per_second.value();
         }
         if (m.mm_per_second_sq.has_value()) {
-            state.accel_mm_per_sec_sq =
-                m.mm_per_second_sq.value();
+            state.accel_mm_per_sec_sq = m.mm_per_second_sq.value();
         }
         if (m.mm_per_second_discont.has_value()) {
-            state.speed_mm_per_sec_discont =
-                m.mm_per_second_discont.value();
+            state.speed_mm_per_sec_discont = m.mm_per_second_discont.value();
         }
-        auto move = controller.create_fixed_move(m.id, direction, std::abs(m.mm), state);
+        auto move = make_move(m.id, m.motor_id, direction, std::abs(m.mm),
+                              false, false);
         controller.start_move(move);
     }
 
@@ -280,14 +303,12 @@ class MotorTask {
             state.speed_mm_per_sec = m.mm_per_second.value();
         }
         if (m.mm_per_second_sq.has_value()) {
-            state.accel_mm_per_sec_sq =
-                m.mm_per_second_sq.value();
+            state.accel_mm_per_sec_sq = m.mm_per_second_sq.value();
         }
         if (m.mm_per_second_discont.has_value()) {
-            state.speed_mm_per_sec_discont =
-                m.mm_per_second_discont.value();
+            state.speed_mm_per_sec_discont = m.mm_per_second_discont.value();
         }
-        auto move = controller.create_move(m.id, m.direction, state);
+        auto move = make_move(m.id, m.motor_id, m.direction);
         controller.start_move(move);
     }
 
@@ -423,6 +444,7 @@ class MotorTask {
         .accel_mm_per_sec_sq = Defaults::L::ACCELERATION,
         .speed_mm_per_sec_discont = Defaults::L::SPEED_DISCONT,
     };
+    MoveBuffer _move_queue{10, false};
 };
 
 };  // namespace motor_task

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -15,6 +15,7 @@
 #include "firmware/motor_policy.hpp"
 #include "flex-stacker/errors.hpp"
 #include "flex-stacker/messages.hpp"
+#include "flex-stacker/motor_utils.hpp"
 #include "flex-stacker/tasks.hpp"
 #include "flex-stacker/tmc2160_registers.hpp"
 #include "hal/message_queue.hpp"
@@ -32,32 +33,6 @@ using Message = messages::MotorMessage;
 using Controller = motor_interrupt_controller::MotorInterruptController;
 using Move = motor_interrupt_controller::Move;
 using Error = errors::ErrorCode;
-
-struct MotorState {
-    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-    lms::LinearMotionSystemConfig lms_config;
-    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-    float speed_mm_per_sec;
-    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-    float accel_mm_per_sec_sq;
-    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-    float speed_mm_per_sec_discont;
-    [[nodiscard]] auto get_usteps_per_mm() const -> float {
-        return lms_config.get_usteps_per_mm();
-    }
-    [[nodiscard]] auto get_speed() const -> float {
-        return speed_mm_per_sec * get_usteps_per_mm();
-    }
-    [[nodiscard]] auto get_accel() const -> float {
-        return accel_mm_per_sec_sq * get_usteps_per_mm();
-    }
-    [[nodiscard]] auto get_speed_discont() const -> float {
-        return speed_mm_per_sec_discont * get_usteps_per_mm();
-    }
-    [[nodiscard]] auto get_distance(float mm) const -> uint64_t {
-        return static_cast<uint64_t>(mm * get_usteps_per_mm());
-    }
-};
 
 struct Defaults {
     struct X {
@@ -109,6 +84,7 @@ class MotorTask {
     using Queues = typename tasks::Tasks<QueueImpl>;
     static constexpr size_t MOVE_BUFFER_SIZE = 10;
     using MoveBuffer = circular_buffer::CircularBuffer<Move, MOVE_BUFFER_SIZE>;
+    using MotorState = motor_util::MotorState;
 
   public:
     explicit MotorTask(Queue& q, Aggregator* aggregator, Controller& x_ctrl,

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -66,6 +66,8 @@ struct Defaults {
             lms::LeadScrewConfig::mm_per_rev(9.7536, 1.0);
         static constexpr float STEPS_PER_REV = 200;
         static constexpr float MICROSTEP = 16;
+
+        static constexpr float SWITCH_TO_SWITCH_DISTANCE = 202.0;
     };
 
     struct Z {
@@ -77,6 +79,8 @@ struct Defaults {
             lms::LeadScrewConfig::mm_per_rev(9.7536, 1.0);
         static constexpr float STEPS_PER_REV = 200;
         static constexpr float MICROSTEP = 16;
+
+        static constexpr float SWITCH_TO_SWITCH_DISTANCE = 113.75;
     };
 
     struct L {
@@ -89,7 +93,6 @@ struct Defaults {
         static constexpr float STEPS_PER_REV = 200;
         static constexpr float MICROSTEP = 16;
     };
-};
 
 template <template <class> class QueueImpl>
 requires MessageQueue<QueueImpl<Message>, Message>
@@ -167,6 +170,44 @@ class MotorTask {
     }
 
   private:
+    auto send_error_message(errors::ErrorCode error) -> void {
+        if (_task_registry) {
+            auto msg = messages::ErrorMessage{.code = error};
+            static_cast<void>(
+                _task_registry->send_to_address(msg, Queues::HostCommsAddress));
+        }
+    }
+
+    auto send_ack_message(uint32_t response_id, errors::ErrorCode error_code = errors::ErrorCode::NO_ERROR) -> void {
+        if (_task_registry) {
+            auto msg = messages::AcknowledgePrevious{
+                .responding_to_id = response_id, .with_error = error_code};
+            static_cast<void>(
+                _task_registry->send_to_address(msg, Queues::HostCommsAddress));
+        }
+    }
+
+    template <MotorControlPolicy Policy>
+    auto start_home_motor(uint32_t msg_id, MotorID motor_id, bool direction, Policy& policy) -> errors::ErrorCode {
+        Controller& controller = controller_from_id(motor_id);
+        MotorState& state = motor_state(motor_id);
+        if (motor_id != MotorID::MOTOR_L && policy.check_limit_switch(motor_id, !direction)) {
+            // if the opposite limit switch is triggered, we know where we are
+            // and can do a fast homing routine
+            auto fast_move = controller.create_fixed_move(msg_id, direction, 200.0, state, true);
+            auto slow_move = controller.create_move(msg_id, direction, state, false);
+            // schedule the slow move
+            _move_queue.push(ScheduledMove{.motor_id = motor_id, .profile=slow_move});
+            // start the fast move now
+            controller.start_move(fast_move);
+        } else {
+            // we don't know where we are, move towards the limit switch slowly
+            auto slow_move = controller.create_move(msg_id, direction, state, false);
+            controller.start_move(slow_move);
+        }
+        return errors::ErrorCode::NO_ERROR;
+    }
+
     template <MotorControlPolicy Policy>
     auto visit_message(const std::monostate& m, Policy& policy) -> void {
         static_cast<void>(m);
@@ -211,41 +252,43 @@ class MotorTask {
     auto visit_message(const messages::MoveMotorInMmMessage& m, Policy& policy)
         -> void {
         static_cast<void>(policy);
-        auto direction = m.mm > 0;
+        Controller& controller = controller_from_id(m.motor_id);
         MotorState& state = motor_state(m.motor_id);
+        auto direction = m.mm > 0;
         if (m.mm_per_second.has_value()) {
             state.speed_mm_per_sec = m.mm_per_second.value();
         }
         if (m.mm_per_second_sq.has_value()) {
-            state.accel_mm_per_sec_sq = m.mm_per_second_sq.value();
+            state.accel_mm_per_sec_sq =
+                m.mm_per_second_sq.value();
         }
         if (m.mm_per_second_discont.has_value()) {
-            state.speed_mm_per_sec_discont = m.mm_per_second_discont.value();
+            state.speed_mm_per_sec_discont =
+                m.mm_per_second_discont.value();
         }
-        controller_from_id(m.motor_id)
-            .start_fixed_movement(m.id, direction,
-                                  state.get_distance(std::abs(m.mm)),
-                                  state.get_speed_discont(), state.get_speed(),
-                                  state.get_accel());
+        auto move = controller.create_fixed_move(m.id, direction, std::abs(m.mm), state);
+        controller.start_move(move);
     }
 
     template <MotorControlPolicy Policy>
     auto visit_message(const messages::MoveToLimitSwitchMessage& m,
                        Policy& policy) -> void {
         static_cast<void>(policy);
+        Controller& controller = controller_from_id(m.motor_id);
         MotorState& state = motor_state(m.motor_id);
         if (m.mm_per_second.has_value()) {
             state.speed_mm_per_sec = m.mm_per_second.value();
         }
         if (m.mm_per_second_sq.has_value()) {
-            state.accel_mm_per_sec_sq = m.mm_per_second_sq.value();
+            state.accel_mm_per_sec_sq =
+                m.mm_per_second_sq.value();
         }
         if (m.mm_per_second_discont.has_value()) {
-            state.speed_mm_per_sec_discont = m.mm_per_second_discont.value();
+            state.speed_mm_per_sec_discont =
+                m.mm_per_second_discont.value();
         }
-        controller_from_id(m.motor_id)
-            .start_movement(m.id, m.direction, state.get_speed_discont(),
-                            state.get_speed(), state.get_accel());
+        auto move = controller.create_move(m.id, m.direction, state);
+        controller.start_move(move);
     }
 
     template <MotorControlPolicy Policy>
@@ -297,9 +340,7 @@ class MotorTask {
         // successfully
         motor_state(m.motor_id).lms_config.microstep =
             pow(2, m.microsteps_power);
-        auto response = messages::AcknowledgePrevious{.responding_to_id = m.id};
-        static_cast<void>(_task_registry->send_to_address(
-            response, Queues::HostCommsAddress));
+        send_ack_message(m.id);
     }
 
     template <MotorControlPolicy Policy>
@@ -334,10 +375,22 @@ class MotorTask {
         _z_controller.stop_movement(0, true);
         _x_controller.stop_movement(0, false);
         _l_controller.stop_movement(0, false);
-        auto msg = messages::ErrorMessage{
-            .code = errors::ErrorCode::MOTOR_STALL_DETECTED};
-        static_cast<void>(
-            _task_registry->send_to_address(msg, Queues::HostCommsAddress));
+        send_error_message(errors::ErrorCode::MOTOR_STALL_DETECTED);
+    }
+
+    template <MotorControlPolicy Policy>
+    auto visit_message(const messages::HomeMotorMessage& m, Policy& policy)
+        -> void {
+        if (policy.check_limit_switch(m.motor_id, m.direction)) {
+            // motor is already homed
+            send_ack_message(m.id);
+            return;
+        }
+        auto error = start_home_motor(m.id, m.motor_id, m.direction, policy);
+        if (error != errors::ErrorCode::NO_ERROR) {
+            // failed to start homing
+            send_ack_message(m.id, error);
+        };
     }
 
     Queue& _message_queue;

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -278,6 +278,11 @@ class MotorTask {
     auto visit_message(const messages::MoveMotorInStepsMessage& m,
                        Policy& policy) -> void {
         static_cast<void>(policy);
+        auto error = all_motors_idle();
+        if (error != Error::NO_ERROR) {
+            send_ack_message(m.id, error);
+            return;
+        }
         auto direction = m.steps > 0;
         controller_from_id(m.motor_id)
             .start_fixed_movement(m.id, direction, std::abs(m.steps), 0,
@@ -288,6 +293,11 @@ class MotorTask {
     auto visit_message(const messages::MoveMotorInMmMessage& m, Policy& policy)
         -> void {
         static_cast<void>(policy);
+        auto error = all_motors_idle();
+        if (error != Error::NO_ERROR) {
+            send_ack_message(m.id, error);
+            return;
+        }
         Controller& controller = controller_from_id(m.motor_id);
         MotorState& state = motor_state(m.motor_id);
         auto direction = m.mm > 0;
@@ -309,6 +319,11 @@ class MotorTask {
     auto visit_message(const messages::MoveToLimitSwitchMessage& m,
                        Policy& policy) -> void {
         static_cast<void>(policy);
+        auto error = all_motors_idle();
+        if (error != Error::NO_ERROR) {
+            send_ack_message(m.id, error);
+            return;
+        }
         Controller& controller = controller_from_id(m.motor_id);
         MotorState& state = motor_state(m.motor_id);
         if (m.mm_per_second.has_value()) {

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_utils.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_utils.hpp
@@ -4,14 +4,34 @@
 #include <concepts>
 
 #include "core/fixed_point.hpp"
+#include "core/linear_motion_system.hpp"
 
 namespace motor_util {
 
-enum class Parameter : char {
-    Velocity = 'V',
-    Acceleration = 'A',
-    RunCurrent = 'R',
-    HoldCurrent = 'H'
+struct MotorState {
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    lms::LinearMotionSystemConfig lms_config;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    float speed_mm_per_sec;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    float accel_mm_per_sec_sq;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+    float speed_mm_per_sec_discont;
+    [[nodiscard]] auto get_usteps_per_mm() const -> float {
+        return lms_config.get_usteps_per_mm();
+    }
+    [[nodiscard]] auto get_speed() const -> float {
+        return speed_mm_per_sec * get_usteps_per_mm();
+    }
+    [[nodiscard]] auto get_accel() const -> float {
+        return accel_mm_per_sec_sq * get_usteps_per_mm();
+    }
+    [[nodiscard]] auto get_speed_discont() const -> float {
+        return speed_mm_per_sec_discont * get_usteps_per_mm();
+    }
+    [[nodiscard]] auto get_distance(float mm) const -> uint64_t {
+        return static_cast<uint64_t>(mm * get_usteps_per_mm());
+    }
 };
 
 enum class MovementType {


### PR DESCRIPTION
This PR implements the homing routine for each motor on the stacker. 

Unlike the OT-3, the operation of the Flex stacker requires its axes to move from one end to the other most of the time. Only the Z needs to perform fixed distance movements to give clearance to the latch motor. So we've decided to put most of the movement logic on the firmware (motor task to be exact), instead of letting the host control the motors individually. 

If we know the distance to the limit switch, we can make a motor perform a fast move until there's a few mms left, then slowly move towards the switch. To do that, we need to be able to plan multiple moves ahead and and only execute the next move in the buffer when the current move is done. Using a buffer inside the task ensures only one motor is moving at a time. The buffer size is set to 10 moves for now and might change when we implement more complicated commands such as retrieve and store labware.

There are not a single encoder on the stacker so we only do this fast homing sequence if the limit switch at the opposite end is triggered. 

A followup PR will be needed to add the defaults for EVT. 


