### PR TITLE
feat(thermocycler): don't operate the solenoid while trying to close the thermocycler lid

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -983,8 +983,6 @@ class MotorTask {
         if (_lid_stepper_state.status != LidStepperState::Status::IDLE) {
             return false;
         }
-        // First release the latch
-        policy.lid_solenoid_engage();
         // Update velocity for this movement
         std::ignore = policy.lid_stepper_set_rpm(
             LidStepperState::LID_DEFAULT_VELOCITY_RPM);
@@ -1279,9 +1277,6 @@ class MotorTask {
                     LidStepperState::Status::CLOSE_OVERDRIVE;
                 break;
             case LidStepperState::Status::CLOSE_OVERDRIVE:
-                // Now that the lid is at the closed position,
-                // the solenoid can be safely turned off
-                policy.lid_solenoid_disengage();
                 // Turn off lid stepper current
                 policy.lid_stepper_set_dac(LID_STEPPER_HOLD_CURRENT);
                 // Movement is done


### PR DESCRIPTION
## Overview
One of the change from a [previous firmware fix](https://github.com/Opentrons/opentrons-modules/pull/471). 

Instead of opening the solenoid latch while the thermocycler lid closes, then closing the latch after the move is complete, just don't engage the solenoid while closing in order to give the lid's prongs a better chance to catch.