### PR TITLE
fix(flex-stacker): standardize the gcode responses to use key and value pairs.

### DIFF
--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
@@ -157,8 +157,7 @@ struct GetResetReason {
         -> InputIt {
         int res = 0;
         // print a hexadecimal representation of the reset flags
-        res = snprintf(&*buf, (limit - buf), "M114 Last Reset Reason: %X OK\n",
-                       reason);
+        res = snprintf(&*buf, (limit - buf), "M114 R:%X OK\n", reason);
         if (res <= 0) {
             return buf;
         }
@@ -241,7 +240,7 @@ struct GetDoorClosed {
     static auto write_response_into(InputIt buf, InLimit limit, int door_closed)
         -> InputIt {
         int res = 0;
-        res = snprintf(&*buf, (limit - buf), "M122 %i OK\n", door_closed);
+        res = snprintf(&*buf, (limit - buf), "M122 D:%i OK\n", door_closed);
         if (res <= 0) {
             return buf;
         }

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes_motor.hpp
@@ -97,7 +97,7 @@ struct GetTMCRegister {
     static auto write_response_into(InputIt buf, InLimit limit,
                                     MotorID motor_id, uint8_t reg,
                                     uint32_t data) -> InputIt {
-        auto res = snprintf(&*buf, (limit - buf), "M920 %s%u %lu OK\n",
+        auto res = snprintf(&*buf, (limit - buf), "M920 %s:%u V:%lu OK\n",
                             motor_id_to_char(motor_id), reg, data);
         if (res <= 0) {
             return buf;
@@ -817,9 +817,9 @@ struct GetMoveParams {
                           : motor_id == MotorID::MOTOR_Z ? 'Z'
                                                          : 'L';
         int res = 0;
-        res =
-            snprintf(&*buf, (limit - buf), "M120 %c V:%.3f A:%.3f D:%.3f OK\n",
-                     motor_char, velocity, accel, velocity_discont);
+        res = snprintf(&*buf, (limit - buf),
+                       "M120 M:%c V:%.3f A:%.3f D:%.3f OK\n", motor_char,
+                       velocity, accel, velocity_discont);
         if (res <= 0) {
             return buf;
         }
@@ -931,7 +931,7 @@ struct GetMotorStallGuard {
                           : motor_id == MotorID::MOTOR_Z ? 'Z'
                                                          : 'L';
         int res = 0;
-        res = snprintf(&*buf, (limit - buf), "M911 %c%d T:%d OK\n", motor_char,
+        res = snprintf(&*buf, (limit - buf), "M911 %c:%d T:%d OK\n", motor_char,
                        int(enabled), threshold);
         if (res <= 0) {
             return buf;
@@ -994,7 +994,7 @@ struct GetEstopStatus {
     static auto write_response_into(InputIt buf, InLimit limit, int triggered)
         -> InputIt {
         int res = 0;
-        res = snprintf(&*buf, (limit - buf), "M112 %i OK\n", triggered);
+        res = snprintf(&*buf, (limit - buf), "M112 E:%i OK\n", triggered);
         if (res <= 0) {
             return buf;
         }


### PR DESCRIPTION
# Overview 

While working on the flex stacker hardware controller, I noticed that some gcode responses have different formatting, some have key value responses, and others don't. So to make parsing consistent let's standardize the gcode responses to return key:value pairs which are easier to parse.

# Changelog

- Change the gcode message responses to key:value pairs where needed

# Testing

- [x] Make sure that all the Gcodes still work and respond accordingly