### PR TITLE
fix(stacker): motor movement profile step detection

### DIFF
--- a/stm32-modules/flex-stacker/tests/CMakeLists.txt
+++ b/stm32-modules/flex-stacker/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ include(AddBuildAndTestTarget)
 
 add_executable(${TARGET_MODULE_NAME}
         test_main.cpp
+        test_motor_utils.cpp
     )
 
 target_include_directories(${TARGET_MODULE_NAME}

--- a/stm32-modules/flex-stacker/tests/test_motor_utils.cpp
+++ b/stm32-modules/flex-stacker/tests/test_motor_utils.cpp
@@ -1,0 +1,149 @@
+#include <iostream>
+
+#include "catch2/catch.hpp"
+#include "flex-stacker/motor_utils.hpp"
+
+using namespace motor_util;
+
+constexpr int MOTOR_FREQUENCY = 100;  // ticks per second
+
+static auto velocity_to_steps_per_tick(double vel) -> sq0_31 {
+    return convert_to_fixed_point(vel / static_cast<double>(MOTOR_FREQUENCY),
+                                  MovementProfile::radix);
+}
+
+static auto acceleration_to_steps_per_tick_sq(double vel) -> sq0_31 {
+    return convert_to_fixed_point(
+        vel / (static_cast<double>(MOTOR_FREQUENCY * MOTOR_FREQUENCY)),
+        MovementProfile::radix);
+}
+
+TEST_CASE("Fixed Distance MovementProfile without acceleration") {
+    GIVEN("a movement profile with constant velocity") {
+        constexpr int velocity = 1;      // steps per tick
+        constexpr int acceleration = 0;  // steps per ticks^2
+        constexpr int distance = 10;     // total steps
+
+        auto profile =
+            MovementProfile(MOTOR_FREQUENCY, velocity, velocity, acceleration,
+                            MovementType::FixedDistance, distance);
+
+        auto expected_velocity = velocity_to_steps_per_tick(velocity);
+
+        THEN("it takes 10 equal steps to be done") {
+            for (int i = 0; i < 9; ++i) {
+                auto ret = profile.tick();
+                REQUIRE(profile.current_velocity() == expected_velocity);
+                REQUIRE(ret.step == true);
+                REQUIRE(ret.done == false);
+            }
+
+            auto ret = profile.tick();
+            REQUIRE(profile.current_velocity() == expected_velocity);
+            REQUIRE(ret.step == true);
+            REQUIRE(ret.done == true);
+        }
+    }
+}
+
+TEST_CASE("Fixed Distance MovementProfile with acceleration") {
+    int initial_velocity =
+        GENERATE(0, 1);  // testing both 0 and non-zero initial velocity
+
+    GIVEN(
+        "a movement profile with distance long enough to reach max velocity") {
+        constexpr int max_velocity = 5;  // steps per tick
+        constexpr int acceleration =
+            100;  // steps per ticks^2, this acceleration increases the motor
+                  // velocity by 1 step per tick
+        constexpr int distance = 100;  // total steps
+
+        auto profile = MovementProfile(MOTOR_FREQUENCY, initial_velocity,
+                                       max_velocity, acceleration,
+                                       MovementType::FixedDistance, distance);
+
+        auto _acceleration_value =
+            acceleration_to_steps_per_tick_sq(acceleration);
+        auto _max_vel = velocity_to_steps_per_tick(max_velocity);
+        // number of ticks to reach max velocity from initial velocity, and vice
+        // versa
+        auto accel_decel_steps = max_velocity - initial_velocity;
+
+        THEN("the first few ticks are accelerating") {
+            for (int i = 0; i < accel_decel_steps; ++i) {
+                auto v0 = profile.current_velocity();
+                auto ret = profile.tick();
+                auto v1 = profile.current_velocity();
+
+                REQUIRE(v1 - v0 == _acceleration_value);
+                REQUIRE(ret.step == true);
+                REQUIRE(ret.done == false);
+            }
+
+            auto accelerated_distance = profile.current_distance();
+
+            AND_THEN("the next phase is coasting at max speed") {
+                for (int i = 0;
+                     profile.remaining_distance() > accelerated_distance; i++) {
+                    auto ret = profile.tick();
+                    auto v1 = profile.current_velocity();
+
+                    REQUIRE(v1 == _max_vel);
+                    REQUIRE(ret.step == true);
+                    REQUIRE(ret.done == false);
+                }
+
+                AND_THEN("the last few ticks are decelerating") {
+                    for (int i = 0; i < accel_decel_steps - 1; ++i) {
+                        auto v0 = profile.current_velocity();
+                        auto ret = profile.tick();
+                        auto v1 = profile.current_velocity();
+
+                        REQUIRE(v1 - v0 == -1 * _acceleration_value);
+                        REQUIRE(ret.step == true);
+                        REQUIRE(ret.done == false);
+                    }
+
+                    auto ret = profile.tick();
+                    REQUIRE(ret.step == true);
+                    REQUIRE(ret.done == true);
+                }
+            }
+        }
+    }
+
+    GIVEN(
+        "a movement profile with distance so short that it doesn't reach max "
+        "velocity") {
+        constexpr int max_velocity = 4;  // steps per tick
+        constexpr int acceleration =
+            100;  // steps per ticks^2, this acceleration increases the motor
+                  // velocity by 1 step per tick
+        constexpr int distance = 4;  // total steps
+
+        auto profile = MovementProfile(MOTOR_FREQUENCY, initial_velocity,
+                                       max_velocity, acceleration,
+                                       MovementType::FixedDistance, distance);
+
+        auto _acceleration_value =
+            acceleration_to_steps_per_tick_sq(acceleration);
+
+        THEN("the first half is accelerating") {
+            for (int i = 0; i < distance / 2; ++i) {
+                auto v0 = profile.current_velocity();
+                static_cast<void>(profile.tick());
+                auto v1 = profile.current_velocity();
+                REQUIRE(v1 - v0 == _acceleration_value);
+            }
+
+            AND_THEN("the second half is decelerating") {
+                for (int i = 0; i < distance / 2; ++i) {
+                    auto v0 = profile.current_velocity();
+                    static_cast<void>(profile.tick());
+                    auto v1 = profile.current_velocity();
+                    REQUIRE(v1 - v0 == -1 * _acceleration_value);
+                }
+            }
+        }
+    }
+}

--- a/stm32-modules/flex-stacker/tests/test_motor_utils.cpp
+++ b/stm32-modules/flex-stacker/tests/test_motor_utils.cpp
@@ -1,5 +1,3 @@
-#include <iostream>
-
 #include "catch2/catch.hpp"
 #include "flex-stacker/motor_utils.hpp"
 

--- a/stm32-modules/flex-stacker/tests/test_motor_utils.cpp
+++ b/stm32-modules/flex-stacker/tests/test_motor_utils.cpp
@@ -20,7 +20,7 @@ static auto acceleration_to_steps_per_tick_sq(double vel) -> sq0_31 {
 
 TEST_CASE("Fixed Distance MovementProfile without acceleration") {
     GIVEN("a movement profile with constant velocity") {
-        constexpr int velocity = 1;      // steps per tick
+        constexpr int velocity = 100;    // steps per second == 1 step / tick
         constexpr int acceleration = 0;  // steps per ticks^2
         constexpr int distance = 10;     // total steps
 
@@ -39,7 +39,6 @@ TEST_CASE("Fixed Distance MovementProfile without acceleration") {
             }
 
             auto ret = profile.tick();
-            REQUIRE(profile.current_velocity() == expected_velocity);
             REQUIRE(ret.step == true);
             REQUIRE(ret.done == true);
         }

--- a/stm32-modules/flex-stacker/tests/test_motor_utils.cpp
+++ b/stm32-modules/flex-stacker/tests/test_motor_utils.cpp
@@ -18,8 +18,8 @@ static auto acceleration_to_steps_per_tick_sq(double vel) -> sq0_31 {
 
 TEST_CASE("Fixed Distance MovementProfile without acceleration") {
     GIVEN("a movement profile with constant velocity") {
-        constexpr int velocity = 100;    // steps per second == 1 step / tick
-        constexpr int acceleration = 0;  // steps per ticks^2
+        constexpr double velocity = 100.0001; // steps per second == 1 step / tick
+        constexpr double acceleration = 0;  // steps per ticks^2
         constexpr int distance = 10;     // total steps
 
         auto profile =

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_utils.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_utils.hpp
@@ -132,7 +132,8 @@ class MovementProfile {
 
     // When incrementing position tracker, if this bit changes then
     // a step should take place.
-    static constexpr q31_31 _tick_flag = (1 << radix);
+    static constexpr q31_31 _tick_flag =
+        (static_cast<uint64_t>(1) << radix) - 1;
 };
 
 }  // namespace motor_util


### PR DESCRIPTION
This PR adds a test for the movement profile used in the Flex Stacker and fixes a motion bug.

I found a delay in motion control; when the motor speed is set to take exactly one step each time the motor timer ticks, the first tick wouldn't cause a step. It's because the bitwise comparison doesn't work very well while we're at the step boundary. 

By setting the step flag to `(static_cast<uint64_t>(1) << radix) - 1;`, we can make sure we're taking a step right when it happens.

The longer I look at this math, the more confused I get. So apologies in advance if none of this makes sense.


