### PR TITLE
feat(stacker): Add statusbar animation patterns + enable and handle stallguard

### DIFF
--- a/cmake/FindBoost.cmake
+++ b/cmake/FindBoost.cmake
@@ -55,7 +55,7 @@ Cache Variables
 include(FetchContent)
 string(REPLACE "." "_" "_boost_archive_version_component" "${Boost_FIND_VERSION}")
 set(boost_localinstall_root ${CMAKE_SOURCE_DIR}/stm32-tools/boost-${_boost_archive_version_component})
-set(boost_archive_root "https://boostorg.jfrog.io/artifactory/main/release")
+set(boost_archive_root "https://archives.boost.io/release")
 set(boost_archive_url "${boost_archive_root}/${Boost_FIND_VERSION}/source/boost_${_boost_archive_version_component}.zip")
 FetchContent_Declare(Boost
   PREFIX "${boost_localinstall_root}"

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
@@ -127,9 +127,6 @@ void motor_hardware_gpio_init(void){
     init.Pin = Z_STEP_PIN;
     HAL_GPIO_Init(Z_STEP_PORT, &init);
 
-    init.Pin = MOTOR_DIAG0_PIN;
-    HAL_GPIO_Init(MOTOR_DIAG0_PORT, &init);
-
     // X MOTOR
     init.Pin = X_EN_PIN;
     HAL_GPIO_Init(X_EN_PORT, &init);
@@ -408,6 +405,11 @@ bool hw_read_platform_sensor(bool direction) {
 bool hw_read_estop(void) {
     return HAL_GPIO_ReadPin(_motor_hardware.estop.port, _motor_hardware.estop.pin) ==
            _motor_hardware.estop.active_setting;
+}
+
+bool hw_read_diag0(void) {
+    // diag0 is shared by all motors
+    return HAL_GPIO_ReadPin(MOTOR_DIAG0_PORT, MOTOR_DIAG0_PIN) == GPIO_PIN_SET;
 }
 
 void hw_set_diag0_irq(bool enable) {

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_policy.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_policy.cpp
@@ -1,8 +1,7 @@
 #include "firmware/motor_policy.hpp"
 
-#include "firmware/motor_hardware.h"
-
 #include "FreeRTOS.h"
+#include "firmware/motor_hardware.h"
 #include "task.h"
 
 using namespace motor_policy;
@@ -51,10 +50,7 @@ auto MotorPolicy::set_diag0_irq(bool enable) -> void {
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-auto MotorPolicy::check_estop() -> bool {
-    debouncer.debounce_update(hw_read_estop());
-    return debouncer.debounce_state();
-}
+auto MotorPolicy::check_estop() -> bool { return hw_read_estop(); }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto MotorPolicy::check_diag0() -> bool { return hw_read_diag0(); }
@@ -73,4 +69,3 @@ auto MotorPolicy::is_estop_pin(uint16_t pin) -> bool {
 auto MotorPolicy::sleep_ms(uint32_t ms) -> void {
     vTaskDelay(pdMS_TO_TICKS(ms));
 }
-

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_policy.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_policy.cpp
@@ -2,6 +2,9 @@
 
 #include "firmware/motor_hardware.h"
 
+#include "FreeRTOS.h"
+#include "task.h"
+
 using namespace motor_policy;
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
@@ -48,7 +51,13 @@ auto MotorPolicy::set_diag0_irq(bool enable) -> void {
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-auto MotorPolicy::check_estop() -> bool { return hw_read_estop(); }
+auto MotorPolicy::check_estop() -> bool {
+    debouncer.debounce_update(hw_read_estop());
+    return debouncer.debounce_state();
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto MotorPolicy::check_diag0() -> bool { return hw_read_diag0(); }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto MotorPolicy::is_diag0_pin(uint16_t pin) -> bool {
@@ -59,3 +68,9 @@ auto MotorPolicy::is_diag0_pin(uint16_t pin) -> bool {
 auto MotorPolicy::is_estop_pin(uint16_t pin) -> bool {
     return hw_is_estop_pin(pin);
 }
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto MotorPolicy::sleep_ms(uint32_t ms) -> void {
+    vTaskDelay(pdMS_TO_TICKS(ms));
+}
+

--- a/stm32-modules/include/common/firmware/freertos_message_queue.hpp
+++ b/stm32-modules/include/common/firmware/freertos_message_queue.hpp
@@ -45,9 +45,12 @@ class FreeRTOSMessageQueue {
         -> FreeRTOSMessageQueue = delete;
     ~FreeRTOSMessageQueue() = default;
     [[nodiscard]] auto try_send(const Message& message,
-                                const uint32_t timeout_ticks = 0) -> bool {
-        auto sent = xQueueSendToBack(queue, &message, timeout_ticks) == pdTRUE;
-        return sent;
+                                const uint32_t timeout_ticks = 0,
+                                const bool to_front = false) -> bool {
+        auto sent = (to_front)
+                        ? xQueueSendToFront(queue, &message, timeout_ticks)
+                        : xQueueSendToBack(queue, &message, timeout_ticks);
+        return sent == pdTRUE;
     }
 
     [[nodiscard]] auto try_send_from_isr(const Message& message) -> bool {

--- a/stm32-modules/include/flex-stacker/firmware/motor_hardware.h
+++ b/stm32-modules/include/flex-stacker/firmware/motor_hardware.h
@@ -24,6 +24,7 @@ bool hw_read_limit_switch(MotorID motor_id, bool direction);
 void hw_set_diag0_irq(bool enable);
 bool hw_read_platform_sensor(bool direction);
 bool hw_read_estop(void);
+bool hw_read_diag0(void);
 bool hw_is_diag0_pin(uint16_t pin);
 bool hw_is_estop_pin(uint16_t pin);
 

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -101,6 +101,7 @@ class MotorInterruptController {
     auto limit_switch_triggered() -> bool {
         return _policy->check_limit_switch(_id, _direction);
     }
+
     [[nodiscard]] auto get_response_id() const -> uint32_t {
         return _response_id;
     }
@@ -108,6 +109,8 @@ class MotorInterruptController {
         if (_stop) {
             return true;
         }
+        if(_policy->check_estop()) return true;
+        if(!_policy->check_diag0()) return true;
         if (_profile.movement_type() == motor_util::MovementType::OpenLoop) {
             return limit_switch_triggered();
         }

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -109,8 +109,12 @@ class MotorInterruptController {
         if (_stop) {
             return true;
         }
-        if (_policy->check_estop()) return true;
-        if (!_policy->check_diag0()) return true;
+        if (_policy->check_estop()) {
+            return true;
+        }
+        if (!_policy->check_diag0()) {
+            return true;
+        }
         if (_profile.movement_type() == motor_util::MovementType::OpenLoop) {
             return limit_switch_triggered();
         }

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -109,8 +109,8 @@ class MotorInterruptController {
         if (_stop) {
             return true;
         }
-        if(_policy->check_estop()) return true;
-        if(!_policy->check_diag0()) return true;
+        if (_policy->check_estop()) return true;
+        if (!_policy->check_diag0()) return true;
         if (_profile.movement_type() == motor_util::MovementType::OpenLoop) {
             return limit_switch_triggered();
         }

--- a/stm32-modules/include/flex-stacker/firmware/motor_policy.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_policy.hpp
@@ -3,6 +3,8 @@
 #include <cstdint>
 
 #include "systemwide.h"
+#include "core/debounce.hpp"
+//stm32-modules/include//common/core/debounce.hpp
 
 namespace motor_policy {
 
@@ -18,8 +20,10 @@ class MotorPolicy {
     auto set_diag0_irq(bool enable) -> void;
     auto check_platform_sensor(bool direction) -> bool;
     auto check_estop() -> bool;
+    auto check_diag0() -> bool;
     auto is_diag0_pin(uint16_t pin) -> bool;
     auto is_estop_pin(uint16_t pin) -> bool;
+    auto sleep_ms(uint32_t ms) -> void;
+    debouncer::Debouncer debouncer = debouncer::Debouncer{};
 };
-
 }  // namespace motor_policy

--- a/stm32-modules/include/flex-stacker/firmware/motor_policy.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_policy.hpp
@@ -2,9 +2,9 @@
 
 #include <cstdint>
 
-#include "systemwide.h"
 #include "core/debounce.hpp"
-//stm32-modules/include//common/core/debounce.hpp
+#include "systemwide.h"
+// stm32-modules/include//common/core/debounce.hpp
 
 namespace motor_policy {
 
@@ -24,6 +24,5 @@ class MotorPolicy {
     auto is_diag0_pin(uint16_t pin) -> bool;
     auto is_estop_pin(uint16_t pin) -> bool;
     auto sleep_ms(uint32_t ms) -> void;
-    debouncer::Debouncer debouncer = debouncer::Debouncer{};
 };
 }  // namespace motor_policy

--- a/stm32-modules/include/flex-stacker/firmware/motor_policy.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_policy.hpp
@@ -2,9 +2,7 @@
 
 #include <cstdint>
 
-#include "core/debounce.hpp"
 #include "systemwide.h"
-// stm32-modules/include//common/core/debounce.hpp
 
 namespace motor_policy {
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
@@ -251,9 +251,9 @@ struct GetDoorClosed {
 struct SetStatusBarState {
     std::optional<StatusBarID> bar_id;
     std::optional<StatusBarColor> color;
-    std::optional<StatusBarColor> fade;
     std::optional<StatusBarPattern> pattern;
-    std::optional<float> duration;
+    std::optional<uint32_t> duration;
+    std::optional<int8_t> reps;
     float power;
 
     using ParseResult = std::optional<SetStatusBarState>;
@@ -264,8 +264,8 @@ struct SetStatusBarState {
     using ColorArg = Arg<uint8_t, 'C'>;
     using KindArg = Arg<uint8_t, 'K'>;
     using PatternArg = Arg<uint8_t, 'A'>;
-    using DurationArg = Arg<float, 'D'>;
-    using FadeArg = Arg<uint8_t, 'F'>;
+    using DurationArg = Arg<uint32_t, 'D'>;
+    using RepsArg = Arg<int8_t, 'R'>;
 
     template <typename InputIt, typename Limit>
     requires std::forward_iterator<InputIt> &&
@@ -274,7 +274,7 @@ struct SetStatusBarState {
         -> std::pair<ParseResult, InputIt> {
         auto res =
             gcode::SingleParser<PowerArg, ColorArg, KindArg, PatternArg,
-                                DurationArg, FadeArg>::parse_gcode(input, limit,
+                                DurationArg, RepsArg>::parse_gcode(input, limit,
                                                                    prefix);
         if (!res.first.has_value()) {
             return std::make_pair(ParseResult(), input);
@@ -282,9 +282,9 @@ struct SetStatusBarState {
 
         auto ret = SetStatusBarState{.bar_id = std::nullopt,
                                      .color = std::nullopt,
-                                     .fade = std::nullopt,
                                      .pattern = std::nullopt,
-                                     .duration = 0,
+                                     .duration = std::nullopt,
+                                     .reps = std::nullopt,
                                      .power = 0};
 
         auto arguments = res.first.value();
@@ -306,8 +306,7 @@ struct SetStatusBarState {
             ret.duration = static_cast<float>(std::get<4>(arguments).value);
         }
         if (std::get<5>(arguments).present) {
-            ret.fade =
-                static_cast<StatusBarColor>(std::get<5>(arguments).value);
+            ret.reps = static_cast<int8_t>(std::get<5>(arguments).value);
         }
         return std::make_pair(ret, res.second);
     }

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
@@ -248,45 +248,66 @@ struct GetDoorClosed {
     }
 };
 
-struct SetStatusBarColor {
+struct SetStatusBarState {
     std::optional<StatusBarID> bar_id;
     std::optional<StatusBarColor> color;
+    std::optional<StatusBarColor> fade;
+    std::optional<StatusBarPattern> pattern;
+    std::optional<float> duration;
     float power;
 
-    using ParseResult = std::optional<SetStatusBarColor>;
+    using ParseResult = std::optional<SetStatusBarState>;
     static constexpr auto prefix = std::array{'M', '2', '0', '0', ' '};
     static constexpr const char* response = "M200 OK\n";
 
     using PowerArg = Arg<float, 'P'>;
     using ColorArg = Arg<uint8_t, 'C'>;
-    using KArg = Arg<uint8_t, 'K'>;
+    using KindArg = Arg<uint8_t, 'K'>;
+    using PatternArg = Arg<uint8_t, 'A'>;
+    using DurationArg = Arg<float, 'D'>;
+    using FadeArg = Arg<uint8_t, 'F'>;
 
     template <typename InputIt, typename Limit>
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<Limit, InputIt>
     static auto parse(const InputIt& input, Limit limit)
         -> std::pair<ParseResult, InputIt> {
-        auto res = gcode::SingleParser<PowerArg, ColorArg, KArg>::parse_gcode(
-            input, limit, prefix);
+        auto res =
+            gcode::SingleParser<PowerArg, ColorArg, KindArg, PatternArg,
+                                DurationArg, FadeArg>::parse_gcode(input, limit,
+                                                                   prefix);
         if (!res.first.has_value()) {
             return std::make_pair(ParseResult(), input);
         }
 
-        auto ret = SetStatusBarColor{
-            .bar_id = std::nullopt, .color = std::nullopt, .power = 0};
+        auto ret = SetStatusBarState{.bar_id = std::nullopt,
+                                     .color = std::nullopt,
+                                     .fade = std::nullopt,
+                                     .pattern = std::nullopt,
+                                     .duration = 0,
+                                     .power = 0};
 
         auto arguments = res.first.value();
         if (std::get<0>(arguments).present) {
             ret.power = static_cast<float>(std::get<0>(arguments).value);
         }
-
         if (std::get<1>(arguments).present) {
             ret.color =
                 static_cast<StatusBarColor>(std::get<1>(arguments).value);
         }
-
         if (std::get<2>(arguments).present) {
             ret.bar_id = static_cast<StatusBarID>(std::get<2>(arguments).value);
+        }
+        if (std::get<3>(arguments).present) {
+            ret.pattern =
+                static_cast<StatusBarPattern>(std::get<3>(arguments).value);
+        }
+        if (std::get<4>(arguments).present) {
+            ret.duration = static_cast<float>(std::get<4>(arguments).value);
+        }
+        if (std::get<5>(arguments).present) {
+            ret.fade =
+                static_cast<StatusBarColor>(std::get<5>(arguments).value);
         }
         return std::make_pair(ret, res.second);
     }

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
@@ -305,7 +305,9 @@ struct SetStatusBarState {
         if (std::get<4>(arguments).present) {
             ret.duration = static_cast<float>(std::get<4>(arguments).value);
         }
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if (std::get<5>(arguments).present) {
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
             ret.reps = static_cast<int8_t>(std::get<5>(arguments).value);
         }
         return std::make_pair(ret, res.second);

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -49,14 +49,14 @@ class HostCommsTask {
         gcode::GetLimitSwitches, gcode::SetMicrosteps, gcode::GetMoveParams,
         gcode::SetMotorStallGuard, gcode::GetMotorStallGuard, gcode::HomeMotor,
         gcode::GetPlatformSensors, gcode::GetDoorClosed, gcode::GetEstopStatus,
-        gcode::StopMotor, gcode::GetResetReason, gcode::SetStatusBarColor>;
+        gcode::StopMotor, gcode::GetResetReason, gcode::SetStatusBarState>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::SetTMCRegister, gcode::SetRunCurrent,
                  gcode::SetHoldCurrent, gcode::EnableMotor, gcode::DisableMotor,
                  gcode::MoveMotorInSteps, gcode::MoveToLimitSwitch,
                  gcode::MoveMotorInMm, gcode::SetMicrosteps,
-                 gcode::SetStatusBarColor, gcode::SetMotorStallGuard,
+                 gcode::SetStatusBarState, gcode::SetMotorStallGuard,
                  gcode::HomeMotor, gcode::StopMotor>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetTMCRegisterCache = AckCache<8, gcode::GetTMCRegister>;
@@ -1049,7 +1049,7 @@ class HostCommsTask {
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputLimit, InputIt>
-    auto visit_gcode(const gcode::SetStatusBarColor& gcode, InputIt tx_into,
+    auto visit_gcode(const gcode::SetStatusBarState& gcode, InputIt tx_into,
                      InputLimit tx_limit) -> std::pair<bool, InputIt> {
         auto id = ack_only_cache.add(gcode);
         if (id == 0) {
@@ -1057,11 +1057,14 @@ class HostCommsTask {
                 false, errors::write_into(tx_into, tx_limit,
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
-        auto message = messages::SetStatusBarColorMessage{
+        auto message = messages::SetStatusBarStateMessage{
             .id = id,
             .bar_id = gcode.bar_id,
-            .power = gcode.power,
             .color = gcode.color,
+            .fade = gcode.fade,
+            .pattern = gcode.pattern,
+            .duration = gcode.duration,
+            .power = gcode.power,
         };
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -1061,9 +1061,9 @@ class HostCommsTask {
             .id = id,
             .bar_id = gcode.bar_id,
             .color = gcode.color,
-            .fade = gcode.fade,
             .pattern = gcode.pattern,
             .duration = gcode.duration,
+            .reps = gcode.reps,
             .power = gcode.power,
         };
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -281,11 +281,18 @@ struct GetEstopResponse {
     bool triggered;
 };
 
-struct SetStatusBarColorMessage {
+struct UpdateUIMessage {
+    // Empty struct
+};
+
+struct SetStatusBarStateMessage {
     uint32_t id = 0;
     std::optional<StatusBarID> bar_id = std::nullopt;
-    std::optional<float> power = std::nullopt;
     std::optional<StatusBarColor> color = std::nullopt;
+    std::optional<StatusBarColor> fade = std::nullopt;
+    std::optional<StatusBarPattern> pattern = std::nullopt;
+    std::optional<float> duration = std::nullopt;
+    std::optional<float> power = std::nullopt;
 };
 
 using HostCommsMessage =
@@ -301,7 +308,8 @@ using SystemMessage =
                    SetSerialNumberMessage, EnterBootloaderMessage,
                    GetDoorClosedMessage, GetResetReasonMessage>;
 
-using UIMessage = ::std::variant<std::monostate, SetStatusBarColorMessage>;
+using UIMessage =
+    ::std::variant<std::monostate, UpdateUIMessage, SetStatusBarStateMessage>;
 
 using MotorDriverMessage =
     ::std::variant<std::monostate, SetTMCRegisterMessage, GetTMCRegisterMessage,

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -289,9 +289,9 @@ struct SetStatusBarStateMessage {
     uint32_t id = 0;
     std::optional<StatusBarID> bar_id = std::nullopt;
     std::optional<StatusBarColor> color = std::nullopt;
-    std::optional<StatusBarColor> fade = std::nullopt;
     std::optional<StatusBarPattern> pattern = std::nullopt;
-    std::optional<float> duration = std::nullopt;
+    std::optional<uint32_t> duration = std::nullopt;
+    std::optional<int8_t> reps = std::nullopt;
     std::optional<float> power = std::nullopt;
 };
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -26,7 +26,7 @@ namespace motor_driver_task {
 using Message = messages::MotorDriverMessage;
 
 static constexpr tmc2160::TMC2160RegisterMap motor_z_config{
-    .gconfig = {.diag0_error = 0, .diag0_stall = 0},
+    .gconfig = {.diag0_error = 1, .diag0_stall = 1},
     .short_conf = {.s2vs_level = 0x6,
                    .s2g_level = 0x6,
                    .shortfilter = 1,

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_driver_task.hpp
@@ -26,7 +26,7 @@ namespace motor_driver_task {
 using Message = messages::MotorDriverMessage;
 
 static constexpr tmc2160::TMC2160RegisterMap motor_z_config{
-    .gconfig = {.diag0_error = 1, .diag0_stall = 1},
+    .gconfig = {.diag0_error = 0, .diag0_stall = 1},
     .short_conf = {.s2vs_level = 0x6,
                    .s2g_level = 0x6,
                    .shortfilter = 1,
@@ -45,7 +45,7 @@ static constexpr tmc2160::TMC2160RegisterMap motor_z_config{
                  .hend = 0b11,
                  .tbl = 0b1,
                  .mres = 0b100},
-    .coolconf = {.semin = 0b11, .semax = 0b100, .sgt = 1},
+    .coolconf = {.semin = 0b11, .semax = 0b100, .sgt = 2},
     .pwmconf = {.pwm_ofs = 0x1F,
                 .pwm_grad = 0x18,
                 .pwm_autoscale = 1,
@@ -55,7 +55,7 @@ static constexpr tmc2160::TMC2160RegisterMap motor_z_config{
 };
 
 static constexpr tmc2160::TMC2160RegisterMap motor_x_config{
-    .gconfig = {.diag0_error = 0, .diag0_stall = 0},
+    .gconfig = {.diag0_error = 0, .diag0_stall = 1},
     .short_conf = {.s2vs_level = 0x6,
                    .s2g_level = 0x6,
                    .shortfilter = 1,
@@ -74,7 +74,7 @@ static constexpr tmc2160::TMC2160RegisterMap motor_x_config{
                  .hend = 0b1001,
                  .tbl = 0b1,
                  .mres = 0b100},
-    .coolconf = {.semin = 0b11, .semax = 0b100, .sgt = 1},
+    .coolconf = {.semin = 0b11, .semax = 0b100, .sgt = 2},
     .pwmconf = {.pwm_ofs = 0x1F,
                 .pwm_grad = 0x18,
                 .pwm_autoscale = 1,
@@ -84,7 +84,7 @@ static constexpr tmc2160::TMC2160RegisterMap motor_x_config{
 };
 
 static constexpr tmc2160::TMC2160RegisterMap motor_l_config{
-    .gconfig = {.diag0_error = 0, .diag0_stall = 0},
+    .gconfig = {.diag0_error = 0, .diag0_stall = 1},
     .short_conf = {.s2vs_level = 0x6,
                    .s2g_level = 0x6,
                    .shortfilter = 1,
@@ -103,7 +103,7 @@ static constexpr tmc2160::TMC2160RegisterMap motor_l_config{
                  .hend = 0b1001,
                  .tbl = 0b1,
                  .mres = 0b100},
-    .coolconf = {.semin = 0b11, .semax = 0b100, .sgt = 1},
+    .coolconf = {.semin = 0b11, .semax = 0b100, .sgt = 2},
     .pwmconf = {.pwm_ofs = 0x1F,
                 .pwm_grad = 0x18,
                 .pwm_autoscale = 1,

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -423,31 +423,57 @@ class MotorTask {
     }
 
     auto reset_debounce() -> void { _debounce_timer.stop(); }
+    //auto reset_debounce(bool triggered) -> void {
+    //    if (triggered) {
+    //        // Set status bars to flashing RED
+    //        auto message = messages::SetStatusBarStateMessage{
+    //            .color = StatusBarColor::Red,
+    //            .pattern = StatusBarPattern::Flash,
+    //            .duration = 1000,
+    //            .reps = 3};
+    //        static_cast<void>(
+    //            _task_registry->send_to_address(message, Queues::UIAddress));
+    //    }
+    //    _debounce_timer.stop();
+    //}
 
     template <MotorControlPolicy Policy>
     auto visit_message(const messages::GPIOInterruptMessage& m, Policy& policy)
         -> void {
         // Debounce
         if (_debounce_timer.is_running()) return;
+        //_debounce_timer.update_callback(
+        //    [ThisPtr = this, &policy] { ThisPtr->reset_debounce(policy.check_estop()); }
+        //);
         _debounce_timer.start();
 
+        auto triggered = false;
         auto error = Error::NO_ERROR;
         if (policy.is_diag0_pin(m.pin)) {
+            policy.sleep_ms(100);
+            triggered = policy.check_diag0();
             error = Error::MOTOR_STALL_DETECTED;
         } else if (policy.is_estop_pin(m.pin)) {
+            //policy.sleep_ms(800);
+            triggered = policy.check_estop();
             error = Error::ESTOP_TRIGGERED;
         } else {
             // don't care about other interrupts
             return;
         }
 
-        stop_motors();
-        send_error_message(error);
-        // Set status bars to flashing RED
-        auto message = messages::SetStatusBarStateMessage{
-            .color = StatusBarColor::Red, .pattern = StatusBarPattern::Flash};
-        static_cast<void>(
-            _task_registry->send_to_address(message, Queues::UIAddress));
+        if (triggered) {
+            stop_motors();
+            send_error_message(error);
+            // Set status bars to flashing RED
+            auto message = messages::SetStatusBarStateMessage{
+                .color = StatusBarColor::Red,
+                .pattern = StatusBarPattern::Flash,
+                .duration = 1000,
+                .reps = 3};
+            static_cast<void>(
+                _task_registry->send_to_address(message, Queues::UIAddress));
+        }
     }
 
     /**

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -5,6 +5,7 @@
  */
 #pragma once
 #include <cmath>
+#include <cstdint>
 
 #include "core/ack_cache.hpp"
 #include "core/circular_buffer.hpp"
@@ -38,6 +39,9 @@ using Error = errors::ErrorCode;
 
 // Gpio irq debounce time
 static constexpr uint32_t DEBOUNCE_MS = 1000;
+static constexpr uint32_t DEBOUNCE_SLEEP_MS = 200;
+static constexpr uint32_t LED_ERROR_DURATION_MS = 1000;
+static constexpr uint32_t LED_ERROR_REPS = 3;
 
 struct Defaults {
     struct X {
@@ -428,17 +432,19 @@ class MotorTask {
     auto visit_message(const messages::GPIOInterruptMessage& m, Policy& policy)
         -> void {
         // Debounce
-        if (_debounce_timer.is_running()) return;
+        if (_debounce_timer.is_running()) {
+            return;
+        }
         _debounce_timer.start();
 
         auto triggered = false;
         auto error = Error::NO_ERROR;
         if (policy.is_diag0_pin(m.pin)) {
-            policy.sleep_ms(200);
+            policy.sleep_ms(DEBOUNCE_SLEEP_MS);
             triggered = policy.check_diag0();
             error = Error::MOTOR_STALL_DETECTED;
         } else if (policy.is_estop_pin(m.pin)) {
-            policy.sleep_ms(200);
+            policy.sleep_ms(DEBOUNCE_SLEEP_MS);
             triggered = policy.check_estop();
             error = Error::ESTOP_TRIGGERED;
         } else {
@@ -456,7 +462,10 @@ class MotorTask {
         auto pattern =
             triggered ? StatusBarPattern::Flash : StatusBarPattern::Static;
         auto message = messages::SetStatusBarStateMessage{
-            .color = color, .pattern = pattern, .duration = 1000, .reps = 3};
+            .color = color,
+            .pattern = pattern,
+            .duration = LED_ERROR_DURATION_MS,
+            .reps = LED_ERROR_REPS};
         static_cast<void>(
             _task_registry->send_to_address(message, Queues::UIAddress));
     }

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -423,38 +423,22 @@ class MotorTask {
     }
 
     auto reset_debounce() -> void { _debounce_timer.stop(); }
-    //auto reset_debounce(bool triggered) -> void {
-    //    if (triggered) {
-    //        // Set status bars to flashing RED
-    //        auto message = messages::SetStatusBarStateMessage{
-    //            .color = StatusBarColor::Red,
-    //            .pattern = StatusBarPattern::Flash,
-    //            .duration = 1000,
-    //            .reps = 3};
-    //        static_cast<void>(
-    //            _task_registry->send_to_address(message, Queues::UIAddress));
-    //    }
-    //    _debounce_timer.stop();
-    //}
 
     template <MotorControlPolicy Policy>
     auto visit_message(const messages::GPIOInterruptMessage& m, Policy& policy)
         -> void {
         // Debounce
         if (_debounce_timer.is_running()) return;
-        //_debounce_timer.update_callback(
-        //    [ThisPtr = this, &policy] { ThisPtr->reset_debounce(policy.check_estop()); }
-        //);
         _debounce_timer.start();
 
         auto triggered = false;
         auto error = Error::NO_ERROR;
         if (policy.is_diag0_pin(m.pin)) {
-            policy.sleep_ms(100);
+            policy.sleep_ms(200);
             triggered = policy.check_diag0();
             error = Error::MOTOR_STALL_DETECTED;
         } else if (policy.is_estop_pin(m.pin)) {
-            //policy.sleep_ms(800);
+            policy.sleep_ms(200);
             triggered = policy.check_estop();
             error = Error::ESTOP_TRIGGERED;
         } else {
@@ -465,15 +449,16 @@ class MotorTask {
         if (triggered) {
             stop_motors();
             send_error_message(error);
-            // Set status bars to flashing RED
-            auto message = messages::SetStatusBarStateMessage{
-                .color = StatusBarColor::Red,
-                .pattern = StatusBarPattern::Flash,
-                .duration = 1000,
-                .reps = 3};
-            static_cast<void>(
-                _task_registry->send_to_address(message, Queues::UIAddress));
         }
+
+        // Set status bars
+        auto color = triggered ? StatusBarColor::Red : StatusBarColor::Green;
+        auto pattern =
+            triggered ? StatusBarPattern::Flash : StatusBarPattern::Static;
+        auto message = messages::SetStatusBarStateMessage{
+            .color = color, .pattern = pattern, .duration = 1000, .reps = 3};
+        static_cast<void>(
+            _task_registry->send_to_address(message, Queues::UIAddress));
     }
 
     /**

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -19,9 +19,11 @@
 #include "flex-stacker/tasks.hpp"
 #include "flex-stacker/tmc2160_registers.hpp"
 #include "hal/message_queue.hpp"
+#include "ot_utils/freertos/freertos_timer.hpp"
 #include "messages.hpp"
 
 namespace motor_task {
+using namespace ot_utils::freertos_timer;
 
 template <typename P>
 concept MotorControlPolicy = requires(P p, MotorID motor_id) {
@@ -33,6 +35,9 @@ using Message = messages::MotorMessage;
 using Controller = motor_interrupt_controller::MotorInterruptController;
 using Move = motor_interrupt_controller::Move;
 using Error = errors::ErrorCode;
+
+// Gpio irq debounce time
+static constexpr uint32_t DEBOUNCE_MS = 1000;
 
 struct Defaults {
     struct X {
@@ -94,7 +99,8 @@ class MotorTask {
           _x_controller(x_ctrl),
           _z_controller(z_ctrl),
           _l_controller(l_ctrl),
-          _initialized(false) {}
+          _initialized(false),
+          _debounce_timer("DB Timer", [ThisPtr = this] { ThisPtr->reset_debounce(); }, DEBOUNCE_MS) {}
     MotorTask(const MotorTask& other) = delete;
     auto operator=(const MotorTask& other) -> MotorTask& = delete;
     MotorTask(MotorTask&& other) noexcept = delete;
@@ -414,26 +420,34 @@ class MotorTask {
         _x_controller.set_diag0_irq(m.enable);
     }
 
+    auto reset_debounce() -> void {
+        _debounce_timer.stop();
+    }
+
     template <MotorControlPolicy Policy>
     auto visit_message(const messages::GPIOInterruptMessage& m, Policy& policy)
         -> void {
-        static_cast<void>(m);
+        // Debounce
+        if (_debounce_timer.is_running()) return;
+        _debounce_timer.start();
+
+        auto error = Error::NO_ERROR;
         if (policy.is_diag0_pin(m.pin)) {
-            send_error_message(Error::MOTOR_STALL_DETECTED);
+            error = Error::MOTOR_STALL_DETECTED;
         } else if (policy.is_estop_pin(m.pin)) {
-            send_error_message(Error::ESTOP_TRIGGERED);
+            error = Error::ESTOP_TRIGGERED;
         } else {
             // don't care about other interrupts
             return;
         }
-        stop_motors();
 
+        stop_motors();
+        send_error_message(error);
         // Set status bars to RED
-        // TODO: Enable this after SLAS
-        // auto message =
-        //    messages::SetStatusBarColorMessage{.color = StatusBarColor::Red};
-        // static_cast<void>(
-        //    _task_registry->send_to_address(message, Queues::UIAddress));
+         auto message =
+            messages::SetStatusBarColorMessage{.color = StatusBarColor::Red};
+         static_cast<void>(
+            _task_registry->send_to_address(message, Queues::UIAddress));
     }
 
     /**
@@ -477,6 +491,8 @@ class MotorTask {
     Controller& _z_controller;
     Controller& _l_controller;
     bool _initialized;
+    FreeRTOSTimer _debounce_timer;
+
     MotorState _x_state{
         .lms_config = {.mm_per_rev = Defaults::X::MM_PER_REV,
                        .steps_per_rev = Defaults::X::STEPS_PER_REV,

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -19,8 +19,8 @@
 #include "flex-stacker/tasks.hpp"
 #include "flex-stacker/tmc2160_registers.hpp"
 #include "hal/message_queue.hpp"
-#include "ot_utils/freertos/freertos_timer.hpp"
 #include "messages.hpp"
+#include "ot_utils/freertos/freertos_timer.hpp"
 
 namespace motor_task {
 using namespace ot_utils::freertos_timer;
@@ -100,7 +100,9 @@ class MotorTask {
           _z_controller(z_ctrl),
           _l_controller(l_ctrl),
           _initialized(false),
-          _debounce_timer("DB Timer", [ThisPtr = this] { ThisPtr->reset_debounce(); }, DEBOUNCE_MS) {}
+          _debounce_timer(
+              "DB Timer", [ThisPtr = this] { ThisPtr->reset_debounce(); },
+              DEBOUNCE_MS) {}
     MotorTask(const MotorTask& other) = delete;
     auto operator=(const MotorTask& other) -> MotorTask& = delete;
     MotorTask(MotorTask&& other) noexcept = delete;
@@ -420,9 +422,7 @@ class MotorTask {
         _x_controller.set_diag0_irq(m.enable);
     }
 
-    auto reset_debounce() -> void {
-        _debounce_timer.stop();
-    }
+    auto reset_debounce() -> void { _debounce_timer.stop(); }
 
     template <MotorControlPolicy Policy>
     auto visit_message(const messages::GPIOInterruptMessage& m, Policy& policy)
@@ -444,9 +444,9 @@ class MotorTask {
         stop_motors();
         send_error_message(error);
         // Set status bars to RED
-         auto message =
-            messages::SetStatusBarColorMessage{.color = StatusBarColor::Red};
-         static_cast<void>(
+        auto message =
+            messages::SetStatusBarStateMessage{.color = StatusBarColor::Red};
+        static_cast<void>(
             _task_registry->send_to_address(message, Queues::UIAddress));
     }
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -443,9 +443,9 @@ class MotorTask {
 
         stop_motors();
         send_error_message(error);
-        // Set status bars to RED
-        auto message =
-            messages::SetStatusBarStateMessage{.color = StatusBarColor::Red};
+        // Set status bars to flashing RED
+        auto message = messages::SetStatusBarStateMessage{
+            .color = StatusBarColor::Red, .pattern = StatusBarPattern::Flash};
         static_cast<void>(
             _task_registry->send_to_address(message, Queues::UIAddress));
     }

--- a/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
@@ -197,7 +197,9 @@ class UITask {
     }
 
     template <UIPolicyIface Policy>
-    auto visit_message(const messages::UpdateUIMessage& m, Policy& policy)
+    auto visit_message(
+        const messages::UpdateUIMessage& m,
+        Policy& policy)  // NOLINT[readability-function-cognitive-complexity]
         -> void {
         static_cast<void>(m);
         static_cast<void>(policy);

--- a/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
@@ -52,7 +52,7 @@ static auto color_to_channels(StatusBarColor color) -> const ChannelMapping& {
 }
 
 // The timer driving LED update frequency should run at this period
-static constexpr uint32_t UPDATE_PERIOD_MS = 1;
+static constexpr uint32_t UPDATE_PERIOD_MS = 10;
 static constexpr uint8_t LED_DRIVER0_I2C_ADDRESS = 0x6C << 1;  // Internal
 static constexpr uint8_t LED_DRIVER1_I2C_ADDRESS = 0x6F << 1;  // External
 static constexpr auto DEFAULT_COLOR = StatusBarColor::Green;
@@ -60,7 +60,7 @@ static constexpr auto DEFAULT_POWER = 0.5F;
 static constexpr auto SYSTEM_LED_COUNT = 16;
 
 // Time between each write to the LED strip
-static constexpr uint32_t LED_UPDATE_PERIOD_MS = 5U;
+static constexpr uint32_t LED_UPDATE_PERIOD_MS = 1U * UPDATE_PERIOD_MS;
 // Time to fade from one color to the next
 static constexpr uint32_t LED_FADE_PERIOD_MS = 500U;
 // Time that each full "pulse" action should take (sine wave)
@@ -70,7 +70,7 @@ static constexpr uint32_t LED_CONFIRM_FADE_PERIOD_MS = 5000U;
 // Time that it takes for the confirm color to flash
 static constexpr uint32_t LED_CONFIRM_PERIOD_MS = 300U;
 // Time to blink heartbeat LED
-static constexpr uint32_t HB_UPDATE_PERIOD_MS = 500U;
+static constexpr uint32_t HB_UPDATE_PERIOD_MS = 500U / UPDATE_PERIOD_MS;
 // Max duration of the animation in ms (10 seconds)
 static constexpr uint32_t MAX_UPDATE_PERIOD_MS = 10000U;
 // Min duration of the animation in ms (25 ms)
@@ -421,7 +421,9 @@ class UITask {
                         std::optional<bool> wipe = std::nullopt) -> bool {
         // Skip if driver not initialized
         auto status_bar = get_statusbar_state(bar);
-        if (!status_bar.driver_ok) return false;
+        if (!status_bar.driver_ok) {
+            return false;
+        }
 
         // Skip if there is no state change
         if (power.has_value() and power.has_value()) {

--- a/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
@@ -33,6 +33,8 @@ static constexpr ChannelMapping red_channels{6, 9, 12, 15};
 static constexpr ChannelMapping green_channels{7, 10, 13, 16};
 static constexpr ChannelMapping blue_channels{8, 11, 14, 17};
 static constexpr ChannelMapping yellow_channels{6, 7, 12, 13};
+static constexpr int LED_CHANNEL_START = 2;
+static constexpr int LED_CHANNEL_END = 17;
 
 static auto color_to_channels(StatusBarColor color) -> const ChannelMapping& {
     switch (color) {
@@ -63,12 +65,17 @@ static constexpr auto SYSTEM_LED_COUNT = 16;
 static constexpr uint32_t LED_UPDATE_PERIOD_MS = 1U * UPDATE_PERIOD_MS;
 // Time to fade from one color to the next
 static constexpr uint32_t LED_FADE_PERIOD_MS = 500U;
+// Time to flash the color on and off
+static constexpr uint32_t LED_FLASH_PERIOD_MS = 500U;
 // Time that each full "pulse" action should take (sine wave)
 static constexpr uint32_t LED_PULSE_PERIOD_MS = 1000U;
 // Time that it takes to fade from confirm color to original color
 static constexpr uint32_t LED_CONFIRM_FADE_PERIOD_MS = 5000U;
 // Time that it takes for the confirm color to flash
 static constexpr uint32_t LED_CONFIRM_PERIOD_MS = 300U;
+// Time that it takes for the confirm pattern to turn on the led
+static constexpr uint32_t LED_CONFIRM_ON_PERIOD_MS =
+    LED_CONFIRM_PERIOD_MS + 100;
 // Time to blink heartbeat LED
 static constexpr uint32_t HB_UPDATE_PERIOD_MS = 500U / UPDATE_PERIOD_MS;
 // Max duration of the animation in ms (10 seconds)
@@ -76,7 +83,7 @@ static constexpr uint32_t MAX_UPDATE_PERIOD_MS = 10000U;
 // Min duration of the animation in ms (25 ms)
 static constexpr uint32_t MIN_UPDATE_PERIOD_MS = 25U;
 // Reps to signify runnning forever
-static constexpr int FOREVER = -1;
+static constexpr int8_t FOREVER = -1;
 
 struct StatusBarState {
     StatusBarID kind;
@@ -86,7 +93,7 @@ struct StatusBarState {
     float power;
     float power_dt;
     uint32_t duration = LED_FADE_PERIOD_MS;
-    int reps = 0;
+    int8_t reps = 0;
     uint32_t counter = 0;
     bool driver_ok = false;
 };
@@ -192,13 +199,19 @@ class UITask {
     template <UIPolicyIface Policy>
     auto visit_message(const messages::UpdateUIMessage& m, Policy& policy)
         -> void {
+        static_cast<void>(m);
+        static_cast<void>(policy);
         static constexpr double TWO = 2.0F;
         for (auto bar_id : {StatusBarID::Internal, StatusBarID::External}) {
             _led_update_pending = false;
             auto led_bar = &get_statusbar_state(bar_id);
             // Skip if driver not initialized or reps reached 0
-            if (!led_bar->driver_ok) continue;
-            if (led_bar->reps != FOREVER && led_bar->reps < 1) continue;
+            if (!led_bar->driver_ok) {
+                continue;
+            }
+            if (led_bar->reps != FOREVER && led_bar->reps < 1) {
+                continue;
+            }
 
             // Turn off LEDs when power = 0
             if (led_bar->power == 0) {
@@ -233,7 +246,7 @@ class UITask {
                 case StatusBarPattern::Pulse: {
                     // Set color as a triangle wave
                     float power = led_bar->power;
-                    if (led_bar->counter < (led_bar->duration / 2)) {
+                    if (led_bar->counter < (led_bar->duration / TWO)) {
                         power = static_cast<float>(led_bar->counter) /
                                 (static_cast<float>(led_bar->duration) / TWO);
                     } else {
@@ -251,7 +264,7 @@ class UITask {
                 case StatusBarPattern::Flash: {
                     // Blink the statusbar by turning on/off by half the
                     // duration.
-                    auto power = (led_bar->counter < (led_bar->duration / 2))
+                    auto power = (led_bar->counter < (led_bar->duration / TWO))
                                      ? 0
                                      : led_bar->power;
                     set_status_bar(bar_id, led_bar->color, power);
@@ -262,13 +275,13 @@ class UITask {
                     // turn on then off led to new color
                     if (led_bar->counter < LED_CONFIRM_PERIOD_MS) {
                         auto power =
-                            (led_bar->counter < LED_CONFIRM_PERIOD_MS / 2)
+                            (led_bar->counter < LED_CONFIRM_PERIOD_MS / TWO)
                                 ? led_bar->power
                                 : 0;
                         set_status_bar(bar_id, led_bar->color, power);
                         led_bar->power_dt = power;
                         // turn on led to new color
-                    } else if (led_bar->counter < LED_CONFIRM_PERIOD_MS + 100) {
+                    } else if (led_bar->counter < LED_CONFIRM_ON_PERIOD_MS) {
                         set_status_bar(bar_id, led_bar->color, led_bar->power);
                         // fade to old color
                     } else {
@@ -330,10 +343,11 @@ class UITask {
 
         // clear the LEDs not being set
         if (wipe) {
-            for (int i = 2; i <= 17; i++) {
+            for (int i = LED_CHANNEL_START; i <= LED_CHANNEL_END; i++) {
                 if (std::find(std::begin(channels), std::end(channels), i) !=
-                    std::end(channels))
+                    std::end(channels)) {
                     continue;
+                }
                 if (bar == Internal) {
                     _led_driver0.set_current(i, 0);
                 }
@@ -370,7 +384,7 @@ class UITask {
     auto get_default_period(StatusBarPattern pattern) -> uint32_t {
         switch (pattern) {
             case Flash:
-                return LED_FADE_PERIOD_MS;
+                return LED_FLASH_PERIOD_MS;
             case Static:
                 return LED_FADE_PERIOD_MS;
             case Pulse:
@@ -382,7 +396,7 @@ class UITask {
         }
     }
 
-    auto get_default_reps(StatusBarPattern pattern) -> int {
+    auto get_default_reps(StatusBarPattern pattern) -> int8_t {
         switch (pattern) {
             case Static:
             case Confirm:

--- a/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
@@ -220,8 +220,8 @@ class UITask {
                         power = static_cast<float>(led_bar->counter) /
                                 (static_cast<float>(led_bar->duration));
                         power = std::clamp(power, 0.0F, led_bar->power);
-                        led_bar->power_dt = power;
                         set_status_bar(bar_id, led_bar->color, power, true);
+                        led_bar->power_dt = power;
                     } else {
                         // Static only happens once
                         led_bar->reps = 0;
@@ -243,9 +243,9 @@ class UITask {
                         power = static_cast<float>(inverse_count) /
                                 (static_cast<float>(led_bar->duration) / TWO);
                     }
-
-                    led_bar->power_dt = std::clamp(power, 0.0F, led_bar->power);
+                    power = std::clamp(power, 0.0F, led_bar->power);
                     set_status_bar(bar_id, led_bar->color, power);
+                    led_bar->power_dt = power;
                     break;
                 }
                 case StatusBarPattern::Flash: {
@@ -254,8 +254,8 @@ class UITask {
                     auto power = (led_bar->counter < (led_bar->duration / 2))
                                      ? 0
                                      : led_bar->power;
-                    led_bar->power_dt = power;
                     set_status_bar(bar_id, led_bar->color, power);
+                    led_bar->power_dt = power;
                     break;
                 }
                 case StatusBarPattern::Confirm: {
@@ -266,6 +266,7 @@ class UITask {
                                 ? led_bar->power
                                 : 0;
                         set_status_bar(bar_id, led_bar->color, power);
+                        led_bar->power_dt = power;
                         // turn on led to new color
                     } else if (led_bar->counter < LED_CONFIRM_PERIOD_MS + 100) {
                         set_status_bar(bar_id, led_bar->color, led_bar->power);
@@ -276,9 +277,9 @@ class UITask {
                             power = static_cast<float>(led_bar->counter) /
                                     (static_cast<float>(led_bar->duration));
                             power = std::clamp(power, 0.0F, led_bar->power);
-                            led_bar->power_dt = power;
                             set_status_bar(bar_id, led_bar->old_color, power,
                                            true);
+                            led_bar->power_dt = power;
                         } else {
                             led_bar->reps = 0;
                             led_bar->power_dt = 0;
@@ -421,6 +422,14 @@ class UITask {
         // Skip if driver not initialized
         auto status_bar = get_statusbar_state(bar);
         if (!status_bar.driver_ok) return false;
+
+        // Skip if there is no state change
+        if (power.has_value() and power.has_value()) {
+            if (power.value() == status_bar.power_dt &&
+                color.value() == status_bar.color) {
+                return true;
+            }
+        }
 
         auto power_ = power.value_or(status_bar.power);
         auto color_ = color.value_or(status_bar.color);

--- a/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
@@ -197,9 +197,8 @@ class UITask {
     }
 
     template <UIPolicyIface Policy>
-    auto visit_message(
-        const messages::UpdateUIMessage& m,
-        Policy& policy)  // NOLINT[readability-function-cognitive-complexity]
+    // NOLINTNEXTLINE[readability-function-cognitive-complexity]
+    auto visit_message(const messages::UpdateUIMessage& m, Policy& policy)
         -> void {
         static_cast<void>(m);
         static_cast<void>(policy);

--- a/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
@@ -32,7 +32,7 @@ static constexpr ChannelMapping white_channels{2, 3, 4, 5};
 static constexpr ChannelMapping red_channels{6, 9, 12, 15};
 static constexpr ChannelMapping green_channels{7, 10, 13, 16};
 static constexpr ChannelMapping blue_channels{8, 11, 14, 17};
-static constexpr ChannelMapping yellow_channels{8, 11, 14, 17};  // FIX THIS
+static constexpr ChannelMapping yellow_channels{6, 7, 9, 10};
 
 static auto color_to_channels(StatusBarColor color) -> const ChannelMapping& {
     switch (color) {

--- a/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
@@ -2,6 +2,9 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
+#include <iterator>
+#include <optional>
 
 #include "core/is31fl_driver.hpp"
 #include "errors.hpp"
@@ -29,6 +32,7 @@ static constexpr ChannelMapping white_channels{2, 3, 4, 5};
 static constexpr ChannelMapping red_channels{6, 9, 12, 15};
 static constexpr ChannelMapping green_channels{7, 10, 13, 16};
 static constexpr ChannelMapping blue_channels{8, 11, 14, 17};
+static constexpr ChannelMapping yellow_channels{8, 11, 14, 17};  // FIX THIS
 
 static auto color_to_channels(StatusBarColor color) -> const ChannelMapping& {
     switch (color) {
@@ -40,34 +44,60 @@ static auto color_to_channels(StatusBarColor color) -> const ChannelMapping& {
             return green_channels;
         case StatusBarColor::Blue:
             return blue_channels;
+        case StatusBarColor::Yellow:
+            return yellow_channels;
         default:
             return white_channels;
     }
 }
 
 // The timer driving LED update frequency should run at this period
-static constexpr uint32_t UPDATE_PERIOD_MS = 1000;
+static constexpr uint32_t UPDATE_PERIOD_MS = 5;
 static constexpr uint8_t LED_DRIVER0_I2C_ADDRESS = 0x6C << 1;  // Internal
 static constexpr uint8_t LED_DRIVER1_I2C_ADDRESS = 0x6F << 1;  // External
 static constexpr auto DEFAULT_COLOR = StatusBarColor::Green;
 static constexpr auto DEFAULT_POWER = 0.5F;
+static constexpr auto SYSTEM_LED_COUNT = 16;
+
+// Time between each write to the LED strip
+static constexpr uint32_t LED_UPDATE_PERIOD_MS = 5;
+// Time to fade from one color to the next
+static constexpr uint32_t LED_FADE_PERIOD_MS = 500;
+// Time that each full "pulse" action should take (sine wave)
+static constexpr uint32_t LED_PULSE_PERIOD_MS = 1000;
+// Time to blink heartbeat LED
+static constexpr uint32_t HB_UPDATE_PERIOD_MS = 500;
+// Period to signify runnning forever
+static constexpr int FOREVER = -1;
 
 struct StatusBarState {
     StatusBarID kind;
     StatusBarColor color;
+    StatusBarColor old_color;
+    StatusBarPattern pattern = StatusBarPattern::Static;
     float power;
+    float old_power;
+    float duration = 0;
+    int reps = 0;
+    uint32_t counter = 0;
+    uint32_t period = LED_FADE_PERIOD_MS;
+    bool driver_ok = false;
 };
 
 const StatusBarState led_bar_internal = {
     .kind = StatusBarID::Internal,
     .color = DEFAULT_COLOR,
+    .old_color = DEFAULT_COLOR,
     .power = DEFAULT_POWER,
+    .old_power = DEFAULT_POWER,
 };
 
 const StatusBarState led_bar_external = {
     .kind = StatusBarID::External,
     .color = DEFAULT_COLOR,
+    .old_color = DEFAULT_COLOR,
     .power = DEFAULT_POWER,
+    .old_power = DEFAULT_POWER,
 };
 
 using Message = messages::UIMessage;
@@ -85,7 +115,7 @@ class UITask {
           _task_registry(aggregator),
           _policy(policy),
           _ui_timer(
-              "UI Timer", [ThisPtr = this] { ThisPtr->heartbeat_led(); },
+              "UI Timer", [ThisPtr = this] { ThisPtr->led_timer_callback(); },
               UPDATE_PERIOD_MS) {
         _ui_timer.start();
     }
@@ -108,13 +138,13 @@ class UITask {
 
             if (!_led_driver0.initialized()) {
                 _led_driver0.initialize(policy);
-                StatusBarState bar_state = get_statusbar_state(Internal);
-                set_status_bar(Internal, bar_state.color, bar_state.power);
+                _led_bar_internal.driver_ok = true;
+                set_status_bar(Internal);
             }
             if (!_led_driver1.initialized()) {
                 _led_driver1.initialize(policy);
-                StatusBarState bar_state = get_statusbar_state(External);
-                set_status_bar(External, bar_state.color, bar_state.power);
+                _led_bar_internal.driver_ok = true;
+                set_status_bar(External);
             }
             _initialized = true;
         }
@@ -127,6 +157,25 @@ class UITask {
     }
 
   private:
+    // Should be provided to LED Timer to send LED Update messages. Ensure that
+    // the timer implementation does NOT execute in an interrupt context.
+    auto led_timer_callback() -> void {
+        // Update heartbeat led
+        hb_counter += 1;
+        if (hb_counter > HB_UPDATE_PERIOD_MS) {
+            hb_led_state = !hb_led_state;
+            _policy->set_heartbeat_led(hb_led_state);
+            hb_counter = 0;
+        }
+
+        if (!_led_update_pending) {
+            auto ret = _message_queue.try_send(messages::UpdateUIMessage());
+            if (ret) {
+                _led_update_pending = true;
+            }
+        }
+    }
+
     template <UIPolicyIface Policy>
     auto visit_message(const std::monostate& m, Policy& policy) -> void {
         static_cast<void>(m);
@@ -134,47 +183,138 @@ class UITask {
     }
 
     template <UIPolicyIface Policy>
-    auto visit_message(const messages::SetStatusBarColorMessage& m,
+    auto visit_message(const messages::UpdateUIMessage& m, Policy& policy)
+        -> void {
+        static constexpr double TWO = 2.0F;
+        for (auto bar_id : {StatusBarID::Internal, StatusBarID::External}) {
+            _led_update_pending = false;
+            auto led_bar = &get_statusbar_state(bar_id);
+            // Skip if driver not initialized
+            if (!led_bar->driver_ok) continue;
+            if (led_bar->reps != FOREVER && led_bar->reps < 1) continue;
+
+            // TODO: fix power=0, it does NOT turn off the statusbar
+            // Turn off status if power is 0
+            //if (led_bar->power == 0) {
+            //    led_bar->reps = 0;
+            //    led_bar->old_power = 0;
+            //    led_bar->old_color = led_bar->color;
+            //    set_status_bar(bar_id);
+            //    continue;
+            //}
+
+            led_bar->counter += LED_UPDATE_PERIOD_MS;
+            if (led_bar->counter > led_bar->period) {
+                led_bar->counter = 0;
+            }
+
+            switch (led_bar->pattern) {
+                case StatusBarPattern::Static: {
+                    float power = led_bar->power;
+                    if (led_bar->counter < led_bar->period) {
+                        power = static_cast<float>(led_bar->counter) /
+                                (static_cast<float>(led_bar->period));
+
+                        auto inverse_count =
+                            std::abs(static_cast<int>(led_bar->period) -
+                                     static_cast<int>(led_bar->counter));
+                        auto inv_power = static_cast<float>(inverse_count) /
+                                         (static_cast<float>(led_bar->period));
+
+                        power = std::clamp(power, 0.0F, led_bar->old_power);
+                        inv_power = std::clamp(inv_power, 0.0F, led_bar->old_power);
+                        led_bar->power = power;
+                        set_status_bar(bar_id, led_bar->old_color, inv_power, true);
+                        set_status_bar(bar_id, led_bar->color, power, true);
+                    } else {
+                        // Static only happens once
+                        led_bar->reps = 0;
+                        led_bar->old_color = led_bar->color;
+                        led_bar->power = led_bar->old_power;
+                        return;
+                    }
+                    break;
+                }
+                case StatusBarPattern::Pulse: {
+                    // Set color as a triangle wave
+                    float power = led_bar->power;
+                    if (led_bar->counter < (led_bar->period / 2)) {
+                        power = static_cast<float>(led_bar->counter) /
+                                (static_cast<float>(led_bar->period) / TWO);
+                    } else {
+                        auto inverse_count =
+                            std::abs(static_cast<int>(led_bar->period) -
+                                     static_cast<int>(led_bar->counter));
+                        power = static_cast<float>(inverse_count) /
+                                (static_cast<float>(led_bar->period) / TWO);
+                    }
+
+                    led_bar->power = std::clamp(power, 0.0F, led_bar->old_power);
+                    set_status_bar(bar_id);
+                    break;
+                }
+                case StatusBarPattern::Flash: {
+                    // Blink the statusbar by turning on/off by half the period.
+                    auto power = (led_bar->counter < (led_bar->period / 2))
+                                     ? led_bar->power
+                                     : 0;
+                    set_status_bar(bar_id, led_bar->color, power);
+                    break;
+                }
+                case StatusBarPattern::Fade:
+                    break;
+            }
+
+            if (led_bar->counter >= led_bar->period) {
+                if (led_bar->reps != FOREVER) {
+                    led_bar->reps -= 1;
+                }
+            }
+        }
+    }
+
+    template <UIPolicyIface Policy>
+    auto visit_message(const messages::SetStatusBarStateMessage& m,
                        Policy& policy) -> void {
         static_cast<void>(policy);
         auto response = messages::AcknowledgePrevious{.responding_to_id = m.id};
-
         for (auto bar_id : {StatusBarID::Internal, StatusBarID::External}) {
-            if (m.bar_id.has_value()) {
-                bar_id = m.bar_id.value();
-            }
+            bar_id = m.bar_id.value_or(bar_id);
             StatusBarState bar = get_statusbar_state(bar_id);
-            StatusBarColor color =
-                (m.color.has_value()) ? m.color.value() : bar.color;
-            float power = (m.power.has_value()) ? m.power.value() : bar.power;
-            if (!set_status_bar(bar_id, color, power)) {
-                response.with_error =
-                    errors::ErrorCode::SYSTEM_SET_STATUSBAR_COLOR_ERROR;
-            }
+            StatusBarColor color = m.color.value_or(bar.color);
+            StatusBarPattern pattern = m.pattern.value_or(bar.pattern);
+            float power = m.power.value_or(bar.power);
+            float duration = m.duration.value_or(bar.duration);
+            update_statusbar_state(bar_id, color, power, pattern, duration);
             // Only set one status bar if one was given.
             if (m.bar_id.has_value()) {
                 break;
             }
         }
-
         static_cast<void>(_task_registry->send_to_address(
             response, Queues::HostCommsAddress));
     }
 
     /**
-     * @brief Set the power (separate from PWM) for a color. Each color has
-     * 3 channels, so this helper will set all of the channels.
+
      */
-    auto set_color_power(StatusBarID bar, StatusBarColor color, float power)
-        -> bool {
+    auto set_color_power(StatusBarID bar, StatusBarColor color, float power,
+                         bool wipe = true) -> bool {
         const auto& channels = color_to_channels(color);
 
-        // clear the current leds
-        if (bar == Internal) {
-            _led_driver0.set_current(0);
-        }
-        if (bar == External) {
-            _led_driver1.set_current(0);
+        // clear the LEDs not being set
+        if (wipe) {
+            for (int i = 2; i < 17; i++) {
+                if (std::find(std::begin(channels), std::end(channels), i) !=
+                    std::end(channels))
+                    continue;
+                if (bar == Internal) {
+                    _led_driver0.set_current(i, 0);
+                }
+                if (bar == External) {
+                    _led_driver1.set_current(i, 0);
+                }
+            }
         }
 
         return std::ranges::all_of(
@@ -189,12 +329,6 @@ class UITask {
             });
     }
 
-    // Callback function for the heartbeat led timer
-    auto heartbeat_led() {
-        hb_led_state = !hb_led_state;
-        _policy->set_heartbeat_led(hb_led_state);
-    }
-
     // Helper to get the StatusBarState given the bar id
     auto get_statusbar_state(StatusBarID bar) -> StatusBarState& {
         switch (bar) {
@@ -207,20 +341,72 @@ class UITask {
         }
     }
 
-    auto set_status_bar(StatusBarID bar, StatusBarColor color, float power)
-        -> bool {
-        power = std::clamp(power, 0.0F, 1.0F);
-        auto status_bar = &get_statusbar_state(bar);
-        status_bar->color = color;
-        status_bar->power = power;
+    auto get_default_period(StatusBarPattern pattern) -> int64_t {
+        switch (pattern) {
+            case Fade:
+                return LED_FADE_PERIOD_MS;
+            case Flash:
+                return LED_FADE_PERIOD_MS;
+            case Static:
+                return LED_FADE_PERIOD_MS;
+            case Pulse:
+                return LED_PULSE_PERIOD_MS;
+            default:
+                return FOREVER;
+        }
+    }
 
-        set_color_power(bar, color, power);
+    auto get_default_reps(StatusBarPattern pattern) -> int {
+        switch (pattern) {
+            case Fade:
+            case Static:
+                return 1;
+            case Flash:
+            case Pulse:
+                return FOREVER;
+            default:
+                return 1;
+        }
+    }
+
+    auto update_statusbar_state(
+        StatusBarID bar, StatusBarColor color, float power,
+        std::optional<StatusBarPattern> pattern = std::nullopt,
+        std::optional<float> duration = std::nullopt,
+        std::optional<int> period = std::nullopt,
+        std::optional<int> reps = std::nullopt) -> void {
+        auto status_bar = &get_statusbar_state(bar);
+        status_bar->old_color = status_bar->color;
+        status_bar->old_power = status_bar->power;
+        status_bar->color = color;
+        status_bar->power = std::clamp(power, 0.0F, 1.0F);
+        status_bar->duration =
+            std::clamp(duration.value_or(status_bar->duration), 0.0F, 30.0F);
+        status_bar->pattern = pattern.value_or(status_bar->pattern);
+        status_bar->period =
+            period.value_or(get_default_period(status_bar->pattern));
+        status_bar->reps = reps.value_or(get_default_reps(status_bar->pattern));
+        status_bar->counter = 0;
+    }
+
+    auto set_status_bar(StatusBarID bar,
+                        std::optional<StatusBarColor> color = std::nullopt,
+                        std::optional<float> power = std::nullopt,
+                        std::optional<bool> wipe = std::nullopt) -> bool {
+        // Skip if driver not initialized
+        auto status_bar = get_statusbar_state(bar);
+        if (!status_bar.driver_ok) return false;
+
+        auto power_ = power.value_or(status_bar.power);
+        auto color_ = color.value_or(status_bar.color);
+        auto wipe_ = wipe.value_or(true);
+        set_color_power(bar, color_, power_, wipe_);
         if (bar == Internal) {
-            _led_driver0.set_pwm(power);
+            _led_driver0.set_pwm(power_);
             return _led_driver0.send_update(*_policy);
         }
         if (bar == External) {
-            _led_driver1.set_pwm(power);
+            _led_driver1.set_pwm(power_);
             return _led_driver1.send_update(*_policy);
         }
         return false;
@@ -237,5 +423,7 @@ class UITask {
     StatusBarState _led_bar_external = led_bar_external;
     bool _initialized = false;
     bool hb_led_state = false;
+    uint32_t hb_counter = 0;
+    bool _led_update_pending = false;
 };
 };  // namespace ui_task

--- a/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
@@ -52,7 +52,7 @@ static auto color_to_channels(StatusBarColor color) -> const ChannelMapping& {
 }
 
 // The timer driving LED update frequency should run at this period
-static constexpr uint32_t UPDATE_PERIOD_MS = 5;
+static constexpr uint32_t UPDATE_PERIOD_MS = 1;
 static constexpr uint8_t LED_DRIVER0_I2C_ADDRESS = 0x6C << 1;  // Internal
 static constexpr uint8_t LED_DRIVER1_I2C_ADDRESS = 0x6F << 1;  // External
 static constexpr auto DEFAULT_COLOR = StatusBarColor::Green;
@@ -76,7 +76,7 @@ struct StatusBarState {
     StatusBarColor old_color;
     StatusBarPattern pattern = StatusBarPattern::Static;
     float power;
-    float old_power;
+    float power_dt;
     float duration = 0;
     int reps = 0;
     uint32_t counter = 0;
@@ -89,7 +89,7 @@ const StatusBarState led_bar_internal = {
     .color = DEFAULT_COLOR,
     .old_color = DEFAULT_COLOR,
     .power = DEFAULT_POWER,
-    .old_power = DEFAULT_POWER,
+    .power_dt = 0,
 };
 
 const StatusBarState led_bar_external = {
@@ -97,7 +97,7 @@ const StatusBarState led_bar_external = {
     .color = DEFAULT_COLOR,
     .old_color = DEFAULT_COLOR,
     .power = DEFAULT_POWER,
-    .old_power = DEFAULT_POWER,
+    .power_dt = 0,
 };
 
 using Message = messages::UIMessage;
@@ -189,19 +189,16 @@ class UITask {
         for (auto bar_id : {StatusBarID::Internal, StatusBarID::External}) {
             _led_update_pending = false;
             auto led_bar = &get_statusbar_state(bar_id);
-            // Skip if driver not initialized
+            // Skip if driver not initialized or reps reached 0
             if (!led_bar->driver_ok) continue;
             if (led_bar->reps != FOREVER && led_bar->reps < 1) continue;
 
-            // TODO: fix power=0, it does NOT turn off the statusbar
-            // Turn off status if power is 0
-            //if (led_bar->power == 0) {
-            //    led_bar->reps = 0;
-            //    led_bar->old_power = 0;
-            //    led_bar->old_color = led_bar->color;
-            //    set_status_bar(bar_id);
-            //    continue;
-            //}
+            // Turn off LEDs when power = 0
+            if (led_bar->reps != FOREVER && led_bar->power == 0) {
+                led_bar->reps = 0;
+                set_status_bar(bar_id);
+                continue;
+            }
 
             led_bar->counter += LED_UPDATE_PERIOD_MS;
             if (led_bar->counter > led_bar->period) {
@@ -210,6 +207,7 @@ class UITask {
 
             switch (led_bar->pattern) {
                 case StatusBarPattern::Static: {
+                    // Fade from current color to new color
                     float power = led_bar->power;
                     if (led_bar->counter < led_bar->period) {
                         power = static_cast<float>(led_bar->counter) /
@@ -221,16 +219,16 @@ class UITask {
                         auto inv_power = static_cast<float>(inverse_count) /
                                          (static_cast<float>(led_bar->period));
 
-                        power = std::clamp(power, 0.0F, led_bar->old_power);
-                        inv_power = std::clamp(inv_power, 0.0F, led_bar->old_power);
-                        led_bar->power = power;
-                        set_status_bar(bar_id, led_bar->old_color, inv_power, true);
+                        power = std::clamp(power, 0.0F, led_bar->power);
+                        inv_power = std::clamp(inv_power, 0.0F, led_bar->power);
+                        led_bar->power_dt = power;
+                        set_status_bar(bar_id, led_bar->old_color, inv_power,
+                                       true);
                         set_status_bar(bar_id, led_bar->color, power, true);
                     } else {
                         // Static only happens once
                         led_bar->reps = 0;
-                        led_bar->old_color = led_bar->color;
-                        led_bar->power = led_bar->old_power;
+                        led_bar->power_dt = 0;
                         return;
                     }
                     break;
@@ -249,8 +247,8 @@ class UITask {
                                 (static_cast<float>(led_bar->period) / TWO);
                     }
 
-                    led_bar->power = std::clamp(power, 0.0F, led_bar->old_power);
-                    set_status_bar(bar_id);
+                    led_bar->power_dt = std::clamp(power, 0.0F, led_bar->power);
+                    set_status_bar(bar_id, led_bar->color, power);
                     break;
                 }
                 case StatusBarPattern::Flash: {
@@ -296,7 +294,8 @@ class UITask {
     }
 
     /**
-
+     * @brief Set the power (separate from PWM) for a color. Each color has
+     * 3 channels, so this helper will set all of the channels.
      */
     auto set_color_power(StatusBarID bar, StatusBarColor color, float power,
                          bool wipe = true) -> bool {
@@ -376,8 +375,9 @@ class UITask {
         std::optional<int> period = std::nullopt,
         std::optional<int> reps = std::nullopt) -> void {
         auto status_bar = &get_statusbar_state(bar);
-        status_bar->old_color = status_bar->color;
-        status_bar->old_power = status_bar->power;
+        // If the old power was 0, set the old color to the new color
+        status_bar->old_color =
+            status_bar->power == 0 ? color : status_bar->color;
         status_bar->color = color;
         status_bar->power = std::clamp(power, 0.0F, 1.0F);
         status_bar->duration =

--- a/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
@@ -32,7 +32,7 @@ static constexpr ChannelMapping white_channels{2, 3, 4, 5};
 static constexpr ChannelMapping red_channels{6, 9, 12, 15};
 static constexpr ChannelMapping green_channels{7, 10, 13, 16};
 static constexpr ChannelMapping blue_channels{8, 11, 14, 17};
-static constexpr ChannelMapping yellow_channels{6, 7, 9, 10};
+static constexpr ChannelMapping yellow_channels{6, 7, 12, 13};
 
 static auto color_to_channels(StatusBarColor color) -> const ChannelMapping& {
     switch (color) {
@@ -71,8 +71,10 @@ static constexpr uint32_t LED_CONFIRM_FADE_PERIOD_MS = 5000U;
 static constexpr uint32_t LED_CONFIRM_PERIOD_MS = 300U;
 // Time to blink heartbeat LED
 static constexpr uint32_t HB_UPDATE_PERIOD_MS = 500U;
-// Max duration of the animation in ms (30 seconds)
-static constexpr uint32_t MAX_UPDATE_PERIOD_MS = 30000U;
+// Max duration of the animation in ms (10 seconds)
+static constexpr uint32_t MAX_UPDATE_PERIOD_MS = 10000U;
+// Min duration of the animation in ms (25 ms)
+static constexpr uint32_t MIN_UPDATE_PERIOD_MS = 25U;
 // Reps to signify runnning forever
 static constexpr int FOREVER = -1;
 
@@ -148,7 +150,7 @@ class UITask {
             }
             if (!_led_driver1.initialized()) {
                 _led_driver1.initialize(policy);
-                _led_bar_internal.driver_ok = true;
+                _led_bar_external.driver_ok = true;
                 set_status_bar(External);
             }
             _initialized = true;
@@ -217,19 +219,8 @@ class UITask {
                     if (led_bar->counter < led_bar->duration) {
                         power = static_cast<float>(led_bar->counter) /
                                 (static_cast<float>(led_bar->duration));
-
-                        auto inverse_count =
-                            std::abs(static_cast<int>(led_bar->duration) -
-                                     static_cast<int>(led_bar->counter));
-                        auto inv_power =
-                            static_cast<float>(inverse_count) /
-                            (static_cast<float>(led_bar->duration));
-
                         power = std::clamp(power, 0.0F, led_bar->power);
-                        inv_power = std::clamp(inv_power, 0.0F, led_bar->power);
                         led_bar->power_dt = power;
-                        set_status_bar(bar_id, led_bar->old_color, inv_power,
-                                       true);
                         set_status_bar(bar_id, led_bar->color, power, true);
                     } else {
                         // Static only happens once
@@ -263,6 +254,7 @@ class UITask {
                     auto power = (led_bar->counter < (led_bar->duration / 2))
                                      ? 0
                                      : led_bar->power;
+                    led_bar->power_dt = power;
                     set_status_bar(bar_id, led_bar->color, power);
                     break;
                 }
@@ -337,7 +329,7 @@ class UITask {
 
         // clear the LEDs not being set
         if (wipe) {
-            for (int i = 2; i < 17; i++) {
+            for (int i = 2; i <= 17; i++) {
                 if (std::find(std::begin(channels), std::end(channels), i) !=
                     std::end(channels))
                     continue;
@@ -416,8 +408,8 @@ class UITask {
         status_bar->pattern = pattern.value_or(status_bar->pattern);
         auto duration_ =
             duration.value_or(get_default_period(status_bar->pattern));
-        status_bar->duration =
-            std::clamp((uint32_t)duration_, (uint32_t)1, MAX_UPDATE_PERIOD_MS);
+        status_bar->duration = std::clamp(
+            (uint32_t)duration_, MIN_UPDATE_PERIOD_MS, MAX_UPDATE_PERIOD_MS);
         status_bar->reps = reps.value_or(get_default_reps(status_bar->pattern));
         status_bar->counter = 0;
     }

--- a/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
@@ -60,14 +60,20 @@ static constexpr auto DEFAULT_POWER = 0.5F;
 static constexpr auto SYSTEM_LED_COUNT = 16;
 
 // Time between each write to the LED strip
-static constexpr uint32_t LED_UPDATE_PERIOD_MS = 5;
+static constexpr uint32_t LED_UPDATE_PERIOD_MS = 5U;
 // Time to fade from one color to the next
-static constexpr uint32_t LED_FADE_PERIOD_MS = 500;
+static constexpr uint32_t LED_FADE_PERIOD_MS = 500U;
 // Time that each full "pulse" action should take (sine wave)
-static constexpr uint32_t LED_PULSE_PERIOD_MS = 1000;
+static constexpr uint32_t LED_PULSE_PERIOD_MS = 1000U;
+// Time that it takes to fade from confirm color to original color
+static constexpr uint32_t LED_CONFIRM_FADE_PERIOD_MS = 5000U;
+// Time that it takes for the confirm color to flash
+static constexpr uint32_t LED_CONFIRM_PERIOD_MS = 300U;
 // Time to blink heartbeat LED
-static constexpr uint32_t HB_UPDATE_PERIOD_MS = 500;
-// Period to signify runnning forever
+static constexpr uint32_t HB_UPDATE_PERIOD_MS = 500U;
+// Max duration of the animation in ms (30 seconds)
+static constexpr uint32_t MAX_UPDATE_PERIOD_MS = 30000U;
+// Reps to signify runnning forever
 static constexpr int FOREVER = -1;
 
 struct StatusBarState {
@@ -77,10 +83,9 @@ struct StatusBarState {
     StatusBarPattern pattern = StatusBarPattern::Static;
     float power;
     float power_dt;
-    float duration = 0;
+    uint32_t duration = LED_FADE_PERIOD_MS;
     int reps = 0;
     uint32_t counter = 0;
-    uint32_t period = LED_FADE_PERIOD_MS;
     bool driver_ok = false;
 };
 
@@ -194,14 +199,14 @@ class UITask {
             if (led_bar->reps != FOREVER && led_bar->reps < 1) continue;
 
             // Turn off LEDs when power = 0
-            if (led_bar->reps != FOREVER && led_bar->power == 0) {
+            if (led_bar->power == 0) {
                 led_bar->reps = 0;
                 set_status_bar(bar_id);
                 continue;
             }
 
             led_bar->counter += LED_UPDATE_PERIOD_MS;
-            if (led_bar->counter > led_bar->period) {
+            if (led_bar->counter > led_bar->duration) {
                 led_bar->counter = 0;
             }
 
@@ -209,15 +214,16 @@ class UITask {
                 case StatusBarPattern::Static: {
                     // Fade from current color to new color
                     float power = led_bar->power;
-                    if (led_bar->counter < led_bar->period) {
+                    if (led_bar->counter < led_bar->duration) {
                         power = static_cast<float>(led_bar->counter) /
-                                (static_cast<float>(led_bar->period));
+                                (static_cast<float>(led_bar->duration));
 
                         auto inverse_count =
-                            std::abs(static_cast<int>(led_bar->period) -
+                            std::abs(static_cast<int>(led_bar->duration) -
                                      static_cast<int>(led_bar->counter));
-                        auto inv_power = static_cast<float>(inverse_count) /
-                                         (static_cast<float>(led_bar->period));
+                        auto inv_power =
+                            static_cast<float>(inverse_count) /
+                            (static_cast<float>(led_bar->duration));
 
                         power = std::clamp(power, 0.0F, led_bar->power);
                         inv_power = std::clamp(inv_power, 0.0F, led_bar->power);
@@ -236,15 +242,15 @@ class UITask {
                 case StatusBarPattern::Pulse: {
                     // Set color as a triangle wave
                     float power = led_bar->power;
-                    if (led_bar->counter < (led_bar->period / 2)) {
+                    if (led_bar->counter < (led_bar->duration / 2)) {
                         power = static_cast<float>(led_bar->counter) /
-                                (static_cast<float>(led_bar->period) / TWO);
+                                (static_cast<float>(led_bar->duration) / TWO);
                     } else {
                         auto inverse_count =
-                            std::abs(static_cast<int>(led_bar->period) -
+                            std::abs(static_cast<int>(led_bar->duration) -
                                      static_cast<int>(led_bar->counter));
                         power = static_cast<float>(inverse_count) /
-                                (static_cast<float>(led_bar->period) / TWO);
+                                (static_cast<float>(led_bar->duration) / TWO);
                     }
 
                     led_bar->power_dt = std::clamp(power, 0.0F, led_bar->power);
@@ -252,18 +258,47 @@ class UITask {
                     break;
                 }
                 case StatusBarPattern::Flash: {
-                    // Blink the statusbar by turning on/off by half the period.
-                    auto power = (led_bar->counter < (led_bar->period / 2))
-                                     ? led_bar->power
-                                     : 0;
+                    // Blink the statusbar by turning on/off by half the
+                    // duration.
+                    auto power = (led_bar->counter < (led_bar->duration / 2))
+                                     ? 0
+                                     : led_bar->power;
                     set_status_bar(bar_id, led_bar->color, power);
                     break;
                 }
-                case StatusBarPattern::Fade:
+                case StatusBarPattern::Confirm: {
+                    // turn on then off led to new color
+                    if (led_bar->counter < LED_CONFIRM_PERIOD_MS) {
+                        auto power =
+                            (led_bar->counter < LED_CONFIRM_PERIOD_MS / 2)
+                                ? led_bar->power
+                                : 0;
+                        set_status_bar(bar_id, led_bar->color, power);
+                        // turn on led to new color
+                    } else if (led_bar->counter < LED_CONFIRM_PERIOD_MS + 100) {
+                        set_status_bar(bar_id, led_bar->color, led_bar->power);
+                        // fade to old color
+                    } else {
+                        float power = led_bar->power;
+                        if (led_bar->counter < led_bar->duration) {
+                            power = static_cast<float>(led_bar->counter) /
+                                    (static_cast<float>(led_bar->duration));
+                            power = std::clamp(power, 0.0F, led_bar->power);
+                            led_bar->power_dt = power;
+                            set_status_bar(bar_id, led_bar->old_color, power,
+                                           true);
+                        } else {
+                            led_bar->reps = 0;
+                            led_bar->power_dt = 0;
+                            led_bar->color = led_bar->old_color;
+                            return;
+                        }
+                    }
                     break;
+                }
             }
 
-            if (led_bar->counter >= led_bar->period) {
+            if (led_bar->counter >= led_bar->duration) {
                 if (led_bar->reps != FOREVER) {
                     led_bar->reps -= 1;
                 }
@@ -280,10 +315,9 @@ class UITask {
             bar_id = m.bar_id.value_or(bar_id);
             StatusBarState bar = get_statusbar_state(bar_id);
             StatusBarColor color = m.color.value_or(bar.color);
-            StatusBarPattern pattern = m.pattern.value_or(bar.pattern);
             float power = m.power.value_or(bar.power);
-            float duration = m.duration.value_or(bar.duration);
-            update_statusbar_state(bar_id, color, power, pattern, duration);
+            update_statusbar_state(bar_id, color, power, m.pattern, m.duration,
+                                   m.reps);
             // Only set one status bar if one was given.
             if (m.bar_id.has_value()) {
                 break;
@@ -340,25 +374,25 @@ class UITask {
         }
     }
 
-    auto get_default_period(StatusBarPattern pattern) -> int64_t {
+    auto get_default_period(StatusBarPattern pattern) -> uint32_t {
         switch (pattern) {
-            case Fade:
-                return LED_FADE_PERIOD_MS;
             case Flash:
                 return LED_FADE_PERIOD_MS;
             case Static:
                 return LED_FADE_PERIOD_MS;
             case Pulse:
                 return LED_PULSE_PERIOD_MS;
+            case Confirm:
+                return LED_CONFIRM_FADE_PERIOD_MS;
             default:
-                return FOREVER;
+                return MAX_UPDATE_PERIOD_MS;
         }
     }
 
     auto get_default_reps(StatusBarPattern pattern) -> int {
         switch (pattern) {
-            case Fade:
             case Static:
+            case Confirm:
                 return 1;
             case Flash:
             case Pulse:
@@ -371,20 +405,19 @@ class UITask {
     auto update_statusbar_state(
         StatusBarID bar, StatusBarColor color, float power,
         std::optional<StatusBarPattern> pattern = std::nullopt,
-        std::optional<float> duration = std::nullopt,
-        std::optional<int> period = std::nullopt,
-        std::optional<int> reps = std::nullopt) -> void {
+        std::optional<uint32_t> duration = std::nullopt,
+        std::optional<int8_t> reps = std::nullopt) -> void {
         auto status_bar = &get_statusbar_state(bar);
         // If the old power was 0, set the old color to the new color
         status_bar->old_color =
             status_bar->power == 0 ? color : status_bar->color;
         status_bar->color = color;
         status_bar->power = std::clamp(power, 0.0F, 1.0F);
-        status_bar->duration =
-            std::clamp(duration.value_or(status_bar->duration), 0.0F, 30.0F);
         status_bar->pattern = pattern.value_or(status_bar->pattern);
-        status_bar->period =
-            period.value_or(get_default_period(status_bar->pattern));
+        auto duration_ =
+            duration.value_or(get_default_period(status_bar->pattern));
+        status_bar->duration =
+            std::clamp((uint32_t)duration_, (uint32_t)1, MAX_UPDATE_PERIOD_MS);
         status_bar->reps = reps.value_or(get_default_reps(status_bar->pattern));
         status_bar->counter = 0;
     }

--- a/stm32-modules/include/flex-stacker/systemwide.h
+++ b/stm32-modules/include/flex-stacker/systemwide.h
@@ -24,7 +24,7 @@ typedef enum StatusBarPattern {
     Static = 0,
     Flash,
     Pulse,
-    Fade,
+    Confirm,
 } StatusBarPattern;
 
 enum MotorSelection { Z, X, L, ALL };

--- a/stm32-modules/include/flex-stacker/systemwide.h
+++ b/stm32-modules/include/flex-stacker/systemwide.h
@@ -17,7 +17,15 @@ typedef enum StatusBarColor {
     Red,
     Green,
     Blue,
+    Yellow,
 } StatusBarColor;
+
+typedef enum StatusBarPattern {
+    Static = 0,
+    Flash,
+    Pulse,
+    Fade,
+} StatusBarPattern;
 
 enum MotorSelection { Z, X, L, ALL };
 


### PR DESCRIPTION
# Overview

Now that the Flex Stacker is in ABR and Science, let's enable stallguard and add UI led to some states to inform the user what's happening with the device. This pull request goes in conjunction with this monorepo pull request [Opentrons/opentrons#17349](https://github.com/Opentrons/opentrons/17349)

# Changelog

- Enable stallguard motor error (diag0_stall = 1) and set the stallguard threshold to 2 for all motor axis
- Add debounce when handling GPIO interrupt messages
- check estop and diag0 pin in the motor interrupt so we can react while moving an axis
- change heartbeat led to blink after 500ms without setting the timer directly
- add animation patterns (Static, Pulse, Flash, Confirm) and expose duration, reps to the `SetStatusBarState` gcodes
- add the color yellow to the list of LED colors


# Testing

- [x] Make sure we can set the led status bar pattern, duration, and reps via repl
- [x] Make sure the flex stacker motors stop moving when there is a stall
- [x] Make sure the flex stacker motors stop moving when the estop is pressed
- [x] Make sure we only send an error message when `triggering` estop or stall


# Review requests