### PR TITLE
fix(build): add flex-stacker to set_build_vars script to deploy the firmware to aws.

### DIFF
--- a/scripts/set_build_vars.sh
+++ b/scripts/set_build_vars.sh
@@ -32,6 +32,11 @@ case $TRAVIS_TAG in
     export RELEASE_UPLOAD_DIR="thermocycler-gen2/${RELEASE_VERSION}"
     ;;
 
+  flex-stacker@v*)
+    export RELEASE_LOCAL_DIR="${DIST_DIR}/flex-stacker"
+    export RELEASE_UPLOAD_DIR="flex-stacker/${RELEASE_VERSION}"
+    ;;
+
   *)
     export RELEASE_LOCAL_DIR=$DIST_DIR
     export RELEASE_UPLOAD_DIR="modules-${THIS_BUILD_TAG}-${TRAVIS_BRANCH}"


### PR DESCRIPTION

Let's add flex-stacker to set build vars script, as this is used when deploying binaries to aws.