### PR TITLE
Revert "fix(stacker): use actual serial number in usb serial number descriptor" to enable testing

### DIFF
--- a/stm32-modules/flex-stacker/firmware/host_comms_task/usbd_desc.c
+++ b/stm32-modules/flex-stacker/firmware/host_comms_task/usbd_desc.c
@@ -233,18 +233,18 @@ uint8_t *USBD_Class_InterfaceStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *le
   */
 static void Get_SerialNum(void)
 {
-  uint32_t sg_0, sg_1;
-  uint32_t pointer = USB_STRING_SERIAL_BASE;
-  // Serial number is stored in 6 32-bit words
-  for (uint8_t idx = 0; idx < 4; idx++) {
-      sg_0 = *(uint32_t *)(pointer + 4);
-      sg_1 = *(uint32_t *)(pointer);
+  uint32_t deviceserial0, deviceserial1, deviceserial2;
 
-      if (sg_0 == 0U) break;
+  deviceserial0 = *(uint32_t *)(UID_BASE+4);
+  deviceserial1 = *(uint32_t *)(UID_BASE+8);
+  deviceserial2 = *(uint32_t *)(UID_BASE+12);
 
-      IntToUnicode(sg_0, &USBD_StringSerial[2 + 16*idx], 4U);
-      IntToUnicode(sg_1, &USBD_StringSerial[10 + 16*idx], 4U);
-      pointer += 8;
+  deviceserial0 += deviceserial2;
+
+  if (deviceserial0 != 0U)
+  {
+    IntToUnicode(deviceserial0, &USBD_StringSerial[2], 8U);
+    IntToUnicode(deviceserial1, &USBD_StringSerial[18], 4U);
   }
 }
 
@@ -259,15 +259,20 @@ static void IntToUnicode(uint32_t value, uint8_t *pbuf, uint8_t len)
 {
   uint8_t idx = 0U;
 
-  for (idx = 0U; idx < len; idx++)
+  for (idx = 0U ; idx < len ; idx ++)
   {
-    // Extract the most significant byte
-    pbuf[2U * idx] = (value >> 24) & 0xFF;
-    // Add a null byte for Unicode (UTF-16)
-    pbuf[2U * idx + 1] = 0U;
+    if (((value >> 28)) < 0xAU)
+    {
+      pbuf[ 2U * idx] = (value >> 28) + '0';
+    }
+    else
+    {
+      pbuf[2U * idx] = (value >> 28) + 'A' - 10U;
+    }
 
-    // Shift the value to process the next byte
-    value = value << 8;
+    value = value << 4;
+
+    pbuf[2U * idx + 1] = 0U;
   }
 }
 

--- a/stm32-modules/flex-stacker/firmware/host_comms_task/usbd_desc.h
+++ b/stm32-modules/flex-stacker/firmware/host_comms_task/usbd_desc.h
@@ -26,8 +26,8 @@
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
-#define USB_SIZ_STRING_SERIAL 0x32
-#define USB_STRING_SERIAL_BASE 0x0807F800
+
+#define USB_SIZ_STRING_SERIAL 0x1A
 
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */


### PR DESCRIPTION
This fix actually causes the firmware to crash whenever we try to set the serial number via usb. Since it's not a must-have feature and was only needed to support the SLAS demo, I'm removing it right now and will revisit this when we have more bandwidth. 


Reverts Opentrons/opentrons-modules#497