### PR TITLE
fix(build): upgrade ubuntu-20.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/arduino-modules.yaml
+++ b/.github/workflows/arduino-modules.yaml
@@ -29,7 +29,7 @@ defaults:
 jobs:
   build-deploy-arduino:
     name: 'arduino-modules configure'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     steps:
       - uses: 'actions/checkout@v4'

--- a/.github/workflows/flex-stacker-create-release.yaml
+++ b/.github/workflows/flex-stacker-create-release.yaml
@@ -17,7 +17,7 @@ defaults:
 jobs:
   cross-compile-check-and-release:
     name: 'Cross-Compile/Check and Create Release'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     steps:
       - uses: 'actions/checkout@v4'

--- a/.github/workflows/flex-stacker.yaml
+++ b/.github/workflows/flex-stacker.yaml
@@ -45,7 +45,7 @@ defaults:
 jobs:
   cross-compile-check:
     name: 'Cross-Compile/Check'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     steps:
       - uses: 'actions/checkout@v4'
@@ -72,7 +72,7 @@ jobs:
         run: cmake --build --preset cross --target flex-stacker-image-bin
   host-compile-test:
     name: 'Host-Compile/Test'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     env:
       CC: gcc-10

--- a/.github/workflows/heater-shaker-create-release.yaml
+++ b/.github/workflows/heater-shaker-create-release.yaml
@@ -17,7 +17,7 @@ defaults:
 jobs:
   cross-compile-check-and-release:
     name: 'Cross-Compile/Check and Create Release'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     steps:
       - uses: 'actions/checkout@v4'

--- a/.github/workflows/heater-shaker.yaml
+++ b/.github/workflows/heater-shaker.yaml
@@ -46,7 +46,7 @@ defaults:
 jobs:
   cross-compile-check:
     name: 'Cross-Compile/Check'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     steps:
       - uses: 'actions/checkout@v4'
@@ -73,7 +73,7 @@ jobs:
         run: cmake --build --preset cross --target heater-shaker-image-bin
   host-compile-test:
     name: 'Host-Compile/Test'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     env:
       CC: gcc-10

--- a/.github/workflows/stm32-codecov.yaml
+++ b/.github/workflows/stm32-codecov.yaml
@@ -14,7 +14,7 @@ defaults:
 jobs:
   generate-coverage:
     name: 'Generate-Coverage'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     env:
       CC: gcc-10

--- a/.github/workflows/stm32-common.yaml
+++ b/.github/workflows/stm32-common.yaml
@@ -30,7 +30,7 @@ defaults:
 jobs:
   cross-compile-check:
     name: 'Cross-Compile/Check'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     steps:
       - uses: 'actions/checkout@v4'
@@ -49,7 +49,7 @@ jobs:
         run: cmake --build --preset cross --target common-lint
   host-compile-test:
     name: 'Host-Compile/Test'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     env:
       CC: gcc-10

--- a/.github/workflows/tempdeck-gen3.yaml
+++ b/.github/workflows/tempdeck-gen3.yaml
@@ -45,7 +45,7 @@ defaults:
 jobs:
   cross-compile-check:
     name: 'Cross-Compile/Check'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     steps:
       - uses: 'actions/checkout@v4'
@@ -72,7 +72,7 @@ jobs:
         run: cmake --build --preset cross --target tempdeck-gen3-image-bin
   host-compile-test:
     name: 'Host-Compile/Test'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     env:
       CC: gcc-10

--- a/.github/workflows/thermocycler-gen2-create-release.yaml
+++ b/.github/workflows/thermocycler-gen2-create-release.yaml
@@ -17,7 +17,7 @@ defaults:
 jobs:
   cross-compile-check-and-release:
     name: 'Cross-Compile/Check and Create Release'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     steps:
       - uses: 'actions/checkout@v4'

--- a/.github/workflows/thermocycler-gen2.yaml
+++ b/.github/workflows/thermocycler-gen2.yaml
@@ -46,7 +46,7 @@ defaults:
 jobs:
   cross-compile-check:
     name: 'Cross-Compile/Check'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     steps:
       - uses: 'actions/checkout@v4'
@@ -73,7 +73,7 @@ jobs:
         run: cmake --build --preset cross --target thermocycler-gen2-image-bin
   host-compile-test:
     name: 'Host-Compile/Test'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 10
     env:
       CC: gcc-10


### PR DESCRIPTION
ubuntu-20.04 runners will be deprecated soon, there is a scheduled brownout today to encourage migration. So lets migrate from ubuntu-20.04 to ubuntu-24.04