### PR TITLE
fix(stacker): check for estop and stall inside motor interrupt

### DIFF
--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -119,6 +119,14 @@ class MotorInterruptController {
         // this will only error if the limit switch in the move direction
         // is triggered
         // Stop if moving left motor in an allowed direction
+        if (_policy->check_estop()) {
+            _error = Error::ESTOP_TRIGGERED;
+            return true;
+        }
+        if (!_policy->check_diag0()) {
+            _error = Error::MOTOR_STALL_DETECTED;
+            return true;
+        }
         if ((_id != MotorID::MOTOR_L || !_direction) &&
             limit_switch_triggered()) {
             if (_profile.movement_type() ==

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -438,22 +438,15 @@ class MotorTask {
         _debounce_timer.start();
 
         auto triggered = false;
-        auto error = Error::NO_ERROR;
         if (policy.is_diag0_pin(m.pin)) {
             policy.sleep_ms(DEBOUNCE_SLEEP_MS);
             triggered = policy.check_diag0();
-            error = Error::MOTOR_STALL_DETECTED;
         } else if (policy.is_estop_pin(m.pin)) {
             policy.sleep_ms(DEBOUNCE_SLEEP_MS);
             triggered = policy.check_estop();
-            error = Error::ESTOP_TRIGGERED;
         } else {
             // don't care about other interrupts
             return;
-        }
-
-        if (triggered) {
-            stop_motors(error);
         }
 
         // Set status bars


### PR DESCRIPTION
My changes from a previous PR tried to stop the motor interrupt from the motor task when the estop/stallguard is triggered... which just doesn't work! We should just check for those inside the interrupt like we were before and set the error when it occurs. 