### PR TITLE
fix(flex-stacker): actually set short-range mode for the TOF sensors.

### DIFF
--- a/stm32-modules/include/flex-stacker/flex-stacker/tmf8820.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmf8820.hpp
@@ -411,8 +411,8 @@ class TMF8820 {
             return false;
         }
         _config->registers->active_range.active_range = active_range;
-        if( !set_register(_config->registers->active_range, sensor_id)
-            .has_value()) {
+        if (!set_register(_config->registers->active_range, sensor_id)
+                 .has_value()) {
             return false;
         }
         // Write the config page

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmf8820.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmf8820.hpp
@@ -411,8 +411,10 @@ class TMF8820 {
             return false;
         }
         _config->registers->active_range.active_range = active_range;
-        return set_register(_config->registers->active_range, sensor_id)
-            .has_value();
+        if( !set_register(_config->registers->active_range, sensor_id)
+            .has_value()) {
+            return false;
+        }
         // Write the config page
         return send_write_config_page(sensor_id);
     }


### PR DESCRIPTION
We were not setting the short-range mode for the TOF sensors because we were returning after setting the short-range register, but were not writing the change with the write config page command.