### PR TITLE
fix(stacker): enable IRQ handler for limit switches

### DIFF
--- a/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_task.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_task.cpp
@@ -62,6 +62,22 @@ static auto _top_task = motor_task::MotorTask(
     }
 }
 
+[[nodiscard]] static auto lim_sw_callback_glue(MotorID motor_id) {
+    switch (motor_id) {
+        case MotorID::MOTOR_L:
+            l_motor_interrupt.limit_switch_detected();
+            break;
+        case MotorID::MOTOR_X:
+            x_motor_interrupt.limit_switch_detected();
+            break;
+        case MotorID::MOTOR_Z:
+            z_motor_interrupt.limit_switch_detected();
+            break;
+        default:
+            break;
+    }
+}
+
 auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
     auto* handle = xTaskGetCurrentTaskHandle();
     _queue.provide_handle(handle);
@@ -70,6 +86,7 @@ auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
 
     motor_hardware_init();
     initialize_callbacks(callback_glue);
+    initialize_limit_switch_callbacks(lim_sw_callback_glue);
     auto policy = motor_policy::MotorPolicy();
     while (true) {
         _top_task.run_once(policy);

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
@@ -42,6 +42,8 @@ typedef struct stepper_hardware_struct {
     PinConfig limit_switch_plus;
     PinConfig ebrake;
     PinConfig diag0;
+    IRQn_Type limit_switch_minus_it;
+    IRQn_Type limit_switch_plus_it;
 } stepper_hardware_t;
 
 typedef struct platform_sensor_struct {
@@ -70,6 +72,8 @@ static motor_hardware_t _motor_hardware = {
         .limit_switch_plus = {X_PLUS_LIMIT_PORT, X_PLUS_LIMIT_PIN, GPIO_PIN_SET},
         .diag0 = {MOTOR_DIAG0_PORT, MOTOR_DIAG0_PIN, GPIO_PIN_SET},
         .ebrake = {0},
+        .limit_switch_minus_it = EXTI1_IRQn,
+        .limit_switch_plus_it = EXTI2_IRQn,
     },
     .motor_z = {
         .timer = {0},
@@ -80,6 +84,8 @@ static motor_hardware_t _motor_hardware = {
         .limit_switch_plus = {Z_PLUS_LIMIT_PORT, Z_PLUS_LIMIT_PIN, GPIO_PIN_SET},
         .diag0 = {MOTOR_DIAG0_PORT, MOTOR_DIAG0_PIN, GPIO_PIN_SET},
         .ebrake = {Z_N_BRAKE_PORT, Z_N_BRAKE_PIN, GPIO_PIN_RESET},
+        .limit_switch_minus_it = EXTI0_IRQn,
+        .limit_switch_plus_it = EXTI3_IRQn,
     },
     .motor_l = {
         .timer = {0},
@@ -90,6 +96,8 @@ static motor_hardware_t _motor_hardware = {
         .limit_switch_plus = {0},
         .diag0 = {MOTOR_DIAG0_PORT, MOTOR_DIAG0_PIN, GPIO_PIN_SET},
         .ebrake = {0},
+        .limit_switch_minus_it = EXTI9_5_IRQn,
+        .limit_switch_plus_it = 0,
     },
     .platform_sensors = {
         .x_minus = {PLAT_SENSE_MINUS_PORT, PLAT_SENSE_MINUS_PIN, GPIO_PIN_SET},
@@ -152,30 +160,12 @@ void motor_hardware_gpio_init(void){
     init.Pull = GPIO_NOPULL;
     init.Speed = GPIO_SPEED_FREQ_LOW;
 
-    // Z MOTOR
-    init.Pin = Z_MINUS_LIMIT_PIN;
-    HAL_GPIO_Init(Z_MINUS_LIMIT_PORT, &init);
-
-    init.Pin = Z_PLUS_LIMIT_PIN;
-    HAL_GPIO_Init(Z_PLUS_LIMIT_PORT, &init);
-
-    // X MOTOR
-    init.Pin = X_MINUS_LIMIT_PIN;
-    HAL_GPIO_Init(X_MINUS_LIMIT_PORT, &init);
-
-    init.Pin = X_PLUS_LIMIT_PIN;
-    HAL_GPIO_Init(X_PLUS_LIMIT_PORT, &init);
-
     // Platform sensors
     init.Pin = PLAT_SENSE_PLUS_PIN;
     HAL_GPIO_Init(PLAT_SENSE_PLUS_PORT, &init);
 
     init.Pin = PLAT_SENSE_MINUS_PIN;
     HAL_GPIO_Init(PLAT_SENSE_MINUS_PORT, &init);
-
-    // L MOTOR
-    init.Pin = L_N_HELD_PIN;
-    HAL_GPIO_Init(L_N_HELD_PORT, &init);
 
     /*Configure GPIO pins : INPUTs IRQ */
     init.Mode = GPIO_MODE_IT_FALLING;
@@ -190,6 +180,46 @@ void motor_hardware_gpio_init(void){
     HAL_GPIO_Init(N_ESTOP_PORT, &init);
     HAL_NVIC_SetPriority(EXTI9_5_IRQn, 0, 0);
     HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
+
+    init.Mode = GPIO_MODE_IT_RISING;
+    init.Pull = GPIO_NOPULL;
+
+    // Z MOTOR
+    init.Pin = Z_MINUS_LIMIT_PIN;
+    HAL_GPIO_Init(Z_MINUS_LIMIT_PORT, &init);
+
+
+    init.Pin = Z_PLUS_LIMIT_PIN;
+    HAL_GPIO_Init(Z_PLUS_LIMIT_PORT, &init);
+
+    // X MOTOR
+    init.Pin = X_MINUS_LIMIT_PIN;
+    HAL_GPIO_Init(X_MINUS_LIMIT_PORT, &init);
+
+    init.Pin = X_PLUS_LIMIT_PIN;
+    HAL_GPIO_Init(X_PLUS_LIMIT_PORT, &init);
+
+    // L MOTOR
+    init.Mode = GPIO_MODE_IT_FALLING;
+
+    init.Pin = L_N_HELD_PIN;
+    HAL_GPIO_Init(L_N_HELD_PORT, &init);
+
+    HAL_NVIC_SetPriority(EXTI0_IRQn, 5, 0);
+//    HAL_NVIC_EnableIRQ(EXTI0_IRQn);
+
+    HAL_NVIC_SetPriority(EXTI1_IRQn, 5, 0);
+//    HAL_NVIC_EnableIRQ(EXTI1_IRQn);
+
+    HAL_NVIC_SetPriority(EXTI2_IRQn, 5, 0);
+//    HAL_NVIC_EnableIRQ(EXTI2_IRQn);
+
+    HAL_NVIC_SetPriority(EXTI3_IRQn, 5, 0);
+//    HAL_NVIC_EnableIRQ(EXTI3_IRQn);
+
+    HAL_NVIC_SetPriority(EXTI9_5_IRQn, 5, 0);
+//    HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
+
 }
 
 // X motor timer
@@ -377,6 +407,24 @@ void hw_step_motor(MotorID motor_id) {
 void hw_set_direction(MotorID motor_id, bool direction) {
     stepper_hardware_t motor = get_motor(motor_id);
     direction ? set_pin(motor.direction) : reset_pin(motor.direction);
+}
+
+void hw_enable_lim_switch_irq(MotorID motor_id, bool direction) {
+    if (motor_id == MOTOR_L && direction) {
+        // L motor only has one limit switch on the minus direction, so ignore the direction
+        return;
+    }
+    stepper_hardware_t motor = get_motor(motor_id);
+    direction ? HAL_NVIC_EnableIRQ(motor.limit_switch_plus_it) : HAL_NVIC_EnableIRQ(motor.limit_switch_minus_it);
+}
+
+void hw_disable_lim_switch_irq(MotorID motor_id, bool direction) {
+    if (motor_id == MOTOR_L && direction) {
+        // L motor only has one limit switch on the minus direction, so ignore the direction
+        return;
+    }
+    stepper_hardware_t motor = get_motor(motor_id);
+    direction ? HAL_NVIC_DisableIRQ(motor.limit_switch_plus_it) : HAL_NVIC_DisableIRQ(motor.limit_switch_minus_it);
 }
 
 bool hw_read_limit_switch(MotorID motor_id, bool direction) {

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
@@ -84,8 +84,8 @@ static motor_hardware_t _motor_hardware = {
         .limit_switch_plus = {Z_PLUS_LIMIT_PORT, Z_PLUS_LIMIT_PIN, GPIO_PIN_SET},
         .diag0 = {MOTOR_DIAG0_PORT, MOTOR_DIAG0_PIN, GPIO_PIN_SET},
         .ebrake = {Z_N_BRAKE_PORT, Z_N_BRAKE_PIN, GPIO_PIN_RESET},
-        .limit_switch_minus_it = EXTI0_IRQn,
-        .limit_switch_plus_it = EXTI3_IRQn,
+        .limit_switch_minus_it = EXTI3_IRQn,
+        .limit_switch_plus_it = EXTI0_IRQn,
     },
     .motor_l = {
         .timer = {0},

--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_policy.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_policy.cpp
@@ -38,6 +38,13 @@ auto MotorPolicy::set_direction(MotorID motor_id, bool direction) -> void {
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto MotorPolicy::set_limit_switch_irq(MotorID motor_id, bool direction,
+                                       bool enable) -> void {
+    enable ? hw_enable_lim_switch_irq(motor_id, direction)
+           : hw_disable_lim_switch_irq(motor_id, direction);
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto MotorPolicy::check_limit_switch(MotorID motor_id, bool direction) -> bool {
     return hw_read_limit_switch(motor_id, direction);
 }

--- a/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.c
+++ b/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.c
@@ -31,6 +31,7 @@ extern SPI_HandleTypeDef hspi2;
 
 
 motor_interrupt_callback interrupt_callback = NULL;
+limit_switch_callback lim_switch_callback = NULL;
 /******************************************************************************/
 /*           Cortex-M4 Processor Interruption and Exception Handlers          */
 /******************************************************************************/
@@ -122,6 +123,10 @@ void initialize_callbacks(motor_interrupt_callback callback_glue) {
     interrupt_callback = callback_glue;
 }
 
+void initialize_limit_switch_callbacks(limit_switch_callback callback_glue) {
+    lim_switch_callback = callback_glue;
+}
+
 // MOTOR_DIAG0_PIN interrupt
 void EXTI15_10_IRQHandler(void) {
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_12)) {
@@ -129,10 +134,64 @@ void EXTI15_10_IRQHandler(void) {
     }
 }
 
-// Estop interrupt
 void EXTI9_5_IRQHandler(void)
 {
+    // Estop interrupt
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_6)) {
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_6);
     }
+    // Latch held limit switch interrupt
+    if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_5)) {
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_5);
+        if (lim_switch_callback) {
+            lim_switch_callback(MOTOR_L);
+        }
+
+    }
 }
+
+// Z+ limit switch interrupt
+void EXTI0_IRQHandler(void)
+{
+    if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_0)) {
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_0);
+        if (lim_switch_callback) {
+            lim_switch_callback(MOTOR_Z);
+        }
+    }
+}
+
+// X- limit switch interrupt
+void EXTI1_IRQHandler(void)
+{
+    if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_1)) {
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_1);
+        if (lim_switch_callback) {
+            lim_switch_callback(MOTOR_X);
+        }
+    }
+}
+
+// X+ limit switch interrupt
+void EXTI2_IRQHandler(void)
+{
+    if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_2)) {
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_2);
+        if (lim_switch_callback) {
+            lim_switch_callback(MOTOR_X);
+        }
+    }
+}
+
+// Z- limit switch interrupt
+void EXTI3_IRQHandler(void)
+{
+    if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_3)) {
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_3);
+        if (lim_switch_callback) {
+            lim_switch_callback(MOTOR_Z);
+        }
+    }
+}
+
+

--- a/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.h
+++ b/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.h
@@ -34,6 +34,10 @@ void UsageFault_Handler(void);
 void DebugMon_Handler(void);
 // void SysTick_Handler(void);
 void RCC_IRQHandler(void);
+void EXTI0_IRQHandler(void);
+void EXTI1_IRQHandler(void);
+void EXTI2_IRQHandler(void);
+void EXTI3_IRQHandler(void);
 void EXTI15_10_IRQHandler(void);
 void EXTI9_5_IRQHandler(void);
 // void DMA1_Channel1_IRQHandler(void);
@@ -41,6 +45,9 @@ void EXTI9_5_IRQHandler(void);
 
 typedef void (*motor_interrupt_callback)(MotorID motor_id);
 void initialize_callbacks(motor_interrupt_callback callback_glue);
+
+typedef void (*limit_switch_callback)(MotorID motor_id);
+void initialize_limit_switch_callbacks(limit_switch_callback callback_glue);
 #ifdef __cplusplus
 }
 #endif

--- a/stm32-modules/include/flex-stacker/firmware/motor_hardware.h
+++ b/stm32-modules/include/flex-stacker/firmware/motor_hardware.h
@@ -20,6 +20,8 @@ void hw_start_motor_timer(MotorID motor_id);
 bool hw_disable_motor(MotorID motor_id);
 bool hw_stop_motor(MotorID motor_id);
 void hw_set_direction(MotorID, bool direction);
+void hw_enable_lim_switch_irq(MotorID motor_id, bool direction);
+void hw_disable_lim_switch_irq(MotorID motor_id, bool direction);
 bool hw_read_limit_switch(MotorID motor_id, bool direction);
 void hw_set_diag0_irq(bool enable);
 bool hw_read_platform_sensor(bool direction);

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -116,6 +116,9 @@ class MotorInterruptController {
     }
     [[nodiscard]] auto get_error_code() const -> Error { return _error; }
     auto stop_condition_met() -> bool {
+        if (_stop) {
+            return true;
+        }
         // this will only error if the limit switch in the move direction
         // is triggered
         // Stop if moving left motor in an allowed direction
@@ -127,15 +130,20 @@ class MotorInterruptController {
             _error = Error::MOTOR_STALL_DETECTED;
             return true;
         }
-        if ((_id != MotorID::MOTOR_L || !_direction) &&
-            limit_switch_triggered()) {
+
+        if (limit_switch_triggered()) {
             if (_profile.movement_type() ==
-                motor_util::MovementType::FixedDistance) {
-                _error = Error::UNEXPECTED_LIMIT_SWITCH;
+                motor_util::MovementType::OpenLoop) {
+                return true;
             }
+            if (_id == MotorID::MOTOR_L && !_direction) {
+                // don't error if moving to limit switch
+                return false;
+            }
+            error = Error::UNEXPECTED_LIMIT_SWITCH;
             return true;
         }
-        return _stop;
+        return false;
     }
 
     auto set_diag0_irq(bool enable) -> void { _policy->set_diag0_irq(enable); }

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -140,7 +140,7 @@ class MotorInterruptController {
                 // don't error if moving to limit switch
                 return false;
             }
-            error = Error::UNEXPECTED_LIMIT_SWITCH;
+            _error = Error::UNEXPECTED_LIMIT_SWITCH;
             return true;
         }
         return false;

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -122,6 +122,14 @@ class MotorInterruptController {
         if (_stop) {
             return true;
         }
+        if (_switch_detected) {
+            if (_profile.movement_type() ==
+                motor_util::MovementType::OpenLoop) {
+                return true;
+            }
+            _error = Error::UNEXPECTED_LIMIT_SWITCH;
+            return true;
+        }
         // this will only error if the limit switch in the move direction
         // is triggered
         // Stop if moving left motor in an allowed direction
@@ -134,14 +142,6 @@ class MotorInterruptController {
             return true;
         }
 
-        if (_switch_detected) {
-            if (_profile.movement_type() ==
-                motor_util::MovementType::OpenLoop) {
-                return true;
-            }
-            _error = Error::UNEXPECTED_LIMIT_SWITCH;
-            return true;
-        }
         return false;
     }
 

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -49,6 +49,7 @@ class MotorInterruptController {
         }
         if (ret.done || stop_condition_met()) {
             _policy->stop_motor(_id);
+            _policy->set_limit_switch_irq(_id, _direction, false);
             _stop = true;
             return true;
         }
@@ -62,6 +63,9 @@ class MotorInterruptController {
     auto reset() -> void {
         _stop = false;
         _error = Error::NO_ERROR;
+        _switch_detected = false;
+        _policy->set_limit_switch_irq(_id, _direction, false);
+        _policy->set_limit_switch_irq(_id, !_direction, false);
     }
 
     auto start_fixed_movement(uint32_t move_id, bool direction, long steps,
@@ -101,14 +105,13 @@ class MotorInterruptController {
         if (disable_motor) {
             _policy->disable_motor(_id);
         }
+        _policy->set_limit_switch_irq(_id, _direction, false);
     }
 
     auto set_direction(bool direction) -> void {
-        _policy->set_direction(_id, direction);
         _direction = direction;
-    }
-    auto limit_switch_triggered() -> bool {
-        return _policy->check_limit_switch(_id, _direction);
+        _policy->set_direction(_id, direction);
+        _policy->set_limit_switch_irq(_id, direction, true);
     }
 
     [[nodiscard]] auto get_response_id() const -> uint32_t {
@@ -131,20 +134,18 @@ class MotorInterruptController {
             return true;
         }
 
-        if (limit_switch_triggered()) {
+        if (_switch_detected) {
             if (_profile.movement_type() ==
                 motor_util::MovementType::OpenLoop) {
                 return true;
-            }
-            if (_id == MotorID::MOTOR_L && !_direction) {
-                // don't error if moving to limit switch
-                return false;
             }
             _error = Error::UNEXPECTED_LIMIT_SWITCH;
             return true;
         }
         return false;
     }
+
+    auto limit_switch_detected() -> void { _switch_detected = true; }
 
     auto set_diag0_irq(bool enable) -> void { _policy->set_diag0_irq(enable); }
 
@@ -159,6 +160,7 @@ class MotorInterruptController {
     Error _error = Error::NO_ERROR;
     bool _direction = false;
     bool _stop = true;
+    bool _switch_detected = false;
 };
 
 }  // namespace motor_interrupt_controller

--- a/stm32-modules/include/flex-stacker/firmware/motor_policy.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_policy.hpp
@@ -14,6 +14,8 @@ class MotorPolicy {
     auto stop_motor(MotorID motor_id) -> bool;
     auto step(MotorID motor_id) -> void;
     auto set_direction(MotorID motor_id, bool direction) -> void;
+    auto set_limit_switch_irq(MotorID motor_id, bool direction, bool enable)
+        -> void;
     auto check_limit_switch(MotorID motor_id, bool direction) -> bool;
     auto set_diag0_irq(bool enable) -> void;
     auto check_platform_sensor(bool direction) -> bool;

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -312,6 +312,11 @@ class MotorTask {
             send_ack_message(m.id, error);
             return;
         }
+        if (policy.check_limit_switch(m.motor_id, m.direction)) {
+            // motor is already homed
+            send_ack_message(m.id);
+            return;
+        }
         Controller& controller = controller_from_id(m.motor_id);
         MotorState& state = motor_state(m.motor_id);
         if (m.mm_per_second.has_value()) {


### PR DESCRIPTION
We now read the limit switch input every motor interrupt tick and it's significantly slowing the motor movements. This PR fixes that by setting the relevant limit switch as an external GPIO interrupt to alert the motor interrupt when it is triggered. 