### PR TITLE
fix(stacker): latch limit switch responded even when not prompted

### DIFF
--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
@@ -217,7 +217,7 @@ void motor_hardware_gpio_init(void){
     HAL_NVIC_SetPriority(EXTI3_IRQn, 5, 0);
 //    HAL_NVIC_EnableIRQ(EXTI3_IRQn);
 
-    HAL_NVIC_SetPriority(EXTI9_5_IRQn, 5, 0);
+//    HAL_NVIC_SetPriority(EXTI9_5_IRQn, 5, 0);
 //    HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
 
 }
@@ -410,7 +410,7 @@ void hw_set_direction(MotorID motor_id, bool direction) {
 }
 
 void hw_enable_lim_switch_irq(MotorID motor_id, bool direction) {
-    if (motor_id == MOTOR_L && direction) {
+    if (motor_id == MOTOR_L) {
         // L motor only has one limit switch on the minus direction, so ignore the direction
         return;
     }
@@ -419,7 +419,7 @@ void hw_enable_lim_switch_irq(MotorID motor_id, bool direction) {
 }
 
 void hw_disable_lim_switch_irq(MotorID motor_id, bool direction) {
-    if (motor_id == MOTOR_L && direction) {
+    if (motor_id == MOTOR_L) {
         // L motor only has one limit switch on the minus direction, so ignore the direction
         return;
     }

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -147,6 +147,7 @@ class MotorInterruptController {
 
     auto limit_switch_detected() -> void {
         if (_id == MotorID::MOTOR_L) {
+            // NOLINTNEXTLINE(readability-simplify-boolean-expr)
             _switch_detected = _direction ? false : true;
         } else {
             _switch_detected = true;

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -145,7 +145,13 @@ class MotorInterruptController {
         return false;
     }
 
-    auto limit_switch_detected() -> void { _switch_detected = true; }
+    auto limit_switch_detected() -> void {
+        if (_id == MotorID::MOTOR_L) {
+            _switch_detected = _direction ? false : true;
+        } else {
+            _switch_detected = true;
+        };
+    }
 
     auto set_diag0_irq(bool enable) -> void { _policy->set_diag0_irq(enable); }
 


### PR DESCRIPTION
This is a quick fix to enable dvt QC. We should diagnose why latch limit switch interrupt is behaving incorrectly when we have more time.