### PR TITLE
feat(flex-stacker): add set tof configuration (M227) and get tof configuration (M228) Gcodes.

### DIFF
--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
@@ -671,7 +671,7 @@ struct GetTOFMeasurement {
     }
 };
 
-struct ConfigureTOFSensor {
+struct SetTOFConfiguration {
     TOFSensorID sensor_id;
     TOFSpadMapID spad_map_id;
     std::optional<TOFActiveRange> active_range;
@@ -679,7 +679,7 @@ struct ConfigureTOFSensor {
     std::optional<uint16_t> report_period_ms;
     std::optional<bool> histogram_dump;
 
-    using ParseResult = std::optional<ConfigureTOFSensor>;
+    using ParseResult = std::optional<SetTOFConfiguration>;
     static constexpr auto prefix = std::array{'M', '2', '2', '7', ' '};
     static constexpr const char* response = "M227 OK\n";
 
@@ -702,7 +702,7 @@ struct ConfigureTOFSensor {
             return std::make_pair(ParseResult(), input);
         }
 
-        auto ret = ConfigureTOFSensor{
+        auto ret = SetTOFConfiguration{
             .sensor_id = TOFSensorID::TOF_X,
             .spad_map_id = TOFSpadMapID::SPAD_MAP_ID_14,
         };
@@ -724,12 +724,16 @@ struct ConfigureTOFSensor {
             ret.kilo_iterations =
                 static_cast<uint16_t>(std::get<4>(arguments).value);
         }
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if (std::get<5>(arguments).present) {
             ret.report_period_ms =
+                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
                 static_cast<uint16_t>(std::get<5>(arguments).value);
         }
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if (std::get<6>(arguments).present) {
             ret.histogram_dump =
+                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
                 static_cast<bool>(std::get<6>(arguments).value);
         }
         return std::make_pair(ret, res.second);
@@ -740,6 +744,59 @@ struct ConfigureTOFSensor {
         std::sized_sentinel_for<InputIt, InLimit>
     static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
         return write_string_to_iterpair(buf, limit, response);
+    }
+};
+
+struct GetTOFConfiguration {
+    TOFSensorID sensor_id;
+
+    using ParseResult = std::optional<GetTOFConfiguration>;
+    static constexpr auto prefix = std::array{'M', '2', '2', '8', ' '};
+
+    using XArg = ArgNoVal<'X'>;
+    using ZArg = ArgNoVal<'Z'>;
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto res =
+            gcode::SingleParser<XArg, ZArg>::parse_gcode(input, limit, prefix);
+        if (!res.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+
+        auto ret = GetTOFConfiguration{
+            .sensor_id = TOFSensorID::TOF_X,
+        };
+        auto arguments = res.first.value();
+        if (std::get<1>(arguments).present) {
+            ret.sensor_id = TOFSensorID::TOF_Z;
+        } else if (!std::get<0>(arguments).present) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ret, res.second);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit,
+                                    TOFSensorID sensor_id,
+                                    TOFSpadMapID spad_map_id,
+                                    TOFActiveRange active_range,
+                                    uint16_t kilo_iterations,
+                                    uint16_t report_period_ms,
+                                    bool histogram_dump) -> InputIt {
+        auto res = snprintf(
+            &*buf, (limit - buf), "M228 %c I:%d A:%d K:%d P:%d H:%d OK\n",
+            sensor_id_to_char(sensor_id), spad_map_id, active_range,
+            kilo_iterations, report_period_ms, histogram_dump);
+        if (res <= 0) {
+            return buf;
+        }
+        return buf + res;
     }
 };
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
@@ -681,6 +681,7 @@ struct ConfigureTOFSensor {
 
     using ParseResult = std::optional<ConfigureTOFSensor>;
     static constexpr auto prefix = std::array{'M', '2', '2', '7', ' '};
+    static constexpr const char* response = "M227 OK\n";
 
     using XArg = ArgNoVal<'X'>;
     using ZArg = ArgNoVal<'Z'>;
@@ -738,11 +739,7 @@ struct ConfigureTOFSensor {
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputIt, InLimit>
     static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
-        auto res = snprintf(&*buf, (limit - buf), "M227 OK\n");
-        if (res <= 0) {
-            return buf;
-        }
-        return buf + res;
+        return write_string_to_iterpair(buf, limit, response);
     }
 };
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/gcodes.hpp
@@ -671,4 +671,79 @@ struct GetTOFMeasurement {
     }
 };
 
+struct ConfigureTOFSensor {
+    TOFSensorID sensor_id;
+    TOFSpadMapID spad_map_id;
+    std::optional<TOFActiveRange> active_range;
+    std::optional<uint16_t> kilo_iterations;
+    std::optional<uint16_t> report_period_ms;
+    std::optional<bool> histogram_dump;
+
+    using ParseResult = std::optional<ConfigureTOFSensor>;
+    static constexpr auto prefix = std::array{'M', '2', '2', '7', ' '};
+
+    using XArg = ArgNoVal<'X'>;
+    using ZArg = ArgNoVal<'Z'>;
+    using IArg = Arg<uint8_t, 'I'>;
+    using AArg = Arg<uint8_t, 'A'>;
+    using KArg = Arg<uint8_t, 'K'>;
+    using PArg = Arg<uint8_t, 'P'>;
+    using HArg = Arg<uint8_t, 'H'>;
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto res = gcode::SingleParser<XArg, ZArg, IArg, AArg, KArg, PArg,
+                                       HArg>::parse_gcode(input, limit, prefix);
+        if (!res.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+
+        auto ret = ConfigureTOFSensor{
+            .sensor_id = TOFSensorID::TOF_X,
+            .spad_map_id = TOFSpadMapID::SPAD_MAP_ID_14,
+        };
+        auto arguments = res.first.value();
+        if (std::get<1>(arguments).present) {
+            ret.sensor_id = TOFSensorID::TOF_Z;
+        } else if (!std::get<0>(arguments).present) {
+            return std::make_pair(ParseResult(), input);
+        }
+        if (std::get<2>(arguments).present) {
+            ret.spad_map_id =
+                static_cast<TOFSpadMapID>(std::get<2>(arguments).value);
+        }
+        if (std::get<3>(arguments).present) {
+            ret.active_range =
+                static_cast<TOFActiveRange>(std::get<3>(arguments).value);
+        }
+        if (std::get<4>(arguments).present) {
+            ret.kilo_iterations =
+                static_cast<uint16_t>(std::get<4>(arguments).value);
+        }
+        if (std::get<5>(arguments).present) {
+            ret.report_period_ms =
+                static_cast<uint16_t>(std::get<5>(arguments).value);
+        }
+        if (std::get<6>(arguments).present) {
+            ret.histogram_dump =
+                static_cast<bool>(std::get<6>(arguments).value);
+        }
+        return std::make_pair(ret, res.second);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        auto res = snprintf(&*buf, (limit - buf), "M227 OK\n");
+        if (res <= 0) {
+            return buf;
+        }
+        return buf + res;
+    }
+};
+
 }  // namespace gcode

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -48,15 +48,18 @@ class HostCommsTask {
         gcode::StopMotor, gcode::GetResetReason, gcode::SetStatusBarState,
         gcode::GetTOFSensorStatus, gcode::GetTOFRegister, gcode::SetTOFRegister,
         gcode::EnableTOFSensor, gcode::ManageTOFMeasurement,
-        gcode::GetTOFMeasurement, gcode::GetInstalledStatus>;
+        gcode::GetTOFMeasurement, gcode::GetInstalledStatus,
+        gcode::ConfigureTOFSensor>;
 
-    using AckOnlyCache = AckCache<
-        8, gcode::EnterBootloader, gcode::SetSerialNumber,
-        gcode::SetTMCRegister, gcode::SetRunCurrent, gcode::SetHoldCurrent,
-        gcode::EnableMotor, gcode::DisableMotor, gcode::MoveMotorInSteps,
-        gcode::MoveToLimitSwitch, gcode::MoveMotorInMm, gcode::SetMicrosteps,
-        gcode::SetStatusBarState, gcode::SetMotorStallGuard, gcode::HomeMotor,
-        gcode::StopMotor, gcode::SetTOFRegister, gcode::EnableTOFSensor>;
+    using AckOnlyCache =
+        AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
+                 gcode::SetTMCRegister, gcode::SetRunCurrent,
+                 gcode::SetHoldCurrent, gcode::EnableMotor, gcode::DisableMotor,
+                 gcode::MoveMotorInSteps, gcode::MoveToLimitSwitch,
+                 gcode::MoveMotorInMm, gcode::SetMicrosteps,
+                 gcode::SetStatusBarState, gcode::SetMotorStallGuard,
+                 gcode::HomeMotor, gcode::StopMotor, gcode::SetTOFRegister,
+                 gcode::EnableTOFSensor, gcode::ConfigureTOFSensor>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetTMCRegisterCache = AckCache<8, gcode::GetTMCRegister>;
     using GetLimitSwitchesCache = AckCache<8, gcode::GetLimitSwitches>;
@@ -1331,6 +1334,34 @@ class HostCommsTask {
                 }
             },
             cache_entry);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::ConfigureTOFSensor& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::ConfigureTOFSensorMessage{
+            .id = id,
+            .sensor_id = gcode.sensor_id,
+            .spad_map_id = gcode.spad_map_id,
+            .active_range = gcode.active_range,
+            .kilo_iterations = gcode.kilo_iterations,
+            .report_period_ms = gcode.report_period_ms,
+            .histogram_dump = gcode.histogram_dump};
+        if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
     }
 
     // Our error handler just writes an error and bails

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -49,7 +49,7 @@ class HostCommsTask {
         gcode::GetTOFSensorStatus, gcode::GetTOFRegister, gcode::SetTOFRegister,
         gcode::EnableTOFSensor, gcode::ManageTOFMeasurement,
         gcode::GetTOFMeasurement, gcode::GetInstalledStatus,
-        gcode::ConfigureTOFSensor>;
+        gcode::SetTOFConfiguration, gcode::GetTOFConfiguration>;
 
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
@@ -59,7 +59,7 @@ class HostCommsTask {
                  gcode::MoveMotorInMm, gcode::SetMicrosteps,
                  gcode::SetStatusBarState, gcode::SetMotorStallGuard,
                  gcode::HomeMotor, gcode::StopMotor, gcode::SetTOFRegister,
-                 gcode::EnableTOFSensor, gcode::ConfigureTOFSensor>;
+                 gcode::EnableTOFSensor, gcode::SetTOFConfiguration>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetTMCRegisterCache = AckCache<8, gcode::GetTMCRegister>;
     using GetLimitSwitchesCache = AckCache<8, gcode::GetLimitSwitches>;
@@ -74,6 +74,7 @@ class HostCommsTask {
     using GetTOFRegisterCache = AckCache<8, gcode::GetTOFRegister>;
     using ManageTOFMeasurementCache = AckCache<8, gcode::ManageTOFMeasurement>;
     using GetTOFMeasurementCache = AckCache<8, gcode::GetTOFMeasurement>;
+    using GetTOFConfigurationCache = AckCache<8, gcode::GetTOFConfiguration>;
 
   public:
     static constexpr size_t TICKS_TO_WAIT_ON_SEND = 10;
@@ -1339,7 +1340,7 @@ class HostCommsTask {
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputLimit, InputIt>
-    auto visit_gcode(const gcode::ConfigureTOFSensor& gcode, InputIt tx_into,
+    auto visit_gcode(const gcode::SetTOFConfiguration& gcode, InputIt tx_into,
                      InputLimit tx_limit) -> std::pair<bool, InputIt> {
         auto id = ack_only_cache.add(gcode);
         if (id == 0) {
@@ -1347,7 +1348,7 @@ class HostCommsTask {
                 false, errors::write_into(tx_into, tx_limit,
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
-        auto message = messages::ConfigureTOFSensorMessage{
+        auto message = messages::SetTOFConfigurationMessage{
             .id = id,
             .sensor_id = gcode.sensor_id,
             .spad_map_id = gcode.spad_map_id,
@@ -1362,6 +1363,53 @@ class HostCommsTask {
             return std::make_pair(false, wrote_to);
         }
         return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::GetTOFConfiguration& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = get_tof_configuration_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::GetTOFConfigurationMessage{
+            .id = id, .sensor_id = gcode.sensor_id};
+        if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            get_tof_configuration_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(const messages::GetTOFConfigurationResponse& response,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto cache_entry = get_tof_configuration_cache.remove_if_present(
+            response.responding_to_id);
+        return std::visit(
+            [tx_into, tx_limit, response](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (std::is_same_v<std::monostate, T>) {
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                } else {
+                    return cache_element.write_response_into(
+                        tx_into, tx_limit, response.sensor_id,
+                        response.spad_map_id, response.active_range,
+                        response.kilo_iterations, response.report_period_ms,
+                        response.histogram_dump);
+                }
+            },
+            cache_entry);
     }
 
     // Our error handler just writes an error and bails
@@ -1393,6 +1441,7 @@ class HostCommsTask {
     GetTOFRegisterCache get_tof_register_cache;
     ManageTOFMeasurementCache manage_tof_measurement_cache;
     GetTOFMeasurementCache get_tof_measurement_cache;
+    GetTOFConfigurationCache get_tof_configuration_cache;
     bool may_connect_latch = true;
 };
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -372,14 +372,29 @@ struct GetTOFMeasurementResponse {
     const char* data;
 };
 
-struct ConfigureTOFSensorMessage {
-    uint32_t id;
-    TOFSensorID sensor_id;
-    TOFSpadMapID spad_map_id;
+struct SetTOFConfigurationMessage {
+    uint32_t id = 0;
+    TOFSensorID sensor_id = TOF_X;
+    TOFSpadMapID spad_map_id = SPAD_MAP_ID_14;
     std::optional<TOFActiveRange> active_range;
     std::optional<uint16_t> kilo_iterations;
     std::optional<uint16_t> report_period_ms;
     std::optional<bool> histogram_dump;
+};
+
+struct GetTOFConfigurationMessage {
+    uint32_t id;
+    TOFSensorID sensor_id;
+};
+
+struct GetTOFConfigurationResponse {
+    uint32_t responding_to_id;
+    TOFSensorID sensor_id;
+    TOFSpadMapID spad_map_id;
+    TOFActiveRange active_range;
+    uint16_t kilo_iterations;
+    uint16_t report_period_ms;
+    bool histogram_dump;
 };
 
 using HostCommsMessage =
@@ -391,7 +406,7 @@ using HostCommsMessage =
                    GetEstopResponse, GetResetReasonResponse,
                    GetTOFSensorStatusResponse, GetTOFRegisterResponse,
                    ManageTOFMeasurementResponse, GetTOFMeasurementResponse,
-                   GetInstalledResponse>;
+                   GetInstalledResponse, GetTOFConfigurationResponse>;
 
 using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,
@@ -419,6 +434,6 @@ using TOFSensorMessage =
     ::std::variant<std::monostate, SetTOFRegisterMessage, GetTOFRegisterMessage,
                    EnableTOFSensorMessage, GetTOFSensorStatusMessage,
                    ManageTOFMeasurementMessage, GetTOFMeasurementMessage,
-                   ConfigureTOFSensorMessage>;
+                   SetTOFConfigurationMessage, GetTOFConfigurationMessage>;
 
 };  // namespace messages

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -372,6 +372,16 @@ struct GetTOFMeasurementResponse {
     const char* data;
 };
 
+struct ConfigureTOFSensorMessage {
+    uint32_t id;
+    TOFSensorID sensor_id;
+    TOFSpadMapID spad_map_id;
+    std::optional<TOFActiveRange> active_range;
+    std::optional<uint16_t> kilo_iterations;
+    std::optional<uint16_t> report_period_ms;
+    std::optional<bool> histogram_dump;
+};
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
@@ -408,6 +418,7 @@ using MotorMessage = ::std::variant<
 using TOFSensorMessage =
     ::std::variant<std::monostate, SetTOFRegisterMessage, GetTOFRegisterMessage,
                    EnableTOFSensorMessage, GetTOFSensorStatusMessage,
-                   ManageTOFMeasurementMessage, GetTOFMeasurementMessage>;
+                   ManageTOFMeasurementMessage, GetTOFMeasurementMessage,
+                   ConfigureTOFSensorMessage>;
 
 };  // namespace messages

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmf8820.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmf8820.hpp
@@ -460,6 +460,9 @@ class TMF8820 {
 
     auto configure_sensor(TOFSensorID sensor_id, TMF8820Config* config)
         -> bool {
+        if (!set_sensor_histogram_dump(sensor_id, config->histogram_dump)) {
+            return false;
+        }
         if (!set_sensor_report_period(sensor_id, config->report_period_ms)) {
             return false;
         }
@@ -467,9 +470,6 @@ class TMF8820 {
             return false;
         }
         if (!set_sensor_active_range(sensor_id, config->active_range)) {
-            return false;
-        }
-        if (!set_sensor_histogram_dump(sensor_id, config->histogram_dump)) {
             return false;
         }
         if (!set_sensor_spad_map(sensor_id, config->spad_map_id)) {

--- a/stm32-modules/include/flex-stacker/flex-stacker/tmf8820.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tmf8820.hpp
@@ -30,12 +30,6 @@ constexpr uint16_t TOF_Z_ADDRESS = 0x40;
 constexpr uint8_t DEFAULT_RETRIES = 5;
 constexpr uint32_t DEFAULT_SLEEP_MS = 250;
 
-// Default config
-constexpr uint8_t DEFAULT_SPAD_MAP_ID = 14;
-constexpr uint16_t DEFAULT_REPORT_PERIOD_MS = 500;
-constexpr uint16_t DEFAULT_KILO_ITERATIONS = 4000;
-constexpr bool DEFAULT_HISTOGRAM_DUMP = true;
-
 // Bootloader commands (bl_cmd_stat)
 
 // Remap RAM to Address 0 and Reset
@@ -94,24 +88,6 @@ constexpr uint8_t STAT_WARNING_OSC_TRIM_NOT_ACCEPTED = 0x0C;
 constexpr uint8_t STAT_WARNING_I2C_ADDRESS_NOT_ACCEPTED = 0x0D;
 constexpr uint8_t STAT_ERR_UNKNOWN_MODE = 0x0E;
 
-// SPAD Map Config
-
-// 3x3 normal mode 33°x32° FoV
-constexpr uint8_t SPAD_MAP_ID_1 = 1;
-// 3x3 macro 1 mode 33°x47° FoV off center
-constexpr uint8_t SPAD_MAP_ID_2 = 2;
-// 3x3 macro 2 mode 33°x47° FoV
-constexpr uint8_t SPAD_MAP_ID_3 = 3;
-// 3x3 wide mode 41°x52° FoV
-constexpr uint8_t SPAD_MAP_ID_6 = 6;
-// 3x3 mode 33°x32° FoV, checkerboard
-constexpr uint8_t SPAD_MAP_ID_11 = 11;
-// 3x3 mode 33°x32° FoV, inverted checkerboard
-constexpr uint8_t SPAD_MAP_ID_12 = 12;
-// User defined mode, single measurement mode
-// using config_page_spad1 only
-constexpr uint8_t SPAD_MAP_ID_14 = 14;
-
 // Histogram measurement
 // 3 header + 4 sub header + 128bytes = 135bytes
 constexpr uint8_t HIST_FRAME_LEN = 135;
@@ -133,21 +109,14 @@ constexpr uint8_t HIST_NOT_READY = 1;
 constexpr uint8_t HIST_DONE = 2;
 constexpr uint8_t HIST_ERROR = 3;
 
-// Active range
-enum TOFActiveRange : uint8_t {
-    NOT_SUPPORTED = 0,
-    SHORT_RANGE = 0x6E,
-    LONG_RANGE = 0x6F,
-};
-
 struct TMF8820Config {
     tmf8820::TMF8820RegisterMap* registers;
     const tmf8820_spad::TMF8820SPADConfig* spad_config;
+    TOFSpadMapID spad_map_id = SPAD_MAP_ID_14;
     TOFActiveRange active_range = SHORT_RANGE;
-    uint16_t report_period_ms = DEFAULT_REPORT_PERIOD_MS;
-    uint16_t kilo_iterations = DEFAULT_KILO_ITERATIONS;
-    bool histogram_dump = DEFAULT_HISTOGRAM_DUMP;
-    uint8_t spad_map_id = DEFAULT_SPAD_MAP_ID;
+    uint16_t report_period_ms = 500;
+    uint16_t kilo_iterations = 4000;
+    bool histogram_dump = true;
 };
 
 class TMF8820 {
@@ -487,6 +456,26 @@ class TMF8820 {
         }
         // Write the config page
         return send_write_config_page(sensor_id);
+    }
+
+    auto configure_sensor(TOFSensorID sensor_id, TMF8820Config* config)
+        -> bool {
+        if (!set_sensor_report_period(sensor_id, config->report_period_ms)) {
+            return false;
+        }
+        if (!set_sensor_kilo_iterations(sensor_id, config->kilo_iterations)) {
+            return false;
+        }
+        if (!set_sensor_active_range(sensor_id, config->active_range)) {
+            return false;
+        }
+        if (!set_sensor_histogram_dump(sensor_id, config->histogram_dump)) {
+            return false;
+        }
+        if (!set_sensor_spad_map(sensor_id, config->spad_map_id)) {
+            return false;
+        }
+        return true;
     }
 
     auto start_measurement(TOFSensorID sensor_id,
@@ -856,26 +845,6 @@ class TMF8820 {
             default:
                 return -1;
         }
-    }
-
-    auto configure_sensor(TOFSensorID sensor_id, TMF8820Config* config)
-        -> bool {
-        if (!set_sensor_report_period(sensor_id, config->report_period_ms)) {
-            return false;
-        }
-        if (!set_sensor_kilo_iterations(sensor_id, config->kilo_iterations)) {
-            return false;
-        }
-        if (!set_sensor_active_range(sensor_id, config->active_range)) {
-            return false;
-        }
-        if (!set_sensor_histogram_dump(sensor_id, config->histogram_dump)) {
-            return false;
-        }
-        if (!set_sensor_spad_map(sensor_id, config->spad_map_id)) {
-            return false;
-        }
-        return true;
     }
 
     TOFSensorPolicy* _policy{nullptr};

--- a/stm32-modules/include/flex-stacker/flex-stacker/tof_sensor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tof_sensor_task.hpp
@@ -282,7 +282,7 @@ class TOFSensorTask {
         }
     }
 
-    auto visit_message(const messages::ConfigureTOFSensorMessage& m) -> void {
+    auto visit_message(const messages::SetTOFConfigurationMessage& m) -> void {
         auto response = messages::AcknowledgePrevious{.responding_to_id = m.id};
         auto& sensor = get_sensor(m.sensor_id);
         if (!sensor.ok) {
@@ -307,6 +307,20 @@ class TOFSensorTask {
         if (!sensor.driver.configure_sensor(m.sensor_id, &config)) {
             response.with_error = errors::ErrorCode::TMF8820_COMM_ERROR;
         }
+        send_response(response);
+    }
+
+    auto visit_message(const messages::GetTOFConfigurationMessage& m) -> void {
+        messages::HostCommsMessage response;
+        auto sensor = get_sensor(m.sensor_id);
+        response = messages::GetTOFConfigurationResponse{
+            .responding_to_id = m.id,
+            .sensor_id = m.sensor_id,
+            .spad_map_id = sensor.config.spad_map_id,
+            .active_range = sensor.config.active_range,
+            .kilo_iterations = sensor.config.kilo_iterations,
+            .report_period_ms = sensor.config.report_period_ms,
+            .histogram_dump = sensor.config.histogram_dump};
         send_response(response);
     }
 

--- a/stm32-modules/include/flex-stacker/flex-stacker/tof_sensor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tof_sensor_task.hpp
@@ -282,6 +282,34 @@ class TOFSensorTask {
         }
     }
 
+    auto visit_message(const messages::ConfigureTOFSensorMessage& m) -> void {
+        auto response = messages::AcknowledgePrevious{.responding_to_id = m.id};
+        auto& sensor = get_sensor(m.sensor_id);
+        if (!sensor.ok) {
+            response = messages::AcknowledgePrevious{
+                .responding_to_id = m.id,
+                .with_error = errors::ErrorCode::TMF8820_COMM_ERROR};
+            return send_response(response);
+        }
+
+        // Update sensor config state
+        auto& config = sensor.config;
+        config.spad_map_id = m.spad_map_id;
+        config.active_range = m.active_range.value_or(config.active_range);
+        config.report_period_ms =
+            m.report_period_ms.value_or(config.report_period_ms);
+        config.kilo_iterations =
+            m.kilo_iterations.value_or(config.kilo_iterations);
+        config.histogram_dump =
+            m.histogram_dump.value_or(config.histogram_dump);
+
+        // Configure the sensor
+        if (!sensor.driver.configure_sensor(m.sensor_id, &config)) {
+            response.with_error = errors::ErrorCode::TMF8820_COMM_ERROR;
+        }
+        send_response(response);
+    }
+
     auto send_response(messages::HostCommsMessage response) -> void {
         static_cast<void>(_task_registry->send_to_address(
             response, Queues::HostCommsAddress));

--- a/stm32-modules/include/flex-stacker/systemwide.h
+++ b/stm32-modules/include/flex-stacker/systemwide.h
@@ -32,6 +32,29 @@ typedef enum TOFMeasurementKind {
     MEASUREMENT = 1,
 } TOFMeasurementKind;
 
+typedef enum TOFActiveRange {
+    NOT_SUPPORTED = 0,
+    SHORT_RANGE = 0x6E,
+    LONG_RANGE = 0x6F,
+} TOFActiveRange;
+
+typedef enum TOFSpadMapID {
+    // 3x3 normal mode 33°x32° FoV
+    SPAD_MAP_ID_1 = 1,
+    // 3x3 macro 1 mode 33°x47° FoV off center
+    SPAD_MAP_ID_2 = 2,
+    // 3x3 macro 2 mode 33°x47° FoV
+    SPAD_MAP_ID_3 = 3,
+    // 3x3 wide mode 41°x52° FoV
+    SPAD_MAP_ID_6 = 6,
+    // 3x3 mode 33°x32° FoV, checkerboard
+    SPAD_MAP_ID_11 = 11,
+    // 3x3 mode 33°x32° FoV, inverted checkerboard
+    SPAD_MAP_ID_12 = 12,
+    // User defined mode, single measurement mode
+    SPAD_MAP_ID_14 = 14,
+} TOFSpadMapID;
+
 typedef enum StatusBarID {
     Internal = 0,
     External,


### PR DESCRIPTION
# Overview

We want to explore additional ways of using the TOF sensors on the flex stackers, to do so, we need an easy way to configure the sensor when collecting data. This pull request adds the Set TOF Configuration (M227) ad Get TOF Configuration (M228) Gcodes to allow for TOF sensor configuration. This pull request is in conjunction with this monorepo [Opentrons/opentrons#17856](https://github.com/Opentrons/opentrons/pull/17856) pull request. 

## Test Plan and Hands on Testing

- [x] Make sure you can set and get the configuration for both TOF sensors.

## Changelog

- Add Set TOF Sensor configuration (M227) Gcode
- Add Get TOF Sensor configuration (M228) Gcode

## Review requests
## Risk assessment