### PR TITLE
fix(flex-stacker): add correct PRIMARY_REVISION define to cmake to check install detect board rev.

### DIFF
--- a/stm32-modules/flex-stacker/firmware/system/system_hardware.c
+++ b/stm32-modules/flex-stacker/firmware/system/system_hardware.c
@@ -224,9 +224,9 @@ bool system_hardware_read_door_closed(void) {
 }
 
 bool system_hardware_read_install_detected(void) {
-#if flex-stacker_BOARD_REVISION != 'b'
+#if PRIMARY_REVISION == 'a'
     return false;
-#elif
+#else
     return HAL_GPIO_ReadPin(INSTALL_DETECTION_PORT, INSTALL_DETECTION_PIN) == GPIO_PIN_SET;
 #endif
 }

--- a/stm32-modules/flex-stacker/src/CMakeLists.txt
+++ b/stm32-modules/flex-stacker/src/CMakeLists.txt
@@ -38,6 +38,8 @@ endif()
 
 set(${TARGET_MODULE_NAME}_VERSION "${VERSION}" CACHE STRING "${TARGET_MODULE_NAME} fw version" FORCE)
 set(${TARGET_MODULE_NAME}_BOARD_REVISION "${TARGET_MODULE_NAME}-${STACKER_REVISION}" CACHE STRING "${TARGET_MODULE_NAME} board revision" FORCE)
+string(SUBSTRING ${STACKER_REVISION} 0 1 PRIMARY_REVISION)
+string(SUBSTRING ${STACKER_REVISION} 1 1 SECONDARY_REVISION)
 message(STATUS "Building ${TARGET_MODULE_NAME} version: ${${TARGET_MODULE_NAME}_VERSION} for board revision: ${${TARGET_MODULE_NAME}_BOARD_REVISION}")
 
 configure_file(./version.cpp.in ./version.cpp)
@@ -72,6 +74,11 @@ set_target_properties(${TARGET_MODULE_NAME}-core
         C_STANDARD_REQUIRED TRUE)
 
 target_link_libraries(${TARGET_MODULE_NAME}-core PUBLIC common-core)
+
+target_compile_definitions(${TARGET_MODULE_NAME}-core PUBLIC
+        PRIMARY_REVISION='${PRIMARY_REVISION}'
+        SECONDARY_REVISION='${SECONDARY_REVISION}'
+    )
 
 target_include_directories(${TARGET_MODULE_NAME}-core
         PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../include/${TARGET_MODULE_NAME}


### PR DESCRIPTION
# Overview

Install detect was introduced in rev b, so let's introduce PRIMARY_REVISION and SECONDARY_REVISION defines to check the board rev at compile time.

# Changes

- Add PRIMARY_REVISION and SECONDARY_REVISION to cmake
- Check PRIMARY_REVISION when compiling in INSTALL detect for rev b of flex stacker

# Testing

- Tested and works in sz with DVT Flex Stackers