### PR TITLE
fix(stacker): let host command led changes

### DIFF
--- a/stm32-modules/flex-stacker/firmware/main.cpp
+++ b/stm32-modules/flex-stacker/firmware/main.cpp
@@ -73,18 +73,6 @@ static auto i2c3_comms = i2c::hardware::I2C();
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto i2c_handles = I2CHandlerStruct{};
 
-extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
-    switch (GPIO_Pin) {
-        case MOTOR_DIAG0_PIN:
-        case N_ESTOP_PIN:
-            static_cast<void>(aggregator.send_from_isr(
-                messages::GPIOInterruptMessage{.pin = GPIO_Pin}));
-            break;
-        default:
-            break;
-    }
-}
-
 auto main() -> int {
     HardwareInit();
 

--- a/stm32-modules/flex-stacker/firmware/main.cpp
+++ b/stm32-modules/flex-stacker/firmware/main.cpp
@@ -1,4 +1,3 @@
-#include <cstdint>
 #include <functional>
 
 #include "FreeRTOS.h"
@@ -8,7 +7,6 @@
 #include "firmware/i2c_hardware.h"
 #include "firmware/motor_hardware.h"
 #include "firmware/system_stm32g4xx.h"
-#include "flex-stacker/messages.hpp"
 #include "ot_utils/freertos/freertos_task.hpp"
 #include "systemwide.h"
 #include "task.h"

--- a/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/host_comms_task.hpp
@@ -1089,7 +1089,6 @@ class HostCommsTask {
         }
         auto message = messages::SetStatusBarStateMessage{
             .id = id,
-            .from_host = true,
             .bar_id = gcode.bar_id,
             .color = gcode.color,
             .pattern = gcode.pattern,

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -427,8 +427,8 @@ using MotorMessage = ::std::variant<
     std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,
     MoveToLimitSwitchMessage, StopMotorMessage, MoveCompleteMessage,
     GetLimitSwitchesMessage, MoveMotorInMmMessage, SetMicrostepsMessage,
-    GetMoveParamsMessage, SetDiag0IRQMessage, GPIOInterruptMessage,
-    HomeMotorMessage, GetPlatformSensorsMessage, GetEstopMessage>;
+    GetMoveParamsMessage, SetDiag0IRQMessage, HomeMotorMessage,
+    GetPlatformSensorsMessage, GetEstopMessage>;
 
 using TOFSensorMessage =
     ::std::variant<std::monostate, SetTOFRegisterMessage, GetTOFRegisterMessage,

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -296,7 +296,6 @@ struct UpdateUIMessage {
 
 struct SetStatusBarStateMessage {
     uint32_t id = 0;
-    bool from_host = false;
     std::optional<StatusBarID> bar_id = std::nullopt;
     std::optional<StatusBarColor> color = std::nullopt;
     std::optional<StatusBarPattern> pattern = std::nullopt;

--- a/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/messages.hpp
@@ -422,12 +422,13 @@ using MotorDriverMessage =
                    SetMotorCurrentMessage, SetMicrostepsMessage,
                    SetMotorStallGuardMessage, GetMotorStallGuardMessage>;
 
-using MotorMessage = ::std::variant<
-    std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,
-    MoveToLimitSwitchMessage, StopMotorMessage, MoveCompleteMessage,
-    GetLimitSwitchesMessage, MoveMotorInMmMessage, SetMicrostepsMessage,
-    GetMoveParamsMessage, SetDiag0IRQMessage, HomeMotorMessage,
-    GetPlatformSensorsMessage, GetEstopMessage>;
+using MotorMessage =
+    ::std::variant<std::monostate, MotorEnableMessage, MoveMotorInStepsMessage,
+                   MoveToLimitSwitchMessage, StopMotorMessage,
+                   MoveCompleteMessage, GetLimitSwitchesMessage,
+                   MoveMotorInMmMessage, SetMicrostepsMessage,
+                   GetMoveParamsMessage, SetDiag0IRQMessage, HomeMotorMessage,
+                   GetPlatformSensorsMessage, GetEstopMessage>;
 
 using TOFSensorMessage =
     ::std::variant<std::monostate, SetTOFRegisterMessage, GetTOFRegisterMessage,

--- a/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/motor_task.hpp
@@ -102,10 +102,7 @@ class MotorTask {
           _task_registry(aggregator),
           _x_controller(x_ctrl),
           _z_controller(z_ctrl),
-          _l_controller(l_ctrl),
-          _debounce_timer(
-              "DB Timer", [ThisPtr = this] { ThisPtr->reset_debounce(); },
-              DEBOUNCE_MS) {}
+          _l_controller(l_ctrl) {}
     MotorTask(const MotorTask& other) = delete;
     auto operator=(const MotorTask& other) -> MotorTask& = delete;
     MotorTask(MotorTask&& other) noexcept = delete;
@@ -431,42 +428,6 @@ class MotorTask {
         _x_controller.set_diag0_irq(m.enable);
     }
 
-    auto reset_debounce() -> void { _debounce_timer.stop(); }
-
-    template <MotorControlPolicy Policy>
-    auto visit_message(const messages::GPIOInterruptMessage& m, Policy& policy)
-        -> void {
-        // Debounce
-        if (_debounce_timer.is_running()) {
-            return;
-        }
-        _debounce_timer.start();
-
-        auto triggered = false;
-        if (policy.is_diag0_pin(m.pin)) {
-            policy.sleep_ms(DEBOUNCE_SLEEP_MS);
-            triggered = policy.check_diag0();
-        } else if (policy.is_estop_pin(m.pin)) {
-            policy.sleep_ms(DEBOUNCE_SLEEP_MS);
-            triggered = policy.check_estop();
-        } else {
-            // don't care about other interrupts
-            return;
-        }
-
-        // Set status bars
-        auto color = triggered ? StatusBarColor::Red : StatusBarColor::Green;
-        auto pattern =
-            triggered ? StatusBarPattern::Flash : StatusBarPattern::Static;
-        auto message = messages::SetStatusBarStateMessage{
-            .color = color,
-            .pattern = pattern,
-            .duration = LED_ERROR_DURATION_MS,
-            .reps = LED_ERROR_REPS};
-        static_cast<void>(
-            _task_registry->send_to_address(message, Queues::UIAddress));
-    }
-
     /**
      * @brief Move the motor to the limit switch; apply fast moves to XZ motors
      * whenever possible.
@@ -516,7 +477,6 @@ class MotorTask {
     Controller& _z_controller;
     Controller& _l_controller;
     bool _initialized{false};
-    FreeRTOSTimer _debounce_timer;
 
     MotorState _x_state{
         .lms_config = {.mm_per_rev = Defaults::X::MM_PER_REV,

--- a/stm32-modules/include/flex-stacker/flex-stacker/tof_sensor_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/tof_sensor_task.hpp
@@ -106,10 +106,6 @@ class TOFSensorTask {
                 sensor.mode = sensor.driver.get_sensor_mode(sensor_id);
             }
             _initialized = _tof_sensor_x.ok && _tof_sensor_z.ok;
-            auto message = messages::SetStatusBarStateMessage{
-                .color = _initialized ? Green : Red, .pattern = Static};
-            static_cast<void>(
-                _task_registry->send_to_address(message, Queues::UIAddress));
         }
 
         auto message = Message(std::monostate());

--- a/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
+++ b/stm32-modules/include/flex-stacker/flex-stacker/ui_task.hpp
@@ -329,12 +329,9 @@ class UITask {
                 break;
             }
         }
-        if (m.from_host) {
-            // Only send ack if this was requested by the host
-            static_cast<void>(_task_registry->send_to_address(
-                messages::AcknowledgePrevious{.responding_to_id = m.id},
-                Queues::HostCommsAddress));
-        }
+        static_cast<void>(_task_registry->send_to_address(
+            messages::AcknowledgePrevious{.responding_to_id = m.id},
+            Queues::HostCommsAddress));
     }
 
     /**


### PR DESCRIPTION
Since the stacker status LEDs needs to match the FLEX robot status bar, we should let the host take care of controlling the LEDs. This PR removes the ability of other tasks to update the UI task by sending `SetStatusBarStateMessage`.

One improvement we should consider implementing in the future is to make use of RTOS task notifications to block the UI task until all the other tasks have finish initializing. 