### PR TITLE
fix(thermocycler): clear cache after motor-related errors

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -268,11 +268,7 @@ class HostCommsTask {
         std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_message(const messages::ErrorMessage& msg, InputIt tx_into,
                        InputLimit tx_limit) -> InputIt {
-        // stall detected, clear the message cache.
-        if ((msg.code == errors::ErrorCode::MOTOR_STALL_DETECTED) ||
-            (msg.code == errors::ErrorCode::ESTOP_TRIGGERED)) {
-            ack_only_cache.clear();
-        }
+        ack_only_cache.clear();
         return errors::write_into_async(tx_into, tx_limit, msg.code);
     }
 

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -268,6 +268,11 @@ class HostCommsTask {
         std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_message(const messages::ErrorMessage& msg, InputIt tx_into,
                        InputLimit tx_limit) -> InputIt {
+        // stall detected, clear the message cache.
+        if ((msg.code == errors::ErrorCode::MOTOR_STALL_DETECTED) ||
+            (msg.code == errors::ErrorCode::ESTOP_TRIGGERED)) {
+            ack_only_cache.clear();
+        }
         return errors::write_into_async(tx_into, tx_limit, msg.code);
     }
 


### PR DESCRIPTION
## Overview
On the thermocycler, not clearing the message cache after errors can cause weird behavior on subsequent protocol runs, unless you power cycle the module. This can be fixed by clearing the cache after motor-related errors.