### PR TITLE
feat(thermocycler): check lid status again after extending seal

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -982,7 +982,6 @@ class MotorTask {
         if (policy.lid_read_closed_switch()) {
             return start_latch_release_overdrive(response_id, policy);
         }
-
         // Update velocity for this movement
         std::ignore = policy.lid_stepper_set_rpm(
             LidStepperState::LID_DEFAULT_VELOCITY_RPM);

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -979,6 +979,10 @@ class MotorTask {
         policy.lid_solenoid_engage();
         // If the move is starting at the bottom of the lid's axis,
         // overdrive the lid first to release the solenoid latch
+        if (policy.lid_read_closed_switch()) {
+            return start_latch_release_overdrive(response_id, policy);
+        }
+
         // Update velocity for this movement
         std::ignore = policy.lid_stepper_set_rpm(
             LidStepperState::LID_DEFAULT_VELOCITY_RPM);

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1147,8 +1147,9 @@ class MotorTask {
                 // if the lid has been opened by extending the seal, overwrite
                 // the error status
                 if (!policy.lid_read_closed_switch()) {
-                    // if error is none, overwrite it, otherwise leave the original error
-                    if (error == errors:ErrorCode::NO_ERROR) {
+                    // if error is none, overwrite it, otherwise leave the
+                    // original error
+                    if (error == errors : ErrorCode::NO_ERROR) {
                         error = errors::ErrorCode::UNEXPECTED_LID_STATE;
                     }
                 }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1149,7 +1149,7 @@ class MotorTask {
                 if (!policy.lid_read_closed_switch()) {
                     // if error is none, overwrite it, otherwise leave the
                     // original error
-                    if (error == errors : ErrorCode::NO_ERROR) {
+                    if (error == errors::ErrorCode::NO_ERROR) {
                         error = errors::ErrorCode::UNEXPECTED_LID_STATE;
                     }
                 }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1144,6 +1144,11 @@ class MotorTask {
                 error = start_seal_movement(
                     SealStepperState::SWITCH_BACKOFF_MICROSTEPS_RETRACT, false,
                     policy);
+                // if the lid has been opened by extending the seal, overwrite
+                // the error status
+                if (!policy.lid_read_closed_switch()) {
+                    error |= errors::ErrorCode::UNEXPECTED_LID_STATE;
+                }
                 state_for_system_task =
                     messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING;
                 break;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1147,7 +1147,10 @@ class MotorTask {
                 // if the lid has been opened by extending the seal, overwrite
                 // the error status
                 if (!policy.lid_read_closed_switch()) {
-                    error |= errors::ErrorCode::UNEXPECTED_LID_STATE;
+                    // if error is none, overwrite it, otherwise leave the original error
+                    if (error == errors:ErrorCode::NO_ERROR) {
+                        error = errors::ErrorCode::UNEXPECTED_LID_STATE;
+                    }
                 }
                 state_for_system_task =
                     messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -224,6 +224,7 @@ struct LidState {
         CLOSING_EXTEND_SEAL_BACKOFF,  /**< Retract seal to ease off of the
                                            limit switch.*/
         PLATE_LIFTING, /**< Lid is walking through its state machine.*/
+        LID_CLOSED_SEQUENCE_FINISHED, /**< Lid is closed and plate is extended.*/
     };
     // Current status of the lid. Declared atomic because
     // this flag is set & cleared by both the actual task context
@@ -606,6 +607,7 @@ class MotorTask {
     auto visit_message(const messages::CloseLidMessage& msg, Policy& policy)
         -> void {
         auto error = start_lid_close(msg.id, policy);
+
 
         if (error != errors::ErrorCode::NO_ERROR) {
             auto response = messages::AcknowledgePrevious{
@@ -1088,6 +1090,13 @@ class MotorTask {
                 state_for_system_task =
                     messages::UpdateMotorState::MotorState::IDLE;
                 break;
+            case LidState::Status::LID_CLOSED_SEQUENCE_FINISHED:
+                if (!policy.lid_read_closed_switch()) {
+                    error = errors::ErrorCode::UNEXPECTED_LID_STATE;
+                }
+                else {
+                    handle_lid_state_enter(LidState::Status::IDLE, policy);
+                }
             case LidState::Status::OPENING_RETRACT_SEAL:
                 // The seal stepper is retracted to the limit switch
                 error = start_seal_movement(
@@ -1144,15 +1153,6 @@ class MotorTask {
                 error = start_seal_movement(
                     SealStepperState::SWITCH_BACKOFF_MICROSTEPS_RETRACT, false,
                     policy);
-                // if the lid has been opened by extending the seal, overwrite
-                // the error status
-                if (!policy.lid_read_closed_switch()) {
-                    // if error is none, overwrite it, otherwise leave the
-                    // original error
-                    if (error == errors::ErrorCode::NO_ERROR) {
-                        error = errors::ErrorCode::UNEXPECTED_LID_STATE;
-                    }
-                }
                 state_for_system_task =
                     messages::UpdateMotorState::MotorState::OPENING_OR_CLOSING;
                 break;
@@ -1258,13 +1258,15 @@ class MotorTask {
             }
             case LidState::Status::CLOSING_EXTEND_SEAL_BACKOFF: {
                 _seal_position = motor_util::SealStepper::Status::ENGAGED;
-                error = handle_lid_state_enter(LidState::Status::IDLE, policy);
+                error = handle_lid_state_enter(LidState::Status::LID_CLOSED_SEQUENCE_FINISHED, policy);
                 break;
             }
             case LidState::Status::PLATE_LIFTING: {
                 error = handle_lid_state_enter(LidState::Status::IDLE, policy);
                 break;
             }
+            default:
+                break;
         }
         if (error != errors::ErrorCode::NO_ERROR) {
             // Clear the lid status no matter what
@@ -1328,10 +1330,6 @@ class MotorTask {
                     motor_util::LidStepper::Position::CLOSED;
                 // The overall lid state machine can advance now
                 error = handle_lid_state_end(policy);
-                // if the lid isn't actually closed, overwrite error status
-                if (!policy.lid_read_closed_switch()) {
-                    error = errors::ErrorCode::UNEXPECTED_LID_STATE;
-                }
                 break;
             case LidStepperState::Status::LIFT_NUDGE:
                 policy.lid_stepper_start(

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -224,7 +224,6 @@ struct LidState {
         CLOSING_EXTEND_SEAL_BACKOFF,  /**< Retract seal to ease off of the
                                            limit switch.*/
         PLATE_LIFTING, /**< Lid is walking through its state machine.*/
-        LID_CLOSED_SEQUENCE_FINISHED, /**< Lid is closed and plate is extended.*/
     };
     // Current status of the lid. Declared atomic because
     // this flag is set & cleared by both the actual task context
@@ -608,7 +607,6 @@ class MotorTask {
         -> void {
         auto error = start_lid_close(msg.id, policy);
 
-
         if (error != errors::ErrorCode::NO_ERROR) {
             auto response = messages::AcknowledgePrevious{
                 .responding_to_id = msg.id, .with_error = error};
@@ -981,9 +979,6 @@ class MotorTask {
         policy.lid_solenoid_engage();
         // If the move is starting at the bottom of the lid's axis,
         // overdrive the lid first to release the solenoid latch
-        if (policy.lid_read_closed_switch()) {
-            return start_latch_release_overdrive(response_id, policy);
-        }
         // Update velocity for this movement
         std::ignore = policy.lid_stepper_set_rpm(
             LidStepperState::LID_DEFAULT_VELOCITY_RPM);
@@ -1090,13 +1085,6 @@ class MotorTask {
                 state_for_system_task =
                     messages::UpdateMotorState::MotorState::IDLE;
                 break;
-            case LidState::Status::LID_CLOSED_SEQUENCE_FINISHED:
-                if (!policy.lid_read_closed_switch()) {
-                    error = errors::ErrorCode::UNEXPECTED_LID_STATE;
-                }
-                else {
-                    handle_lid_state_enter(LidState::Status::IDLE, policy);
-                }
             case LidState::Status::OPENING_RETRACT_SEAL:
                 // The seal stepper is retracted to the limit switch
                 error = start_seal_movement(
@@ -1253,20 +1241,23 @@ class MotorTask {
                     shared_switches
                         ? LidState::Status::CLOSING_EXTEND_SEAL_BACKOFF
                         : LidState::Status::IDLE;
-                error = handle_lid_state_enter(next_state, policy);
+                if (!policy.lid_read_closed_switch()) {
+                    error = errors::ErrorCode::UNEXPECTED_LID_STATE;
+                } else {
+                    error = handle_lid_state_enter(next_state, policy);
+                }
+
                 break;
             }
             case LidState::Status::CLOSING_EXTEND_SEAL_BACKOFF: {
                 _seal_position = motor_util::SealStepper::Status::ENGAGED;
-                error = handle_lid_state_enter(LidState::Status::LID_CLOSED_SEQUENCE_FINISHED, policy);
+                error = handle_lid_state_enter(LidState::Status::IDLE, policy);
                 break;
             }
             case LidState::Status::PLATE_LIFTING: {
                 error = handle_lid_state_enter(LidState::Status::IDLE, policy);
                 break;
             }
-            default:
-                break;
         }
         if (error != errors::ErrorCode::NO_ERROR) {
             // Clear the lid status no matter what

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
@@ -633,7 +633,6 @@ struct MotorStep {
     std::optional<double> lid_rpm = std::nullopt;
     // If true, expect an ack in the host comms task
     std::optional<messages::AcknowledgePrevious> ack = std::nullopt;
-    std::optional<int> debug_id = std::nullopt;
 };
 
 /**
@@ -662,9 +661,6 @@ void test_motor_state_machine(std::shared_ptr<TaskBuilder> tasks,
             }
             if (step.lid_angle_decreased) {
                 THEN("the lid motor closed") {
-                    if (motor_policy.get_angle() >= lid_angle_before) {
-                        printf("step id = %u\n", step.debug_id);
-                    }
                     REQUIRE(motor_policy.get_angle() < lid_angle_before);
                 }
             }
@@ -692,9 +688,6 @@ void test_motor_state_machine(std::shared_ptr<TaskBuilder> tasks,
                             msg));
                     auto response =
                         std::get<messages::AcknowledgePrevious>(msg);
-                    if (response.responding_to_id != ack.responding_to_id) {
-                        printf("astep id = %u", step.debug_id);
-                    }
                     REQUIRE(response.responding_to_id == ack.responding_to_id);
                     REQUIRE(response.with_error == ack.with_error);
                 }
@@ -745,8 +738,7 @@ SCENARIO("motor task lid state machine") {
                  .lid_angle_decreased = true,
                  .lid_overdrive = true,
                  .lid_rpm =
-                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM,
-                .debug_id = 1},
+                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
                 // Fourth step fully opening lid
                 {.msg = messages::LidStepperComplete(),
                  .lid_angle_increased = true,
@@ -907,35 +899,23 @@ SCENARIO("motor task lid state machine") {
                 {.msg = messages::LidStepperComplete(),
                  .lid_angle_decreased = true,
                  .lid_overdrive = true},
-//                // Now extend seal to switch
-//                {.msg = messages::LidStepperComplete(),
-//                 .seal_on = true,
-//                 .seal_direction = false,
-//                 .seal_switch_armed = true},
-//                // Retract seal from switch
-//                {.msg =
-//                     messages::SealStepperComplete{
-//                         .reason = messages::SealStepperComplete::
-//                             CompletionReason::LIMIT},
-//                 .seal_on = true,
-//                 .seal_direction = true,
-//                 .seal_switch_armed = false},
             };
             AND_WHEN("the closed switch is triggered") {
                 motor_policy.set_lid_closed_switch(true);
                 // Now extend seal to switch
                 steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
-                 .seal_on = true,
-                 .seal_direction = false,
-                 .seal_switch_armed = true});
+                                          .seal_on = true,
+                                          .seal_direction = false,
+                                          .seal_switch_armed = true});
                 // Retract seal from switch
-                steps.push_back(MotorStep{.msg =
-                     messages::SealStepperComplete{
-                         .reason = messages::SealStepperComplete::
-                             CompletionReason::LIMIT},
-                 .seal_on = true,
-                 .seal_direction = true,
-                 .seal_switch_armed = false});
+                steps.push_back(
+                    MotorStep{.msg =
+                                  messages::SealStepperComplete{
+                                      .reason = messages::SealStepperComplete::
+                                          CompletionReason::LIMIT},
+                              .seal_on = true,
+                              .seal_direction = true,
+                              .seal_switch_armed = false});
                 steps.push_back(
                     // an ack with error code NO_ERROR should follow
                     MotorStep{.msg =
@@ -948,39 +928,26 @@ SCENARIO("motor task lid state machine") {
                                   .with_error = errors::ErrorCode::NO_ERROR}});
                 test_motor_state_machine(tasks, steps);
             }
-            AND_WHEN("the closed switch is not triggered") { // failure here
+            AND_WHEN("the closed switch is not triggered") {
                 motor_policy.set_lid_closed_switch(false);
                 // Now extend seal to switch
-                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
-                 .seal_on = true,
-                 .seal_direction = false,
-                 .seal_switch_armed = true,
+                steps.push_back(MotorStep{
+                    .msg = messages::LidStepperComplete(),
+                    .seal_on = true,
+                    .seal_direction = false,
+                    .seal_switch_armed = true,
                 });
                 // Retract seal from switch
-                steps.push_back(MotorStep{.msg =
-                     messages::SealStepperComplete{
-                         .reason = messages::SealStepperComplete::
-                             CompletionReason::DONE},
-                 .motor_state = MotorStep::MotorState::IDLE,
-                 .ack = messages::AcknowledgePrevious{
-                     .responding_to_id = 123,
-                     .with_error =
-                         errors::ErrorCode::UNEXPECTED_LID_STATE},
-                .debug_id = 2}
-                );
-//                steps.push_back(
-////                     an ack with error code UNEXPECTED_LID_STATE should follow
-//                    MotorStep{
-//                        .msg =
-//                            messages::SealStepperComplete{
-//                                .reason = messages::SealStepperComplete::
-//                                    CompletionReason::DONE},
-//                        .motor_state = MotorStep::MotorState::IDLE,
-//                        .ack = messages::AcknowledgePrevious{
-//                            .responding_to_id = 123,
-//                            .with_error =
-//                                errors::ErrorCode::UNEXPECTED_LID_STATE},
-//                        .debug_id = 3});
+                steps.push_back(MotorStep{
+                    .msg =
+                        messages::SealStepperComplete{
+                            .reason = messages::SealStepperComplete::
+                                CompletionReason::DONE},
+                    .motor_state = MotorStep::MotorState::IDLE,
+                    .ack = messages::AcknowledgePrevious{
+                        .responding_to_id = 123,
+                        .with_error =
+                            errors::ErrorCode::UNEXPECTED_LID_STATE}});
                 test_motor_state_machine(tasks, steps);
             }
         }
@@ -1068,20 +1035,19 @@ SCENARIO("motor task lid state machine") {
                     {.msg = messages::LidStepperComplete(),
                      .seal_on = true,
                      .seal_direction = false,
-                     .seal_switch_armed = true}
-                };
+                     .seal_switch_armed = true}};
                 AND_WHEN("the closed switch is triggered") {
                     motor_policy.set_lid_closed_switch(true);
                     steps.push_back(
                         // Retract seal from switch
-                        MotorStep{.msg =
-                             messages::SealStepperComplete{
-                                 .reason = messages::SealStepperComplete::
-                                     CompletionReason::LIMIT},
-                         .seal_on = true,
-                         .seal_direction = true,
-                         .seal_switch_armed = false}
-                    );
+                        MotorStep{
+                            .msg =
+                                messages::SealStepperComplete{
+                                    .reason = messages::SealStepperComplete::
+                                        CompletionReason::LIMIT},
+                            .seal_on = true,
+                            .seal_direction = true,
+                            .seal_switch_armed = false});
                     steps.push_back(
                         // an ack with error code NO_ERROR should follow
                         MotorStep{
@@ -1095,32 +1061,19 @@ SCENARIO("motor task lid state machine") {
                                 .with_error = errors::ErrorCode::NO_ERROR}});
                     test_motor_state_machine(tasks, steps);
                 }
-                AND_WHEN("the closed switch is not triggered") { // failure here
+                AND_WHEN("the closed switch is not triggered") {
                     motor_policy.set_lid_closed_switch(false);
                     steps.push_back(
                         // Retract seal from switch
-                        MotorStep{.msg =
-                                      messages::SealStepperComplete{
-                                          .reason = messages::SealStepperComplete::
-                                              CompletionReason::LIMIT},
-                                  .ack = messages::AcknowledgePrevious{
-                                      .responding_to_id = 123,
-                                      .with_error =
-                                          errors::ErrorCode::UNEXPECTED_LID_STATE}}
-                    );
-//                    steps.push_back(
-//                        // an ack with error code UNEXPECTED_LID_STATE should
-//                        // follow
-//                        MotorStep{
-//                            .msg =
-//                                messages::SealStepperComplete{
-//                                    .reason = messages::SealStepperComplete::
-//                                        CompletionReason::DONE},
-//                            .motor_state = MotorStep::MotorState::IDLE,
-//                            .ack = messages::AcknowledgePrevious{
-//                                .responding_to_id = 0,
-//                                .with_error =
-//                                    errors::ErrorCode::UNEXPECTED_LID_STATE}});
+                        MotorStep{
+                            .msg =
+                                messages::SealStepperComplete{
+                                    .reason = messages::SealStepperComplete::
+                                        CompletionReason::LIMIT},
+                            .ack = messages::AcknowledgePrevious{
+                                .responding_to_id = 123,
+                                .with_error =
+                                    errors::ErrorCode::UNEXPECTED_LID_STATE}});
                     test_motor_state_machine(tasks, steps);
                 }
             }
@@ -1299,27 +1252,15 @@ SCENARIO("motor task lid state machine") {
                                           .seal_direction = false,
                                           .seal_switch_armed = true});
                 // Retract seal from switch
-                steps.push_back(
-                    MotorStep{.msg =
-                                  messages::SealStepperComplete{
-                                      .reason = messages::SealStepperComplete::
-                                          CompletionReason::LIMIT},
-                              .ack = messages::AcknowledgePrevious{
-                                  .responding_to_id = 123,
-                                  .with_error = errors::ErrorCode::UNEXPECTED_LID_STATE}
-                    });
-//                steps.push_back(
-//                    // an ack with error code UNEXPECTED_LID_STATE should follow
-//                    MotorStep{
-//                        .msg =
-//                            messages::SealStepperComplete{
-//                                .reason = messages::SealStepperComplete::
-//                                    CompletionReason::DONE},
-//                        .ack = messages::AcknowledgePrevious{
-//                            .responding_to_id = 0,
-//                            .with_error =
-//                                errors::ErrorCode::UNEXPECTED_LID_STATE}
-//                    });
+                steps.push_back(MotorStep{
+                    .msg =
+                        messages::SealStepperComplete{
+                            .reason = messages::SealStepperComplete::
+                                CompletionReason::LIMIT},
+                    .ack = messages::AcknowledgePrevious{
+                        .responding_to_id = 123,
+                        .with_error =
+                            errors::ErrorCode::UNEXPECTED_LID_STATE}});
                 test_motor_state_machine(tasks, steps);
             }
         }

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
@@ -1200,7 +1200,8 @@ SCENARIO("motor task lid state machine") {
                  .lid_angle_decreased = true,
                  .lid_overdrive = false,
                  .lid_rpm =
-                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM}};
+                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM}
+            };
             test_motor_state_machine(tasks, steps);
             steps.clear();
             AND_WHEN("the closed switch is triggered") {

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
@@ -1200,8 +1200,7 @@ SCENARIO("motor task lid state machine") {
                  .lid_angle_decreased = true,
                  .lid_overdrive = false,
                  .lid_rpm =
-                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM}
-            };
+                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM}};
             test_motor_state_machine(tasks, steps);
             steps.clear();
             AND_WHEN("the closed switch is triggered") {

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
@@ -633,6 +633,7 @@ struct MotorStep {
     std::optional<double> lid_rpm = std::nullopt;
     // If true, expect an ack in the host comms task
     std::optional<messages::AcknowledgePrevious> ack = std::nullopt;
+    std::optional<int> debug_id = std::nullopt;
 };
 
 /**
@@ -661,6 +662,9 @@ void test_motor_state_machine(std::shared_ptr<TaskBuilder> tasks,
             }
             if (step.lid_angle_decreased) {
                 THEN("the lid motor closed") {
+                    if (motor_policy.get_angle() >= lid_angle_before) {
+                        printf("step id = %u\n", step.debug_id);
+                    }
                     REQUIRE(motor_policy.get_angle() < lid_angle_before);
                 }
             }
@@ -688,6 +692,9 @@ void test_motor_state_machine(std::shared_ptr<TaskBuilder> tasks,
                             msg));
                     auto response =
                         std::get<messages::AcknowledgePrevious>(msg);
+                    if (response.responding_to_id != ack.responding_to_id) {
+                        printf("astep id = %u", step.debug_id);
+                    }
                     REQUIRE(response.responding_to_id == ack.responding_to_id);
                     REQUIRE(response.with_error == ack.with_error);
                 }
@@ -738,7 +745,8 @@ SCENARIO("motor task lid state machine") {
                  .lid_angle_decreased = true,
                  .lid_overdrive = true,
                  .lid_rpm =
-                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
+                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM,
+                .debug_id = 1},
                 // Fourth step fully opening lid
                 {.msg = messages::LidStepperComplete(),
                  .lid_angle_increased = true,
@@ -899,22 +907,35 @@ SCENARIO("motor task lid state machine") {
                 {.msg = messages::LidStepperComplete(),
                  .lid_angle_decreased = true,
                  .lid_overdrive = true},
+//                // Now extend seal to switch
+//                {.msg = messages::LidStepperComplete(),
+//                 .seal_on = true,
+//                 .seal_direction = false,
+//                 .seal_switch_armed = true},
+//                // Retract seal from switch
+//                {.msg =
+//                     messages::SealStepperComplete{
+//                         .reason = messages::SealStepperComplete::
+//                             CompletionReason::LIMIT},
+//                 .seal_on = true,
+//                 .seal_direction = true,
+//                 .seal_switch_armed = false},
+            };
+            AND_WHEN("the closed switch is triggered") {
+                motor_policy.set_lid_closed_switch(true);
                 // Now extend seal to switch
-                {.msg = messages::LidStepperComplete(),
+                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
                  .seal_on = true,
                  .seal_direction = false,
-                 .seal_switch_armed = true},
+                 .seal_switch_armed = true});
                 // Retract seal from switch
-                {.msg =
+                steps.push_back(MotorStep{.msg =
                      messages::SealStepperComplete{
                          .reason = messages::SealStepperComplete::
                              CompletionReason::LIMIT},
                  .seal_on = true,
                  .seal_direction = true,
-                 .seal_switch_armed = false},
-            };
-            AND_WHEN("the closed switch is triggered") {
-                motor_policy.set_lid_closed_switch(true);
+                 .seal_switch_armed = false});
                 steps.push_back(
                     // an ack with error code NO_ERROR should follow
                     MotorStep{.msg =
@@ -927,20 +948,39 @@ SCENARIO("motor task lid state machine") {
                                   .with_error = errors::ErrorCode::NO_ERROR}});
                 test_motor_state_machine(tasks, steps);
             }
-            AND_WHEN("the closed switch is not triggered") {
+            AND_WHEN("the closed switch is not triggered") { // failure here
                 motor_policy.set_lid_closed_switch(false);
-                steps.push_back(
-                    // an ack with error code UNEXPECTED_LID_STATE should follow
-                    MotorStep{
-                        .msg =
-                            messages::SealStepperComplete{
-                                .reason = messages::SealStepperComplete::
-                                    CompletionReason::DONE},
-                        .motor_state = MotorStep::MotorState::IDLE,
-                        .ack = messages::AcknowledgePrevious{
-                            .responding_to_id = 0,
-                            .with_error =
-                                errors::ErrorCode::UNEXPECTED_LID_STATE}});
+                // Now extend seal to switch
+                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
+                 .seal_on = true,
+                 .seal_direction = false,
+                 .seal_switch_armed = true,
+                });
+                // Retract seal from switch
+                steps.push_back(MotorStep{.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::DONE},
+                 .motor_state = MotorStep::MotorState::IDLE,
+                 .ack = messages::AcknowledgePrevious{
+                     .responding_to_id = 123,
+                     .with_error =
+                         errors::ErrorCode::UNEXPECTED_LID_STATE},
+                .debug_id = 2}
+                );
+//                steps.push_back(
+////                     an ack with error code UNEXPECTED_LID_STATE should follow
+//                    MotorStep{
+//                        .msg =
+//                            messages::SealStepperComplete{
+//                                .reason = messages::SealStepperComplete::
+//                                    CompletionReason::DONE},
+//                        .motor_state = MotorStep::MotorState::IDLE,
+//                        .ack = messages::AcknowledgePrevious{
+//                            .responding_to_id = 123,
+//                            .with_error =
+//                                errors::ErrorCode::UNEXPECTED_LID_STATE},
+//                        .debug_id = 3});
                 test_motor_state_machine(tasks, steps);
             }
         }
@@ -1028,18 +1068,20 @@ SCENARIO("motor task lid state machine") {
                     {.msg = messages::LidStepperComplete(),
                      .seal_on = true,
                      .seal_direction = false,
-                     .seal_switch_armed = true},
-                    // Retract seal from switch
-                    {.msg =
-                         messages::SealStepperComplete{
-                             .reason = messages::SealStepperComplete::
-                                 CompletionReason::LIMIT},
-                     .seal_on = true,
-                     .seal_direction = true,
-                     .seal_switch_armed = false},
+                     .seal_switch_armed = true}
                 };
                 AND_WHEN("the closed switch is triggered") {
                     motor_policy.set_lid_closed_switch(true);
+                    steps.push_back(
+                        // Retract seal from switch
+                        MotorStep{.msg =
+                             messages::SealStepperComplete{
+                                 .reason = messages::SealStepperComplete::
+                                     CompletionReason::LIMIT},
+                         .seal_on = true,
+                         .seal_direction = true,
+                         .seal_switch_armed = false}
+                    );
                     steps.push_back(
                         // an ack with error code NO_ERROR should follow
                         MotorStep{
@@ -1053,21 +1095,32 @@ SCENARIO("motor task lid state machine") {
                                 .with_error = errors::ErrorCode::NO_ERROR}});
                     test_motor_state_machine(tasks, steps);
                 }
-                AND_WHEN("the closed switch is not triggered") {
+                AND_WHEN("the closed switch is not triggered") { // failure here
                     motor_policy.set_lid_closed_switch(false);
                     steps.push_back(
-                        // an ack with error code UNEXPECTED_LID_STATE should
-                        // follow
-                        MotorStep{
-                            .msg =
-                                messages::SealStepperComplete{
-                                    .reason = messages::SealStepperComplete::
-                                        CompletionReason::DONE},
-                            .motor_state = MotorStep::MotorState::IDLE,
-                            .ack = messages::AcknowledgePrevious{
-                                .responding_to_id = 0,
-                                .with_error =
-                                    errors::ErrorCode::UNEXPECTED_LID_STATE}});
+                        // Retract seal from switch
+                        MotorStep{.msg =
+                                      messages::SealStepperComplete{
+                                          .reason = messages::SealStepperComplete::
+                                              CompletionReason::LIMIT},
+                                  .ack = messages::AcknowledgePrevious{
+                                      .responding_to_id = 123,
+                                      .with_error =
+                                          errors::ErrorCode::UNEXPECTED_LID_STATE}}
+                    );
+//                    steps.push_back(
+//                        // an ack with error code UNEXPECTED_LID_STATE should
+//                        // follow
+//                        MotorStep{
+//                            .msg =
+//                                messages::SealStepperComplete{
+//                                    .reason = messages::SealStepperComplete::
+//                                        CompletionReason::DONE},
+//                            .motor_state = MotorStep::MotorState::IDLE,
+//                            .ack = messages::AcknowledgePrevious{
+//                                .responding_to_id = 0,
+//                                .with_error =
+//                                    errors::ErrorCode::UNEXPECTED_LID_STATE}});
                     test_motor_state_machine(tasks, steps);
                 }
             }
@@ -1129,7 +1182,7 @@ SCENARIO("motor task lid state machine") {
                                         CompletionReason::DONE},
                             .motor_state = MotorStep::MotorState::IDLE,
                             .ack = messages::AcknowledgePrevious{
-                                .responding_to_id = 0,
+                                .responding_to_id = 123,
                                 .with_error =
                                     errors::ErrorCode::UNEXPECTED_LID_STATE}});
                     test_motor_state_machine(tasks, steps);
@@ -1251,20 +1304,22 @@ SCENARIO("motor task lid state machine") {
                                   messages::SealStepperComplete{
                                       .reason = messages::SealStepperComplete::
                                           CompletionReason::LIMIT},
-                              .seal_on = true,
-                              .seal_direction = true,
-                              .seal_switch_armed = false});
-                steps.push_back(
-                    // an ack with error code UNEXPECTED_LID_STATE should follow
-                    MotorStep{
-                        .msg =
-                            messages::SealStepperComplete{
-                                .reason = messages::SealStepperComplete::
-                                    CompletionReason::DONE},
-                        .ack = messages::AcknowledgePrevious{
-                            .responding_to_id = 0,
-                            .with_error =
-                                errors::ErrorCode::UNEXPECTED_LID_STATE}});
+                              .ack = messages::AcknowledgePrevious{
+                                  .responding_to_id = 123,
+                                  .with_error = errors::ErrorCode::UNEXPECTED_LID_STATE}
+                    });
+//                steps.push_back(
+//                    // an ack with error code UNEXPECTED_LID_STATE should follow
+//                    MotorStep{
+//                        .msg =
+//                            messages::SealStepperComplete{
+//                                .reason = messages::SealStepperComplete::
+//                                    CompletionReason::DONE},
+//                        .ack = messages::AcknowledgePrevious{
+//                            .responding_to_id = 0,
+//                            .with_error =
+//                                errors::ErrorCode::UNEXPECTED_LID_STATE}
+//                    });
                 test_motor_state_machine(tasks, steps);
             }
         }


### PR DESCRIPTION
## Overview
In most of the remaining cases where the thermocycler lid is opened unexpectedly, it's caused by the seal pushing against the latch when the lid isn't really all the way closed. We can catch this and throw an error by checking the lid status one more time after the seal is extended.