### PR TITLE
fix(flex-stacker): add atomics + remove the UNEXPECTED_LIMIT_SWITCH error from the motor interrupt.

### DIFF
--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
@@ -415,7 +415,9 @@ void hw_enable_lim_switch_irq(MotorID motor_id, bool direction) {
         return;
     }
     stepper_hardware_t motor = get_motor(motor_id);
-    direction ? HAL_NVIC_EnableIRQ(motor.limit_switch_plus_it) : HAL_NVIC_EnableIRQ(motor.limit_switch_minus_it);
+    IRQn_Type limit_switch_it = direction ? motor.limit_switch_plus_it : motor.limit_switch_minus_it;
+    NVIC_ClearPendingIRQ(limit_switch_it);
+    HAL_NVIC_EnableIRQ(limit_switch_it);
 }
 
 void hw_disable_lim_switch_irq(MotorID motor_id, bool direction) {
@@ -424,7 +426,9 @@ void hw_disable_lim_switch_irq(MotorID motor_id, bool direction) {
         return;
     }
     stepper_hardware_t motor = get_motor(motor_id);
-    direction ? HAL_NVIC_DisableIRQ(motor.limit_switch_plus_it) : HAL_NVIC_DisableIRQ(motor.limit_switch_minus_it);
+    IRQn_Type limit_switch_it = direction ? motor.limit_switch_plus_it : motor.limit_switch_minus_it;
+    HAL_NVIC_DisableIRQ(limit_switch_it);
+    NVIC_ClearPendingIRQ(limit_switch_it);
 }
 
 bool hw_read_limit_switch(MotorID motor_id, bool direction) {
@@ -461,9 +465,12 @@ bool hw_read_diag0(void) {
 }
 
 void hw_set_diag0_irq(bool enable) {
-    enable ?
-        HAL_NVIC_EnableIRQ(EXTI15_10_IRQn) :
+    if (enable) {
+        HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
+    } else {
         HAL_NVIC_DisableIRQ(EXTI15_10_IRQn);
+        NVIC_ClearPendingIRQ(EXTI15_10_IRQn);
+    }
 }
 
 bool hw_is_diag0_pin(uint16_t pin) {

--- a/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.c
+++ b/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.c
@@ -134,15 +134,21 @@ void EXTI15_10_IRQHandler(void) {
     }
 }
 
+//    // Check that the pin is actually set - the interrupt doesn't do this for us,
+//    // and other pins trigger the same interrupt vector.
+//    if(__HAL_GPIO_EXTI_GET_IT(ADC_ALERT_PIN) != 0x00u) {
+
+
 void EXTI9_5_IRQHandler(void)
 {
     // Estop interrupt
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_6)) {
+        __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_6);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_6);
     }
     // Latch held limit switch interrupt
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_5)) {
-        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_5);
+        __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_5);
         if (lim_switch_callback) {
             lim_switch_callback(MOTOR_L);
         }
@@ -154,7 +160,7 @@ void EXTI9_5_IRQHandler(void)
 void EXTI0_IRQHandler(void)
 {
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_0)) {
-        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_0);
+        __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_0);
         if (lim_switch_callback) {
             lim_switch_callback(MOTOR_Z);
         }
@@ -165,7 +171,7 @@ void EXTI0_IRQHandler(void)
 void EXTI1_IRQHandler(void)
 {
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_1)) {
-        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_1);
+        __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_1);
         if (lim_switch_callback) {
             lim_switch_callback(MOTOR_X);
         }
@@ -176,7 +182,7 @@ void EXTI1_IRQHandler(void)
 void EXTI2_IRQHandler(void)
 {
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_2)) {
-        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_2);
+        __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_2);
         if (lim_switch_callback) {
             lim_switch_callback(MOTOR_X);
         }
@@ -187,7 +193,7 @@ void EXTI2_IRQHandler(void)
 void EXTI3_IRQHandler(void)
 {
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_3)) {
-        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_3);
+        __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_3);
         if (lim_switch_callback) {
             lim_switch_callback(MOTOR_Z);
         }

--- a/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.c
+++ b/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.c
@@ -134,11 +134,6 @@ void EXTI15_10_IRQHandler(void) {
     }
 }
 
-//    // Check that the pin is actually set - the interrupt doesn't do this for us,
-//    // and other pins trigger the same interrupt vector.
-//    if(__HAL_GPIO_EXTI_GET_IT(ADC_ALERT_PIN) != 0x00u) {
-
-
 void EXTI9_5_IRQHandler(void)
 {
     // Estop interrupt

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -30,7 +30,6 @@ class MotorInterruptController {
     explicit MotorInterruptController(MotorID id, MotorPolicy* policy)
         : _id(id),
           _policy(policy),
-          _initialized(false),
           _profile(TIMER_FREQ, 0, 0, 0, motor_util::MovementType::OpenLoop, 0) {
     }
     MotorInterruptController(MotorInterruptController const&) = delete;
@@ -40,7 +39,7 @@ class MotorInterruptController {
     ~MotorInterruptController() = default;
 
     auto tick() -> bool {
-        if (!_initialized) {
+        if (!_initialized.load()) {
             return false;
         }
         auto ret = _profile.tick();
@@ -50,22 +49,22 @@ class MotorInterruptController {
         if (ret.done || stop_condition_met()) {
             _policy->stop_motor(_id);
             _policy->set_limit_switch_irq(_id, _direction, false);
-            _stop = true;
+            _stop.store(true);
             return true;
         }
         return ret.done;
     }
     auto initialize(MotorPolicy* policy) -> void {
         _policy = policy;
-        _initialized = true;
+        _initialized.store(true);
     }
 
     auto reset() -> void {
-        _stop = false;
-        _error = Error::NO_ERROR;
-        _switch_detected = false;
+        _stop.store(false);
         _policy->set_limit_switch_irq(_id, _direction, false);
         _policy->set_limit_switch_irq(_id, !_direction, false);
+        _switch_detected.store(false);
+        _error = Error::NO_ERROR;
     }
 
     auto start_fixed_movement(uint32_t move_id, bool direction, long steps,
@@ -99,13 +98,13 @@ class MotorInterruptController {
     }
 
     auto stop_movement(Error error, bool disable_motor) -> void {
-        _stop = true;
-        _error = error;
+        _stop.store(true);
         _policy->stop_motor(_id);
         if (disable_motor) {
             _policy->disable_motor(_id);
         }
         _policy->set_limit_switch_irq(_id, _direction, false);
+        _error = error;
     }
 
     auto set_direction(bool direction) -> void {
@@ -119,15 +118,17 @@ class MotorInterruptController {
     }
     [[nodiscard]] auto get_error_code() const -> Error { return _error; }
     auto stop_condition_met() -> bool {
-        if (_stop) {
+        if (_stop.load()) {
             return true;
         }
-        if (_switch_detected) {
+        if (_switch_detected.load()) {
             if (_profile.movement_type() ==
                 motor_util::MovementType::OpenLoop) {
                 return true;
             }
-            _error = Error::UNEXPECTED_LIMIT_SWITCH;
+            // TODO(ba, 2025-05-14): Enable this error once we understand why
+            // the limit switch is triggered during a Fixed movement.
+            //_error = Error::UNEXPECTED_LIMIT_SWITCH;
             return true;
         }
         // this will only error if the limit switch in the move direction
@@ -148,9 +149,9 @@ class MotorInterruptController {
     auto limit_switch_detected() -> void {
         if (_id == MotorID::MOTOR_L) {
             // NOLINTNEXTLINE(readability-simplify-boolean-expr)
-            _switch_detected = _direction ? false : true;
+            _switch_detected.store(!_direction);
         } else {
-            _switch_detected = true;
+            _switch_detected.store(true);
         };
     }
 
@@ -161,13 +162,14 @@ class MotorInterruptController {
   private:
     MotorID _id;
     MotorPolicy* _policy;
-    std::atomic_bool _initialized;
     motor_util::MovementProfile _profile;
     uint32_t _response_id = 0;
     Error _error = Error::NO_ERROR;
     bool _direction = false;
-    bool _stop = true;
-    bool _switch_detected = false;
+    std::atomic_bool _stop = true;
+    std::atomic_bool _initialized = false;
+    ;
+    std::atomic_bool _switch_detected = false;
 };
 
 }  // namespace motor_interrupt_controller

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -168,7 +168,6 @@ class MotorInterruptController {
     bool _direction = false;
     std::atomic_bool _stop = true;
     std::atomic_bool _initialized = false;
-    ;
     std::atomic_bool _switch_detected = false;
 };
 


### PR DESCRIPTION
Sometimes, the limit switch triggers when it's not supposed to, specifically during a Fixed movement, when we raise an UNEXPECTED_LIMIT_SWITCH error. We are not sure why this happens yet and need more time to investigate. For now, let's disable raising this error and use atomics for the variables to prevent OOO and irq issues.

Closes: [RABR-767](https://opentrons.atlassian.net/browse/RABR-767)

TODO:
Look into clearing the pending bit in EXTI, maybe there's a pending irq that triggers.

[RABR-767]: https://opentrons.atlassian.net/browse/RABR-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ