### PR TITLE
fix(flex-stacker): use stall and estop interrupts instead of checking GPIO every motor tick

### DIFF
--- a/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_task.cpp
+++ b/stm32-modules/flex-stacker/firmware/motor_control/freertos_motor_task.cpp
@@ -78,6 +78,12 @@ static auto _top_task = motor_task::MotorTask(
     }
 }
 
+[[nodiscard]] static auto stall_callback_glue() {
+    // L motor does not have a stall detection mechanism
+    x_motor_interrupt.stall_detected();
+    z_motor_interrupt.stall_detected();
+}
+
 auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
     auto* handle = xTaskGetCurrentTaskHandle();
     _queue.provide_handle(handle);
@@ -87,6 +93,7 @@ auto run(tasks::FirmwareTasks::QueueAggregator* aggregator) -> void {
     motor_hardware_init();
     initialize_callbacks(callback_glue);
     initialize_limit_switch_callbacks(lim_sw_callback_glue);
+    initialize_shared_stall_callback(stall_callback_glue);
     auto policy = motor_policy::MotorPolicy();
     while (true) {
         _top_task.run_once(policy);

--- a/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.c
+++ b/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.c
@@ -1,24 +1,25 @@
 /**
-  ******************************************************************************
-  * @file    stm32g4xx_it.c
-  * @brief   Interrupt Service Routines.
-  ******************************************************************************
-  * @attention
-  *
-  * Copyright (c) 2024 STMicroelectronics.
-  * All rights reserved.
-  *
-  * This software is licensed under terms that can be found in the LICENSE file
-  * in the root directory of this software component.
-  * If no LICENSE file comes with this software, it is provided AS-IS.
-  *
-  ******************************************************************************
+ ******************************************************************************
+ * @file    stm32g4xx_it.c
+ * @brief   Interrupt Service Routines.
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2024 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software is licensed under terms that can be found in the LICENSE file
+ * in the root directory of this software component.
+ * If no LICENSE file comes with this software, it is provided AS-IS.
+ *
+ ******************************************************************************
  */
 
 /* Includes ------------------------------------------------------------------*/
-#include "main.h"
 #include "stm32g4xx_it.h"
+
 #include "FreeRTOS.h"
+#include "main.h"
 #include "task.h"
 
 /* External variables --------------------------------------------------------*/
@@ -29,68 +30,56 @@ extern TIM_HandleTypeDef htim20;
 extern TIM_HandleTypeDef htim3;
 extern SPI_HandleTypeDef hspi2;
 
-
 motor_interrupt_callback interrupt_callback = NULL;
 limit_switch_callback lim_switch_callback = NULL;
+shared_interrupt_callback shared_stall_callback = NULL;
 /******************************************************************************/
 /*           Cortex-M4 Processor Interruption and Exception Handlers          */
 /******************************************************************************/
 /**
-  * @brief This function handles Non maskable interrupt.
+ * @brief This function handles Non maskable interrupt.
  */
-void NMI_Handler(void)
-{
-    while (1)
-    {
+void NMI_Handler(void) {
+    while (1) {
     }
 }
 
 /**
-  * @brief This function handles Hard fault interrupt.
+ * @brief This function handles Hard fault interrupt.
  */
-void HardFault_Handler(void)
-{
-    while (1)
-    {
+void HardFault_Handler(void) {
+    while (1) {
     }
 }
 
 /**
-  * @brief This function handles Memory management fault.
+ * @brief This function handles Memory management fault.
  */
-void MemManage_Handler(void)
-{
-    while (1)
-    {
+void MemManage_Handler(void) {
+    while (1) {
     }
 }
 
 /**
-  * @brief This function handles Prefetch fault, memory access fault.
+ * @brief This function handles Prefetch fault, memory access fault.
  */
-void BusFault_Handler(void)
-{
-    while (1)
-    {
+void BusFault_Handler(void) {
+    while (1) {
     }
 }
 
 /**
-  * @brief This function handles Undefined instruction or illegal state.
+ * @brief This function handles Undefined instruction or illegal state.
  */
-void UsageFault_Handler(void)
-{
-    while (1)
-    {
+void UsageFault_Handler(void) {
+    while (1) {
     }
 }
 
 /**
-  * @brief This function handles Debug monitor.
+ * @brief This function handles Debug monitor.
  */
-void DebugMon_Handler(void)
-{
-}
+void DebugMon_Handler(void) {}
 
 /******************************************************************************/
 /* STM32G4xx Peripheral Interrupt Handlers                                    */
@@ -99,22 +88,20 @@ void DebugMon_Handler(void)
 /* please refer to the startup file (startup_stm32g4xx.s).                    */
 /******************************************************************************/
 
-
 /**
  * TIM7 = timebase counter
  * TIM17 = Interrupt for X
  * TIM20 = Interrupt for Z
  * TIM3 = Interrupt for L
  */
-void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
-{
-    if(htim->Instance == TIM7) {
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
+    if (htim->Instance == TIM7) {
         HAL_IncTick();
-    } else if(htim->Instance == TIM17 && interrupt_callback) {
+    } else if (htim->Instance == TIM17 && interrupt_callback) {
         interrupt_callback(MOTOR_X);
-    } else if(htim->Instance == TIM20 && interrupt_callback) {
+    } else if (htim->Instance == TIM20 && interrupt_callback) {
         interrupt_callback(MOTOR_Z);
-    } else if(htim->Instance == TIM3 && interrupt_callback) {
+    } else if (htim->Instance == TIM3 && interrupt_callback) {
         interrupt_callback(MOTOR_L);
     }
 }
@@ -127,15 +114,21 @@ void initialize_limit_switch_callbacks(limit_switch_callback callback_glue) {
     lim_switch_callback = callback_glue;
 }
 
+void initialize_shared_stall_callback(shared_interrupt_callback callback_glue) {
+    shared_stall_callback = callback_glue;
+}
+
 // MOTOR_DIAG0_PIN interrupt
 void EXTI15_10_IRQHandler(void) {
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_12)) {
+        if (shared_stall_callback) {
+            shared_stall_callback();
+        }
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_12);
     }
 }
 
-void EXTI9_5_IRQHandler(void)
-{
+void EXTI9_5_IRQHandler(void) {
     // Estop interrupt
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_6)) {
         __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_6);
@@ -147,13 +140,11 @@ void EXTI9_5_IRQHandler(void)
         if (lim_switch_callback) {
             lim_switch_callback(MOTOR_L);
         }
-
     }
 }
 
 // Z+ limit switch interrupt
-void EXTI0_IRQHandler(void)
-{
+void EXTI0_IRQHandler(void) {
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_0)) {
         __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_0);
         if (lim_switch_callback) {
@@ -163,8 +154,7 @@ void EXTI0_IRQHandler(void)
 }
 
 // X- limit switch interrupt
-void EXTI1_IRQHandler(void)
-{
+void EXTI1_IRQHandler(void) {
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_1)) {
         __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_1);
         if (lim_switch_callback) {
@@ -174,8 +164,7 @@ void EXTI1_IRQHandler(void)
 }
 
 // X+ limit switch interrupt
-void EXTI2_IRQHandler(void)
-{
+void EXTI2_IRQHandler(void) {
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_2)) {
         __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_2);
         if (lim_switch_callback) {
@@ -185,8 +174,7 @@ void EXTI2_IRQHandler(void)
 }
 
 // Z- limit switch interrupt
-void EXTI3_IRQHandler(void)
-{
+void EXTI3_IRQHandler(void) {
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_3)) {
         __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_3);
         if (lim_switch_callback) {
@@ -194,5 +182,3 @@ void EXTI3_IRQHandler(void)
         }
     }
 }
-
-

--- a/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.h
+++ b/stm32-modules/flex-stacker/firmware/system/stm32g4xx_it.h
@@ -48,6 +48,10 @@ void initialize_callbacks(motor_interrupt_callback callback_glue);
 
 typedef void (*limit_switch_callback)(MotorID motor_id);
 void initialize_limit_switch_callbacks(limit_switch_callback callback_glue);
+
+typedef void (*shared_interrupt_callback)();
+void initialize_shared_stall_callback(shared_interrupt_callback callback_glue);
+
 #ifdef __cplusplus
 }
 #endif

--- a/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
+++ b/stm32-modules/include/flex-stacker/firmware/motor_interrupt.hpp
@@ -64,6 +64,7 @@ class MotorInterruptController {
         _policy->set_limit_switch_irq(_id, _direction, false);
         _policy->set_limit_switch_irq(_id, !_direction, false);
         _switch_detected.store(false);
+        _stall_detected.store(false);
         _error = Error::NO_ERROR;
     }
 
@@ -138,7 +139,7 @@ class MotorInterruptController {
             _error = Error::ESTOP_TRIGGERED;
             return true;
         }
-        if (!_policy->check_diag0()) {
+        if (_stall_detected.load()) {
             _error = Error::MOTOR_STALL_DETECTED;
             return true;
         }
@@ -155,6 +156,12 @@ class MotorInterruptController {
         };
     }
 
+    auto stall_detected() -> void {
+        if (!_stop) {
+            _stall_detected.store(true);
+        }
+    }
+
     auto set_diag0_irq(bool enable) -> void { _policy->set_diag0_irq(enable); }
 
     [[nodiscard]] auto is_moving() const -> bool { return !_stop; }
@@ -169,6 +176,7 @@ class MotorInterruptController {
     std::atomic_bool _stop = true;
     std::atomic_bool _initialized = false;
     std::atomic_bool _switch_detected = false;
+    std::atomic_bool _stall_detected = false;
 };
 
 }  // namespace motor_interrupt_controller


### PR DESCRIPTION
We already have the motor driver `Diag0`and `estop` input as interrupts so we should make use of them to inform our motor timer interrupt logic, instead of checking the pins every time the timer ticks. 