### PR TITLE
fix(flex-stacker): Explicitly enable the limit switch IRQ on boot to clear any pending IRQ held after a FW update.

### DIFF
--- a/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
+++ b/stm32-modules/flex-stacker/firmware/motor_control/motor_hardware.c
@@ -187,39 +187,32 @@ void motor_hardware_gpio_init(void){
     // Z MOTOR
     init.Pin = Z_MINUS_LIMIT_PIN;
     HAL_GPIO_Init(Z_MINUS_LIMIT_PORT, &init);
-
+    HAL_NVIC_SetPriority(EXTI3_IRQn, 5, 0);
+    HAL_NVIC_EnableIRQ(EXTI3_IRQn);
 
     init.Pin = Z_PLUS_LIMIT_PIN;
     HAL_GPIO_Init(Z_PLUS_LIMIT_PORT, &init);
+    HAL_NVIC_SetPriority(EXTI0_IRQn, 5, 0);
+    HAL_NVIC_EnableIRQ(EXTI0_IRQn);
 
     // X MOTOR
     init.Pin = X_MINUS_LIMIT_PIN;
     HAL_GPIO_Init(X_MINUS_LIMIT_PORT, &init);
+    HAL_NVIC_SetPriority(EXTI1_IRQn, 5, 0);
+    HAL_NVIC_EnableIRQ(EXTI1_IRQn);
 
     init.Pin = X_PLUS_LIMIT_PIN;
     HAL_GPIO_Init(X_PLUS_LIMIT_PORT, &init);
+    HAL_NVIC_SetPriority(EXTI2_IRQn, 5, 0);
+    HAL_NVIC_EnableIRQ(EXTI2_IRQn);
 
     // L MOTOR
     init.Mode = GPIO_MODE_IT_FALLING;
 
     init.Pin = L_N_HELD_PIN;
     HAL_GPIO_Init(L_N_HELD_PORT, &init);
-
-    HAL_NVIC_SetPriority(EXTI0_IRQn, 5, 0);
-//    HAL_NVIC_EnableIRQ(EXTI0_IRQn);
-
-    HAL_NVIC_SetPriority(EXTI1_IRQn, 5, 0);
-//    HAL_NVIC_EnableIRQ(EXTI1_IRQn);
-
-    HAL_NVIC_SetPriority(EXTI2_IRQn, 5, 0);
-//    HAL_NVIC_EnableIRQ(EXTI2_IRQn);
-
-    HAL_NVIC_SetPriority(EXTI3_IRQn, 5, 0);
-//    HAL_NVIC_EnableIRQ(EXTI3_IRQn);
-
-//    HAL_NVIC_SetPriority(EXTI9_5_IRQn, 5, 0);
-//    HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
-
+    HAL_NVIC_SetPriority(EXTI9_5_IRQn, 5, 0);
+    HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
 }
 
 // X motor timer


### PR DESCRIPTION
## Overview

The flex stacker was failing on the first dispense after a firmware update, which is caused by an interrupt not getting cleared between boots. Which is not usually a problem when cold booting, but when doing a firmware update (which should reset everything !), an interrupt line was being held, and the -Z limit switch was triggering when it was not supposed to. This translates to the stacker failing a dispense the first time after an update; however, subsequent dispenses are passing successfully.
 
Closes: [RQA-4536](https://opentrons.atlassian.net/browse/RQA-4536) [RABR-822](https://opentrons.atlassian.net/browse/RABR-822)

## Change log

- enable limit switch irq on boot to clear lingering signals


[RQA-4536]: https://opentrons.atlassian.net/browse/RQA-4536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RABR-822]: https://opentrons.atlassian.net/browse/RABR-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ