### PR TITLE
fix(build): Set the TRAVIS_TAG env var in GitHub Actions to deploy Arduino modules to the correct directory.

### DIFF
--- a/.github/workflows/arduino-modules.yaml
+++ b/.github/workflows/arduino-modules.yaml
@@ -58,7 +58,4 @@ jobs:
           TRAVIS_TAG: ${{ github.ref_name }}
         run: |
           . ./scripts/set_build_vars.sh
-
-          echo ${RELEASE_LOCAL_DIR}
-          echo ${RELEASE_UPLOAD_DIR}
-          # aws s3 sync --acl=public-read ${RELEASE_LOCAL_DIR} s3://opentrons-modules-builds/${RELEASE_UPLOAD_DIR}
+          aws s3 sync --acl=public-read ${RELEASE_LOCAL_DIR} s3://opentrons-modules-builds/${RELEASE_UPLOAD_DIR}

--- a/.github/workflows/arduino-modules.yaml
+++ b/.github/workflows/arduino-modules.yaml
@@ -55,6 +55,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_MODULES_DEPLOY_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_MODULES_DEPLOY_SECRET }}
           AWS_DEFAULT_REGION: us-east-2
+          TRAVIS_TAG: ${{ github.ref_name }}
         run: |
           . ./scripts/set_build_vars.sh
           aws s3 sync --acl=public-read ${RELEASE_LOCAL_DIR} s3://opentrons-modules-builds/${RELEASE_UPLOAD_DIR}

--- a/.github/workflows/arduino-modules.yaml
+++ b/.github/workflows/arduino-modules.yaml
@@ -58,4 +58,7 @@ jobs:
           TRAVIS_TAG: ${{ github.ref_name }}
         run: |
           . ./scripts/set_build_vars.sh
-          aws s3 sync --acl=public-read ${RELEASE_LOCAL_DIR} s3://opentrons-modules-builds/${RELEASE_UPLOAD_DIR}
+
+          echo ${RELEASE_LOCAL_DIR}
+          echo ${RELEASE_UPLOAD_DIR}
+          # aws s3 sync --acl=public-read ${RELEASE_LOCAL_DIR} s3://opentrons-modules-builds/${RELEASE_UPLOAD_DIR}

--- a/.github/workflows/flex-stacker-create-release.yaml
+++ b/.github/workflows/flex-stacker-create-release.yaml
@@ -54,4 +54,6 @@ jobs:
           TRAVIS_TAG: ${{ github.ref_name }}
         run: |
           . ./scripts/set_build_vars.sh
-          aws s3 sync --acl=public-read ${RELEASE_LOCAL_DIR} s3://opentrons-modules-builds/${RELEASE_UPLOAD_DIR}
+          echo ${RELEASE_LOCAL_DIR}
+          echo ${RELEASE_UPLOAD_DIR}
+          # aws s3 sync --acl=public-read ${RELEASE_LOCAL_DIR} s3://opentrons-modules-builds/${RELEASE_UPLOAD_DIR}

--- a/.github/workflows/flex-stacker-create-release.yaml
+++ b/.github/workflows/flex-stacker-create-release.yaml
@@ -54,6 +54,4 @@ jobs:
           TRAVIS_TAG: ${{ github.ref_name }}
         run: |
           . ./scripts/set_build_vars.sh
-          echo ${RELEASE_LOCAL_DIR}
-          echo ${RELEASE_UPLOAD_DIR}
-          # aws s3 sync --acl=public-read ${RELEASE_LOCAL_DIR} s3://opentrons-modules-builds/${RELEASE_UPLOAD_DIR}
+          aws s3 sync --acl=public-read ${RELEASE_LOCAL_DIR} s3://opentrons-modules-builds/${RELEASE_UPLOAD_DIR}


### PR DESCRIPTION
# Overview

The TRAVIS_TAG env was never set, so the `set_build_vars.sh` script always defaulted to `modules-magdeck`.

Closes: [EXEC-1749](https://opentrons.atlassian.net/browse/EXEC-1749)

## Note
Once we create new module release builds, we should fix the tempdeck source URL in [oe-core](https://github.com/Opentrons/oe-core/commit/5e3be70474bab12594953dd7b1eee6dfc9134277) and [buildroot](https://github.com/Opentrons/buildroot/commit/ae4b488380ae59853836d8bc057ec23c9f2c48ce).


[EXEC-1749]: https://opentrons.atlassian.net/browse/EXEC-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ