### PR TITLE
feat(thermocycler-gen2): Implement ramp rate gcodes

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -1103,6 +1103,60 @@ struct SetLidTemperature {
     }
 };
 
+struct SetRampRate {
+    /**
+     * SetRampRate uses M566. Only parameter is optional and it is
+     * the ramp rate to use in C°/s. If not defined, the temperature ramp rate
+     * will be infinite
+     *
+     * M566 S44\n
+     */
+    using ParseResult = std::optional<SetRampRate>;
+    static constexpr auto prefix = std::array{'M', '5', '6', '6'};
+    static constexpr auto prefix_with_temp =
+        std::array{'M', '5', '6', '6', ' ', 'S'};
+    static constexpr const char* response = "M566 OK\n";
+
+    static constexpr double default_ramp_rate = 0.0F;
+
+    double ramp_rate;
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix_with_temp);
+        if (working == input) {
+            // NO RampRate SETTING but it might just be a bare command
+            working = prefix_matches(input, limit, prefix);
+            if (working == input) {
+                return std::make_pair(ParseResult(), input);
+            }
+            // Return a struct with default temperature
+            return std::make_pair(
+                ParseResult(SetRampRate{.ramp_rate = default_ramp_rate}),
+                working);
+        }
+        // We are expecting a temperature setting
+        auto ramp_rate = parse_value<float>(working, limit);
+        if (!ramp_rate.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+        auto ramp_rate_val = ramp_rate.first.value();
+        return std::make_pair(
+            ParseResult(SetRampRate{.ramp_rate = ramp_rate_val}),
+            ramp_rate.second);
+    }
+};
+
 struct DeactivateLidHeating {
     /**
      * DeactivateLidHeating uses M108. It has no parameters and just

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -1191,6 +1191,8 @@ struct SetPlateTemperature {
      * SetPlateTemperature uses M104. Parameters:
      * - S - setpoint temperature
      * - H - hold time (optional)
+     * - V - liquid volume (optional)
+     * - R - ramp rate (optional)
      *
      * M104 S44\n
      */
@@ -1198,10 +1200,13 @@ struct SetPlateTemperature {
     static constexpr auto prefix = std::array{'M', '1', '0', '4', ' ', 'S'};
     static constexpr auto hold_prefix = std::array{' ', 'H'};
     static constexpr auto volume_prefix = std::array{' ', 'V'};
+    static constexpr auto ramp_prefix = std::array{' ', 'R'};
     static constexpr const char* response = "M104 OK\n";
 
     // 0 seconds means infinite hold time
     constexpr static double infinite_hold = 0.0F;
+    // 0 means infinite ramp rate
+    constexpr static double infinite_ramp = 0.0F;
     // If no volume is specified, set to a negative number and let
     // the rest of the firmware decide a default value
     constexpr static double default_volume = -1.0F;
@@ -1209,6 +1214,7 @@ struct SetPlateTemperature {
     double setpoint;
     double hold_time;
     double volume;
+    double ramp_rate;
 
     template <typename InputIt, typename InLimit>
     requires std::forward_iterator<InputIt> &&
@@ -1258,10 +1264,24 @@ struct SetPlateTemperature {
             working = vol.second;
         }
 
+        auto ramp_rate_val = infinite_ramp;
+        auto working_ramp = working;
+        working = prefix_matches(working_ramp, limit, ramp_prefix);
+        if (working != working_ramp) {
+            // This command specified a ramp rate
+            auto ramp = parse_value<float>(working, limit);
+            if (!ramp.first.has_value()) {
+                return std::make_pair(ParseResult(), input);
+            }
+            ramp_rate_val = ramp.first.value();
+            working = ramp.second;
+        }
+
         return std::make_pair(
             ParseResult(SetPlateTemperature{.setpoint = temperature_val,
                                             .hold_time = hold_val,
-                                            .volume = volume_val}),
+                                            .volume = volume_val,
+                                            .ramp_rate = ramp_rate_val}),
             working);
     }
 };

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -1128,7 +1128,33 @@ class HostCommsTask {
             messages::SetPlateTemperatureMessage{.id = id,
                                                  .setpoint = gcode.setpoint,
                                                  .hold_time = gcode.hold_time,
-                                                 .volume = gcode.volume};
+                                                 .volume = gcode.volume,
+                                                 .ramp_rate = gcode.ramp_rate};
+        if (!task_registry->thermal_plate->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::SetRampRate& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+
+        auto message = messages::SetRampRateMessage{
+            .id = id, .ramp_rate = gcode.ramp_rate};
         if (!task_registry->thermal_plate->get_message_queue().try_send(
                 message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -258,6 +258,7 @@ struct SetPlateTemperatureMessage {
     double setpoint;
     double hold_time;
     double volume = 0.0F;
+    double ramp_rate = 0.0F;
 };
 
 struct SetRampRateMessage {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -260,6 +260,11 @@ struct SetPlateTemperatureMessage {
     double volume = 0.0F;
 };
 
+struct SetRampRateMessage {
+    uint32_t id;
+    double ramp_rate;
+};
+
 struct SetFanAutomaticMessage {
     uint32_t id;
 };
@@ -436,7 +441,7 @@ using HostCommsMessage = ::std::variant<
 using ThermalPlateMessage =
     ::std::variant<std::monostate, ThermalPlateTempReadComplete,
                    GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,
-                   SetFanManualMessage, GetPlateTempMessage,
+                   SetFanManualMessage, GetPlateTempMessage, SetRampRateMessage,
                    SetPlateTemperatureMessage, DeactivatePlateMessage,
                    SetPIDConstantsMessage, SetFanAutomaticMessage,
                    GetThermalPowerMessage, SetOffsetConstantsMessage,

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/plate_control.hpp
@@ -158,7 +158,14 @@ class PlateControl {
     auto set_new_target(double setpoint, double volume_ul,
                         double hold_time = HOLD_INFINITE,
                         double ramp_rate = RAMP_INFINITE) -> bool;
-
+    /**
+     * @brief Set a new target ramp rate.
+     *
+     * @param[in] ramp_rate The rate to drive the peltiers at, in degrees
+     * celsius per second.
+     * @return True if the temperature target could be updated
+     */
+    auto set_new_ramp_rate(double ramp_rate) -> bool;
     /**
      * @brief This function will return the correct fan PWM to be set if
      * the fan is in idle mode, as a percentage from 0 to 1.0.

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -573,7 +573,7 @@ class ThermalPlateTask {
             reset_peltier_filters();
         } else {
             if (_plate_control.set_new_target(msg.setpoint, volume_ul,
-                                              msg.hold_time)) {
+                                              msg.hold_time, msg.ramp_rate)) {
                 _state.system_status = State::CONTROLLING;
             } else {
                 response.with_error = errors::ErrorCode::THERMAL_TARGET_BAD;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -515,6 +515,20 @@ class ThermalPlateTask {
     }
 
     template <ThermalPlateExecutionPolicy Policy>
+    auto visit_message(const messages::SetRampRateMessage& msg, Policy& policy)
+        -> void {
+        std::ignore = policy;
+        auto response =
+            messages::AcknowledgePrevious{.responding_to_id = msg.id};
+        if (_state.system_status == State::ERROR) {
+            response.with_error = most_relevant_error();
+        }
+        _plate_control.set_new_ramp_rate(msg.ramp_rate);
+        static_cast<void>(
+            _task_registry->comms->get_message_queue().try_send(response));
+    }
+
+    template <ThermalPlateExecutionPolicy Policy>
     auto visit_message(const messages::SetPlateTemperatureMessage& msg,
                        Policy& policy) -> void {
         auto response =

--- a/stm32-modules/thermocycler-gen2/src/plate_control.cpp
+++ b/stm32-modules/thermocycler-gen2/src/plate_control.cpp
@@ -136,6 +136,12 @@ auto PlateControl::set_new_target(double setpoint, double volume_ul,
     return true;
 }
 
+auto PlateControl::set_new_ramp_rate(double ramp_rate) -> bool {
+    _ramp_rate = ramp_rate;
+
+    return true;
+}
+
 [[nodiscard]] auto PlateControl::fan_idle_power() const -> double {
     auto temp = _fan.current_temp();
     if (temp < IDLE_FAN_INACTIVE_THRESHOLD) {

--- a/stm32-modules/thermocycler-gen2/src/version.cpp.in
+++ b/stm32-modules/thermocycler-gen2/src/version.cpp.in
@@ -3,6 +3,7 @@
 static constexpr const char* _FW_VERSION_GENERATED = "${${TARGET_MODULE_NAME}_VERSION}";
 static constexpr const char* _HW_VERSION_GENERATED = "Opentrons-${TARGET_MODULE_NAME}";
 
+
 const char* version::fw_version() {
     return _FW_VERSION_GENERATED;
 }

--- a/stm32-modules/thermocycler-gen2/tests/test_m104.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m104.cpp
@@ -40,6 +40,8 @@ SCENARIO("SetPlateTemperature (M104) parser works", "[gcode][parse][m104]") {
                         gcode::SetPlateTemperature::infinite_hold);
                 REQUIRE(val.value().volume ==
                         gcode::SetPlateTemperature::default_volume);
+                REQUIRE(val.value().ramp_rate ==
+                        gcode::SetPlateTemperature::infinite_ramp);
             }
         }
         WHEN("Setting target to 0.0") {
@@ -55,6 +57,8 @@ SCENARIO("SetPlateTemperature (M104) parser works", "[gcode][parse][m104]") {
                         gcode::SetPlateTemperature::infinite_hold);
                 REQUIRE(val.value().volume ==
                         gcode::SetPlateTemperature::default_volume);
+                REQUIRE(val.value().ramp_rate ==
+                        gcode::SetPlateTemperature::infinite_ramp);
             }
         }
         WHEN("Setting target to 50C with a hold time of 40 seconds") {
@@ -69,6 +73,8 @@ SCENARIO("SetPlateTemperature (M104) parser works", "[gcode][parse][m104]") {
                 REQUIRE(val.value().hold_time == 40.0F);
                 REQUIRE(val.value().volume ==
                         gcode::SetPlateTemperature::default_volume);
+                REQUIRE(val.value().ramp_rate ==
+                        gcode::SetPlateTemperature::infinite_ramp);
             }
         }
         WHEN("Setting target to 50C with a volume of 40.5") {
@@ -84,6 +90,8 @@ SCENARIO("SetPlateTemperature (M104) parser works", "[gcode][parse][m104]") {
                         gcode::SetPlateTemperature::infinite_hold);
                 REQUIRE_THAT(val.value().volume,
                              Catch::Matchers::WithinAbs(40.5, 0.01));
+                REQUIRE(val.value().ramp_rate ==
+                        gcode::SetPlateTemperature::infinite_ramp);
             }
         }
         WHEN(
@@ -100,6 +108,24 @@ SCENARIO("SetPlateTemperature (M104) parser works", "[gcode][parse][m104]") {
                 REQUIRE(val.value().hold_time == 10.0F);
                 REQUIRE_THAT(val.value().volume,
                              Catch::Matchers::WithinAbs(40.5, 0.01));
+                REQUIRE(val.value().ramp_rate ==
+                        gcode::SetPlateTemperature::infinite_ramp);
+            }
+        }
+        WHEN("Setting target to 50 with a ramp rate of 2.0") {
+            std::string buffer = "M104 S50.0 R2.0\n";
+            auto parsed =
+                gcode::SetPlateTemperature::parse(buffer.begin(), buffer.end());
+            THEN("the target should be 50") {
+                auto &val = parsed.first;
+                REQUIRE(parsed.second != buffer.begin());
+                REQUIRE(val.has_value());
+                REQUIRE(val.value().setpoint == 50.0F);
+                REQUIRE(val.value().ramp_rate == 2.0F);
+                REQUIRE(val.value().hold_time ==
+                        gcode::SetPlateTemperature::infinite_hold);
+                REQUIRE(val.value().volume ==
+                        gcode::SetPlateTemperature::default_volume);
             }
         }
     }


### PR DESCRIPTION
This adds the SetRampRate gcode message and expands the SetPlateTemp message to have an additional optional ramp rate argument.

It also updates the firmware side handling of these to connect the ramp rate to the already existing layers that would use it in the temperature controller tasks.