### PR TITLE
thermocycler-gen2: add error control

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,clang-analyzer-*,bugprone-*,cppcoreguidelines-*,-cppcoreguidelines-pro-type-vararg,misc-*,-misc-use-anonymous-namespace,modernize-*,-modernize-avoid-c-arrays,readability-*,-readability-magic-numbers,performance-*,-cppcoreguidelines-avoid-const-or-ref-data-members,-bugprone-easily-swappable-parameters'
+Checks:          '-*,clang-analyzer-*,bugprone-*,cppcoreguidelines-*,-cppcoreguidelines-pro-type-vararg,misc-*,-misc-use-anonymous-namespace,modernize-*,-modernize-avoid-c-arrays,readability-*,-readability-magic-numbers,performance-*,-cppcoreguidelines-avoid-const-or-ref-data-members,-bugprone-easily-swappable-parameters,-readability-named-parameter,-readability-function-cognitive-complexity'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*/stm32-modules/.*hpp'
 FormatStyle:     none

--- a/stm32-modules/heater-shaker/tests/test_motor_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_motor_task.cpp
@@ -101,19 +101,7 @@ SCENARIO("motor task core message handling", "[motor]") {
                 }
                 AND_THEN(
                     "the task should respond to the message to the system") {
-                    REQUIRE(
-                        tasks->get_host_comms_queue().backing_deque.empty());
-                    REQUIRE_FALSE(
-                        tasks->get_system_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_system_queue().backing_deque.front();
-                    tasks->get_system_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto ack =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(ack.responding_to_id == message.id);
+                    tasks->require_has_ack_for(message);
                 }
                 AND_THEN("the task state should be running") {
                     REQUIRE(tasks->get_motor_task().get_state() ==

--- a/stm32-modules/heater-shaker/tests/test_motor_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_motor_task.cpp
@@ -101,7 +101,12 @@ SCENARIO("motor task core message handling", "[motor]") {
                 }
                 AND_THEN(
                     "the task should respond to the message to the system") {
-                    tasks->require_has_ack_for(message);
+                    REQUIRE_FALSE(tasks->get_system_queue().backing_deque.empty());
+                    auto msg = tasks->get_system_queue().backing_deque.front();
+                    REQUIRE(std::holds_alternative<messages::AcknowledgePrevious>(msg));
+                    auto ack = std::get<messages::AcknowledgePrevious>(msg);
+                    REQUIRE(ack.responding_to_id == message.id);
+                    REQUIRE(ack.with_error == errors::ErrorCode::NO_ERROR);
                 }
                 AND_THEN("the task state should be running") {
                     REQUIRE(tasks->get_motor_task().get_state() ==

--- a/stm32-modules/heater-shaker/tests/test_motor_task.cpp
+++ b/stm32-modules/heater-shaker/tests/test_motor_task.cpp
@@ -101,9 +101,12 @@ SCENARIO("motor task core message handling", "[motor]") {
                 }
                 AND_THEN(
                     "the task should respond to the message to the system") {
-                    REQUIRE_FALSE(tasks->get_system_queue().backing_deque.empty());
+                    REQUIRE_FALSE(
+                        tasks->get_system_queue().backing_deque.empty());
                     auto msg = tasks->get_system_queue().backing_deque.front();
-                    REQUIRE(std::holds_alternative<messages::AcknowledgePrevious>(msg));
+                    REQUIRE(
+                        std::holds_alternative<messages::AcknowledgePrevious>(
+                            msg));
                     auto ack = std::get<messages::AcknowledgePrevious>(msg);
                     REQUIRE(ack.responding_to_id == message.id);
                     REQUIRE(ack.with_error == errors::ErrorCode::NO_ERROR);

--- a/stm32-modules/include/thermocycler-gen2/test/task_builder.hpp
+++ b/stm32-modules/include/thermocycler-gen2/test/task_builder.hpp
@@ -2,6 +2,8 @@
 #include <memory>
 #include <utility>
 
+#include "catch2/catch.hpp"
+
 #include "test/test_lid_heater_policy.hpp"
 #include "test/test_message_queue.hpp"
 #include "test/test_motor_policy.hpp"
@@ -84,6 +86,33 @@ struct TaskBuilder {
     }
 
     auto run_motor_task() -> void { motor_task.run_once(motor_policy); }
+
+    template <typename Message,
+              typename AckMessage = messages::AcknowledgePrevious>
+    auto require_has_ack_for(
+        Message message, errors::ErrorCode error = errors::ErrorCode::NO_ERROR)
+        -> AckMessage {
+        return require_has_ack_for_id<AckMessage>(message.id, error);
+    }
+
+    template <typename AckMessage = messages::AcknowledgePrevious>
+    auto require_has_ack_for_id(
+        uint32_t id, errors::ErrorCode error = errors::ErrorCode::NO_ERROR)
+        -> AckMessage {
+        auto ack = get_latest_host_comms_message<AckMessage>();
+        REQUIRE(ack.responding_to_id == id);
+        REQUIRE(ack.with_error == error);
+        return ack;
+    }
+
+    template <typename Message>
+    auto get_latest_host_comms_message() -> Message {
+        CHECK_FALSE(host_comms_queue.backing_deque.empty());
+        auto resp = host_comms_queue.backing_deque.front();
+        CHECK(std::holds_alternative<Message>(resp));
+        host_comms_queue.backing_deque.pop_front();
+        return std::get<Message>(resp);
+    }
 
   private:
     TaskBuilder();

--- a/stm32-modules/include/thermocycler-gen2/test/task_builder.hpp
+++ b/stm32-modules/include/thermocycler-gen2/test/task_builder.hpp
@@ -3,7 +3,6 @@
 #include <utility>
 
 #include "catch2/catch.hpp"
-
 #include "test/test_lid_heater_policy.hpp"
 #include "test/test_message_queue.hpp"
 #include "test/test_motor_policy.hpp"

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -1900,4 +1900,132 @@ struct SetLightsDebug {
     }
 };
 
+struct GetErrorState {
+    /**
+     * GetErrorState is M411.
+     *
+     * Acknowledged immediately upon receipt.
+     */
+    using ParseResult = std::optional<GetErrorState>;
+    static constexpr auto prefix = std::array{'M', '4', '1', '1'};
+    static constexpr const char* response = "M411 OK\n";
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(GetErrorState()), working);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt write_to_buf,
+                                    InLimit write_to_limit) {
+        return write_string_to_iterpair(write_to_buf, write_to_limit, response);
+    }
+};
+
+struct SetErrorStateDebug {
+    /**
+     * SetErrorState is M412.D <E NNN> <T NNN>
+     *
+     * Acknowledged immediately on receipt. Will cause the error state specified
+     * by E to happen T seconds after receipt. T is optional; if omitted, the
+     * error is set immediately.
+     * */
+    using ParseResult = std::optional<SetErrorStateDebug>;
+    static constexpr auto prefix = std::array{'M', '4', '1', '2', '.', 'D'};
+    static constexpr auto prefix_t = std::array{' ', 'T'};
+    static constexpr auto prefix_e = std::array{' ', 'E'};
+    static constexpr const char* response = "M412.D OK\n";
+
+    uint32_t delay_s = 0;
+    errors::ErrorCode error = errors::ErrorCode::NO_ERROR;
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        auto old_working = working;
+        auto ret = SetErrorStateDebug();
+        working = prefix_matches(old_working, limit, prefix_e);
+        if (working != old_working) {
+            old_working = working;
+            auto e = parse_value<uint16_t>(working, limit);
+            if (!e.first.has_value()) {
+                return std::make_pair(std::nullopt, input);
+            }
+            ret.error = static_cast<errors::ErrorCode>(e.first.value());
+            working = e.second;
+        } else {
+            return std::make_pair(std::nullopt, input);
+        }
+        old_working = working;
+
+        working = prefix_matches(old_working, limit, prefix_t);
+        if (working != old_working) {
+            old_working = working;
+            auto t = parse_value<uint32_t>(working, limit);
+            if (!t.first.has_value()) {
+                return std::make_pair(ParseResult(ret), input);
+            }
+            ret.delay_s = t.first.value();
+            working = t.second;
+        }
+        return std::make_pair(ParseResult(ret), working);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt write_to_buf,
+                                    InLimit write_to_limit) {
+        return write_string_to_iterpair(write_to_buf, write_to_limit, response);
+    }
+};
+
+struct ClearErrorState {
+    /**
+     * ClearErrorState is M413.
+     *
+     * Acknolwedged immediately on receipt. Clears the current error state, if
+     *any, though if the error state is from detecting a hardware error state it
+     *will likely rapidly reoccur.
+     **/
+    using ParseResult = std::optional<ClearErrorState>;
+    static constexpr auto prefix = std::array{'M', '4', '1', '3'};
+    static constexpr const char* response = "M413 OK\n";
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(ClearErrorState()), working);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt write_to_buf,
+                                    InLimit write_to_limit) {
+        return write_string_to_iterpair(write_to_buf, write_to_limit, response);
+    }
+};
+
 }  // namespace gcode

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -12,6 +12,7 @@
 #include "core/ack_cache.hpp"
 #include "core/gcode_parser.hpp"
 #include "core/version.hpp"
+#include "gcodes.hpp"
 #include "hal/message_queue.hpp"
 #include "thermocycler-gen2/board_revision.hpp"
 #include "thermocycler-gen2/errors.hpp"
@@ -51,7 +52,9 @@ class HostCommsTask {
         gcode::GetOffsetConstants, gcode::OpenLid, gcode::CloseLid,
         gcode::LiftPlate, gcode::DeactivateAll, gcode::GetBoardRevision,
         gcode::GetLidSwitches, gcode::GetFrontButton, gcode::SetLidFans,
-        gcode::SetLightsDebug, gcode::GetResetReason>;
+        gcode::SetLightsDebug, gcode::GetResetReason,
+        gcode::SetErrorStateDebug, gcode::ClearErrorState, gcode::GetErrorState
+        >;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::ActuateSolenoid, gcode::ActuateLidStepperDebug,
@@ -61,7 +64,8 @@ class HostCommsTask {
                  gcode::SetPlateTemperature, gcode::DeactivatePlate,
                  gcode::SetFanAutomatic, gcode::SetSealParameter,
                  gcode::SetOffsetConstants, gcode::OpenLid, gcode::CloseLid,
-                 gcode::LiftPlate, gcode::SetLidFans, gcode::SetLightsDebug>;
+                 gcode::LiftPlate, gcode::SetLidFans, gcode::SetLightsDebug,
+                 gcode::SetErrorStateDebug, gcode::ClearErrorState, gcode::GetErrorState>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetLidTempDebugCache = AckCache<8, gcode::GetLidTemperatureDebug>;
     using GetPlateTempDebugCache = AckCache<8, gcode::GetPlateTemperatureDebug>;
@@ -1570,6 +1574,116 @@ class HostCommsTask {
         }
         return std::make_pair(true, tx_into);
     }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::GetErrorState& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode, 2);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::GetErrorStateMessage{.id = id};
+        if (!task_registry->thermal_plate->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        if (!task_registry->lid_heater->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        if (!task_registry->motor->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::SetErrorStateDebug& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode, 3);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::SetErrorStateMessage{
+            .id = id, .error_to_set = gcode.error, .delay_s = gcode.delay_s};
+        if (!task_registry->thermal_plate->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        if (!task_registry->lid_heater->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        if (!task_registry->motor->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::ClearErrorState& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode, 3);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::ClearErrorStateMessage{.id = id};
+        if (!task_registry->thermal_plate->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        if (!task_registry->lid_heater->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        if (!task_registry->motor->get_message_queue().try_send(
+                message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
 
     // Our error handler just writes an error and bails
     template <typename InputIt, typename InputLimit>

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/host_comms_task.hpp
@@ -52,9 +52,8 @@ class HostCommsTask {
         gcode::GetOffsetConstants, gcode::OpenLid, gcode::CloseLid,
         gcode::LiftPlate, gcode::DeactivateAll, gcode::GetBoardRevision,
         gcode::GetLidSwitches, gcode::GetFrontButton, gcode::SetLidFans,
-        gcode::SetLightsDebug, gcode::GetResetReason,
-        gcode::SetErrorStateDebug, gcode::ClearErrorState, gcode::GetErrorState
-        >;
+        gcode::SetLightsDebug, gcode::GetResetReason, gcode::SetErrorStateDebug,
+        gcode::ClearErrorState, gcode::GetErrorState>;
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::ActuateSolenoid, gcode::ActuateLidStepperDebug,
@@ -65,7 +64,8 @@ class HostCommsTask {
                  gcode::SetFanAutomatic, gcode::SetSealParameter,
                  gcode::SetOffsetConstants, gcode::OpenLid, gcode::CloseLid,
                  gcode::LiftPlate, gcode::SetLidFans, gcode::SetLightsDebug,
-                 gcode::SetErrorStateDebug, gcode::ClearErrorState, gcode::GetErrorState>;
+                 gcode::SetErrorStateDebug, gcode::ClearErrorState,
+                 gcode::GetErrorState>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetLidTempDebugCache = AckCache<8, gcode::GetLidTemperatureDebug>;
     using GetPlateTempDebugCache = AckCache<8, gcode::GetPlateTemperatureDebug>;
@@ -1601,13 +1601,6 @@ class HostCommsTask {
             ack_only_cache.remove_if_present(id);
             return std::make_pair(false, wrote_to);
         }
-        if (!task_registry->motor->get_message_queue().try_send(
-                message, TICKS_TO_WAIT_ON_SEND)) {
-            auto wrote_to = errors::write_into(
-                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
-            ack_only_cache.remove_if_present(id);
-            return std::make_pair(false, wrote_to);
-        }
         return std::make_pair(true, tx_into);
     }
 
@@ -1616,7 +1609,7 @@ class HostCommsTask {
         std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_gcode(const gcode::SetErrorStateDebug& gcode, InputIt tx_into,
                      InputLimit tx_limit) -> std::pair<bool, InputIt> {
-        auto id = ack_only_cache.add(gcode, 3);
+        auto id = ack_only_cache.add(gcode, 2);
         if (id == 0) {
             return std::make_pair(
                 false, errors::write_into(tx_into, tx_limit,
@@ -1638,13 +1631,6 @@ class HostCommsTask {
             ack_only_cache.remove_if_present(id);
             return std::make_pair(false, wrote_to);
         }
-        if (!task_registry->motor->get_message_queue().try_send(
-                message, TICKS_TO_WAIT_ON_SEND)) {
-            auto wrote_to = errors::write_into(
-                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
-            ack_only_cache.remove_if_present(id);
-            return std::make_pair(false, wrote_to);
-        }
         return std::make_pair(true, tx_into);
     }
 
@@ -1653,7 +1639,7 @@ class HostCommsTask {
         std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_gcode(const gcode::ClearErrorState& gcode, InputIt tx_into,
                      InputLimit tx_limit) -> std::pair<bool, InputIt> {
-        auto id = ack_only_cache.add(gcode, 3);
+        auto id = ack_only_cache.add(gcode, 2);
         if (id == 0) {
             return std::make_pair(
                 false, errors::write_into(tx_into, tx_limit,
@@ -1674,16 +1660,8 @@ class HostCommsTask {
             ack_only_cache.remove_if_present(id);
             return std::make_pair(false, wrote_to);
         }
-        if (!task_registry->motor->get_message_queue().try_send(
-                message, TICKS_TO_WAIT_ON_SEND)) {
-            auto wrote_to = errors::write_into(
-                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
-            ack_only_cache.remove_if_present(id);
-            return std::make_pair(false, wrote_to);
-        }
         return std::make_pair(true, tx_into);
     }
-
 
     // Our error handler just writes an error and bails
     template <typename InputIt, typename InputLimit>

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
@@ -12,6 +12,7 @@
 #include "core/pid.hpp"
 #include "core/thermistor_conversion.hpp"
 #include "hal/message_queue.hpp"
+#include "messages.hpp"
 #include "thermistor_lookups.hpp"
 #include "thermocycler-gen2/errors.hpp"
 #include "thermocycler-gen2/messages.hpp"
@@ -392,19 +393,25 @@ class LidHeaterTask {
     }
 
     template <LidHeaterExecutionPolicy Policy>
-    auto visit_message(const messages::GetErrorStateMessage& msg, Policy& policy) -> void {
+    auto visit_message(const messages::GetErrorStateMessage& msg,
+                       Policy& policy) -> void {
+        static_cast<void>(policy);
+        auto ack = messages::AcknowledgePrevious{
+            .responding_to_id = msg.id, .with_error = most_relevant_error()};
+        static_cast<void>(
+            _task_registry->comms->get_message_queue().try_send(ack));
+    }
+
+    template <LidHeaterExecutionPolicy Policy>
+    auto visit_message(const messages::SetErrorStateMessage& msg,
+                       Policy& policy) -> void {
         static_cast<void>(msg);
         static_cast<void>(policy);
     }
 
     template <LidHeaterExecutionPolicy Policy>
-    auto visit_message(const messages::SetErrorStateMessage& msg, Policy& policy) -> void {
-        static_cast<void>(msg);
-        static_cast<void>(policy);
-    }
-
-    template <LidHeaterExecutionPolicy Policy>
-    auto visit_message(const messages::ClearErrorStateMessage& msg, Policy& policy) -> void {
+    auto visit_message(const messages::ClearErrorStateMessage& msg,
+                       Policy& policy) -> void {
         static_cast<void>(msg);
         static_cast<void>(policy);
     }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
@@ -55,6 +55,9 @@ struct State {
     };
     Status system_status;
     uint16_t error_bitmap;
+    errors::ErrorCode manual_error;
+    std::chrono::milliseconds manual_error_countdown;
+    errors::ErrorCode interrupted_by;
     static constexpr uint16_t LID_THERMISTOR_ERROR = (1 << 0);
     static constexpr uint16_t HEATER_POWER_ERROR = (1 << 1);
 };
@@ -100,7 +103,11 @@ class LidHeaterTask {
               .error_bit = State::LID_THERMISTOR_ERROR},
           _converter(THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM, ADC_BIT_MAX,
                      false),
-          _state{.system_status = State::IDLE, .error_bitmap = 0},
+          _state{.system_status = State::IDLE,
+                 .error_bitmap = 0,
+                 .manual_error = errors::ErrorCode::NO_ERROR,
+                 .manual_error_countdown = Milliseconds(0),
+                 .interrupted_by = errors::ErrorCode::NO_ERROR},
           _pid(DEFAULT_KP, DEFAULT_KI, DEFAULT_KD, CONTROL_PERIOD_SECONDS, 1.0,
                -1.0),
           _last_update(0) {}
@@ -148,10 +155,52 @@ class LidHeaterTask {
             message);
     }
 
+    [[nodiscard]] auto most_relevant_error() const -> errors::ErrorCode {
+        // Sometimes more than one error can occur at the same time; sometimes,
+        // that means that one has caused the other. We want to track them
+        // separately, but we also sometimes want to respond with just one error
+        // condition that sums everything up. This method is used by code that
+        // wants the single most relevant code for the current error condition.
+        if ((_state.error_bitmap & _thermistor.error_bit) ==
+            _thermistor.error_bit) {
+            return _thermistor.error;
+        }
+        if ((_state.error_bitmap & State::HEATER_POWER_ERROR) ==
+            State::HEATER_POWER_ERROR) {
+            return errors::ErrorCode::THERMAL_HEATER_ERROR;
+        }
+
+        return errors::ErrorCode::NO_ERROR;
+    }
+
   private:
     template <typename Policy>
     requires LidHeaterExecutionPolicy<Policy>
     auto visit_message(const std::monostate&, Policy&) -> void {}
+
+    auto error_to_error_bitmap_and_set_thermistor(errors::ErrorCode error)
+        -> uint16_t {
+        if (error == errors::ErrorCode::THERMAL_HEATER_ERROR) {
+            return State::HEATER_POWER_ERROR;
+        }
+        // Calculate the bitmap that gives rise to this error code, and also
+        // set the appropriate thermistor error flag if this is a thermistor
+        // error. Note that we don't want to override real thermistor errors,
+        // so if there is one just return early.
+        if (_thermistor.error != errors::ErrorCode::NO_ERROR) {
+            return 0;
+        }
+        switch (error) {
+            case errors::ErrorCode::THERMISTOR_LID_DISCONNECTED:
+            case errors::ErrorCode::THERMISTOR_LID_OVERTEMP:
+            case errors::ErrorCode::THERMISTOR_LID_SHORT: {
+                _thermistor.error = error;
+                return State::LID_THERMISTOR_ERROR;
+            }
+            default:
+                return 0;
+        }
+    }
 
     template <typename Policy>
     requires LidHeaterExecutionPolicy<Policy>
@@ -161,13 +210,29 @@ class LidHeaterTask {
             std::numeric_limits<decltype(msg.timestamp_ms)>::max());
         auto old_error_bitmap = _state.error_bitmap;
         auto current_time = Milliseconds(msg.timestamp_ms);
+        auto time_delta = current_time - _last_update;
+        auto old_status = _state.system_status;
         handle_temperature_conversion(msg.lid_temp, _thermistor);
+
+        if (_state.manual_error_countdown > Milliseconds(0)) {
+            if (time_delta >= _state.manual_error_countdown) {
+                _state.manual_error_countdown = Milliseconds(0);
+                _state.error_bitmap |= error_to_error_bitmap_and_set_thermistor(
+                    _state.manual_error);
+                _state.interrupted_by = _state.manual_error;
+                _state.manual_error = errors::ErrorCode::NO_ERROR;
+            } else {
+                _state.manual_error_countdown -= time_delta;
+            }
+        }
+
         if ((old_error_bitmap != _state.error_bitmap) ||
             (_state.error_bitmap != 0)) {
             if (_state.error_bitmap != 0) {
                 // We entered an error state. Disable power output.
                 _state.system_status = State::ERROR;
                 policy.set_heater_power(0.0F);
+                update_interrupted_by();
             } else {
                 // We went from an error state to no error state... so go idle
                 _state.system_status = State::IDLE;
@@ -187,9 +252,18 @@ class LidHeaterTask {
                 policy.set_heater_power(0.0F);
                 _state.system_status = State::ERROR;
                 _state.error_bitmap |= State::HEATER_POWER_ERROR;
+                update_interrupted_by();
             }
         } else if (_state.system_status != State::HEATER_TEST) {
             policy.set_heater_power(0.0F);
+        }
+        if (_state.system_status == State::ERROR) {
+            if (old_status != State::ERROR) {
+                update_interrupted_by();
+            }
+            if (_state.error_bitmap == 0) {
+                _state.system_status = State::IDLE;
+            }
         }
 
         // Cache the timestamp from this message so the time difference for
@@ -392,18 +466,35 @@ class LidHeaterTask {
     template <LidHeaterExecutionPolicy Policy>
     auto visit_message(const messages::GetErrorStateMessage& msg, Policy&)
         -> void {
+        auto current_error = most_relevant_error();
+        auto interrupted_by = get_and_clear_interrupted_by();
         auto ack = messages::AcknowledgePrevious{
-            .responding_to_id = msg.id, .with_error = most_relevant_error()};
+            .responding_to_id = msg.id,
+            .with_error = current_error == errors::ErrorCode::NO_ERROR
+                              ? interrupted_by
+                              : current_error};
         std::ignore = _task_registry->comms->get_message_queue().try_send(ack);
     }
 
     template <LidHeaterExecutionPolicy Policy>
-    auto visit_message(const messages::SetErrorStateMessage&, Policy&) -> void {
+    auto visit_message(const messages::SetErrorStateMessage& msg, Policy&)
+        -> void {
+        _state.manual_error = msg.error_to_set;
+        _state.manual_error_countdown =
+            Milliseconds(std::max(uint32_t(msg.delay_s * 1000), uint32_t(1)));
+        auto ack = messages::AcknowledgePrevious{.responding_to_id = msg.id};
+        std::ignore = _task_registry->comms->get_message_queue().try_send(ack);
     }
 
     template <LidHeaterExecutionPolicy Policy>
-    auto visit_message(const messages::ClearErrorStateMessage&, Policy&)
-        -> void {}
+    auto visit_message(const messages::ClearErrorStateMessage& msg, Policy&)
+        -> void {
+        _state.error_bitmap = 0;
+        _thermistor.error = errors::ErrorCode::NO_ERROR;
+        std::ignore = get_and_clear_interrupted_by();
+        auto ack = messages::AcknowledgePrevious{.responding_to_id = msg.id};
+        std::ignore = _task_registry->comms->get_message_queue().try_send(ack);
+    }
 
     auto handle_temperature_conversion(uint16_t conversion_result,
                                        Thermistor& thermistor) -> void {
@@ -442,6 +533,8 @@ class LidHeaterTask {
                 therm.error = therm.short_error;
                 break;
             }
+            default:
+                break;
         }
     }
 
@@ -452,24 +545,6 @@ class LidHeaterTask {
             therm.error = errors::ErrorCode::NO_ERROR;
         }
         therm.temp_c = temp;
-    }
-
-    [[nodiscard]] auto most_relevant_error() const -> errors::ErrorCode {
-        // Sometimes more than one error can occur at the same time; sometimes,
-        // that means that one has caused the other. We want to track them
-        // separately, but we also sometimes want to respond with just one error
-        // condition that sums everything up. This method is used by code that
-        // wants the single most relevant code for the current error condition.
-        if ((_state.error_bitmap & _thermistor.error_bit) ==
-            _thermistor.error_bit) {
-            return _thermistor.error;
-        }
-        if ((_state.error_bitmap & State::HEATER_POWER_ERROR) ==
-            State::HEATER_POWER_ERROR) {
-            return errors::ErrorCode::THERMAL_HEATER_ERROR;
-        }
-
-        return errors::ErrorCode::NO_ERROR;
     }
 
     [[nodiscard]] auto update_control(double time_delta) -> double {
@@ -486,6 +561,23 @@ class LidHeaterTask {
 
         // Start integration once we're within the proportional band
         return _pid.compute(_setpoint_c - _thermistor.temp_c, time_delta);
+    }
+
+    auto set_interrupted_by(errors::ErrorCode error) -> void {
+        if (_state.interrupted_by == errors::ErrorCode::NO_ERROR &&
+            error != errors::ErrorCode::NO_ERROR) {
+            _state.interrupted_by = error;
+        }
+    }
+
+    auto update_interrupted_by() -> void {
+        set_interrupted_by(most_relevant_error());
+    }
+
+    auto get_and_clear_interrupted_by() -> errors::ErrorCode {
+        auto interrupted = _state.interrupted_by;
+        _state.interrupted_by = errors::ErrorCode::NO_ERROR;
+        return interrupted;
     }
 
     Queue& _message_queue;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
@@ -391,6 +391,24 @@ class LidHeaterTask {
             _task_registry->comms->get_message_queue().try_send(response));
     }
 
+    template <LidHeaterExecutionPolicy Policy>
+    auto visit_message(const messages::GetErrorStateMessage& msg, Policy& policy) -> void {
+        static_cast<void>(msg);
+        static_cast<void>(policy);
+    }
+
+    template <LidHeaterExecutionPolicy Policy>
+    auto visit_message(const messages::SetErrorStateMessage& msg, Policy& policy) -> void {
+        static_cast<void>(msg);
+        static_cast<void>(policy);
+    }
+
+    template <LidHeaterExecutionPolicy Policy>
+    auto visit_message(const messages::ClearErrorStateMessage& msg, Policy& policy) -> void {
+        static_cast<void>(msg);
+        static_cast<void>(policy);
+    }
+
     auto handle_temperature_conversion(uint16_t conversion_result,
                                        Thermistor& thermistor) -> void {
         auto visitor = [this, &thermistor](const auto value) -> void {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
@@ -214,7 +214,9 @@ class LidHeaterTask {
         auto old_status = _state.system_status;
         handle_temperature_conversion(msg.lid_temp, _thermistor);
 
+        // NOLINTNEXTLINE(modernize-use-nullptr)
         if (_state.manual_error_countdown > Milliseconds(0)) {
+            // NOLINTNEXTLINE(modernize-use-nullptr)
             if (time_delta >= _state.manual_error_countdown) {
                 _state.manual_error_countdown = Milliseconds(0);
                 _state.error_bitmap |= error_to_error_bitmap_and_set_thermistor(
@@ -477,8 +479,9 @@ class LidHeaterTask {
     auto visit_message(const messages::SetErrorStateMessage& msg, Policy&)
         -> void {
         _state.manual_error = msg.error_to_set;
-        _state.manual_error_countdown =
-            Milliseconds(std::max(uint32_t(msg.delay_s * 1000), uint32_t(1)));
+        _state.manual_error_countdown = std::max(
+            std::chrono::duration_cast<Milliseconds>(Seconds(msg.delay_s)),
+            Milliseconds(1));
         auto ack = messages::AcknowledgePrevious{.responding_to_id = msg.id};
         std::ignore = _task_registry->comms->get_message_queue().try_send(ack);
     }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
@@ -233,9 +233,6 @@ class LidHeaterTask {
                 _state.system_status = State::ERROR;
                 policy.set_heater_power(0.0F);
                 update_interrupted_by();
-            } else {
-                // We went from an error state to no error state... so go idle
-                _state.system_status = State::IDLE;
             }
         }
 

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/lid_heater_task.hpp
@@ -31,15 +31,18 @@ using namespace thermal_general;
 
 template <typename Policy>
 concept LidHeaterExecutionPolicy = requires(Policy& p, const Policy& cp) {
-    // A set_heater_power function to set the power of the heater as
-    // a percentage from 0 to 1.0. Automatically toggles the Enable
-    // pin.
+    // A set_heater_power function to set the
+    // power of the heater as a percentage
+    // from 0 to 1.0. Automatically toggles
+    // the Enable pin.
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     { p.set_heater_power(1.0) } -> std::same_as<bool>;
-    // A get_heater_power function to get the power of the heater as
-    // a percentage from 0 to 1.0.
+    // A get_heater_power function to get the
+    // power of the heater as a percentage
+    // from 0 to 1.0.
     { p.get_heater_power() } -> std::same_as<double>;
-    // A function to enable or disable the lid fans
+    // A function to enable or disable the
+    // lid fans
     { p.set_lid_fans(true) } -> std::same_as<void>;
 };
 
@@ -137,7 +140,7 @@ class LidHeaterTask {
         // anywhere up to the provided timeout, which drives the controller
         // frequency.
 
-        static_cast<void>(_message_queue.recv(&message));
+        _message_queue.recv(&message);
         std::visit(
             [this, &policy](const auto& msg) -> void {
                 this->visit_message(msg, policy);
@@ -148,10 +151,7 @@ class LidHeaterTask {
   private:
     template <typename Policy>
     requires LidHeaterExecutionPolicy<Policy>
-    auto visit_message(const std::monostate& _ignore, Policy& policy) -> void {
-        static_cast<void>(policy);
-        static_cast<void>(_ignore);
-    }
+    auto visit_message(const std::monostate&, Policy&) -> void {}
 
     template <typename Policy>
     requires LidHeaterExecutionPolicy<Policy>
@@ -200,22 +200,20 @@ class LidHeaterTask {
     template <typename Policy>
     requires LidHeaterExecutionPolicy<Policy>
     auto visit_message(const messages::GetLidTemperatureDebugMessage& msg,
-                       Policy& policy) -> void {
-        static_cast<void>(policy);
+                       Policy&) -> void {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         auto response = messages::GetLidTemperatureDebugResponse{
             .responding_to_id = msg.id,
             .lid_temp = _thermistor.temp_c,
             .lid_adc = _thermistor.last_adc};
-        static_cast<void>(_task_registry->comms->get_message_queue().try_send(
-            messages::HostCommsMessage(response)));
+        std::ignore = _task_registry->comms->get_message_queue().try_send(
+            messages::HostCommsMessage(response));
     }
 
     template <typename Policy>
     requires LidHeaterExecutionPolicy<Policy>
-    auto visit_message(const messages::GetLidTempMessage& msg, Policy& policy)
+    auto visit_message(const messages::GetLidTempMessage& msg, Policy&)
         -> void {
-        static_cast<void>(policy);
         auto response =
             messages::GetLidTempResponse{.responding_to_id = msg.id,
                                          .current_temp = _thermistor.temp_c,
@@ -223,8 +221,8 @@ class LidHeaterTask {
         if (_state.system_status != State::CONTROLLING) {
             response.set_temp = 0.0F;
         }
-        static_cast<void>(_task_registry->comms->get_message_queue().try_send(
-            messages::HostCommsMessage(response)));
+        std::ignore = _task_registry->comms->get_message_queue().try_send(
+            messages::HostCommsMessage(response));
     }
 
     template <LidHeaterExecutionPolicy Policy>
@@ -234,15 +232,15 @@ class LidHeaterTask {
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
         if (_state.system_status == State::ERROR) {
             response.with_error = most_relevant_error();
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
         if (_state.system_status == State::CONTROLLING) {
             // Send busy error
             response.with_error = errors::ErrorCode::THERMAL_LID_BUSY;
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
 
@@ -255,8 +253,8 @@ class LidHeaterTask {
             _state.error_bitmap |= State::HEATER_POWER_ERROR;
         }
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <LidHeaterExecutionPolicy Policy>
@@ -266,8 +264,8 @@ class LidHeaterTask {
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
         if (_state.system_status == State::ERROR) {
             response.with_error = most_relevant_error();
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
         if (_state.system_status == State::HEATER_TEST) {
@@ -276,9 +274,9 @@ class LidHeaterTask {
                 response.with_error = errors::ErrorCode::THERMAL_HEATER_ERROR;
                 _state.system_status = State::ERROR;
                 _state.error_bitmap |= State::HEATER_POWER_ERROR;
-                static_cast<void>(
+                std::ignore =
                     _task_registry->comms->get_message_queue().try_send(
-                        response));
+                        response);
                 return;
             }
         }
@@ -292,8 +290,8 @@ class LidHeaterTask {
             _pid.reset();
         }
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <LidHeaterExecutionPolicy Policy>
@@ -305,8 +303,8 @@ class LidHeaterTask {
         if (_state.system_status == State::ERROR && !msg.from_system) {
             std::ignore = policy.set_heater_power(0.0F);
             response.with_error = most_relevant_error();
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
 
@@ -320,11 +318,11 @@ class LidHeaterTask {
         }
 
         if (msg.from_system) {
-            static_cast<void>(
-                _task_registry->system->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->system->get_message_queue().try_send(response);
         } else {
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
         }
     }
 
@@ -334,40 +332,39 @@ class LidHeaterTask {
         auto response =
             messages::DeactivateAllResponse{.responding_to_id = msg.id};
 
-        static_cast<void>(policy.set_heater_power(0.0F));
+        std::ignore = policy.set_heater_power(0.0F);
         if (_state.system_status != State::ERROR) {
             _state.system_status = State::IDLE;
         }
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <LidHeaterExecutionPolicy Policy>
-    auto visit_message(const messages::SetPIDConstantsMessage& msg,
-                       Policy& policy) -> void {
-        static_cast<void>(policy);
+    auto visit_message(const messages::SetPIDConstantsMessage& msg, Policy&)
+        -> void {
         auto response =
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
 
         if (_state.system_status == State::CONTROLLING) {
             response.with_error = errors::ErrorCode::THERMAL_LID_BUSY;
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
         if ((msg.p < KP_MIN) || (msg.p > KP_MAX) || (msg.i < KI_MIN) ||
             (msg.i > KI_MAX) || (msg.d < KD_MIN) || (msg.d > KD_MAX)) {
             response.with_error =
                 errors::ErrorCode::THERMAL_CONSTANT_OUT_OF_RANGE;
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
 
         _pid = PID(msg.p, msg.i, msg.d, CONTROL_PERIOD_SECONDS, 1.0, -1.0);
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <LidHeaterExecutionPolicy Policy>
@@ -376,8 +373,8 @@ class LidHeaterTask {
         auto response = messages::GetLidPowerResponse{
             .responding_to_id = msg.id, .heater = policy.get_heater_power()};
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <LidHeaterExecutionPolicy Policy>
@@ -388,33 +385,25 @@ class LidHeaterTask {
 
         policy.set_lid_fans(msg.enable);
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <LidHeaterExecutionPolicy Policy>
-    auto visit_message(const messages::GetErrorStateMessage& msg,
-                       Policy& policy) -> void {
-        static_cast<void>(policy);
+    auto visit_message(const messages::GetErrorStateMessage& msg, Policy&)
+        -> void {
         auto ack = messages::AcknowledgePrevious{
             .responding_to_id = msg.id, .with_error = most_relevant_error()};
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(ack));
+        std::ignore = _task_registry->comms->get_message_queue().try_send(ack);
     }
 
     template <LidHeaterExecutionPolicy Policy>
-    auto visit_message(const messages::SetErrorStateMessage& msg,
-                       Policy& policy) -> void {
-        static_cast<void>(msg);
-        static_cast<void>(policy);
+    auto visit_message(const messages::SetErrorStateMessage&, Policy&) -> void {
     }
 
     template <LidHeaterExecutionPolicy Policy>
-    auto visit_message(const messages::ClearErrorStateMessage& msg,
-                       Policy& policy) -> void {
-        static_cast<void>(msg);
-        static_cast<void>(policy);
-    }
+    auto visit_message(const messages::ClearErrorStateMessage&, Policy&)
+        -> void {}
 
     auto handle_temperature_conversion(uint16_t conversion_result,
                                        Thermistor& thermistor) -> void {
@@ -430,9 +419,9 @@ class LidHeaterTask {
 #if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
                 auto error_message = messages::HostCommsMessage(
                     messages::ErrorMessage{.code = thermistor.error});
-                static_cast<void>(
+                std::ignore =
                     _task_registry->comms->get_message_queue().try_send(
-                        error_message));
+                        error_message);
 #endif
             } else {
                 _state.error_bitmap &= ~thermistor.error_bit;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -453,28 +453,24 @@ using HostCommsMessage = ::std::variant<
     GetLidStatusResponse, GetResetReasonResponse, GetPlatePowerResponse,
     GetLidPowerResponse, GetOffsetConstantsResponse, SealStepperDebugResponse,
     DeactivateAllResponse, GetLidSwitchesResponse, GetFrontButtonResponse>;
-using ThermalPlateMessage =
-    ::std::variant<std::monostate, ThermalPlateTempReadComplete,
-                   GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,
-                   SetFanManualMessage, GetPlateTempMessage, SetRampRateMessage,
-                   SetPlateTemperatureMessage, DeactivatePlateMessage,
-                   SetPIDConstantsMessage, SetFanAutomaticMessage,
-                   GetThermalPowerMessage, SetOffsetConstantsMessage,
-                   GetOffsetConstantsMessage, DeactivateAllMessage,
-                   GetErrorStateMessage, ClearErrorStateMessage, SetErrorStateMessage
-                   >;
+using ThermalPlateMessage = ::std::variant<
+    std::monostate, ThermalPlateTempReadComplete,
+    GetPlateTemperatureDebugMessage, SetPeltierDebugMessage,
+    SetFanManualMessage, GetPlateTempMessage, SetRampRateMessage,
+    SetPlateTemperatureMessage, DeactivatePlateMessage, SetPIDConstantsMessage,
+    SetFanAutomaticMessage, GetThermalPowerMessage, SetOffsetConstantsMessage,
+    GetOffsetConstantsMessage, DeactivateAllMessage, GetErrorStateMessage,
+    ClearErrorStateMessage, SetErrorStateMessage>;
 using LidHeaterMessage = ::std::variant<
     std::monostate, LidTempReadComplete, GetLidTemperatureDebugMessage,
     SetHeaterDebugMessage, GetLidTempMessage, SetLidTemperatureMessage,
     DeactivateLidHeatingMessage, SetPIDConstantsMessage, GetThermalPowerMessage,
-    DeactivateAllMessage, SetLidFansMessage,
-    GetErrorStateMessage, ClearErrorStateMessage, SetErrorStateMessage
-    >;
+    DeactivateAllMessage, SetLidFansMessage, GetErrorStateMessage,
+    ClearErrorStateMessage, SetErrorStateMessage>;
 using MotorMessage = ::std::variant<
     std::monostate, ActuateSolenoidMessage, LidStepperDebugMessage,
     LidStepperComplete, SealStepperDebugMessage, SealStepperComplete,
     GetSealDriveStatusMessage, SetSealParameterMessage, GetLidStatusMessage,
     GetResetReasonMessage, OpenLidMessage, CloseLidMessage, PlateLiftMessage,
-    FrontButtonPressMessage, GetLidSwitchesMessage
-    >;
+    FrontButtonPressMessage, GetLidSwitchesMessage>;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -425,6 +425,20 @@ struct SetLightsDebugMessage {
     bool enable;
 };
 
+struct GetErrorStateMessage {
+    uint32_t id;
+};
+
+struct ClearErrorStateMessage {
+    uint32_t id;
+};
+
+struct SetErrorStateMessage {
+    uint32_t id;
+    errors::ErrorCode error_to_set;
+    uint32_t delay_s;
+};
+
 using SystemMessage =
     ::std::variant<std::monostate, EnterBootloaderMessage, AcknowledgePrevious,
                    SetSerialNumberMessage, GetSystemInfoMessage,
@@ -446,16 +460,22 @@ using ThermalPlateMessage =
                    SetPlateTemperatureMessage, DeactivatePlateMessage,
                    SetPIDConstantsMessage, SetFanAutomaticMessage,
                    GetThermalPowerMessage, SetOffsetConstantsMessage,
-                   GetOffsetConstantsMessage, DeactivateAllMessage>;
+                   GetOffsetConstantsMessage, DeactivateAllMessage,
+                   GetErrorStateMessage, ClearErrorStateMessage, SetErrorStateMessage
+                   >;
 using LidHeaterMessage = ::std::variant<
     std::monostate, LidTempReadComplete, GetLidTemperatureDebugMessage,
     SetHeaterDebugMessage, GetLidTempMessage, SetLidTemperatureMessage,
     DeactivateLidHeatingMessage, SetPIDConstantsMessage, GetThermalPowerMessage,
-    DeactivateAllMessage, SetLidFansMessage>;
+    DeactivateAllMessage, SetLidFansMessage,
+    GetErrorStateMessage, ClearErrorStateMessage, SetErrorStateMessage
+    >;
 using MotorMessage = ::std::variant<
     std::monostate, ActuateSolenoidMessage, LidStepperDebugMessage,
     LidStepperComplete, SealStepperDebugMessage, SealStepperComplete,
     GetSealDriveStatusMessage, SetSealParameterMessage, GetLidStatusMessage,
     GetResetReasonMessage, OpenLidMessage, CloseLidMessage, PlateLiftMessage,
-    FrontButtonPressMessage, GetLidSwitchesMessage>;
+    FrontButtonPressMessage, GetLidSwitchesMessage,
+    GetErrorStateMessage, ClearErrorStateMessage, SetErrorStateMessage
+    >;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/messages.hpp
@@ -475,7 +475,6 @@ using MotorMessage = ::std::variant<
     LidStepperComplete, SealStepperDebugMessage, SealStepperComplete,
     GetSealDriveStatusMessage, SetSealParameterMessage, GetLidStatusMessage,
     GetResetReasonMessage, OpenLidMessage, CloseLidMessage, PlateLiftMessage,
-    FrontButtonPressMessage, GetLidSwitchesMessage,
-    GetErrorStateMessage, ClearErrorStateMessage, SetErrorStateMessage
+    FrontButtonPressMessage, GetLidSwitchesMessage
     >;
 };  // namespace messages

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -674,24 +674,6 @@ class MotorTask {
             _task_registry->comms->get_message_queue().try_send(response));
     }
 
-    template <MotorExecutionPolicy Policy>
-    auto visit_message(const messages::GetErrorStateMessage& msg, Policy& policy) -> void {
-        static_cast<void>(msg);
-        static_cast<void>(policy);
-    }
-
-    template <MotorExecutionPolicy Policy>
-    auto visit_message(const messages::SetErrorStateMessage& msg, Policy& policy) -> void {
-        static_cast<void>(msg);
-        static_cast<void>(policy);
-    }
-
-    template <MotorExecutionPolicy Policy>
-    auto visit_message(const messages::ClearErrorStateMessage& msg, Policy& policy) -> void {
-        static_cast<void>(msg);
-        static_cast<void>(policy);
-    }
-
     // Callback for each tick() during a seal stepper movement
     template <MotorExecutionPolicy Policy>
     auto seal_step_callback(Policy& policy) -> void {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -674,6 +674,24 @@ class MotorTask {
             _task_registry->comms->get_message_queue().try_send(response));
     }
 
+    template <MotorExecutionPolicy Policy>
+    auto visit_message(const messages::GetErrorStateMessage& msg, Policy& policy) -> void {
+        static_cast<void>(msg);
+        static_cast<void>(policy);
+    }
+
+    template <MotorExecutionPolicy Policy>
+    auto visit_message(const messages::SetErrorStateMessage& msg, Policy& policy) -> void {
+        static_cast<void>(msg);
+        static_cast<void>(policy);
+    }
+
+    template <MotorExecutionPolicy Policy>
+    auto visit_message(const messages::ClearErrorStateMessage& msg, Policy& policy) -> void {
+        static_cast<void>(msg);
+        static_cast<void>(policy);
+    }
+
     // Callback for each tick() during a seal stepper movement
     template <MotorExecutionPolicy Policy>
     auto seal_step_callback(Policy& policy) -> void {

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -13,6 +13,7 @@
 
 #include "core/pid.hpp"
 #include "core/thermistor_conversion.hpp"
+#include "errors.hpp"
 #include "hal/message_queue.hpp"
 #include "messages.hpp"
 #include "thermocycler-gen2/eeprom.hpp"
@@ -75,6 +76,9 @@ struct State {
     };
     Status system_status;
     uint16_t error_bitmap;
+    errors::ErrorCode manual_error;
+    std::chrono::milliseconds manual_error_countdown;
+    errors::ErrorCode interrupted_by;
     // NOTE - thermistor error bits are defined in the thermistor array
     // initializor. Additional errors are defined assuming the max thermistor
     // error is (1 << 6), for the heat sink
@@ -201,7 +205,11 @@ class ThermalPlateTask {
                            CONTROL_PERIOD_SECONDS, 1.0, -1.0)},
           _converter(THERMISTOR_CIRCUIT_BIAS_RESISTANCE_KOHM, ADC_BIT_MAX,
                      false),
-          _state{.system_status = State::IDLE, .error_bitmap = 0},
+          _state{.system_status = State::IDLE,
+                 .error_bitmap = 0,
+                 .manual_error = errors::ErrorCode::NO_ERROR,
+                 .manual_error_countdown = Milliseconds(0),
+                 .interrupted_by = errors::ErrorCode::NO_ERROR},
           _plate_control(_peltier_left, _peltier_right, _peltier_center, _fans),
           // NOLINTNEXTLINE(readability-redundant-member-init)
           _eeprom(),
@@ -259,7 +267,7 @@ class ThermalPlateTask {
         // anywhere up to the provided timeout, which drives the controller
         // frequency.
 
-        static_cast<void>(_message_queue.recv(&message));
+        _message_queue.recv(&message);
         std::visit(
             [this, &policy](const auto& msg) -> void {
                 this->visit_message(msg, policy);
@@ -267,12 +275,71 @@ class ThermalPlateTask {
             message);
     }
 
+    [[nodiscard]] auto most_relevant_error() const -> errors::ErrorCode {
+        // Sometimes more than one error can occur at the same time; sometimes,
+        // that means that one has caused the other. We want to track them
+        // separately, but we also sometimes want to respond with just one error
+        // condition that sums everything up. This method is used by code that
+        // wants the single most relevant code for the current error condition.
+        return calculate_most_relevant_error(_state.error_bitmap);
+    }
+
   private:
     template <typename Policy>
     requires ThermalPlateExecutionPolicy<Policy>
-    auto visit_message(const std::monostate& _ignore, Policy& policy) -> void {
-        static_cast<void>(policy);
-        static_cast<void>(_ignore);
+    auto visit_message(const std::monostate&, Policy&) -> void {}
+
+    auto set_thermistor_if_not_errored(ThermistorID thermistor,
+                                       errors::ErrorCode error) -> uint16_t {
+        if (_thermistors[thermistor].error != errors::ErrorCode::NO_ERROR) {
+            return 0;
+        }
+        _thermistors[thermistor].error = error;
+        return thermistorErrorBit(thermistor);
+    }
+
+    auto error_to_bitmap_and_set_thermistor(errors::ErrorCode error)
+        -> uint16_t {
+        switch (error) {
+            case errors::ErrorCode::THERMAL_PELTIER_ERROR:
+                return State::PELTIER_ERROR;
+            case errors::ErrorCode::THERMAL_HEATSINK_FAN_ERROR:
+                return State::FAN_ERROR;
+            case errors::ErrorCode::THERMAL_DRIFT:
+                return State::DRIFT_ERROR;
+            case errors::ErrorCode::THERMISTOR_FRONT_RIGHT_DISCONNECTED:
+            case errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT:
+            case errors::ErrorCode::THERMISTOR_FRONT_RIGHT_OVERTEMP:
+                return set_thermistor_if_not_errored(
+                    ThermistorID::THERM_FRONT_RIGHT, error);
+            case errors::ErrorCode::THERMISTOR_FRONT_LEFT_DISCONNECTED:
+            case errors::ErrorCode::THERMISTOR_FRONT_LEFT_SHORT:
+            case errors::ErrorCode::THERMISTOR_FRONT_LEFT_OVERTEMP:
+                return set_thermistor_if_not_errored(
+                    ThermistorID::THERM_FRONT_LEFT, error);
+            case errors::ErrorCode::THERMISTOR_FRONT_CENTER_DISCONNECTED:
+            case errors::ErrorCode::THERMISTOR_FRONT_CENTER_SHORT:
+            case errors::ErrorCode::THERMISTOR_FRONT_CENTER_OVERTEMP:
+                return set_thermistor_if_not_errored(
+                    ThermistorID::THERM_FRONT_CENTER, error);
+            case errors::ErrorCode::THERMISTOR_BACK_RIGHT_DISCONNECTED:
+            case errors::ErrorCode::THERMISTOR_BACK_RIGHT_SHORT:
+            case errors::ErrorCode::THERMISTOR_BACK_RIGHT_OVERTEMP:
+                return set_thermistor_if_not_errored(
+                    ThermistorID::THERM_BACK_RIGHT, error);
+            case errors::ErrorCode::THERMISTOR_BACK_LEFT_DISCONNECTED:
+            case errors::ErrorCode::THERMISTOR_BACK_LEFT_SHORT:
+            case errors::ErrorCode::THERMISTOR_BACK_LEFT_OVERTEMP:
+                return set_thermistor_if_not_errored(
+                    ThermistorID::THERM_BACK_LEFT, error);
+            case errors::ErrorCode::THERMISTOR_BACK_CENTER_DISCONNECTED:
+            case errors::ErrorCode::THERMISTOR_BACK_CENTER_SHORT:
+            case errors::ErrorCode::THERMISTOR_BACK_CENTER_OVERTEMP:
+                return set_thermistor_if_not_errored(
+                    ThermistorID::THERM_BACK_CENTER, error);
+            default:
+                return 0;
+        }
     }
 
     template <typename Policy>
@@ -281,8 +348,10 @@ class ThermalPlateTask {
                        Policy& policy) -> void {
         constexpr Milliseconds time_overflow_amount = Milliseconds(
             std::numeric_limits<decltype(msg.timestamp_ms)>::max());
+        auto old_status = _state.system_status;
         auto old_error_bitmap = _state.error_bitmap;
         auto current_time = Milliseconds(msg.timestamp_ms);
+        auto time_delta = current_time - _last_update;
 
         // Peltier temperatures are implicitly updated by updating the values
         // in the thermistors
@@ -308,6 +377,20 @@ class ThermalPlateTask {
             msg.back_center, _thermistors[THERM_BACK_CENTER], true, heatsink,
             _offset_constants.a, _offset_constants.bc, _offset_constants.cc);
 
+        // Set the manual error after the conversions so it doesn't get
+        // overridden by the thermistors
+        if (_state.manual_error_countdown > Milliseconds(0)) {
+            if (time_delta >= _state.manual_error_countdown) {
+                _state.manual_error_countdown = Milliseconds(0);
+                _state.error_bitmap |=
+                    error_to_bitmap_and_set_thermistor(_state.manual_error);
+                _state.interrupted_by = _state.manual_error;
+                _state.manual_error = errors::ErrorCode::NO_ERROR;
+            } else {
+                _state.manual_error_countdown -= time_delta;
+            }
+        }
+
         if (_state.system_status == State::CONTROLLING &&
             _plate_control.status() ==
                 plate_control::PlateStatus::STEADY_STATE) {
@@ -323,15 +406,15 @@ class ThermalPlateTask {
                 _state.system_status = State::ERROR;
                 policy.set_enabled(false);
                 reset_peltier_filters();
+                _state.interrupted_by = most_relevant_error();
+                send_current_error();
             } else {
                 // We went from an error state to no error state... so go idle
                 _state.system_status = State::IDLE;
             }
-            send_current_error();
         }
 
         if (_state.system_status == State::CONTROLLING) {
-            auto time_delta = current_time - _last_update;
             if (time_delta.count() < 0) {
                 time_delta += time_overflow_amount;
             }
@@ -345,13 +428,21 @@ class ThermalPlateTask {
                 if (!policy.set_fan(fan_power)) {
                     _state.system_status = State::ERROR;
                     _state.error_bitmap |= State::FAN_ERROR;
+                    update_interrupted_by();
                 }
             }
         }
         // Not an `else` so we can immediately resolve any issue setting outputs
         if (_state.system_status == State::ERROR) {
+            if (old_status != State::ERROR) {
+                update_interrupted_by();
+            }
             policy.set_enabled(false);
             reset_peltier_filters();
+            if (_state.error_bitmap == 0) {
+                _state.system_status = State::IDLE;
+                send_current_state();
+            }
         }
 
         // Cache the timestamp from this message so the time difference for
@@ -362,8 +453,7 @@ class ThermalPlateTask {
     template <typename Policy>
     requires ThermalPlateExecutionPolicy<Policy>
     auto visit_message(const messages::GetPlateTemperatureDebugMessage& msg,
-                       Policy& policy) -> void {
-        static_cast<void>(policy);
+                       Policy&) -> void {
         auto response = messages::GetPlateTemperatureDebugResponse{
             .responding_to_id = msg.id,
             .heat_sink_temp = _thermistors[THERM_HEATSINK].temp_c,
@@ -380,14 +470,13 @@ class ThermalPlateTask {
             .back_right_adc = _thermistors[THERM_BACK_RIGHT].last_adc,
             .back_center_adc = _thermistors[THERM_BACK_CENTER].last_adc,
             .back_left_adc = _thermistors[THERM_BACK_LEFT].last_adc};
-        static_cast<void>(_task_registry->comms->get_message_queue().try_send(
-            messages::HostCommsMessage(response)));
+        std::ignore = _task_registry->comms->get_message_queue().try_send(
+            messages::HostCommsMessage(response));
     }
 
     template <ThermalPlateExecutionPolicy Policy>
-    auto visit_message(const messages::GetPlateTempMessage& msg, Policy& policy)
+    auto visit_message(const messages::GetPlateTempMessage& msg, Policy&)
         -> void {
-        static_cast<void>(policy);
         auto response = messages::GetPlateTempResponse{
             .responding_to_id = msg.id,
             .current_temp = average_plate_temp(),
@@ -402,8 +491,8 @@ class ThermalPlateTask {
         if (_state.system_status != State::CONTROLLING) {
             response.set_temp = 0.0F;
         }
-        static_cast<void>(_task_registry->comms->get_message_queue().try_send(
-            messages::HostCommsMessage(response)));
+        std::ignore = _task_registry->comms->get_message_queue().try_send(
+            messages::HostCommsMessage(response));
     }
 
     template <ThermalPlateExecutionPolicy Policy>
@@ -413,15 +502,15 @@ class ThermalPlateTask {
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
         if (_state.system_status == State::ERROR) {
             response.with_error = most_relevant_error();
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
         if (_state.system_status == State::CONTROLLING) {
             // Send busy error
             response.with_error = errors::ErrorCode::THERMAL_PLATE_BUSY;
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
         bool ok = true;
@@ -464,10 +553,11 @@ class ThermalPlateTask {
             response.with_error = errors::ErrorCode::THERMAL_PELTIER_ERROR;
             _state.system_status = State::ERROR;
             _state.error_bitmap |= State::PELTIER_ERROR;
+            update_interrupted_by();
         }
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <ThermalPlateExecutionPolicy Policy>
@@ -477,8 +567,8 @@ class ThermalPlateTask {
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
         if (_state.system_status == State::ERROR) {
             response.with_error = most_relevant_error();
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
         if (policy.set_fan(msg.power)) {
@@ -487,8 +577,8 @@ class ThermalPlateTask {
             response.with_error = errors::ErrorCode::THERMAL_HEATSINK_FAN_ERROR;
         }
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <ThermalPlateExecutionPolicy Policy>
@@ -498,8 +588,8 @@ class ThermalPlateTask {
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
         if (_state.system_status == State::ERROR) {
             response.with_error = most_relevant_error();
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
         // If we aren't actively in a control loop, deactivate fan
@@ -511,8 +601,8 @@ class ThermalPlateTask {
             }
         }
         _fans.manual_control = false;
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <ThermalPlateExecutionPolicy Policy>
@@ -525,8 +615,8 @@ class ThermalPlateTask {
             response.with_error = most_relevant_error();
         }
         _plate_control.set_new_ramp_rate(msg.ramp_rate);
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <ThermalPlateExecutionPolicy Policy>
@@ -536,8 +626,8 @@ class ThermalPlateTask {
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
         if (_state.system_status == State::ERROR) {
             response.with_error = most_relevant_error();
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
         if (_state.system_status == State::PWM_TEST) {
@@ -558,9 +648,10 @@ class ThermalPlateTask {
                 response.with_error = errors::ErrorCode::THERMAL_PELTIER_ERROR;
                 _state.system_status = State::ERROR;
                 _state.error_bitmap |= State::PELTIER_ERROR;
-                static_cast<void>(
+                update_interrupted_by();
+                std::ignore =
                     _task_registry->comms->get_message_queue().try_send(
-                        response));
+                        response);
                 return;
             }
         }
@@ -581,8 +672,8 @@ class ThermalPlateTask {
             }
         }
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <ThermalPlateExecutionPolicy Policy>
@@ -593,8 +684,8 @@ class ThermalPlateTask {
 
         if (_state.system_status == State::ERROR && !msg.from_system) {
             response.with_error = most_relevant_error();
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
 
@@ -603,11 +694,11 @@ class ThermalPlateTask {
         _state.system_status = State::IDLE;
 
         if (msg.from_system) {
-            static_cast<void>(
-                _task_registry->system->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->system->get_message_queue().try_send(response);
         } else {
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
         }
     }
 
@@ -622,29 +713,28 @@ class ThermalPlateTask {
         if (_state.system_status != State::ERROR) {
             _state.system_status = State::IDLE;
         }
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <ThermalPlateExecutionPolicy Policy>
-    auto visit_message(const messages::SetPIDConstantsMessage& msg,
-                       Policy& policy) -> void {
-        static_cast<void>(policy);
+    auto visit_message(const messages::SetPIDConstantsMessage& msg, Policy&)
+        -> void {
         auto response =
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
 
         if (_state.system_status == State::CONTROLLING) {
             response.with_error = errors::ErrorCode::THERMAL_PLATE_BUSY;
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
         if ((msg.p < KP_MIN) || (msg.p > KP_MAX) || (msg.i < KI_MIN) ||
             (msg.i > KI_MAX) || (msg.d < KD_MIN) || (msg.d > KD_MAX)) {
             response.with_error =
                 errors::ErrorCode::THERMAL_CONSTANT_OUT_OF_RANGE;
-            static_cast<void>(
-                _task_registry->comms->get_message_queue().try_send(response));
+            std::ignore =
+                _task_registry->comms->get_message_queue().try_send(response);
             return;
         }
 
@@ -661,8 +751,8 @@ class ThermalPlateTask {
                 PID(msg.p, msg.i, msg.d, CONTROL_PERIOD_SECONDS, 1.0, -1.0);
         }
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <ThermalPlateExecutionPolicy Policy>
@@ -692,8 +782,8 @@ class ThermalPlateTask {
             right.second *
             (right.first == PeltierDirection::PELTIER_HEATING ? 1.0 : -1.0);
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <ThermalPlateExecutionPolicy Policy>
@@ -740,8 +830,8 @@ class ThermalPlateTask {
             response.with_error = errors::ErrorCode::SYSTEM_EEPROM_ERROR;
         }
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <ThermalPlateExecutionPolicy Policy>
@@ -759,31 +849,48 @@ class ThermalPlateTask {
                                                  .br = _offset_constants.br,
                                                  .cr = _offset_constants.cr};
 
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <ThermalPlateExecutionPolicy Policy>
-    auto visit_message(const messages::GetErrorStateMessage& msg, Policy& policy) -> void {
-        static_cast<void>(policy);
+    auto visit_message(const messages::GetErrorStateMessage& msg, Policy&)
+        -> void {
+        auto most_relevant = most_relevant_error();
+        auto interrupted = get_and_clear_interrupted_by();
         auto response = messages::AcknowledgePrevious{
             .responding_to_id = msg.id,
-            .with_error = most_relevant_error()
-        };
-        static_cast<void>(
-            _task_registry->comms->get_message_queue().try_send(response));
+            .with_error = ((most_relevant == errors::ErrorCode::NO_ERROR)
+                               ? interrupted
+                               : most_relevant)};
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <ThermalPlateExecutionPolicy Policy>
-    auto visit_message(const messages::SetErrorStateMessage& msg, Policy& policy) -> void {
-        static_cast<void>(msg);
-        static_cast<void>(policy);
+    auto visit_message(const messages::SetErrorStateMessage& msg, Policy&)
+        -> void {
+        _state.manual_error = msg.error_to_set;
+        _state.manual_error_countdown =
+            Milliseconds(std::max(msg.delay_s * 1000, uint32_t(1)));
+        auto response =
+            messages::AcknowledgePrevious{.responding_to_id = msg.id};
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     template <ThermalPlateExecutionPolicy Policy>
-    auto visit_message(const messages::ClearErrorStateMessage& msg, Policy& policy) -> void {
-        static_cast<void>(msg);
-        static_cast<void>(policy);
+    auto visit_message(const messages::ClearErrorStateMessage& msg, Policy&)
+        -> void {
+        _state.error_bitmap = 0;
+        for (auto& thermistor : _thermistors) {
+            thermistor.error = errors::ErrorCode::NO_ERROR;
+        }
+        std::ignore = get_and_clear_interrupted_by();
+        auto response =
+            messages::AcknowledgePrevious{.responding_to_id = msg.id};
+        std::ignore =
+            _task_registry->comms->get_message_queue().try_send(response);
     }
 
     auto handle_temperature_conversion(
@@ -808,9 +915,9 @@ class ThermalPlateTask {
 #if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
                 auto error_message = messages::HostCommsMessage(
                     messages::ErrorMessage{.code = thermistor.error});
-                static_cast<void>(
+                std::ignore =
                     _task_registry->comms->get_message_queue().try_send(
-                        error_message));
+                        error_message);
 #endif
             } else {
                 _state.error_bitmap &= ~thermistor.error_bit;
@@ -843,29 +950,24 @@ class ThermalPlateTask {
         therm.temp_c = temp;
     }
 
-    [[nodiscard]] auto most_relevant_error() const -> errors::ErrorCode {
-        // Sometimes more than one error can occur at the same time; sometimes,
-        // that means that one has caused the other. We want to track them
-        // separately, but we also sometimes want to respond with just one error
-        // condition that sums everything up. This method is used by code that
-        // wants the single most relevant code for the current error condition.
-        if ((_state.error_bitmap & State::PELTIER_ERROR) ==
-            State::PELTIER_ERROR) {
+    [[nodiscard]] auto calculate_most_relevant_error(uint16_t err_bitmap) const
+        -> errors::ErrorCode {
+        if ((err_bitmap & State::PELTIER_ERROR) == State::PELTIER_ERROR) {
             return errors::ErrorCode::THERMAL_PELTIER_ERROR;
         }
-        if ((_state.error_bitmap & State::FAN_ERROR) == State::FAN_ERROR) {
+        if ((err_bitmap & State::FAN_ERROR) == State::FAN_ERROR) {
             return errors::ErrorCode::THERMAL_HEATSINK_FAN_ERROR;
         }
 
         for (auto therm : _thermistors) {
-            if ((_state.error_bitmap & therm.error_bit) == therm.error_bit) {
+            if ((err_bitmap & therm.error_bit) == therm.error_bit) {
                 return therm.error;
             }
         }
         // Thermistor out-of-range errors are prioritized over drift because
         // the former may be the root cause of the latter; sending a drift
         // error when a thermistor is entirely disconnected is misleading.
-        if ((_state.error_bitmap & State::DRIFT_ERROR) == State::DRIFT_ERROR) {
+        if ((err_bitmap & State::DRIFT_ERROR) == State::DRIFT_ERROR) {
             return errors::ErrorCode::THERMAL_DRIFT;
         }
         return errors::ErrorCode::NO_ERROR;
@@ -912,6 +1014,7 @@ class ThermalPlateTask {
             policy.set_enabled(false);
             _state.system_status = State::ERROR;
             _state.error_bitmap |= State::PELTIER_ERROR;
+            _state.interrupted_by = most_relevant_error();
             return false;
         }
         if (!_fans.manual_control) {
@@ -921,6 +1024,7 @@ class ThermalPlateTask {
                 policy.set_enabled(false);
                 _state.system_status = State::ERROR;
                 _state.error_bitmap |= State::FAN_ERROR;
+                _state.interrupted_by = most_relevant_error();
                 return false;
             }
         }
@@ -966,8 +1070,8 @@ class ThermalPlateTask {
         auto error_msg = messages::UpdateTaskErrorState{
             .task = messages::UpdateTaskErrorState::Tasks::THERMAL_PLATE,
             .current_error = most_relevant_error()};
-        static_cast<void>(
-            _task_registry->system->get_message_queue().try_send(error_msg));
+        std::ignore =
+            _task_registry->system->get_message_queue().try_send(error_msg);
     }
 
     /**
@@ -999,8 +1103,8 @@ class ThermalPlateTask {
         }
 
         auto message = messages::UpdatePlateState{.state = state};
-        static_cast<void>(
-            _task_registry->system->get_message_queue().try_send(message));
+        std::ignore =
+            _task_registry->system->get_message_queue().try_send(message);
     }
 
     /**
@@ -1025,6 +1129,23 @@ class ThermalPlateTask {
         _peltier_left.filter.reset();
         _peltier_right.filter.reset();
         _peltier_center.filter.reset();
+    }
+
+    auto set_interrupted_by(errors::ErrorCode error) -> void {
+        if (_state.interrupted_by == errors::ErrorCode::NO_ERROR &&
+            error != errors::ErrorCode::NO_ERROR) {
+            _state.interrupted_by = error;
+        }
+    }
+
+    auto update_interrupted_by() -> void {
+        set_interrupted_by(most_relevant_error());
+    }
+
+    auto get_and_clear_interrupted_by() -> errors::ErrorCode {
+        auto was_interrupted = _state.interrupted_by;
+        _state.interrupted_by = errors::ErrorCode::NO_ERROR;
+        return was_interrupted;
     }
 
     Queue& _message_queue;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -291,9 +291,11 @@ class ThermalPlateTask {
 
     auto set_thermistor_if_not_errored(ThermistorID thermistor,
                                        errors::ErrorCode error) -> uint16_t {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
         if (_thermistors[thermistor].error != errors::ErrorCode::NO_ERROR) {
             return 0;
         }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
         _thermistors[thermistor].error = error;
         return thermistorErrorBit(thermistor);
     }
@@ -379,7 +381,9 @@ class ThermalPlateTask {
 
         // Set the manual error after the conversions so it doesn't get
         // overridden by the thermistors
+        // NOLINTNEXTLINE(modernize-use-nullptr)
         if (_state.manual_error_countdown > Milliseconds(0)) {
+            // NOLINTNEXTLINE(modernize-use-nullptr)
             if (time_delta >= _state.manual_error_countdown) {
                 _state.manual_error_countdown = Milliseconds(0);
                 _state.error_bitmap |=
@@ -869,8 +873,9 @@ class ThermalPlateTask {
     auto visit_message(const messages::SetErrorStateMessage& msg, Policy&)
         -> void {
         _state.manual_error = msg.error_to_set;
-        _state.manual_error_countdown =
-            Milliseconds(std::max(msg.delay_s * 1000, uint32_t(1)));
+        _state.manual_error_countdown = std::max(
+            std::chrono::duration_cast<Milliseconds>(Seconds(msg.delay_s)),
+            Milliseconds(1));
         auto response =
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
         std::ignore =

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -14,6 +14,7 @@
 #include "core/pid.hpp"
 #include "core/thermistor_conversion.hpp"
 #include "hal/message_queue.hpp"
+#include "messages.hpp"
 #include "thermocycler-gen2/eeprom.hpp"
 #include "thermocycler-gen2/errors.hpp"
 #include "thermocycler-gen2/messages.hpp"
@@ -760,6 +761,24 @@ class ThermalPlateTask {
 
         static_cast<void>(
             _task_registry->comms->get_message_queue().try_send(response));
+    }
+
+    template <ThermalPlateExecutionPolicy Policy>
+    auto visit_message(const messages::GetErrorStateMessage& msg, Policy& policy) -> void {
+        static_cast<void>(msg);
+        static_cast<void>(policy);
+    }
+
+    template <ThermalPlateExecutionPolicy Policy>
+    auto visit_message(const messages::SetErrorStateMessage& msg, Policy& policy) -> void {
+        static_cast<void>(msg);
+        static_cast<void>(policy);
+    }
+
+    template <ThermalPlateExecutionPolicy Policy>
+    auto visit_message(const messages::ClearErrorStateMessage& msg, Policy& policy) -> void {
+        static_cast<void>(msg);
+        static_cast<void>(policy);
     }
 
     auto handle_temperature_conversion(

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -408,9 +408,6 @@ class ThermalPlateTask {
                 reset_peltier_filters();
                 _state.interrupted_by = most_relevant_error();
                 send_current_error();
-            } else {
-                // We went from an error state to no error state... so go idle
-                _state.system_status = State::IDLE;
             }
         }
 
@@ -442,6 +439,7 @@ class ThermalPlateTask {
             if (_state.error_bitmap == 0) {
                 _state.system_status = State::IDLE;
                 send_current_state();
+                send_current_error();
             }
         }
 
@@ -887,6 +885,8 @@ class ThermalPlateTask {
             thermistor.error = errors::ErrorCode::NO_ERROR;
         }
         std::ignore = get_and_clear_interrupted_by();
+        send_current_state();
+        send_current_error();
         auto response =
             messages::AcknowledgePrevious{.responding_to_id = msg.id};
         std::ignore =
@@ -1067,9 +1067,13 @@ class ThermalPlateTask {
      *
      */
     auto send_current_error() -> void {
+        auto relevant = most_relevant_error();
+        auto interrupted_by = _state.interrupted_by;
         auto error_msg = messages::UpdateTaskErrorState{
             .task = messages::UpdateTaskErrorState::Tasks::THERMAL_PLATE,
-            .current_error = most_relevant_error()};
+            .current_error = relevant == errors::ErrorCode::NO_ERROR
+                                 ? interrupted_by
+                                 : relevant};
         std::ignore =
             _task_registry->system->get_message_queue().try_send(error_msg);
     }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/thermal_plate_task.hpp
@@ -765,8 +765,13 @@ class ThermalPlateTask {
 
     template <ThermalPlateExecutionPolicy Policy>
     auto visit_message(const messages::GetErrorStateMessage& msg, Policy& policy) -> void {
-        static_cast<void>(msg);
         static_cast<void>(policy);
+        auto response = messages::AcknowledgePrevious{
+            .responding_to_id = msg.id,
+            .with_error = most_relevant_error()
+        };
+        static_cast<void>(
+            _task_registry->comms->get_message_queue().try_send(response));
     }
 
     template <ThermalPlateExecutionPolicy Policy>

--- a/stm32-modules/thermocycler-gen2/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/host_comms_task/freertos_comms_task.cpp
@@ -84,6 +84,7 @@ void run(void *param) {  // NOLINT(misc-unused-parameters)
                 reinterpret_cast<uint8_t *>(
                     local_task->tx_buf.committed()->data()),
                 tx_end - local_task->tx_buf.committed()->data());
+            vTaskDelay(1);
         }
     }
 }

--- a/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_m140d.cpp
     test_m141.cpp
     test_m301.cpp
+    test_m412d.cpp
     test_g28d.cpp
     test_m240d.cpp
     test_m241d.cpp

--- a/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
+++ b/stm32-modules/thermocycler-gen2/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(${TARGET_MODULE_NAME}
     test_colors.cpp
     test_motor_task.cpp
     test_motor_utils.cpp
+    test_motor_state_machine.cpp
     test_eeprom.cpp
     test_errors.cpp
     # GCode parse tests

--- a/stm32-modules/thermocycler-gen2/tests/gcode_test_harness.hpp
+++ b/stm32-modules/thermocycler-gen2/tests/gcode_test_harness.hpp
@@ -1,0 +1,7 @@
+#pragma once
+// Push this diagnostic to avoid a compiler error about printing to too
+// small of a buffer... which we're doing on purpose!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#include "thermocycler-gen2/gcodes.hpp"
+#pragma GCC diagnostic pop

--- a/stm32-modules/thermocycler-gen2/tests/m413.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/m413.cpp
@@ -1,0 +1,53 @@
+#include "catch2/catch.hpp"
+#include "gcode_test_harness.hpp"
+
+SCENARIO("ClearErrorState (M413) parser works", "[gcode][parse][m413]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::ClearErrorState::write_response_into(
+                buffer.begin(), buffer.end(), true);
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::StartsWith("M413 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::ClearErrorState::write_response_into(
+                buffer.begin(), buffer.begin() + 7, true);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M413cccccccccc";
+                response[6] = '\0';
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("valid input") {
+        std::string input = "M413\n";
+        WHEN("parsing input") {
+            auto parsed =
+                gcode::ClearErrorState::parse(input.begin(), input.end());
+            THEN("the gcode is parsed") {
+                REQUIRE(parsed.first.has_value());
+                REQUIRE(parsed.second != input.begin());
+            }
+        }
+    }
+    GIVEN("invalid input") {
+        std::string input = "M4asda\n";
+        WHEN("parsing input") {
+            auto parsed =
+                gcode::ClearErrorState::parse(input.begin(), input.end());
+            THEN("the gcode is not parsed") {
+                REQUIRE(!parsed.first.has_value());
+                REQUIRE(parsed.second == input.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-gen2/tests/m413.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/m413.cpp
@@ -8,8 +8,7 @@ SCENARIO("ClearErrorState (M413) parser works", "[gcode][parse][m413]") {
             auto written = gcode::ClearErrorState::write_response_into(
                 buffer.begin(), buffer.end(), true);
             THEN("the response should be written in full") {
-                REQUIRE_THAT(buffer,
-                             Catch::Matchers::StartsWith("M413 OK\n"));
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M413 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }

--- a/stm32-modules/thermocycler-gen2/tests/test_g28d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_g28d.cpp
@@ -1,5 +1,5 @@
 #include "catch2/catch.hpp"
-#include "thermocycler-gen2/gcodes.hpp"
+#include "gcode_test_harness.hpp"
 
 SCENARIO("gcode g28.d works", "[gcode][parse][g28d]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_host_comms_task.cpp
@@ -972,6 +972,97 @@ SCENARIO("message passing for ack-only gcodes from usb input") {
                 }
             }
         }
+        WHEN("sending a GetErrorState") {
+            std::string message_text = std::string("M411\n");
+            auto message_obj =
+                messages::HostCommsMessage(messages::IncomingMessageFromHost(
+                    &*message_text.begin(), &*message_text.end()));
+            tasks->get_host_comms_queue().backing_deque.push_back(message_obj);
+            std::ignore = tasks->get_host_comms_task().run_once(tx_buf.begin(),
+                                                                tx_buf.end());
+            THEN("the task should message lid and thermal tasks") {
+                REQUIRE(tasks->get_thermal_plate_queue().backing_deque.size() !=
+                        0);
+                auto plate_message =
+                    tasks->get_thermal_plate_queue().backing_deque.front();
+                REQUIRE(std::holds_alternative<messages::GetErrorStateMessage>(
+                    plate_message));
+                auto plate_get_error =
+                    std::get<messages::GetErrorStateMessage>(plate_message);
+                REQUIRE(tasks->get_lid_heater_queue().backing_deque.size() !=
+                        0);
+                auto lid_message =
+                    tasks->get_lid_heater_queue().backing_deque.front();
+                REQUIRE(std::holds_alternative<messages::GetErrorStateMessage>(
+                    lid_message));
+                auto lid_get_error =
+                    std::get<messages::GetErrorStateMessage>(lid_message);
+
+                AND_WHEN("getting two good responses") {
+                    std::string tx_buf_1(128, 'c');
+                    std::string tx_buf_2(128, 'c');
+                    auto response_1 = messages::AcknowledgePrevious{
+                        .responding_to_id = plate_get_error.id};
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response_1);
+                    auto response_2 = messages::AcknowledgePrevious{
+                        .responding_to_id = lid_get_error.id};
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response_2);
+                    THEN("two acks should be written") {
+                        auto written_first_response =
+                            tasks->get_host_comms_task().run_once(
+                                tx_buf_1.begin(), tx_buf_1.end());
+                        REQUIRE(written_first_response > tx_buf_1.begin());
+                        REQUIRE_THAT(tx_buf_1,
+                                     Catch::Matchers::StartsWith("M411 OK"));
+                        auto written_second_response =
+                            tasks->get_host_comms_task().run_once(
+                                tx_buf_2.begin(), tx_buf_2.end());
+                        REQUIRE(written_second_response > tx_buf_2.begin());
+                        REQUIRE_THAT(tx_buf_2,
+                                     Catch::Matchers::StartsWith("M411 OK"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+                AND_WHEN("getting two error responses") {
+                    std::string tx_buf_1(128, 'c');
+                    std::string tx_buf_2(128, 'c');
+                    auto response_1 = messages::AcknowledgePrevious{
+                        .responding_to_id = plate_get_error.id,
+                        .with_error =
+                            errors::ErrorCode::THERMISTOR_BACK_CENTER_SHORT};
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response_1);
+                    auto response_2 = messages::AcknowledgePrevious{
+                        .responding_to_id = lid_get_error.id,
+                        .with_error =
+                            errors::ErrorCode::THERMISTOR_LID_OVERTEMP};
+                    tasks->get_host_comms_queue().backing_deque.push_back(
+                        response_2);
+                    THEN("two acks with errors should be written") {
+                        auto written_first_response =
+                            tasks->get_host_comms_task().run_once(
+                                tx_buf_1.begin(), tx_buf_1.end());
+                        REQUIRE(written_first_response > tx_buf_1.begin());
+                        REQUIRE_THAT(
+                            tx_buf_1,
+                            Catch::Matchers::StartsWith(
+                                "ERR220:Back center thermistor shorted OK"));
+                        auto written_second_response =
+                            tasks->get_host_comms_task().run_once(
+                                tx_buf_2.begin(), tx_buf_2.end());
+                        REQUIRE(written_second_response > tx_buf_2.begin());
+                        REQUIRE_THAT(tx_buf_2,
+                                     Catch::Matchers::StartsWith(
+                                         "ERR224:Lid thermistor overtemp OK"));
+                        REQUIRE(tasks->get_host_comms_queue()
+                                    .backing_deque.empty());
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/stm32-modules/thermocycler-gen2/tests/test_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_lid_heater_task.cpp
@@ -353,6 +353,8 @@ SCENARIO("lid heater task message passing") {
         CHECK(error_msg.code == errors::ErrorCode::THERMISTOR_LID_DISCONNECTED);
 #endif
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
+        CHECK(tasks->get_lid_heater_task().most_relevant_error() ==
+              errors::ErrorCode::THERMISTOR_LID_DISCONNECTED);
 
         WHEN("Sending a SetHeaterDebug message to enable the heater") {
             auto message =
@@ -366,6 +368,79 @@ SCENARIO("lid heater task message passing") {
                     message, errors::ErrorCode::THERMISTOR_LID_DISCONNECTED);
                 REQUIRE(tasks->get_lid_heater_policy().get_heater_power() ==
                         0.0F);
+            }
+        }
+        WHEN("it naturally clears") {
+            read_message.lid_temp = _valid_adc;
+            timestamp += TIME_DELTA;
+            tasks->get_lid_heater_queue().backing_deque.push_back(read_message);
+            tasks->run_lid_heater_task();
+            THEN("the error is cleared") {
+                REQUIRE(tasks->get_lid_heater_task().most_relevant_error() ==
+                        errors::ErrorCode::NO_ERROR);
+            }
+            THEN("a get error still gets it") {
+                tasks->get_host_comms_queue().backing_deque.clear();
+                auto get_message = messages::GetErrorStateMessage{.id = 222};
+                tasks->get_lid_heater_queue().backing_deque.push_back(
+                    get_message);
+                tasks->run_lid_heater_task();
+                tasks->require_has_ack_for(
+                    get_message,
+                    errors::ErrorCode::THERMISTOR_LID_DISCONNECTED);
+                AND_THEN("a subsequent get error doesn't") {
+                    get_message.id = 223;
+                    tasks->get_lid_heater_queue().backing_deque.push_back(
+                        get_message);
+                    tasks->run_lid_heater_task();
+                    tasks->require_has_ack_for(get_message);
+                }
+            }
+        }
+        WHEN("Sending a get error state message") {
+            auto get_message = messages::GetErrorStateMessage{.id = 333};
+            tasks->get_lid_heater_queue().backing_deque.push_back(get_message);
+            tasks->run_lid_heater_task();
+            THEN("the acknowledgement has the error") {
+                tasks->require_has_ack_for(
+                    get_message,
+                    errors::ErrorCode::THERMISTOR_LID_DISCONNECTED);
+            }
+        }
+        WHEN("sending a clear error state message") {
+            auto message = messages::ClearErrorStateMessage{.id = 123};
+            tasks->get_lid_heater_queue().backing_deque.push_back(message);
+            tasks->run_lid_heater_task();
+            AND_WHEN("the error is not physically cleared") {
+                read_message.timestamp_ms += TIME_DELTA;
+                tasks->get_lid_heater_queue().backing_deque.push_back(
+                    read_message);
+                tasks->run_lid_heater_task();
+                tasks->get_host_comms_queue().backing_deque.clear();
+                THEN("the error reoccurs") {
+                    auto message = messages::GetErrorStateMessage{.id = 333};
+                    tasks->get_lid_heater_queue().backing_deque.push_back(
+                        message);
+                    tasks->run_lid_heater_task();
+                    tasks->require_has_ack_for(
+                        message,
+                        errors::ErrorCode::THERMISTOR_LID_DISCONNECTED);
+                }
+            }
+            AND_WHEN("the error is physically cleared") {
+                read_message.timestamp_ms += TIME_DELTA;
+                read_message.lid_temp = _valid_adc;
+                tasks->get_lid_heater_queue().backing_deque.push_back(
+                    read_message);
+                tasks->run_lid_heater_task();
+                tasks->get_host_comms_queue().backing_deque.clear();
+                THEN("the error is cleared") {
+                    auto message = messages::GetErrorStateMessage{.id = 333};
+                    tasks->get_lid_heater_queue().backing_deque.push_back(
+                        message);
+                    tasks->run_lid_heater_task();
+                    tasks->require_has_ack_for(message);
+                }
             }
         }
     }
@@ -407,6 +482,35 @@ SCENARIO("lid heater error flag handling") {
         timestamp += TIME_DELTA;
         lid_queue.backing_deque.push_back(read_message);
         tasks->run_lid_heater_task();
+        CHECK(tasks->get_lid_heater_task().most_relevant_error() ==
+              errors::ErrorCode::THERMISTOR_LID_SHORT);
+        WHEN("it naturally clears") {
+            read_message.lid_temp = _valid_adc;
+            timestamp += TIME_DELTA;
+            tasks->get_lid_heater_queue().backing_deque.push_back(read_message);
+            tasks->run_lid_heater_task();
+            THEN("the error is cleared") {
+                REQUIRE(tasks->get_lid_heater_task().most_relevant_error() ==
+                        errors::ErrorCode::NO_ERROR);
+            }
+            THEN("a get error still gets it") {
+                tasks->get_host_comms_queue().backing_deque.clear();
+                auto get_message = messages::GetErrorStateMessage{.id = 222};
+                tasks->get_lid_heater_queue().backing_deque.push_back(
+                    get_message);
+                tasks->run_lid_heater_task();
+                tasks->require_has_ack_for(
+                    get_message, errors::ErrorCode::THERMISTOR_LID_SHORT);
+                AND_THEN("a subsequent get error doesn't") {
+                    get_message.id = 223;
+                    tasks->get_lid_heater_queue().backing_deque.push_back(
+                        get_message);
+                    tasks->run_lid_heater_task();
+                    tasks->require_has_ack_for(get_message);
+                }
+            }
+        }
+
         WHEN("sending a get error status message") {
             auto message = messages::GetErrorStateMessage{.id = 123};
             tasks->get_lid_heater_queue().backing_deque.push_back(message);
@@ -414,6 +518,41 @@ SCENARIO("lid heater error flag handling") {
             THEN("the task should respond with an error") {
                 tasks->require_has_ack_for(
                     message, errors::ErrorCode::THERMISTOR_LID_SHORT);
+            }
+        }
+        WHEN("sending a clear error state message") {
+            auto message = messages::ClearErrorStateMessage{.id = 123};
+            tasks->get_lid_heater_queue().backing_deque.push_back(message);
+            tasks->run_lid_heater_task();
+            AND_WHEN("the error is not physically cleared") {
+                read_message.timestamp_ms += TIME_DELTA;
+                tasks->get_lid_heater_queue().backing_deque.push_back(
+                    read_message);
+                tasks->run_lid_heater_task();
+                tasks->get_host_comms_queue().backing_deque.clear();
+                THEN("the error reoccurs") {
+                    auto message = messages::GetErrorStateMessage{.id = 333};
+                    tasks->get_lid_heater_queue().backing_deque.push_back(
+                        message);
+                    tasks->run_lid_heater_task();
+                    tasks->require_has_ack_for(
+                        message, errors::ErrorCode::THERMISTOR_LID_SHORT);
+                }
+            }
+            AND_WHEN("the error is physically cleared") {
+                read_message.timestamp_ms += TIME_DELTA;
+                read_message.lid_temp = _valid_adc;
+                tasks->get_lid_heater_queue().backing_deque.push_back(
+                    read_message);
+                tasks->run_lid_heater_task();
+                tasks->get_host_comms_queue().backing_deque.clear();
+                THEN("the error is cleared") {
+                    auto message = messages::GetErrorStateMessage{.id = 333};
+                    tasks->get_lid_heater_queue().backing_deque.push_back(
+                        message);
+                    tasks->run_lid_heater_task();
+                    tasks->require_has_ack_for(message);
+                }
             }
         }
         WHEN("sending a SetPlateTemperature message") {
@@ -439,6 +578,121 @@ SCENARIO("lid heater error flag handling") {
                 THEN("the response shows an error") {
                     tasks->require_has_ack_for(
                         set_msg, errors::ErrorCode::THERMISTOR_LID_SHORT);
+                }
+            }
+        }
+    }
+}
+
+SCENARIO("lid set-error") {
+    uint32_t timestamp = 1000;
+    GIVEN("a good lid heater task") {
+        auto tasks = TaskBuilder::build();
+        auto read_message = messages::LidTempReadComplete{
+            .lid_temp = _valid_adc, .timestamp_ms = timestamp};
+        tasks->get_lid_heater_queue().backing_deque.push_back(
+            messages::LidHeaterMessage(read_message));
+        tasks->run_lid_heater_task();
+        tasks->get_host_comms_queue().backing_deque.clear();
+        auto error_message = messages::SetErrorStateMessage{
+            .id = 333,
+            .error_to_set = errors::ErrorCode::THERMAL_HEATER_ERROR,
+            .delay_s = 5};
+        tasks->get_lid_heater_queue().backing_deque.push_back(error_message);
+        tasks->run_lid_heater_task();
+        tasks->require_has_ack_for(error_message);
+
+        THEN("after just less than the time the error is not set") {
+            read_message.timestamp_ms = 5999;
+            tasks->get_lid_heater_queue().backing_deque.push_back(read_message);
+            tasks->run_lid_heater_task();
+            REQUIRE(tasks->get_lid_heater_task().most_relevant_error() ==
+                    errors::ErrorCode::NO_ERROR);
+            auto get_message = messages::GetErrorStateMessage{.id = 100};
+            tasks->get_lid_heater_queue().backing_deque.push_back(get_message);
+            tasks->run_lid_heater_task();
+            tasks->require_has_ack_for(get_message);
+        }
+        THEN("after exactly the time the error is set") {
+            read_message.timestamp_ms = 6000;
+            tasks->get_lid_heater_queue().backing_deque.push_back(read_message);
+            tasks->run_lid_heater_task();
+#if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
+            REQUIRE(
+                tasks->get_latest_host_comms_message<messages::ErrorMessage>()
+                    .error == errors::ErrorCode::THERMAL_HEATER_ERROR);
+
+#endif
+            REQUIRE(tasks->get_lid_heater_task().most_relevant_error() ==
+                    errors::ErrorCode::THERMAL_HEATER_ERROR);
+            auto get_message = messages::GetErrorStateMessage{.id = 100};
+            tasks->get_lid_heater_queue().backing_deque.push_back(get_message);
+            tasks->run_lid_heater_task();
+            tasks->require_has_ack_for(get_message,
+                                       errors::ErrorCode::THERMAL_HEATER_ERROR);
+        }
+        THEN("after more than the time the error is set") {
+            read_message.timestamp_ms = 10000;
+            tasks->get_lid_heater_queue().backing_deque.push_back(read_message);
+            tasks->run_lid_heater_task();
+#if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
+            REQUIRE(
+                tasks->get_latest_host_comms_message<messages::ErrorMessage>()
+                    .error == errors::ErrorCode::THERMAL_HEATER_ERROR);
+
+#endif
+            REQUIRE(tasks->get_lid_heater_task().most_relevant_error() ==
+                    errors::ErrorCode::THERMAL_HEATER_ERROR);
+            auto get_message = messages::GetErrorStateMessage{.id = 100};
+            tasks->get_lid_heater_queue().backing_deque.push_back(get_message);
+            tasks->run_lid_heater_task();
+            tasks->require_has_ack_for(get_message,
+                                       errors::ErrorCode::THERMAL_HEATER_ERROR);
+        }
+        auto error = GENERATE(errors::ErrorCode::THERMISTOR_LID_SHORT,
+                              errors::ErrorCode::THERMISTOR_LID_DISCONNECTED,
+                              errors::ErrorCode::THERMISTOR_LID_OVERTEMP,
+                              errors::ErrorCode::THERMAL_HEATER_ERROR);
+        WHEN(std::string("Setting error ") +
+             std::to_string(static_cast<uint32_t>(error))) {
+            auto set_message = messages::SetErrorStateMessage{
+                .id = 1231, .error_to_set = error, .delay_s = 0};
+            tasks->get_lid_heater_queue().backing_deque.push_back(set_message);
+            tasks->run_lid_heater_task();
+            tasks->require_has_ack_for(set_message);
+            read_message.timestamp_ms = 2000;
+            tasks->get_lid_heater_queue().backing_deque.push_back(read_message);
+            tasks->run_lid_heater_task();
+#if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
+            THEN("the error is reported asynchronously") {
+                auto error_msg = tasks->get_latest_host_comms_message<
+                    messages::ErrorMessage>();
+                REQUIRE(error_msg.error == error);
+                plate_queue.backing_deque.pop_front();
+            }
+#endif
+            THEN("the error is reported by a get-error-state") {
+                auto get_state = messages::GetErrorStateMessage{.id = 2222};
+                tasks->get_lid_heater_queue().backing_deque.push_back(
+                    get_state);
+                tasks->run_lid_heater_task();
+                tasks->require_has_ack_for(get_state, error);
+            }
+            AND_WHEN("clearing the error and updating the state") {
+                auto clear = messages::ClearErrorStateMessage{.id = 99};
+                tasks->get_lid_heater_queue().backing_deque.push_back(clear);
+                tasks->run_lid_heater_task();
+                tasks->require_has_ack_for(clear);
+                read_message.timestamp_ms = 3000;
+                tasks->get_lid_heater_queue().backing_deque.push_back(
+                    read_message);
+                tasks->run_lid_heater_task();
+                THEN("the error is gone") {
+                    auto get_state = messages::GetErrorStateMessage{.id = 3333};
+                    tasks->get_lid_heater_queue().backing_deque.push_back(
+                        get_state);
+                    tasks->run_lid_heater_task();
+                    tasks->require_has_ack_for(get_state);
                 }
             }
         }

--- a/stm32-modules/thermocycler-gen2/tests/test_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_lid_heater_task.cpp
@@ -405,7 +405,7 @@ SCENARIO("lid heater error flag handling") {
         auto read_message = messages::LidTempReadComplete{
             .lid_temp = _shorted_adc, .timestamp_ms = timestamp};
         timestamp += TIME_DELTA;
-        REQUIRE(lid_queue.try_send(read_message));
+        lid_queue.backing_deque.push_back(read_message);
         tasks->run_lid_heater_task();
         WHEN("sending a get error status message") {
             auto message = messages::GetErrorStateMessage{.id = 123};
@@ -419,7 +419,7 @@ SCENARIO("lid heater error flag handling") {
         WHEN("sending a SetPlateTemperature message") {
             auto set_msg =
                 messages::SetLidTemperatureMessage{.id = 123, .setpoint = 50};
-            REQUIRE(lid_queue.try_send(set_msg));
+            lid_queue.backing_deque.push_back(set_msg);
             tasks->run_lid_heater_task();
             THEN("the response shows an error") {
                 tasks->require_has_ack_for(
@@ -428,13 +428,13 @@ SCENARIO("lid heater error flag handling") {
         }
         WHEN("sending a DeactivateAll message") {
             auto deactivate = messages::DeactivateAllMessage{.id = 444};
-            REQUIRE(lid_queue.try_send(deactivate));
+            lid_queue.backing_deque.push_back(deactivate);
             tasks->run_lid_heater_task();
             host_queue.backing_deque.clear();
             AND_THEN("sending a SetPlateTemperature message") {
                 auto set_msg = messages::SetLidTemperatureMessage{
                     .id = 123, .setpoint = 50};
-                REQUIRE(lid_queue.try_send(set_msg));
+                lid_queue.backing_deque.push_back(set_msg);
                 tasks->run_lid_heater_task();
                 THEN("the response shows an error") {
                     tasks->require_has_ack_for(

--- a/stm32-modules/thermocycler-gen2/tests/test_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_lid_heater_task.cpp
@@ -31,17 +31,8 @@ SCENARIO("lid heater task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
                 AND_THEN("the task should respond to the messsage") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(std::holds_alternative<
-                            messages::GetLidTemperatureDebugResponse>(
-                        response));
-                    auto gettemp =
-                        std::get<messages::GetLidTemperatureDebugResponse>(
-                            response);
+                    auto gettemp = tasks->get_latest_host_comms_message<
+                        messages::GetLidTemperatureDebugResponse>();
                     REQUIRE(gettemp.responding_to_id == message.id);
                     REQUIRE_THAT(gettemp.lid_temp,
                                  Catch::Matchers::WithinAbs(_valid_temp, 0.1));
@@ -57,16 +48,8 @@ SCENARIO("lid heater task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
                 AND_THEN("the task should respond to the messsage") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::GetLidTempResponse>(
-                            response));
-                    auto gettemp =
-                        std::get<messages::GetLidTempResponse>(response);
+                    auto gettemp = tasks->get_latest_host_comms_message<
+                        messages::GetLidTempResponse>();
                     REQUIRE(gettemp.responding_to_id == message.id);
                     REQUIRE_THAT(gettemp.current_temp,
                                  Catch::Matchers::WithinAbs(_valid_temp, 0.1));
@@ -86,20 +69,7 @@ SCENARIO("lid heater task message passing") {
                 AND_THEN("the task should act on the message") {
                     REQUIRE(
                         tasks->get_thermal_plate_queue().backing_deque.empty());
-
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 123);
-                    REQUIRE(response_msg.with_error ==
-                            errors::ErrorCode::NO_ERROR);
+                    tasks->require_has_ack_for(message);
                     REQUIRE(tasks->get_lid_heater_policy().get_heater_power() ==
                             0.65);
                 }
@@ -120,20 +90,7 @@ SCENARIO("lid heater task message passing") {
                 AND_THEN("the task should act on the message") {
                     REQUIRE(
                         tasks->get_thermal_plate_queue().backing_deque.empty());
-
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 123);
-                    REQUIRE(response_msg.with_error ==
-                            errors::ErrorCode::NO_ERROR);
+                    tasks->require_has_ack_for(message);
                 }
             }
         }
@@ -152,20 +109,8 @@ SCENARIO("lid heater task message passing") {
                 AND_THEN("the task should act on the message") {
                     REQUIRE(
                         tasks->get_thermal_plate_queue().backing_deque.empty());
-
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 555);
-                    REQUIRE(response_msg.with_error ==
-                            errors::ErrorCode::THERMAL_CONSTANT_OUT_OF_RANGE);
+                    tasks->require_has_ack_for(
+                        message, errors::ErrorCode::THERMAL_CONSTANT_OUT_OF_RANGE);
                 }
             }
         }
@@ -178,19 +123,7 @@ SCENARIO("lid heater task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
                 AND_THEN("the task should respond to the message") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 123);
-                    REQUIRE(response_msg.with_error ==
-                            errors::ErrorCode::NO_ERROR);
+                    tasks->require_has_ack_for(message);
                     AND_WHEN("sending a GetLidTemp query") {
                         auto tempMessage =
                             messages::GetLidTempMessage{.id = 555};
@@ -198,12 +131,9 @@ SCENARIO("lid heater task message passing") {
                             messages::LidHeaterMessage(tempMessage));
                         tasks->run_lid_heater_task();
                         THEN("the response should have the new setpoint") {
-                            REQUIRE(!tasks->get_host_comms_queue()
-                                         .backing_deque.empty());
-                            REQUIRE(std::get<messages::GetLidTempResponse>(
-                                        tasks->get_host_comms_queue()
-                                            .backing_deque.front())
-                                        .set_temp == message.setpoint);
+                            auto response = tasks->get_latest_host_comms_message<
+                                messages::GetLidTempResponse>();
+                            REQUIRE(response.set_temp == message.setpoint);
                         }
                     }
                 }
@@ -228,13 +158,7 @@ SCENARIO("lid heater task message passing") {
                     messages::LidHeaterMessage(tempMessage));
                 tasks->run_lid_heater_task();
                 THEN("the task should respond to the message") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    REQUIRE(
-                        std::get<messages::AcknowledgePrevious>(
-                            tasks->get_host_comms_queue().backing_deque.front())
-                            .responding_to_id == 321);
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
+                    tasks->require_has_ack_for(tempMessage);
                     AND_WHEN("sending a GetLidTemp query") {
                         auto tempMessage =
                             messages::GetLidTempMessage{.id = 555};
@@ -242,12 +166,9 @@ SCENARIO("lid heater task message passing") {
                             messages::LidHeaterMessage(tempMessage));
                         tasks->run_lid_heater_task();
                         THEN("the response should have no setpoint") {
-                            REQUIRE(!tasks->get_host_comms_queue()
-                                         .backing_deque.empty());
-                            REQUIRE(std::get<messages::GetLidTempResponse>(
-                                        tasks->get_host_comms_queue()
-                                            .backing_deque.front())
-                                        .set_temp == 0.0F);
+                            auto response = tasks->get_latest_host_comms_message<
+                                messages::GetLidTempResponse>();
+                            REQUIRE(response.set_temp == 0.0F);
                         }
                     }
                 }
@@ -257,14 +178,15 @@ SCENARIO("lid heater task message passing") {
                 tasks->get_host_comms_queue().backing_deque.pop_front();
                 auto tempMessage = messages::DeactivateLidHeatingMessage{
                     .id = 321, .from_system = true};
-                tasks->get_lid_heater_queue().backing_deque.push_back(
-                    messages::LidHeaterMessage(tempMessage));
+                tasks->get_lid_heater_queue().backing_deque.push_back(tempMessage);
                 tasks->run_lid_heater_task();
                 THEN("the task should respond to the message") {
-                    REQUIRE(!tasks->get_system_queue().backing_deque.empty());
-                    REQUIRE(std::get<messages::AcknowledgePrevious>(
-                                tasks->get_system_queue().backing_deque.front())
-                                .responding_to_id == 321);
+                    REQUIRE_FALSE(tasks->get_system_queue().backing_deque.empty());
+                    auto response = tasks->get_system_queue().backing_deque.front();
+                    REQUIRE(std::holds_alternative<messages::AcknowledgePrevious>(response));
+                    auto ack = std::get<messages::AcknowledgePrevious>(response);
+                    REQUIRE(ack.responding_to_id == tempMessage.id);
+                    REQUIRE(ack.with_error == errors::ErrorCode::NO_ERROR);
                 }
             }
             AND_WHEN("sending a DeactivateAll command") {
@@ -274,13 +196,9 @@ SCENARIO("lid heater task message passing") {
                     messages::LidHeaterMessage(tempMessage));
                 tasks->run_lid_heater_task();
                 THEN("the task should respond to the message") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    REQUIRE(
-                        std::get<messages::DeactivateAllResponse>(
-                            tasks->get_host_comms_queue().backing_deque.front())
-                            .responding_to_id == 321);
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
+                    auto response = tasks->get_latest_host_comms_message<
+                        messages::DeactivateAllResponse>();
+                    REQUIRE(response.responding_to_id == 321);
                     AND_WHEN("sending a GetLidTemp query") {
                         auto tempMessage =
                             messages::GetLidTempMessage{.id = 555};
@@ -288,12 +206,9 @@ SCENARIO("lid heater task message passing") {
                             messages::LidHeaterMessage(tempMessage));
                         tasks->run_lid_heater_task();
                         THEN("the response should have no setpoint") {
-                            REQUIRE(!tasks->get_host_comms_queue()
-                                         .backing_deque.empty());
-                            REQUIRE(std::get<messages::GetLidTempResponse>(
-                                        tasks->get_host_comms_queue()
-                                            .backing_deque.front())
-                                        .set_temp == 0.0F);
+                            auto gettemp = tasks->get_latest_host_comms_message<
+                                messages::GetLidTempResponse>();
+                            REQUIRE(gettemp.set_temp == 0.0F);
                         }
                     }
                 }
@@ -316,19 +231,7 @@ SCENARIO("lid heater task message passing") {
                     AND_THEN("the task should respond with a busy error") {
                         REQUIRE(tasks->get_thermal_plate_queue()
                                     .backing_deque.empty());
-
-                        REQUIRE(!tasks->get_host_comms_queue()
-                                     .backing_deque.empty());
-                        auto response =
-                            tasks->get_host_comms_queue().backing_deque.front();
-                        tasks->get_host_comms_queue().backing_deque.pop_front();
-                        REQUIRE(std::holds_alternative<
-                                messages::AcknowledgePrevious>(response));
-                        auto response_msg =
-                            std::get<messages::AcknowledgePrevious>(response);
-                        REQUIRE(response_msg.responding_to_id == 808);
-                        REQUIRE(response_msg.with_error ==
-                                errors::ErrorCode::THERMAL_LID_BUSY);
+                        tasks->require_has_ack_for(message, errors::ErrorCode::THERMAL_LID_BUSY);
                     }
                 }
             }
@@ -340,10 +243,8 @@ SCENARIO("lid heater task message passing") {
                 tasks->get_lid_heater_queue().backing_deque.push_back(message);
                 tasks->run_lid_heater_task();
                 THEN("the power is returned correctly") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response = std::get<messages::GetLidPowerResponse>(
-                        tasks->get_host_comms_queue().backing_deque.front());
+                    auto response = tasks->get_latest_host_comms_message<
+                        messages::GetLidPowerResponse>();
                     REQUIRE(response.responding_to_id == message.id);
                     REQUIRE_THAT(response.heater,
                                  Catch::Matchers::WithinAbs(0.5, 0.01));
@@ -360,12 +261,9 @@ SCENARIO("lid heater task message passing") {
             messages::LidHeaterMessage(read_message));
         tasks->run_lid_heater_task();
 #if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
-        CHECK(std::holds_alternative<messages::ErrorMessage>(
-            tasks->get_host_comms_queue().backing_deque.front()));
-        auto error_msg = std::get<messages::ErrorMessage>(
-            tasks->get_host_comms_queue().backing_deque.front());
+        auto error_msg = tasks->get_latest_host_comms_message<
+            messages::ErrorMessage>();
         CHECK(error_msg.code == errors::ErrorCode::THERMISTOR_LID_SHORT);
-        tasks->get_host_comms_queue().backing_deque.pop_front();
 #endif
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
 
@@ -380,22 +278,10 @@ SCENARIO("lid heater task message passing") {
                 AND_THEN("the task should respond with an error") {
                     REQUIRE(
                         tasks->get_lid_heater_queue().backing_deque.empty());
-
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 124);
-                    REQUIRE(response_msg.with_error !=
-                            errors::ErrorCode::NO_ERROR);
                     REQUIRE(tasks->get_lid_heater_policy().get_heater_power() ==
                             0.0F);
+                    tasks->require_has_ack_for(
+                        message, errors::ErrorCode::THERMISTOR_LID_SHORT);
                 }
             }
         }
@@ -408,19 +294,8 @@ SCENARIO("lid heater task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
                 AND_THEN("the task should respond with an error") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 123);
-                    REQUIRE(response_msg.with_error !=
-                            errors::ErrorCode::NO_ERROR);
+                    tasks->require_has_ack_for(
+                        message, errors::ErrorCode::THERMISTOR_LID_SHORT);
                     AND_WHEN("sending a GetLidTemp query") {
                         auto tempMessage =
                             messages::GetLidTempMessage{.id = 555};
@@ -428,12 +303,9 @@ SCENARIO("lid heater task message passing") {
                             messages::LidHeaterMessage(tempMessage));
                         tasks->run_lid_heater_task();
                         THEN("the response should have a setpoint of 0") {
-                            REQUIRE(!tasks->get_host_comms_queue()
-                                         .backing_deque.empty());
-                            REQUIRE(std::get<messages::GetLidTempResponse>(
-                                        tasks->get_host_comms_queue()
-                                            .backing_deque.front())
-                                        .set_temp == 0.0F);
+                            auto gettemp = tasks->get_latest_host_comms_message<
+                                messages::GetLidTempResponse>();
+                            REQUIRE(gettemp.set_temp == 0.0F);
                         }
                     }
                 }
@@ -447,16 +319,8 @@ SCENARIO("lid heater task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
                 AND_THEN("the task should respond with a temp of 0") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::GetLidTempResponse>(
-                            response));
-                    auto gettemp =
-                        std::get<messages::GetLidTempResponse>(response);
+                    auto gettemp = tasks->get_latest_host_comms_message<
+                        messages::GetLidTempResponse>();
                     REQUIRE(gettemp.responding_to_id == message.id);
                     REQUIRE_THAT(gettemp.current_temp,
                                  Catch::Matchers::WithinAbs(0.0, 0.1));
@@ -475,12 +339,9 @@ SCENARIO("lid heater task message passing") {
             messages::LidHeaterMessage(read_message));
         tasks->run_lid_heater_task();
 #if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
-        CHECK(std::holds_alternative<messages::ErrorMessage>(
-            tasks->get_host_comms_queue().backing_deque.front()));
-        auto error_msg = std::get<messages::ErrorMessage>(
-            tasks->get_host_comms_queue().backing_deque.front());
+        auto error_msg = tasks->get_latest_host_comms_message<
+            messages::ErrorMessage>();
         CHECK(error_msg.code == errors::ErrorCode::THERMISTOR_LID_DISCONNECTED);
-        tasks->get_host_comms_queue().backing_deque.pop_front();
 #endif
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
 
@@ -495,20 +356,8 @@ SCENARIO("lid heater task message passing") {
                 AND_THEN("the task should respond with an error") {
                     REQUIRE(
                         tasks->get_lid_heater_queue().backing_deque.empty());
-
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 124);
-                    REQUIRE(response_msg.with_error !=
-                            errors::ErrorCode::NO_ERROR);
+                    tasks->require_has_ack_for(
+                        message, errors::ErrorCode::THERMISTOR_LID_DISCONNECTED);
                     REQUIRE(tasks->get_lid_heater_policy().get_heater_power() ==
                             0.0F);
                 }
@@ -525,13 +374,7 @@ SCENARIO("lid heater task message passing") {
             REQUIRE(tasks->get_lid_heater_policy().lid_fans_enabled());
         }
         THEN("the message is acked") {
-            REQUIRE(tasks->get_host_comms_queue().has_message());
-            auto reply = tasks->get_host_comms_queue().backing_deque.front();
-            REQUIRE(
-                std::holds_alternative<messages::AcknowledgePrevious>(reply));
-            auto ack = std::get<messages::AcknowledgePrevious>(reply);
-            REQUIRE(ack.responding_to_id == fan_msg.id);
-            REQUIRE(ack.with_error == errors::ErrorCode::NO_ERROR);
+            tasks->require_has_ack_for(fan_msg);
         }
         AND_WHEN("sending another message to disable the fans") {
             fan_msg.id = 456;
@@ -544,19 +387,13 @@ SCENARIO("lid heater task message passing") {
                 REQUIRE(!tasks->get_lid_heater_policy().lid_fans_enabled());
             }
             THEN("the message is acked") {
-                REQUIRE(tasks->get_host_comms_queue().has_message());
-                auto reply =
-                    tasks->get_host_comms_queue().backing_deque.front();
-                REQUIRE(std::holds_alternative<messages::AcknowledgePrevious>(
-                    reply));
-                auto ack = std::get<messages::AcknowledgePrevious>(reply);
-                REQUIRE(ack.responding_to_id == fan_msg.id);
-                REQUIRE(ack.with_error == errors::ErrorCode::NO_ERROR);
+                tasks->require_has_ack_for(fan_msg);
             }
         }
     }
 }
-TEST_CASE("lid heater error flag handling") {
+
+SCENARIO("lid heater error flag handling") {
     uint32_t timestamp = TIME_DELTA;
     GIVEN("a lid heater task with invalid temperatures") {
         auto tasks = TaskBuilder::build();
@@ -573,13 +410,7 @@ TEST_CASE("lid heater error flag handling") {
             REQUIRE(lid_queue.try_send(set_msg));
             tasks->run_lid_heater_task();
             THEN("the response shows an error") {
-                REQUIRE(host_queue.has_message());
-                auto rsp = host_queue.backing_deque.front();
-                REQUIRE(
-                    std::holds_alternative<messages::AcknowledgePrevious>(rsp));
-                auto response = std::get<messages::AcknowledgePrevious>(rsp);
-                REQUIRE(response.responding_to_id == 123);
-                REQUIRE(response.with_error != errors::ErrorCode::NO_ERROR);
+                tasks->require_has_ack_for(set_msg, errors::ErrorCode::THERMISTOR_LID_SHORT);
             }
         }
         WHEN("sending a DeactivateAll message") {
@@ -593,15 +424,7 @@ TEST_CASE("lid heater error flag handling") {
                 REQUIRE(lid_queue.try_send(set_msg));
                 tasks->run_lid_heater_task();
                 THEN("the response shows an error") {
-                    REQUIRE(host_queue.has_message());
-                    auto rsp = host_queue.backing_deque.front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            rsp));
-                    auto response =
-                        std::get<messages::AcknowledgePrevious>(rsp);
-                    REQUIRE(response.responding_to_id == 123);
-                    REQUIRE(response.with_error != errors::ErrorCode::NO_ERROR);
+                    tasks->require_has_ack_for(set_msg, errors::ErrorCode::THERMISTOR_LID_SHORT);
                 }
             }
         }

--- a/stm32-modules/thermocycler-gen2/tests/test_lid_heater_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_lid_heater_task.cpp
@@ -110,7 +110,8 @@ SCENARIO("lid heater task message passing") {
                     REQUIRE(
                         tasks->get_thermal_plate_queue().backing_deque.empty());
                     tasks->require_has_ack_for(
-                        message, errors::ErrorCode::THERMAL_CONSTANT_OUT_OF_RANGE);
+                        message,
+                        errors::ErrorCode::THERMAL_CONSTANT_OUT_OF_RANGE);
                 }
             }
         }
@@ -131,8 +132,9 @@ SCENARIO("lid heater task message passing") {
                             messages::LidHeaterMessage(tempMessage));
                         tasks->run_lid_heater_task();
                         THEN("the response should have the new setpoint") {
-                            auto response = tasks->get_latest_host_comms_message<
-                                messages::GetLidTempResponse>();
+                            auto response =
+                                tasks->get_latest_host_comms_message<
+                                    messages::GetLidTempResponse>();
                             REQUIRE(response.set_temp == message.setpoint);
                         }
                     }
@@ -166,8 +168,9 @@ SCENARIO("lid heater task message passing") {
                             messages::LidHeaterMessage(tempMessage));
                         tasks->run_lid_heater_task();
                         THEN("the response should have no setpoint") {
-                            auto response = tasks->get_latest_host_comms_message<
-                                messages::GetLidTempResponse>();
+                            auto response =
+                                tasks->get_latest_host_comms_message<
+                                    messages::GetLidTempResponse>();
                             REQUIRE(response.set_temp == 0.0F);
                         }
                     }
@@ -178,13 +181,19 @@ SCENARIO("lid heater task message passing") {
                 tasks->get_host_comms_queue().backing_deque.pop_front();
                 auto tempMessage = messages::DeactivateLidHeatingMessage{
                     .id = 321, .from_system = true};
-                tasks->get_lid_heater_queue().backing_deque.push_back(tempMessage);
+                tasks->get_lid_heater_queue().backing_deque.push_back(
+                    tempMessage);
                 tasks->run_lid_heater_task();
                 THEN("the task should respond to the message") {
-                    REQUIRE_FALSE(tasks->get_system_queue().backing_deque.empty());
-                    auto response = tasks->get_system_queue().backing_deque.front();
-                    REQUIRE(std::holds_alternative<messages::AcknowledgePrevious>(response));
-                    auto ack = std::get<messages::AcknowledgePrevious>(response);
+                    REQUIRE_FALSE(
+                        tasks->get_system_queue().backing_deque.empty());
+                    auto response =
+                        tasks->get_system_queue().backing_deque.front();
+                    REQUIRE(
+                        std::holds_alternative<messages::AcknowledgePrevious>(
+                            response));
+                    auto ack =
+                        std::get<messages::AcknowledgePrevious>(response);
                     REQUIRE(ack.responding_to_id == tempMessage.id);
                     REQUIRE(ack.with_error == errors::ErrorCode::NO_ERROR);
                 }
@@ -231,7 +240,8 @@ SCENARIO("lid heater task message passing") {
                     AND_THEN("the task should respond with a busy error") {
                         REQUIRE(tasks->get_thermal_plate_queue()
                                     .backing_deque.empty());
-                        tasks->require_has_ack_for(message, errors::ErrorCode::THERMAL_LID_BUSY);
+                        tasks->require_has_ack_for(
+                            message, errors::ErrorCode::THERMAL_LID_BUSY);
                     }
                 }
             }
@@ -261,11 +271,21 @@ SCENARIO("lid heater task message passing") {
             messages::LidHeaterMessage(read_message));
         tasks->run_lid_heater_task();
 #if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
-        auto error_msg = tasks->get_latest_host_comms_message<
-            messages::ErrorMessage>();
+        auto error_msg =
+            tasks->get_latest_host_comms_message<messages::ErrorMessage>();
         CHECK(error_msg.code == errors::ErrorCode::THERMISTOR_LID_SHORT);
 #endif
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
+
+        WHEN("sending a get error status message") {
+            auto message = messages::GetErrorStateMessage{.id = 123};
+            tasks->get_lid_heater_queue().backing_deque.push_back(message);
+            tasks->run_lid_heater_task();
+            THEN("the task should respond with an error") {
+                tasks->require_has_ack_for(
+                    message, errors::ErrorCode::THERMISTOR_LID_SHORT);
+            }
+        }
 
         WHEN("Sending a SetHeaterDebug message to enable the heater") {
             auto message =
@@ -273,16 +293,12 @@ SCENARIO("lid heater task message passing") {
             tasks->get_lid_heater_queue().backing_deque.push_back(
                 messages::LidHeaterMessage(message));
             tasks->run_lid_heater_task();
-            THEN("the task should get the message") {
+            THEN("the task should respond with an error") {
                 REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
-                AND_THEN("the task should respond with an error") {
-                    REQUIRE(
-                        tasks->get_lid_heater_queue().backing_deque.empty());
-                    REQUIRE(tasks->get_lid_heater_policy().get_heater_power() ==
-                            0.0F);
-                    tasks->require_has_ack_for(
-                        message, errors::ErrorCode::THERMISTOR_LID_SHORT);
-                }
+                REQUIRE(tasks->get_lid_heater_policy().get_heater_power() ==
+                        0.0F);
+                tasks->require_has_ack_for(
+                    message, errors::ErrorCode::THERMISTOR_LID_SHORT);
             }
         }
         WHEN("Sending a SetLidTemperature message to enable the lid") {
@@ -291,22 +307,18 @@ SCENARIO("lid heater task message passing") {
             tasks->get_lid_heater_queue().backing_deque.push_back(
                 messages::LidHeaterMessage(message));
             tasks->run_lid_heater_task();
-            THEN("the task should get the message") {
-                REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
-                AND_THEN("the task should respond with an error") {
-                    tasks->require_has_ack_for(
-                        message, errors::ErrorCode::THERMISTOR_LID_SHORT);
-                    AND_WHEN("sending a GetLidTemp query") {
-                        auto tempMessage =
-                            messages::GetLidTempMessage{.id = 555};
-                        tasks->get_lid_heater_queue().backing_deque.push_back(
-                            messages::LidHeaterMessage(tempMessage));
-                        tasks->run_lid_heater_task();
-                        THEN("the response should have a setpoint of 0") {
-                            auto gettemp = tasks->get_latest_host_comms_message<
-                                messages::GetLidTempResponse>();
-                            REQUIRE(gettemp.set_temp == 0.0F);
-                        }
+            THEN("the task should respond with an error") {
+                tasks->require_has_ack_for(
+                    message, errors::ErrorCode::THERMISTOR_LID_SHORT);
+                AND_WHEN("sending a GetLidTemp query") {
+                    auto tempMessage = messages::GetLidTempMessage{.id = 555};
+                    tasks->get_lid_heater_queue().backing_deque.push_back(
+                        messages::LidHeaterMessage(tempMessage));
+                    tasks->run_lid_heater_task();
+                    THEN("the response should have a setpoint of 0") {
+                        auto gettemp = tasks->get_latest_host_comms_message<
+                            messages::GetLidTempResponse>();
+                        REQUIRE(gettemp.set_temp == 0.0F);
                     }
                 }
             }
@@ -316,17 +328,14 @@ SCENARIO("lid heater task message passing") {
             tasks->get_lid_heater_queue().backing_deque.push_back(
                 messages::LidHeaterMessage(message));
             tasks->run_lid_heater_task();
-            THEN("the task should get the message") {
-                REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
-                AND_THEN("the task should respond with a temp of 0") {
-                    auto gettemp = tasks->get_latest_host_comms_message<
-                        messages::GetLidTempResponse>();
-                    REQUIRE(gettemp.responding_to_id == message.id);
-                    REQUIRE_THAT(gettemp.current_temp,
-                                 Catch::Matchers::WithinAbs(0.0, 0.1));
-                    REQUIRE_THAT(gettemp.set_temp,
-                                 Catch::Matchers::WithinAbs(0.0, 0.1));
-                }
+            THEN("the task should respond with a temp of 0") {
+                auto gettemp = tasks->get_latest_host_comms_message<
+                    messages::GetLidTempResponse>();
+                REQUIRE(gettemp.responding_to_id == message.id);
+                REQUIRE_THAT(gettemp.current_temp,
+                             Catch::Matchers::WithinAbs(0.0, 0.1));
+                REQUIRE_THAT(gettemp.set_temp,
+                             Catch::Matchers::WithinAbs(0.0, 0.1));
             }
         }
     }
@@ -339,8 +348,8 @@ SCENARIO("lid heater task message passing") {
             messages::LidHeaterMessage(read_message));
         tasks->run_lid_heater_task();
 #if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
-        auto error_msg = tasks->get_latest_host_comms_message<
-            messages::ErrorMessage>();
+        auto error_msg =
+            tasks->get_latest_host_comms_message<messages::ErrorMessage>();
         CHECK(error_msg.code == errors::ErrorCode::THERMISTOR_LID_DISCONNECTED);
 #endif
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
@@ -351,16 +360,12 @@ SCENARIO("lid heater task message passing") {
             tasks->get_lid_heater_queue().backing_deque.push_back(
                 messages::LidHeaterMessage(message));
             tasks->run_lid_heater_task();
-            THEN("the task should get the message") {
+            THEN("the task should respond with an error") {
                 REQUIRE(tasks->get_lid_heater_queue().backing_deque.empty());
-                AND_THEN("the task should respond with an error") {
-                    REQUIRE(
-                        tasks->get_lid_heater_queue().backing_deque.empty());
-                    tasks->require_has_ack_for(
-                        message, errors::ErrorCode::THERMISTOR_LID_DISCONNECTED);
-                    REQUIRE(tasks->get_lid_heater_policy().get_heater_power() ==
-                            0.0F);
-                }
+                tasks->require_has_ack_for(
+                    message, errors::ErrorCode::THERMISTOR_LID_DISCONNECTED);
+                REQUIRE(tasks->get_lid_heater_policy().get_heater_power() ==
+                        0.0F);
             }
         }
     }
@@ -373,9 +378,7 @@ SCENARIO("lid heater task message passing") {
         THEN("the lid fan is enabled") {
             REQUIRE(tasks->get_lid_heater_policy().lid_fans_enabled());
         }
-        THEN("the message is acked") {
-            tasks->require_has_ack_for(fan_msg);
-        }
+        THEN("the message is acked") { tasks->require_has_ack_for(fan_msg); }
         AND_WHEN("sending another message to disable the fans") {
             fan_msg.id = 456;
             fan_msg.enable = false;
@@ -404,13 +407,23 @@ SCENARIO("lid heater error flag handling") {
         timestamp += TIME_DELTA;
         REQUIRE(lid_queue.try_send(read_message));
         tasks->run_lid_heater_task();
+        WHEN("sending a get error status message") {
+            auto message = messages::GetErrorStateMessage{.id = 123};
+            tasks->get_lid_heater_queue().backing_deque.push_back(message);
+            tasks->run_lid_heater_task();
+            THEN("the task should respond with an error") {
+                tasks->require_has_ack_for(
+                    message, errors::ErrorCode::THERMISTOR_LID_SHORT);
+            }
+        }
         WHEN("sending a SetPlateTemperature message") {
             auto set_msg =
                 messages::SetLidTemperatureMessage{.id = 123, .setpoint = 50};
             REQUIRE(lid_queue.try_send(set_msg));
             tasks->run_lid_heater_task();
             THEN("the response shows an error") {
-                tasks->require_has_ack_for(set_msg, errors::ErrorCode::THERMISTOR_LID_SHORT);
+                tasks->require_has_ack_for(
+                    set_msg, errors::ErrorCode::THERMISTOR_LID_SHORT);
             }
         }
         WHEN("sending a DeactivateAll message") {
@@ -424,7 +437,8 @@ SCENARIO("lid heater error flag handling") {
                 REQUIRE(lid_queue.try_send(set_msg));
                 tasks->run_lid_heater_task();
                 THEN("the response shows an error") {
-                    tasks->require_has_ack_for(set_msg, errors::ErrorCode::THERMISTOR_LID_SHORT);
+                    tasks->require_has_ack_for(
+                        set_msg, errors::ErrorCode::THERMISTOR_LID_SHORT);
                 }
             }
         }

--- a/stm32-modules/thermocycler-gen2/tests/test_m103d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m103d.cpp
@@ -1,8 +1,5 @@
 #include "catch2/catch.hpp"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("GetThermalPowerDebug (M103.D) parser works",
          "[gocde][parse][m103.d]") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m104.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m104.cpp
@@ -1,5 +1,5 @@
 #include "catch2/catch.hpp"
-#include "thermocycler-gen2/gcodes.hpp"
+#include "gcode_test_harness.hpp"
 
 SCENARIO("SetPlateTemperature (M104) parser works", "[gcode][parse][m104]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m104d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m104d.cpp
@@ -1,5 +1,5 @@
 #include "catch2/catch.hpp"
-#include "thermocycler-gen2/gcodes.hpp"
+#include "gcode_test_harness.hpp"
 
 SCENARIO("SetPeltierDebug (M104.D) parser works", "[gcode][parse][m104.d]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m105.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m105.cpp
@@ -1,11 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("GetPlateTemperature (M105) parser works", "[gcode][parse][M105]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m105d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m105d.cpp
@@ -1,10 +1,7 @@
 #include <array>
 
 #include "catch2/catch.hpp"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("GetPlateTemperatureDebug (M105.D) parser works",
          "[gcode][parse][m105.d]") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m106.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m106.cpp
@@ -1,5 +1,5 @@
 #include "catch2/catch.hpp"
-#include "thermocycler-gen2/gcodes.hpp"
+#include "gcode_test_harness.hpp"
 
 SCENARIO("SetFanManual (M106) parser works", "[gcode][parse][m106]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m107.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m107.cpp
@@ -1,11 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("SetFanAutomatic (M107) parser works", "[gcode][parse][m107]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m108.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m108.cpp
@@ -1,11 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("DeactivateLidHeating (M108) parser works", "[gcode][parse][m108]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m115.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m115.cpp
@@ -1,8 +1,8 @@
 #include <array>
 
 #include "catch2/catch.hpp"
-#include "systemwide.h"
 #include "gcode_test_harness.hpp"
+#include "systemwide.h"
 
 SCENARIO("GetSystemInfo (M115) response works", "[gcode][parse][m115]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m115.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m115.cpp
@@ -2,10 +2,7 @@
 
 #include "catch2/catch.hpp"
 #include "systemwide.h"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("GetSystemInfo (M115) response works", "[gcode][parse][m115]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m116.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m116.cpp
@@ -1,8 +1,8 @@
 #include <utility>
 
 #include "catch2/catch.hpp"
-#include "systemwide.h"
 #include "gcode_test_harness.hpp"
+#include "systemwide.h"
 
 SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m116.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m116.cpp
@@ -2,7 +2,7 @@
 
 #include "catch2/catch.hpp"
 #include "systemwide.h"
-#include "thermocycler-gen2/gcodes.hpp"
+#include "gcode_test_harness.hpp"
 
 SCENARIO("SetOffsetConstants (M116) parser works", "[gcode][parse][m116]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m117.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m117.cpp
@@ -1,8 +1,5 @@
 #include "catch2/catch.hpp"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("GetOffsetConstants (M105.D) parser works", "[gcode][parse][m105.d]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m119.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m119.cpp
@@ -1,12 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
-
+#include "gcode_test_harness.hpp"
 #include "thermocycler-gen2/motor_utils.hpp"
 
 SCENARIO("GetLidStatus (M119) parser works", "[gcode][parse][m119]") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m126.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m126.cpp
@@ -1,11 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("OpenLid (M126) parser works", "[gcode][parse][m126]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m127.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m127.cpp
@@ -1,11 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("CloseLid (M127) parser works", "[gcode][parse][m127]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m128.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m128.cpp
@@ -1,11 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("LiftPlate (M128) parser works", "[gcode][parse][m128]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m14.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m14.cpp
@@ -1,11 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("DeactivatePlate (M14) parser works", "[gcode][parse][m14]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m140.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m140.cpp
@@ -1,5 +1,5 @@
 #include "catch2/catch.hpp"
-#include "thermocycler-gen2/gcodes.hpp"
+#include "gcode_test_harness.hpp"
 
 SCENARIO("SetLidTemperature (M140) parser works", "[gcode][parse][m140]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m140d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m140d.cpp
@@ -1,5 +1,5 @@
 #include "catch2/catch.hpp"
-#include "thermocycler-gen2/gcodes.hpp"
+#include "gcode_test_harness.hpp"
 
 SCENARIO("SetHeaterDebug (M140.D) parser works", "[gcode][parse][m140d]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m141.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m141.cpp
@@ -1,11 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("GetLidTemperature (M141) parser works", "[gcode][parse][M141]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m141d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m141d.cpp
@@ -1,10 +1,7 @@
 #include <array>
 
 #include "catch2/catch.hpp"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("GetLidTemperatureDebug (M141.D) parser works",
          "[gcode][parse][M141.d]") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m18.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m18.cpp
@@ -1,11 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("DeactivateAll (M18) parser works", "[gcode][parse][m18]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m240d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m240d.cpp
@@ -1,5 +1,5 @@
 #include "catch2/catch.hpp"
-#include "thermocycler-gen2/gcodes.hpp"
+#include "gcode_test_harness.hpp"
 
 SCENARIO("gcode m240.d works", "[gcode][parse][m240d]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m241d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m241d.cpp
@@ -1,8 +1,5 @@
 #include "catch2/catch.hpp"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("gcode m241.d works", "[gcode][parse][m241d]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m242d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m242d.cpp
@@ -1,8 +1,5 @@
 #include "catch2/catch.hpp"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("gcode m242.d works", "[gcode][parse][m242d]") {
     auto status = tmc2130::DriveStatus{.sg_result = 123, .stallguard = 1};

--- a/stm32-modules/thermocycler-gen2/tests/test_m243d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m243d.cpp
@@ -1,5 +1,5 @@
 #include "catch2/catch.hpp"
-#include "thermocycler-gen2/gcodes.hpp"
+#include "gcode_test_harness.hpp"
 
 SCENARIO("gcode m243.d parameter utility function works") {
     GIVEN("invalid parameter") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m301.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m301.cpp
@@ -1,11 +1,6 @@
 #include "catch2/catch.hpp"
 #include "systemwide.h"
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("SetPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m301.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m301.cpp
@@ -1,6 +1,6 @@
 #include "catch2/catch.hpp"
-#include "systemwide.h"
 #include "gcode_test_harness.hpp"
+#include "systemwide.h"
 
 SCENARIO("SetPIDConstants (M301) parser works", "[gcode][parse][m301]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m411.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m411.cpp
@@ -1,0 +1,53 @@
+#include "catch2/catch.hpp"
+#include "gcode_test_harness.hpp"
+
+SCENARIO("GetErrorState (M411) parser works", "[gcode][parse][m411]") {
+    GIVEN("a response buffer large enough for the formatted response") {
+        std::string buffer(256, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetErrorState::write_response_into(
+                buffer.begin(), buffer.end(), true);
+            THEN("the response should be written in full") {
+                REQUIRE_THAT(buffer,
+                             Catch::Matchers::StartsWith("M411 OK\n"));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+
+    GIVEN("a response buffer not large enough for the formatted response") {
+        std::string buffer(16, 'c');
+        WHEN("filling response") {
+            auto written = gcode::GetErrorState::write_response_into(
+                buffer.begin(), buffer.begin() + 7, true);
+            THEN("the response should write only up to the available space") {
+                std::string response = "M411cccccccccc";
+                response[6] = '\0';
+                REQUIRE_THAT(buffer, Catch::Matchers::Equals(response));
+                REQUIRE(written != buffer.begin());
+            }
+        }
+    }
+    GIVEN("valid input") {
+        std::string input = "M411\n";
+        WHEN("parsing input") {
+            auto parsed =
+                gcode::GetErrorState::parse(input.begin(), input.end());
+            THEN("the gcode is parsed") {
+                REQUIRE(parsed.first.has_value());
+                REQUIRE(parsed.second != input.begin());
+            }
+        }
+    }
+    GIVEN("invalid input") {
+        std::string input = "M4asda\n";
+        WHEN("parsing input") {
+            auto parsed =
+                gcode::GetErrorState::parse(input.begin(), input.end());
+            THEN("the gcode is not parsed") {
+                REQUIRE(!parsed.first.has_value());
+                REQUIRE(parsed.second == input.begin());
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-gen2/tests/test_m411.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m411.cpp
@@ -8,8 +8,7 @@ SCENARIO("GetErrorState (M411) parser works", "[gcode][parse][m411]") {
             auto written = gcode::GetErrorState::write_response_into(
                 buffer.begin(), buffer.end(), true);
             THEN("the response should be written in full") {
-                REQUIRE_THAT(buffer,
-                             Catch::Matchers::StartsWith("M411 OK\n"));
+                REQUIRE_THAT(buffer, Catch::Matchers::StartsWith("M411 OK\n"));
                 REQUIRE(written != buffer.begin());
             }
         }

--- a/stm32-modules/thermocycler-gen2/tests/test_m412d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m412d.cpp
@@ -1,0 +1,83 @@
+#include <array>
+
+#include "catch2/catch.hpp"
+#include "gcode_test_harness.hpp"
+
+SCENARIO("SetErrorStateDebug parser works", "[gcode][parse][m412.d]") {
+    GIVEN("an empty string") {
+        std::string to_parse = "";
+        WHEN("calling parse") {
+            auto result = gcode::SetErrorStateDebug::parse(to_parse.cbegin(),
+                                                           to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE_FALSE(result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a fully non-matching string") {
+        std::string to_parse = "asdhalghasdasd ";
+
+        WHEN("calling parse") {
+            auto result = gcode::SetErrorStateDebug::parse(to_parse.cbegin(),
+                                                           to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE_FALSE(result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a subprefix matching only") {
+        std::string to_parse = "M4asdlasfhalsd\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetErrorStateDebug::parse(to_parse.cbegin(),
+                                                           to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE_FALSE(result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a good gcode but no E argument") {
+        std::string to_parse = "M412.D T21312\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetErrorStateDebug::parse(to_parse.cbegin(),
+                                                           to_parse.cend());
+            THEN("nothing should be parsed") {
+                REQUIRE_FALSE(result.first.has_value());
+                REQUIRE(result.second == to_parse.cbegin());
+            }
+        }
+    }
+
+    GIVEN("a string with a good gcode and E argument but no T") {
+        std::string to_parse = "M412.D E209\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetErrorStateDebug::parse(to_parse.cbegin(),
+                                                           to_parse.cend());
+            THEN("a gcode should be parsed") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.first->error ==
+                        errors::ErrorCode::THERMISTOR_FRONT_LEFT_OVERTEMP);
+                REQUIRE(result.first->delay_s == 0);
+            }
+        }
+    }
+
+    GIVEN("a string with a good gcode and both arguments") {
+        std::string to_parse = "M412.D E209 T1250\r\n";
+        WHEN("calling parse") {
+            auto result = gcode::SetErrorStateDebug::parse(to_parse.cbegin(),
+                                                           to_parse.cend());
+            THEN("a gcode should be parsed") {
+                REQUIRE(result.first.has_value());
+                REQUIRE(result.first->error ==
+                        errors::ErrorCode::THERMISTOR_FRONT_LEFT_OVERTEMP);
+                REQUIRE(result.first->delay_s == 1250);
+            }
+        }
+    }
+}

--- a/stm32-modules/thermocycler-gen2/tests/test_m900d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m900d.cpp
@@ -1,11 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("GetBoardRevision (M900.D) parser works", "[gcode][parse][m900d]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m901d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m901d.cpp
@@ -1,11 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("GetLidSwitches (M901.D) parser works", "[gcode][parse][m901d]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m902d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m902d.cpp
@@ -1,11 +1,5 @@
 #include "catch2/catch.hpp"
-
-// Push this diagnostic to avoid a compiler error about printing to too
-// small of a buffer... which we're doing on purpose!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("GetFrontButton (M902.D) parser works", "[gcode][parse][m902d]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m903d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m903d.cpp
@@ -1,10 +1,7 @@
 #include <array>
 
 #include "catch2/catch.hpp"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("GetLidTemperatureDebug (M903.D) parser works",
          "[gcode][parse][M903.d]") {

--- a/stm32-modules/thermocycler-gen2/tests/test_m904d.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_m904d.cpp
@@ -1,10 +1,7 @@
 #include <array>
 
 #include "catch2/catch.hpp"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#include "thermocycler-gen2/gcodes.hpp"
-#pragma GCC diagnostic pop
+#include "gcode_test_harness.hpp"
 
 SCENARIO("SetLightsDebug (M904.D) parser works", "[gcode][parse][M904.d]") {
     GIVEN("a response buffer large enough for the formatted response") {

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_state_machine.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_state_machine.cpp
@@ -4,7 +4,6 @@
 #include "thermocycler-gen2/messages.hpp"
 #include "thermocycler-gen2/motor_utils.hpp"
 
-
 struct MotorStep {
     // Message to send on this step
     messages::MotorMessage msg;
@@ -81,7 +80,8 @@ void test_motor_state_machine(std::shared_ptr<TaskBuilder> tasks,
             if (step.ack.has_value()) {
                 THEN("an ack is sent to host comms") {
                     auto ack = step.ack.value();
-                    tasks->require_has_ack_for_id(ack.responding_to_id, ack.with_error);
+                    tasks->require_has_ack_for_id(ack.responding_to_id,
+                                                  ack.with_error);
                 }
             }
             if (step.motor_state.has_value()) {

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_state_machine.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_state_machine.cpp
@@ -1,0 +1,669 @@
+#include "catch2/catch.hpp"
+#include "systemwide.h"
+#include "test/task_builder.hpp"
+#include "thermocycler-gen2/messages.hpp"
+#include "thermocycler-gen2/motor_utils.hpp"
+
+
+struct MotorStep {
+    // Message to send on this step
+    messages::MotorMessage msg;
+    // If true, expect that the lid angle increased after this message
+    bool lid_angle_increased = false;
+    // If true, expect that the lid angle decreased after this message
+    bool lid_angle_decreased = false;
+    // If the lid moved (increase or decrease), check that the limit switches
+    // are either ignored or checked
+    bool lid_overdrive = false;
+    // Expected seal motor state
+    bool seal_on = false;
+    // Retraction is true, extension is false
+    bool seal_direction = false;
+    // If true, seal switch should be armed. If nullopt, doesn't matter.
+    std::optional<bool> seal_switch_armed = std::nullopt;
+
+    using MotorState = messages::UpdateMotorState::MotorState;
+    // If this isn't nullopt, check that the system task got a message
+    // with this MotorState value
+    std::optional<MotorState> motor_state = std::nullopt;
+
+    using SealPos = motor_util::SealStepper::Status;
+    // If this variable is set, expect seal in a specific position
+    std::optional<SealPos> seal_pos = std::nullopt;
+    // If this variable is set, check the lid velocity
+    std::optional<double> lid_rpm = std::nullopt;
+    // If true, expect an ack in the host comms task
+    std::optional<messages::AcknowledgePrevious> ack = std::nullopt;
+};
+
+/**
+ * @brief Executes a set of steps to exercise the lid motor state machine.
+ *
+ * @pre The state of any switches should be set \e before invoking this
+ */
+void test_motor_state_machine(std::shared_ptr<TaskBuilder> tasks,
+                              std::vector<MotorStep> &steps) {
+    auto &motor_task = tasks->get_motor_task();
+    auto &motor_policy = tasks->get_motor_policy();
+    auto &motor_queue = tasks->get_motor_queue();
+    for (size_t i = 0; i < steps.size(); ++i) {
+        auto &step = steps[i];
+
+        auto lid_angle_before = motor_policy.get_angle();
+        motor_queue.backing_deque.push_back(step.msg);
+        tasks->get_system_queue().backing_deque.clear();
+        tasks->run_motor_task();
+
+        DYNAMIC_SECTION("Step " << i) {
+            if (step.lid_angle_increased) {
+                THEN("the lid motor opened") {
+                    REQUIRE(motor_policy.get_angle() > lid_angle_before);
+                }
+            }
+            if (step.lid_angle_decreased) {
+                THEN("the lid motor closed") {
+                    REQUIRE(motor_policy.get_angle() < lid_angle_before);
+                }
+            }
+            THEN("the seal is controlled correctly") {
+                REQUIRE(motor_policy.seal_moving() == step.seal_on);
+                if (step.seal_on) {
+                    REQUIRE(motor_policy.get_tmc2130_direction() ==
+                            step.seal_direction);
+                }
+            }
+            if (step.seal_pos.has_value()) {
+                THEN("the seal position is set correctly") {
+                    REQUIRE(motor_task.get_seal_position() ==
+                            step.seal_pos.value());
+                }
+            }
+            if (step.ack.has_value()) {
+                THEN("an ack is sent to host comms") {
+                    auto ack = step.ack.value();
+                    tasks->require_has_ack_for_id(ack.responding_to_id, ack.with_error);
+                }
+            }
+            if (step.motor_state.has_value()) {
+                THEN("the motor state is updated correctly") {
+                    REQUIRE(tasks->get_system_queue().has_message());
+                    auto state_msg =
+                        tasks->get_system_queue().backing_deque.front();
+                    REQUIRE(std::holds_alternative<messages::UpdateMotorState>(
+                        state_msg));
+                    auto state =
+                        std::get<messages::UpdateMotorState>(state_msg);
+                    REQUIRE(state.state == step.motor_state);
+                }
+            }
+        }
+    }
+}
+
+SCENARIO("motor task lid state machine") {
+    auto tasks = TaskBuilder::build();
+    auto &motor_policy = tasks->get_motor_policy();
+    GIVEN("lid is closed on startup") {
+        motor_policy.set_lid_closed_switch(true);
+        motor_policy.set_lid_open_switch(false);
+        WHEN("sending open lid command") {
+            std::vector<MotorStep> steps = {
+                // First step retracts seal switch
+                {.msg = messages::OpenLidMessage{.id = 123},
+                 .seal_on = true,
+                 .seal_direction = true,
+                 .seal_switch_armed = true,
+                 .motor_state = MotorStep::MotorState::OPENING_OR_CLOSING},
+                // Second step extends seal switch
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::LIMIT},
+                 .seal_on = true,
+                 .seal_direction = false,
+                 .seal_switch_armed = false},
+                // Third step opens hinge
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::DONE},
+                 .lid_angle_decreased = true,
+                 .lid_overdrive = true,
+                 .lid_rpm =
+                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
+                // Fourth step fully opening lid
+                {.msg = messages::LidStepperComplete(),
+                 .lid_angle_increased = true,
+                 .lid_overdrive = false},
+                // Sixth step open overdrive
+                {.msg = messages::LidStepperComplete(),
+                 .lid_angle_decreased = true,
+                 .lid_overdrive = true},
+                // Should send ACK now
+                {.msg = messages::LidStepperComplete(),
+                 .motor_state = MotorStep::MotorState::IDLE,
+                 .ack =
+                     messages::AcknowledgePrevious{
+                         .responding_to_id = 123,
+                         .with_error = errors::ErrorCode::NO_ERROR}},
+            };
+            test_motor_state_machine(tasks, steps);
+        }
+        GIVEN("seal lines aren't shared") {
+            motor_policy.set_switch_lines_shared(false);
+            WHEN("sending open lid command") {
+                std::vector<MotorStep> steps = {
+                    // First step retracts seal switch
+                    {.msg = messages::OpenLidMessage{.id = 123},
+                     .seal_on = true,
+                     .seal_direction = true,
+                     .seal_switch_armed = true,
+                     .motor_state = MotorStep::MotorState::OPENING_OR_CLOSING},
+                    // Second step overdrives lid to ease off the latch
+                    {.msg =
+                         messages::SealStepperComplete{
+                             .reason = messages::SealStepperComplete::
+                                 CompletionReason::DONE},
+                     .lid_angle_decreased = true,
+                     .lid_overdrive = true,
+                     .lid_rpm =
+                         motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
+                    // Third open fully if the close switch is not engaged
+                    {.msg = messages::LidStepperComplete(),
+                     .lid_angle_increased = true,
+                     .lid_overdrive = false},
+                    // Fifth open overdrive
+                    {.msg = messages::LidStepperComplete(),
+                     .lid_angle_decreased = true,
+                     .lid_overdrive = true},
+                    // Should send ACK now
+                    {.msg = messages::LidStepperComplete(),
+                     .motor_state = MotorStep::MotorState::IDLE,
+                     .ack =
+                         messages::AcknowledgePrevious{
+                             .responding_to_id = 123,
+                             .with_error = errors::ErrorCode::NO_ERROR}},
+                };
+                test_motor_state_machine(tasks, steps);
+            }
+        }
+        WHEN("sending close lid command") {
+            std::vector<MotorStep> steps = {
+                // Command should end immediately
+                {.msg = messages::CloseLidMessage{.id = 123},
+                 .ack = messages::AcknowledgePrevious{
+                     .responding_to_id = 123,
+                     .with_error = errors::ErrorCode::NO_ERROR}}};
+            test_motor_state_machine(tasks, steps);
+        }
+        WHEN("sending plate lift command") {
+            std::vector<MotorStep> steps = {
+                // Command should end with error
+                {.msg = messages::PlateLiftMessage{.id = 123},
+                 .ack = messages::AcknowledgePrevious{
+                     .responding_to_id = 123,
+                     .with_error = errors::ErrorCode::LID_CLOSED}}};
+            test_motor_state_machine(tasks, steps);
+        }
+        GIVEN("seal retraction switch is triggered") {
+            motor_policy.set_retraction_switch_triggered(true);
+            WHEN("sending open lid command") {
+                std::vector<MotorStep> steps = {
+                    // First step closes lid to ease off latch
+                    {.msg = messages::OpenLidMessage{.id = 123},
+                     .lid_angle_decreased = true,
+                     .lid_overdrive = true,
+                     .lid_rpm =
+                         motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
+                };
+                test_motor_state_machine(tasks, steps);
+            }
+        }
+        GIVEN("seal retraction and extension switches are triggered") {
+            motor_policy.set_retraction_switch_triggered(true);
+            motor_policy.set_extension_switch_triggered(true);
+            WHEN("sending open lid command") {
+                std::vector<MotorStep> steps = {
+                    // Should throw an error
+                    {.msg = messages::OpenLidMessage{.id = 123},
+                     .seal_on = false,
+                     .ack = messages::AcknowledgePrevious{
+                         .responding_to_id = 123,
+                         .with_error = errors::ErrorCode::SEAL_MOTOR_SWITCH}}};
+                test_motor_state_machine(tasks, steps);
+            }
+        }
+        GIVEN("seal extension switch is triggered") {
+            motor_policy.set_extension_switch_triggered(true);
+            motor_policy.set_retraction_switch_triggered(false);
+            WHEN("sending open lid command") {
+                std::vector<MotorStep> steps = {
+                    // Starts by retracting the seal
+                    {.msg = messages::OpenLidMessage{.id = 123},
+                     .seal_on = true,
+                     .seal_direction = true,
+                     .seal_switch_armed = true,
+                     .motor_state = MotorStep::MotorState::OPENING_OR_CLOSING}};
+                test_motor_state_machine(tasks, steps);
+            }
+        }
+    }
+    GIVEN("lid is open on startup") {
+        motor_policy.set_lid_closed_switch(false);
+        motor_policy.set_lid_open_switch(true);
+        WHEN("sending open lid command") {
+            std::vector<MotorStep> steps = {
+                // No action
+                {.msg = messages::OpenLidMessage{.id = 123},
+                 .ack =
+                     messages::AcknowledgePrevious{
+                         .responding_to_id = 123,
+                         .with_error = errors::ErrorCode::NO_ERROR}},
+            };
+            test_motor_state_machine(tasks, steps);
+        }
+        WHEN("sending close lid command") {
+            std::vector<MotorStep> steps = {
+                // First step retracts seal to switch
+                {.msg = messages::CloseLidMessage{.id = 123},
+                 .seal_on = true,
+                 .seal_direction = true,
+                 .seal_switch_armed = true,
+                 .motor_state = MotorStep::MotorState::OPENING_OR_CLOSING},
+                // Second step extends seal from switch
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::LIMIT},
+                 .seal_on = true,
+                 .seal_direction = false,
+                 .seal_switch_armed = false},
+                // Third step closes hinge
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::DONE},
+                 .lid_angle_decreased = true,
+                 .lid_overdrive = false,
+                 .lid_rpm =
+                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
+                // Fourth step overdrives hinge
+                {.msg = messages::LidStepperComplete(),
+                 .lid_angle_decreased = true,
+                 .lid_overdrive = true},
+            };
+            AND_WHEN("the closed switch is triggered") {
+                motor_policy.set_lid_closed_switch(true);
+                // Now extend seal to switch
+                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
+                                          .seal_on = true,
+                                          .seal_direction = false,
+                                          .seal_switch_armed = true});
+                // Retract seal from switch
+                steps.push_back(
+                    MotorStep{.msg =
+                                  messages::SealStepperComplete{
+                                      .reason = messages::SealStepperComplete::
+                                          CompletionReason::LIMIT},
+                              .seal_on = true,
+                              .seal_direction = true,
+                              .seal_switch_armed = false});
+                steps.push_back(
+                    // an ack with error code NO_ERROR should follow
+                    MotorStep{.msg =
+                                  messages::SealStepperComplete{
+                                      .reason = messages::SealStepperComplete::
+                                          CompletionReason::DONE},
+                              .motor_state = MotorStep::MotorState::IDLE,
+                              .ack = messages::AcknowledgePrevious{
+                                  .responding_to_id = 123,
+                                  .with_error = errors::ErrorCode::NO_ERROR}});
+                test_motor_state_machine(tasks, steps);
+            }
+            AND_WHEN("the closed switch is not triggered") {
+                motor_policy.set_lid_closed_switch(false);
+                // Now extend seal to switch
+                steps.push_back(MotorStep{
+                    .msg = messages::LidStepperComplete(),
+                    .seal_on = true,
+                    .seal_direction = false,
+                    .seal_switch_armed = true,
+                });
+                // Retract seal from switch
+                steps.push_back(MotorStep{
+                    .msg =
+                        messages::SealStepperComplete{
+                            .reason = messages::SealStepperComplete::
+                                CompletionReason::DONE},
+                    .motor_state = MotorStep::MotorState::IDLE,
+                    .ack = messages::AcknowledgePrevious{
+                        .responding_to_id = 123,
+                        .with_error =
+                            errors::ErrorCode::UNEXPECTED_LID_STATE}});
+                test_motor_state_machine(tasks, steps);
+            }
+        }
+        WHEN("sending plate lift command") {
+            std::vector<MotorStep> steps;
+            for (auto angle = motor_task::LidStepperState::
+                     PLATE_LIFT_NUDGE_START_DEGREES;
+                 angle <
+                 motor_task::LidStepperState::PLATE_LIFT_NUDGE_FINAL_DEGREES +
+                     motor_task::LidStepperState::PLATE_LIFT_NUDGE_INCREMENT;
+                 angle +=
+                 motor_task::LidStepperState::PLATE_LIFT_NUDGE_INCREMENT) {
+                // Incremental nudging
+                steps.push_back(MotorStep{
+                    .msg = messages::LidStepperComplete(),
+                    .lid_angle_increased = true,
+                    .lid_overdrive = true,
+                    .lid_rpm =
+                        motor_task::LidStepperState::PLATE_LIFT_VELOCITY_RPM,
+                });
+                steps.push_back(MotorStep{
+                    .msg = messages::LidStepperComplete(),
+                    .lid_angle_decreased = true,
+                    .lid_overdrive = true,
+                    .lid_rpm =
+                        motor_task::LidStepperState::PLATE_LIFT_VELOCITY_RPM,
+                });
+            }
+            // Final open - all the way to the limit
+            steps.push_back(MotorStep{
+                .msg = messages::LidStepperComplete(),
+                .lid_angle_increased = true,
+                .lid_overdrive = true,
+                .lid_rpm =
+                    motor_task::LidStepperState::PLATE_LIFT_VELOCITY_RPM});
+            // Return below switch
+            steps.push_back(MotorStep{
+                .msg = messages::LidStepperComplete(),
+                .lid_angle_increased = false,
+                .lid_angle_decreased = true,
+                .lid_overdrive = true,
+                .lid_rpm =
+                    motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM});
+            // Return to the switch
+            steps.push_back(MotorStep{
+                .msg = messages::LidStepperComplete(),
+                .lid_angle_increased = true,
+                .lid_overdrive = false,
+                .lid_rpm =
+                    motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM});
+            // Now BACK OUT of the switch
+            steps.push_back(MotorStep{
+                .msg = messages::LidStepperComplete(),
+                .lid_angle_increased = false,
+                .lid_angle_decreased = true,
+                .lid_overdrive = true,
+                .lid_rpm =
+                    motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM});
+            steps.push_back(
+                // an ack with error code NO_ERROR should follow
+                MotorStep{.msg = messages::LidStepperComplete(),
+                          .motor_state = MotorStep::MotorState::IDLE,
+                          .ack = messages::AcknowledgePrevious{
+                              .responding_to_id = 123,
+                              .with_error = errors::ErrorCode::NO_ERROR}});
+            steps[0].msg = messages::PlateLiftMessage{.id = 123};
+            steps[0].motor_state = MotorStep::MotorState::PLATE_LIFT;
+            test_motor_state_machine(tasks, steps);
+        }
+        GIVEN("seal retraction switch is triggered") {
+            motor_policy.set_retraction_switch_triggered(true);
+            WHEN("sending close lid command") {
+                std::vector<MotorStep> steps = {
+                    // First step closes hinge - skip seal movements
+                    {.msg = messages::CloseLidMessage{.id = 123},
+                     .lid_angle_decreased = true,
+                     .lid_overdrive = false,
+                     .lid_rpm =
+                         motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
+                    // Fourth step overdrives hinge
+                    {.msg = messages::LidStepperComplete(),
+                     .lid_angle_decreased = true,
+                     .lid_overdrive = true},
+                    // Now extend seal to switch
+                    {.msg = messages::LidStepperComplete(),
+                     .seal_on = true,
+                     .seal_direction = false,
+                     .seal_switch_armed = true}};
+                AND_WHEN("the closed switch is triggered") {
+                    motor_policy.set_lid_closed_switch(true);
+                    steps.push_back(
+                        // Retract seal from switch
+                        MotorStep{
+                            .msg =
+                                messages::SealStepperComplete{
+                                    .reason = messages::SealStepperComplete::
+                                        CompletionReason::LIMIT},
+                            .seal_on = true,
+                            .seal_direction = true,
+                            .seal_switch_armed = false});
+                    steps.push_back(
+                        // an ack with error code NO_ERROR should follow
+                        MotorStep{
+                            .msg =
+                                messages::SealStepperComplete{
+                                    .reason = messages::SealStepperComplete::
+                                        CompletionReason::DONE},
+                            .motor_state = MotorStep::MotorState::IDLE,
+                            .ack = messages::AcknowledgePrevious{
+                                .responding_to_id = 123,
+                                .with_error = errors::ErrorCode::NO_ERROR}});
+                    test_motor_state_machine(tasks, steps);
+                }
+                AND_WHEN("the closed switch is not triggered") {
+                    motor_policy.set_lid_closed_switch(false);
+                    steps.push_back(
+                        // Retract seal from switch
+                        MotorStep{
+                            .msg =
+                                messages::SealStepperComplete{
+                                    .reason = messages::SealStepperComplete::
+                                        CompletionReason::LIMIT},
+                            .ack = messages::AcknowledgePrevious{
+                                .responding_to_id = 123,
+                                .with_error =
+                                    errors::ErrorCode::UNEXPECTED_LID_STATE}});
+                    test_motor_state_machine(tasks, steps);
+                }
+            }
+        }
+        GIVEN("seal switches aren't shared") {
+            motor_policy.set_switch_lines_shared(false);
+            WHEN("sending close lid command") {
+                // Skip the 'backoff' steps
+                std::vector<MotorStep> steps = {
+                    // First step retracts seal to switch
+                    {.msg = messages::CloseLidMessage{.id = 123},
+                     .seal_on = true,
+                     .seal_direction = true,
+                     .seal_switch_armed = true,
+                     .motor_state = MotorStep::MotorState::OPENING_OR_CLOSING},
+                    // Second step closes hinge
+                    {.msg =
+                         messages::SealStepperComplete{
+                             .reason = messages::SealStepperComplete::
+                                 CompletionReason::DONE},
+                     .lid_angle_decreased = true,
+                     .lid_overdrive = false,
+                     .lid_rpm =
+                         motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
+                    // Fourth step overdrives hinge
+                    {.msg = messages::LidStepperComplete(),
+                     .lid_angle_decreased = true,
+                     .lid_overdrive = true},
+                    // Now extend seal to switch
+                    {.msg = messages::LidStepperComplete(),
+                     .seal_on = true,
+                     .seal_direction = false,
+                     .seal_switch_armed = true},
+                };
+                AND_WHEN("the closed switch is triggered") {
+                    motor_policy.set_lid_closed_switch(true);
+                    steps.push_back(
+                        // an ack with error code NO_ERROR should follow
+                        MotorStep{
+                            .msg =
+                                messages::SealStepperComplete{
+                                    .reason = messages::SealStepperComplete::
+                                        CompletionReason::DONE},
+                            .motor_state = MotorStep::MotorState::IDLE,
+                            .ack = messages::AcknowledgePrevious{
+                                .responding_to_id = 123,
+                                .with_error = errors::ErrorCode::NO_ERROR}});
+                    test_motor_state_machine(tasks, steps);
+                }
+                AND_WHEN("the closed switch is not triggered") {
+                    motor_policy.set_lid_closed_switch(false);
+                    steps.push_back(
+                        // an ack with error code UNEXPECTED_LID_STATE should
+                        // follow
+                        MotorStep{
+                            .msg =
+                                messages::SealStepperComplete{
+                                    .reason = messages::SealStepperComplete::
+                                        CompletionReason::DONE},
+                            .motor_state = MotorStep::MotorState::IDLE,
+                            .ack = messages::AcknowledgePrevious{
+                                .responding_to_id = 123,
+                                .with_error =
+                                    errors::ErrorCode::UNEXPECTED_LID_STATE}});
+                    test_motor_state_machine(tasks, steps);
+                }
+            }
+        }
+    }
+    GIVEN("lid is unknown at startup") {
+        motor_policy.set_lid_closed_switch(false);
+        motor_policy.set_lid_open_switch(false);
+        WHEN("sending open lid command") {
+            std::vector<MotorStep> steps = {
+                // First step retracts seal switch
+                {.msg = messages::OpenLidMessage{.id = 123},
+                 .seal_on = true,
+                 .seal_direction = true,
+                 .seal_switch_armed = true},
+                // Second step extends seeal switch
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::LIMIT},
+                 .seal_on = true,
+                 .seal_direction = false,
+                 .seal_switch_armed = false},
+                // Third step opens hinge
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::DONE},
+                 .lid_angle_increased = true,
+                 .lid_overdrive = false,
+                 .lid_rpm =
+                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
+                // Fourth step overdrives hinge
+                {.msg = messages::LidStepperComplete(),
+                 .lid_angle_decreased = true,
+                 .lid_overdrive = true},
+                // Should send ACK now
+                {.msg = messages::LidStepperComplete(),
+                 .ack =
+                     messages::AcknowledgePrevious{
+                         .responding_to_id = 123,
+                         .with_error = errors::ErrorCode::NO_ERROR}},
+            };
+            test_motor_state_machine(tasks, steps);
+        }
+        WHEN("sending close lid command") {
+            std::vector<MotorStep> steps = {
+                // First step retracts seal to switch
+                {.msg = messages::CloseLidMessage{.id = 123},
+                 .seal_on = true,
+                 .seal_direction = true,
+                 .seal_switch_armed = true},
+                // Second step extends seal from switch
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::LIMIT},
+                 .seal_on = true,
+                 .seal_direction = false,
+                 .seal_switch_armed = false},
+                // Third step closes hinge
+                {.msg =
+                     messages::SealStepperComplete{
+                         .reason = messages::SealStepperComplete::
+                             CompletionReason::DONE},
+                 .lid_angle_decreased = true,
+                 .lid_overdrive = false,
+                 .lid_rpm =
+                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM}};
+            test_motor_state_machine(tasks, steps);
+            steps.clear();
+            AND_WHEN("the closed switch is triggered") {
+                motor_policy.set_lid_closed_switch(true);
+                // Fourth step overdrives hinge
+                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
+                                          .lid_angle_decreased = true,
+                                          .lid_overdrive = true});
+                // Now extend seal to switch
+                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
+                                          .seal_on = true,
+                                          .seal_direction = false,
+                                          .seal_switch_armed = true});
+                // Retract seal from switch
+                steps.push_back(
+                    MotorStep{.msg =
+                                  messages::SealStepperComplete{
+                                      .reason = messages::SealStepperComplete::
+                                          CompletionReason::LIMIT},
+                              .seal_on = true,
+                              .seal_direction = true,
+                              .seal_switch_armed = false});
+                steps.push_back(
+                    // an ack with error code NO_ERROR should follow
+                    MotorStep{.msg =
+                                  messages::SealStepperComplete{
+                                      .reason = messages::SealStepperComplete::
+                                          CompletionReason::DONE},
+                              .ack = messages::AcknowledgePrevious{
+                                  .responding_to_id = 123,
+                                  .with_error = errors::ErrorCode::NO_ERROR}});
+                test_motor_state_machine(tasks, steps);
+            }
+            AND_WHEN("the closed switch is not triggered") {
+                motor_policy.set_lid_closed_switch(false);
+                // Fourth step overdrives hinge
+                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
+                                          .lid_angle_decreased = true,
+                                          .lid_overdrive = true});
+                // Now extend seal to switch
+                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
+                                          .seal_on = true,
+                                          .seal_direction = false,
+                                          .seal_switch_armed = true});
+                // Retract seal from switch
+                steps.push_back(MotorStep{
+                    .msg =
+                        messages::SealStepperComplete{
+                            .reason = messages::SealStepperComplete::
+                                CompletionReason::LIMIT},
+                    .ack = messages::AcknowledgePrevious{
+                        .responding_to_id = 123,
+                        .with_error =
+                            errors::ErrorCode::UNEXPECTED_LID_STATE}});
+                test_motor_state_machine(tasks, steps);
+            }
+        }
+        WHEN("sending plate lift command") {
+            std::vector<MotorStep> steps = {
+                // Command should end with error
+                {.msg = messages::PlateLiftMessage{.id = 123},
+                 .ack = messages::AcknowledgePrevious{
+                     .responding_to_id = 123,
+                     .with_error = errors::ErrorCode::LID_CLOSED}}};
+            test_motor_state_machine(tasks, steps);
+        }
+    }
+}

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
@@ -347,7 +347,8 @@ SCENARIO("motor task message passing") {
                     messages::OpenLidMessage{.id = 456});
                 tasks->run_motor_task();
                 THEN("the second command is ignored with an error") {
-                    tasks->require_has_ack_for_id(456, errors::ErrorCode::LID_MOTOR_BUSY);
+                    tasks->require_has_ack_for_id(
+                        456, errors::ErrorCode::LID_MOTOR_BUSY);
                 }
             }
         }
@@ -364,7 +365,8 @@ SCENARIO("motor task message passing") {
                     messages::CloseLidMessage{.id = 456});
                 tasks->run_motor_task();
                 THEN("the second command is ignored with an error") {
-                    tasks->require_has_ack_for_id(456, errors::ErrorCode::LID_MOTOR_BUSY);
+                    tasks->require_has_ack_for_id(
+                        456, errors::ErrorCode::LID_MOTOR_BUSY);
                 }
             }
         }

--- a/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_motor_task.cpp
@@ -25,7 +25,7 @@ SCENARIO("motor task message passing") {
                 "the motor task should tun on the solenoid and respond to the "
                 "message") {
                 REQUIRE(motor_queue.backing_deque.empty());
-                REQUIRE(!tasks->get_host_comms_queue().backing_deque.empty());
+                tasks->require_has_ack_for(message);
             }
             THEN("the TMC2130 has been initialized by the task") {
                 REQUIRE(motor_policy.has_been_written());
@@ -65,17 +65,8 @@ SCENARIO("motor task message passing") {
                 motor_queue.backing_deque.push_back(message);
                 tasks->run_motor_task();
                 THEN("the second message is ACKed with an error") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto ack =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            ack));
-                    auto ack_msg = std::get<messages::AcknowledgePrevious>(ack);
-                    REQUIRE(ack_msg.responding_to_id == 999);
-                    REQUIRE(ack_msg.with_error ==
-                            errors::ErrorCode::LID_MOTOR_BUSY);
+                    tasks->require_has_ack_for(
+                        message, errors::ErrorCode::LID_MOTOR_BUSY);
                 }
             }
             AND_WHEN("receiving a LidStepperComplete message") {
@@ -86,15 +77,7 @@ SCENARIO("motor task message passing") {
                     REQUIRE(motor_policy.get_vref() ==
                             motor_task.LID_STEPPER_HOLD_CURRENT);
                     REQUIRE(motor_queue.backing_deque.empty());
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto ack =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            ack));
-                    auto ack_msg = std::get<messages::AcknowledgePrevious>(ack);
-                    REQUIRE(ack_msg.responding_to_id == 123);
+                    tasks->require_has_ack_for_id(123);
                 }
             }
             AND_WHEN("sending a GetLidStatus message") {
@@ -102,10 +85,8 @@ SCENARIO("motor task message passing") {
                 motor_queue.backing_deque.push_back(message);
                 tasks->run_motor_task();
                 THEN("the response shows the lid moving") {
-                    auto msg =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    auto response =
-                        std::get<messages::GetLidStatusResponse>(msg);
+                    auto response = tasks->get_latest_host_comms_message<
+                        messages::GetLidStatusResponse>();
                     REQUIRE(response.lid ==
                             motor_util::LidStepper::Position::BETWEEN);
                 }
@@ -120,17 +101,8 @@ SCENARIO("motor task message passing") {
                 motor_queue.backing_deque.push_back(message);
                 tasks->run_motor_task();
                 THEN("the message is ACKed with an error") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto ack =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            ack));
-                    auto ack_msg = std::get<messages::AcknowledgePrevious>(ack);
-                    REQUIRE(ack_msg.responding_to_id == 123);
-                    REQUIRE(ack_msg.with_error ==
-                            errors::ErrorCode::LID_MOTOR_FAULT);
+                    tasks->require_has_ack_for(
+                        message, errors::ErrorCode::LID_MOTOR_FAULT);
                 }
                 THEN("no motion is started") {
                     REQUIRE(motor_policy.get_vref() ==
@@ -157,14 +129,8 @@ SCENARIO("motor task message passing") {
                 motor_queue.backing_deque.push_back(message);
                 tasks->run_motor_task();
                 THEN("the second message is ACKed with an error") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto ack =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    REQUIRE(std::holds_alternative<
-                            messages::SealStepperDebugResponse>(ack));
-                    auto ack_msg =
-                        std::get<messages::SealStepperDebugResponse>(ack);
+                    auto ack_msg = tasks->get_latest_host_comms_message<
+                        messages::SealStepperDebugResponse>();
                     REQUIRE(ack_msg.responding_to_id == 999);
                     REQUIRE(ack_msg.steps_taken == 0);
                     REQUIRE(ack_msg.with_error ==
@@ -180,14 +146,8 @@ SCENARIO("motor task message passing") {
                 THEN(
                     "the original message is ACK'd with a reduced step count "
                     "and no error") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto ack =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    REQUIRE(std::holds_alternative<
-                            messages::SealStepperDebugResponse>(ack));
-                    auto ack_msg =
-                        std::get<messages::SealStepperDebugResponse>(ack);
+                    auto ack_msg = tasks->get_latest_host_comms_message<
+                        messages::SealStepperDebugResponse>();
                     REQUIRE(ack_msg.responding_to_id == 123);
                     REQUIRE(ack_msg.steps_taken == 0);
                     REQUIRE(ack_msg.with_error == errors::ErrorCode::NO_ERROR);
@@ -203,14 +163,8 @@ SCENARIO("motor task message passing") {
                 motor_queue.backing_deque.push_back(stall_msg);
                 tasks->run_motor_task();
                 THEN("the original message is ACK'd with an error") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto ack =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    REQUIRE(std::holds_alternative<
-                            messages::SealStepperDebugResponse>(ack));
-                    auto ack_msg =
-                        std::get<messages::SealStepperDebugResponse>(ack);
+                    auto ack_msg = tasks->get_latest_host_comms_message<
+                        messages::SealStepperDebugResponse>();
                     REQUIRE(ack_msg.responding_to_id == 123);
                     REQUIRE(ack_msg.steps_taken == 0);
                     REQUIRE(ack_msg.with_error ==
@@ -225,10 +179,8 @@ SCENARIO("motor task message passing") {
                 motor_queue.backing_deque.push_back(message);
                 tasks->run_motor_task();
                 THEN("the response shows the seal moving") {
-                    auto msg =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    auto response =
-                        std::get<messages::GetLidStatusResponse>(msg);
+                    auto response = tasks->get_latest_host_comms_message<
+                        messages::GetLidStatusResponse>();
                     REQUIRE(response.seal ==
                             motor_util::SealStepper::Status::BETWEEN);
                 }
@@ -259,14 +211,8 @@ SCENARIO("motor task message passing") {
                     tasks->run_motor_task();
                     THEN("an ack is received by the host task") {
                         REQUIRE(motor_queue.backing_deque.empty());
-                        REQUIRE(!tasks->get_host_comms_queue()
-                                     .backing_deque.empty());
-                        auto ack =
-                            tasks->get_host_comms_queue().backing_deque.front();
-                        REQUIRE(std::holds_alternative<
-                                messages::SealStepperDebugResponse>(ack));
-                        auto ack_msg =
-                            std::get<messages::SealStepperDebugResponse>(ack);
+                        auto ack_msg = tasks->get_latest_host_comms_message<
+                            messages::SealStepperDebugResponse>();
                         REQUIRE(ack_msg.responding_to_id == 123);
                         REQUIRE(ack_msg.steps_taken == STEPS);
                         REQUIRE(ack_msg.with_error ==
@@ -300,14 +246,8 @@ SCENARIO("motor task message passing") {
                     tasks->run_motor_task();
                     THEN("an ack is received by the host task") {
                         REQUIRE(motor_queue.backing_deque.empty());
-                        REQUIRE(!tasks->get_host_comms_queue()
-                                     .backing_deque.empty());
-                        auto ack =
-                            tasks->get_host_comms_queue().backing_deque.front();
-                        REQUIRE(std::holds_alternative<
-                                messages::SealStepperDebugResponse>(ack));
-                        auto ack_msg =
-                            std::get<messages::SealStepperDebugResponse>(ack);
+                        auto ack_msg = tasks->get_latest_host_comms_message<
+                            messages::SealStepperDebugResponse>();
                         REQUIRE(ack_msg.responding_to_id == 123);
                         REQUIRE(ack_msg.steps_taken == STEPS);
                         REQUIRE(ack_msg.with_error ==
@@ -325,12 +265,8 @@ SCENARIO("motor task message passing") {
             tasks->run_motor_task();
             THEN("the message is recieved and ACKd with correct data") {
                 REQUIRE(!motor_queue.has_message());
-                REQUIRE(tasks->get_host_comms_queue().has_message());
-                auto msg = tasks->get_host_comms_queue().backing_deque.front();
-                REQUIRE(std::holds_alternative<
-                        messages::GetSealDriveStatusResponse>(msg));
-                auto response =
-                    std::get<messages::GetSealDriveStatusResponse>(msg);
+                auto response = tasks->get_latest_host_comms_message<
+                    messages::GetSealDriveStatusResponse>();
                 REQUIRE(response.responding_to_id == message.id);
                 REQUIRE(response.status.sg_result == 0xF);
                 REQUIRE(response.status.stallguard == 0);
@@ -345,13 +281,7 @@ SCENARIO("motor task message passing") {
             tasks->run_motor_task();
             THEN("the message is recieved and ACKd with correct id") {
                 REQUIRE(!motor_queue.has_message());
-                REQUIRE(tasks->get_host_comms_queue().has_message());
-                auto msg = tasks->get_host_comms_queue().backing_deque.front();
-                REQUIRE(
-                    std::holds_alternative<messages::AcknowledgePrevious>(msg));
-                auto response = std::get<messages::AcknowledgePrevious>(msg);
-                REQUIRE(response.responding_to_id == message.id);
-                REQUIRE(response.with_error == errors::ErrorCode::NO_ERROR);
+                tasks->require_has_ack_for(message);
             }
             THEN("the current is set to a clamped value of 0x1F (5 bits)") {
                 auto reg =
@@ -367,11 +297,8 @@ SCENARIO("motor task message passing") {
             tasks->run_motor_task();
             THEN("the message is received and responded to") {
                 REQUIRE(!motor_queue.has_message());
-                REQUIRE(tasks->get_host_comms_queue().has_message());
-                auto msg = tasks->get_host_comms_queue().backing_deque.front();
-                REQUIRE(std::holds_alternative<messages::GetLidStatusResponse>(
-                    msg));
-                auto response = std::get<messages::GetLidStatusResponse>(msg);
+                auto response = tasks->get_latest_host_comms_message<
+                    messages::GetLidStatusResponse>();
                 REQUIRE(response.responding_to_id == message.id);
                 REQUIRE(response.lid ==
                         motor_util::LidStepper::Position::BETWEEN);
@@ -386,10 +313,8 @@ SCENARIO("motor task message passing") {
                 motor_queue.backing_deque.push_back(message);
                 tasks->run_motor_task();
                 THEN("the response shows the lid closed") {
-                    auto msg =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    auto response =
-                        std::get<messages::GetLidStatusResponse>(msg);
+                    auto response = tasks->get_latest_host_comms_message<
+                        messages::GetLidStatusResponse>();
                     REQUIRE(response.lid ==
                             motor_util::LidStepper::Position::CLOSED);
                 }
@@ -402,10 +327,8 @@ SCENARIO("motor task message passing") {
                 motor_queue.backing_deque.push_back(message);
                 tasks->run_motor_task();
                 THEN("the response shows the lid open") {
-                    auto msg =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    auto response =
-                        std::get<messages::GetLidStatusResponse>(msg);
+                    auto response = tasks->get_latest_host_comms_message<
+                        messages::GetLidStatusResponse>();
                     REQUIRE(response.lid ==
                             motor_util::LidStepper::Position::OPEN);
                 }
@@ -424,14 +347,7 @@ SCENARIO("motor task message passing") {
                     messages::OpenLidMessage{.id = 456});
                 tasks->run_motor_task();
                 THEN("the second command is ignored with an error") {
-                    REQUIRE(tasks->get_host_comms_queue().has_message());
-                    auto msg =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    auto reply_msg =
-                        std::get<messages::AcknowledgePrevious>(msg);
-                    REQUIRE(reply_msg.responding_to_id == 456);
-                    REQUIRE(reply_msg.with_error ==
-                            errors::ErrorCode::LID_MOTOR_BUSY);
+                    tasks->require_has_ack_for_id(456, errors::ErrorCode::LID_MOTOR_BUSY);
                 }
             }
         }
@@ -448,14 +364,7 @@ SCENARIO("motor task message passing") {
                     messages::CloseLidMessage{.id = 456});
                 tasks->run_motor_task();
                 THEN("the second command is ignored with an error") {
-                    REQUIRE(tasks->get_host_comms_queue().has_message());
-                    auto msg =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    auto reply_msg =
-                        std::get<messages::AcknowledgePrevious>(msg);
-                    REQUIRE(reply_msg.responding_to_id == 456);
-                    REQUIRE(reply_msg.with_error ==
-                            errors::ErrorCode::LID_MOTOR_BUSY);
+                    tasks->require_has_ack_for_id(456, errors::ErrorCode::LID_MOTOR_BUSY);
                 }
             }
         }
@@ -509,13 +418,8 @@ SCENARIO("motor task message passing") {
                 THEN(
                     "a response is sent to host comms with the correct "
                     "data") {
-                    REQUIRE(!tasks->get_motor_queue().has_message());
-                    auto host_message =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    REQUIRE(std::holds_alternative<
-                            messages::GetLidSwitchesResponse>(host_message));
-                    auto response = std::get<messages::GetLidSwitchesResponse>(
-                        host_message);
+                    auto response = tasks->get_latest_host_comms_message<
+                        messages::GetLidSwitchesResponse>();
                     REQUIRE(response.responding_to_id == message.id);
                     REQUIRE(response.close_switch_pressed);
                     REQUIRE(!response.open_switch_pressed);
@@ -559,13 +463,8 @@ SCENARIO("motor task message passing") {
                 THEN(
                     "a response is sent to host comms with the correct "
                     "data") {
-                    REQUIRE(!tasks->get_motor_queue().has_message());
-                    auto host_message =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    REQUIRE(std::holds_alternative<
-                            messages::GetLidSwitchesResponse>(host_message));
-                    auto response = std::get<messages::GetLidSwitchesResponse>(
-                        host_message);
+                    auto response = tasks->get_latest_host_comms_message<
+                        messages::GetLidSwitchesResponse>();
                     REQUIRE(response.responding_to_id == message.id);
                     REQUIRE(!response.close_switch_pressed);
                     REQUIRE(response.open_switch_pressed);
@@ -584,14 +483,8 @@ SCENARIO("motor task message passing") {
                         "a response is sent to host comms with the correct "
                         "data") {
                         REQUIRE(!tasks->get_motor_queue().has_message());
-                        auto host_message =
-                            tasks->get_host_comms_queue().backing_deque.front();
-                        REQUIRE(std::holds_alternative<
-                                messages::GetLidSwitchesResponse>(
-                            host_message));
-                        auto response =
-                            std::get<messages::GetLidSwitchesResponse>(
-                                host_message);
+                        auto response = tasks->get_latest_host_comms_message<
+                            messages::GetLidSwitchesResponse>();
                         REQUIRE(response.responding_to_id == message.id);
                         REQUIRE(!response.close_switch_pressed);
                         REQUIRE(response.open_switch_pressed);
@@ -600,678 +493,6 @@ SCENARIO("motor task message passing") {
                     }
                 }
             }
-        }
-    }
-}
-
-struct MotorStep {
-    // Message to send on this step
-    messages::MotorMessage msg;
-    // If true, expect that the lid angle increased after this message
-    bool lid_angle_increased = false;
-    // If true, expect that the lid angle decreased after this message
-    bool lid_angle_decreased = false;
-    // If the lid moved (increase or decrease), check that the limit switches
-    // are either ignored or checked
-    bool lid_overdrive = false;
-    // Expected seal motor state
-    bool seal_on = false;
-    // Retraction is true, extension is false
-    bool seal_direction = false;
-    // If true, seal switch should be armed. If nullopt, doesn't matter.
-    std::optional<bool> seal_switch_armed = std::nullopt;
-
-    using MotorState = messages::UpdateMotorState::MotorState;
-    // If this isn't nullopt, check that the system task got a message
-    // with this MotorState value
-    std::optional<MotorState> motor_state = std::nullopt;
-
-    using SealPos = motor_util::SealStepper::Status;
-    // If this variable is set, expect seal in a specific position
-    std::optional<SealPos> seal_pos = std::nullopt;
-    // If this variable is set, check the lid velocity
-    std::optional<double> lid_rpm = std::nullopt;
-    // If true, expect an ack in the host comms task
-    std::optional<messages::AcknowledgePrevious> ack = std::nullopt;
-};
-
-/**
- * @brief Executes a set of steps to exercise the lid motor state machine.
- *
- * @pre The state of any switches should be set \e before invoking this
- */
-void test_motor_state_machine(std::shared_ptr<TaskBuilder> tasks,
-                              std::vector<MotorStep> &steps) {
-    auto &motor_task = tasks->get_motor_task();
-    auto &motor_policy = tasks->get_motor_policy();
-    auto &motor_queue = tasks->get_motor_queue();
-    for (size_t i = 0; i < steps.size(); ++i) {
-        auto &step = steps[i];
-
-        auto lid_angle_before = motor_policy.get_angle();
-        motor_queue.backing_deque.push_back(step.msg);
-        tasks->get_system_queue().backing_deque.clear();
-        tasks->run_motor_task();
-
-        DYNAMIC_SECTION("Step " << i) {
-            if (step.lid_angle_increased) {
-                THEN("the lid motor opened") {
-                    REQUIRE(motor_policy.get_angle() > lid_angle_before);
-                }
-            }
-            if (step.lid_angle_decreased) {
-                THEN("the lid motor closed") {
-                    REQUIRE(motor_policy.get_angle() < lid_angle_before);
-                }
-            }
-            THEN("the seal is controlled correctly") {
-                REQUIRE(motor_policy.seal_moving() == step.seal_on);
-                if (step.seal_on) {
-                    REQUIRE(motor_policy.get_tmc2130_direction() ==
-                            step.seal_direction);
-                }
-            }
-            if (step.seal_pos.has_value()) {
-                THEN("the seal position is set correctly") {
-                    REQUIRE(motor_task.get_seal_position() ==
-                            step.seal_pos.value());
-                }
-            }
-            if (step.ack.has_value()) {
-                THEN("an ack is sent to host comms") {
-                    auto ack = step.ack.value();
-                    REQUIRE(tasks->get_host_comms_queue().has_message());
-                    auto msg =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            msg));
-                    auto response =
-                        std::get<messages::AcknowledgePrevious>(msg);
-                    REQUIRE(response.responding_to_id == ack.responding_to_id);
-                    REQUIRE(response.with_error == ack.with_error);
-                }
-            }
-            if (step.motor_state.has_value()) {
-                THEN("the motor state is updated correctly") {
-                    REQUIRE(tasks->get_system_queue().has_message());
-                    auto state_msg =
-                        tasks->get_system_queue().backing_deque.front();
-                    REQUIRE(std::holds_alternative<messages::UpdateMotorState>(
-                        state_msg));
-                    auto state =
-                        std::get<messages::UpdateMotorState>(state_msg);
-                    REQUIRE(state.state == step.motor_state);
-                }
-            }
-        }
-    }
-}
-
-SCENARIO("motor task lid state machine") {
-    auto tasks = TaskBuilder::build();
-    auto &motor_policy = tasks->get_motor_policy();
-    GIVEN("lid is closed on startup") {
-        motor_policy.set_lid_closed_switch(true);
-        motor_policy.set_lid_open_switch(false);
-        WHEN("sending open lid command") {
-            std::vector<MotorStep> steps = {
-                // First step retracts seal switch
-                {.msg = messages::OpenLidMessage{.id = 123},
-                 .seal_on = true,
-                 .seal_direction = true,
-                 .seal_switch_armed = true,
-                 .motor_state = MotorStep::MotorState::OPENING_OR_CLOSING},
-                // Second step extends seal switch
-                {.msg =
-                     messages::SealStepperComplete{
-                         .reason = messages::SealStepperComplete::
-                             CompletionReason::LIMIT},
-                 .seal_on = true,
-                 .seal_direction = false,
-                 .seal_switch_armed = false},
-                // Third step opens hinge
-                {.msg =
-                     messages::SealStepperComplete{
-                         .reason = messages::SealStepperComplete::
-                             CompletionReason::DONE},
-                 .lid_angle_decreased = true,
-                 .lid_overdrive = true,
-                 .lid_rpm =
-                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
-                // Fourth step fully opening lid
-                {.msg = messages::LidStepperComplete(),
-                 .lid_angle_increased = true,
-                 .lid_overdrive = false},
-                // Sixth step open overdrive
-                {.msg = messages::LidStepperComplete(),
-                 .lid_angle_decreased = true,
-                 .lid_overdrive = true},
-                // Should send ACK now
-                {.msg = messages::LidStepperComplete(),
-                 .motor_state = MotorStep::MotorState::IDLE,
-                 .ack =
-                     messages::AcknowledgePrevious{
-                         .responding_to_id = 123,
-                         .with_error = errors::ErrorCode::NO_ERROR}},
-            };
-            test_motor_state_machine(tasks, steps);
-        }
-        GIVEN("seal lines aren't shared") {
-            motor_policy.set_switch_lines_shared(false);
-            WHEN("sending open lid command") {
-                std::vector<MotorStep> steps = {
-                    // First step retracts seal switch
-                    {.msg = messages::OpenLidMessage{.id = 123},
-                     .seal_on = true,
-                     .seal_direction = true,
-                     .seal_switch_armed = true,
-                     .motor_state = MotorStep::MotorState::OPENING_OR_CLOSING},
-                    // Second step overdrives lid to ease off the latch
-                    {.msg =
-                         messages::SealStepperComplete{
-                             .reason = messages::SealStepperComplete::
-                                 CompletionReason::DONE},
-                     .lid_angle_decreased = true,
-                     .lid_overdrive = true,
-                     .lid_rpm =
-                         motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
-                    // Third open fully if the close switch is not engaged
-                    {.msg = messages::LidStepperComplete(),
-                     .lid_angle_increased = true,
-                     .lid_overdrive = false},
-                    // Fifth open overdrive
-                    {.msg = messages::LidStepperComplete(),
-                     .lid_angle_decreased = true,
-                     .lid_overdrive = true},
-                    // Should send ACK now
-                    {.msg = messages::LidStepperComplete(),
-                     .motor_state = MotorStep::MotorState::IDLE,
-                     .ack =
-                         messages::AcknowledgePrevious{
-                             .responding_to_id = 123,
-                             .with_error = errors::ErrorCode::NO_ERROR}},
-                };
-                test_motor_state_machine(tasks, steps);
-            }
-        }
-        WHEN("sending close lid command") {
-            std::vector<MotorStep> steps = {
-                // Command should end immediately
-                {.msg = messages::CloseLidMessage{.id = 123},
-                 .ack = messages::AcknowledgePrevious{
-                     .responding_to_id = 123,
-                     .with_error = errors::ErrorCode::NO_ERROR}}};
-            test_motor_state_machine(tasks, steps);
-        }
-        WHEN("sending plate lift command") {
-            std::vector<MotorStep> steps = {
-                // Command should end with error
-                {.msg = messages::PlateLiftMessage{.id = 123},
-                 .ack = messages::AcknowledgePrevious{
-                     .responding_to_id = 123,
-                     .with_error = errors::ErrorCode::LID_CLOSED}}};
-            test_motor_state_machine(tasks, steps);
-        }
-        GIVEN("seal retraction switch is triggered") {
-            motor_policy.set_retraction_switch_triggered(true);
-            WHEN("sending open lid command") {
-                std::vector<MotorStep> steps = {
-                    // First step closes lid to ease off latch
-                    {.msg = messages::OpenLidMessage{.id = 123},
-                     .lid_angle_decreased = true,
-                     .lid_overdrive = true,
-                     .lid_rpm =
-                         motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
-                };
-                test_motor_state_machine(tasks, steps);
-            }
-        }
-        GIVEN("seal retraction and extension switches are triggered") {
-            motor_policy.set_retraction_switch_triggered(true);
-            motor_policy.set_extension_switch_triggered(true);
-            WHEN("sending open lid command") {
-                std::vector<MotorStep> steps = {
-                    // Should throw an error
-                    {.msg = messages::OpenLidMessage{.id = 123},
-                     .seal_on = false,
-                     .ack = messages::AcknowledgePrevious{
-                         .responding_to_id = 123,
-                         .with_error = errors::ErrorCode::SEAL_MOTOR_SWITCH}}};
-                test_motor_state_machine(tasks, steps);
-            }
-        }
-        GIVEN("seal extension switch is triggered") {
-            motor_policy.set_extension_switch_triggered(true);
-            motor_policy.set_retraction_switch_triggered(false);
-            WHEN("sending open lid command") {
-                std::vector<MotorStep> steps = {
-                    // Starts by retracting the seal
-                    {.msg = messages::OpenLidMessage{.id = 123},
-                     .seal_on = true,
-                     .seal_direction = true,
-                     .seal_switch_armed = true,
-                     .motor_state = MotorStep::MotorState::OPENING_OR_CLOSING}};
-                test_motor_state_machine(tasks, steps);
-            }
-        }
-    }
-    GIVEN("lid is open on startup") {
-        motor_policy.set_lid_closed_switch(false);
-        motor_policy.set_lid_open_switch(true);
-        WHEN("sending open lid command") {
-            std::vector<MotorStep> steps = {
-                // No action
-                {.msg = messages::OpenLidMessage{.id = 123},
-                 .ack =
-                     messages::AcknowledgePrevious{
-                         .responding_to_id = 123,
-                         .with_error = errors::ErrorCode::NO_ERROR}},
-            };
-            test_motor_state_machine(tasks, steps);
-        }
-        WHEN("sending close lid command") {
-            std::vector<MotorStep> steps = {
-                // First step retracts seal to switch
-                {.msg = messages::CloseLidMessage{.id = 123},
-                 .seal_on = true,
-                 .seal_direction = true,
-                 .seal_switch_armed = true,
-                 .motor_state = MotorStep::MotorState::OPENING_OR_CLOSING},
-                // Second step extends seal from switch
-                {.msg =
-                     messages::SealStepperComplete{
-                         .reason = messages::SealStepperComplete::
-                             CompletionReason::LIMIT},
-                 .seal_on = true,
-                 .seal_direction = false,
-                 .seal_switch_armed = false},
-                // Third step closes hinge
-                {.msg =
-                     messages::SealStepperComplete{
-                         .reason = messages::SealStepperComplete::
-                             CompletionReason::DONE},
-                 .lid_angle_decreased = true,
-                 .lid_overdrive = false,
-                 .lid_rpm =
-                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
-                // Fourth step overdrives hinge
-                {.msg = messages::LidStepperComplete(),
-                 .lid_angle_decreased = true,
-                 .lid_overdrive = true},
-            };
-            AND_WHEN("the closed switch is triggered") {
-                motor_policy.set_lid_closed_switch(true);
-                // Now extend seal to switch
-                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
-                                          .seal_on = true,
-                                          .seal_direction = false,
-                                          .seal_switch_armed = true});
-                // Retract seal from switch
-                steps.push_back(
-                    MotorStep{.msg =
-                                  messages::SealStepperComplete{
-                                      .reason = messages::SealStepperComplete::
-                                          CompletionReason::LIMIT},
-                              .seal_on = true,
-                              .seal_direction = true,
-                              .seal_switch_armed = false});
-                steps.push_back(
-                    // an ack with error code NO_ERROR should follow
-                    MotorStep{.msg =
-                                  messages::SealStepperComplete{
-                                      .reason = messages::SealStepperComplete::
-                                          CompletionReason::DONE},
-                              .motor_state = MotorStep::MotorState::IDLE,
-                              .ack = messages::AcknowledgePrevious{
-                                  .responding_to_id = 123,
-                                  .with_error = errors::ErrorCode::NO_ERROR}});
-                test_motor_state_machine(tasks, steps);
-            }
-            AND_WHEN("the closed switch is not triggered") {
-                motor_policy.set_lid_closed_switch(false);
-                // Now extend seal to switch
-                steps.push_back(MotorStep{
-                    .msg = messages::LidStepperComplete(),
-                    .seal_on = true,
-                    .seal_direction = false,
-                    .seal_switch_armed = true,
-                });
-                // Retract seal from switch
-                steps.push_back(MotorStep{
-                    .msg =
-                        messages::SealStepperComplete{
-                            .reason = messages::SealStepperComplete::
-                                CompletionReason::DONE},
-                    .motor_state = MotorStep::MotorState::IDLE,
-                    .ack = messages::AcknowledgePrevious{
-                        .responding_to_id = 123,
-                        .with_error =
-                            errors::ErrorCode::UNEXPECTED_LID_STATE}});
-                test_motor_state_machine(tasks, steps);
-            }
-        }
-        WHEN("sending plate lift command") {
-            std::vector<MotorStep> steps;
-            for (auto angle = motor_task::LidStepperState::
-                     PLATE_LIFT_NUDGE_START_DEGREES;
-                 angle <
-                 motor_task::LidStepperState::PLATE_LIFT_NUDGE_FINAL_DEGREES +
-                     motor_task::LidStepperState::PLATE_LIFT_NUDGE_INCREMENT;
-                 angle +=
-                 motor_task::LidStepperState::PLATE_LIFT_NUDGE_INCREMENT) {
-                // Incremental nudging
-                steps.push_back(MotorStep{
-                    .msg = messages::LidStepperComplete(),
-                    .lid_angle_increased = true,
-                    .lid_overdrive = true,
-                    .lid_rpm =
-                        motor_task::LidStepperState::PLATE_LIFT_VELOCITY_RPM,
-                });
-                steps.push_back(MotorStep{
-                    .msg = messages::LidStepperComplete(),
-                    .lid_angle_decreased = true,
-                    .lid_overdrive = true,
-                    .lid_rpm =
-                        motor_task::LidStepperState::PLATE_LIFT_VELOCITY_RPM,
-                });
-            }
-            // Final open - all the way to the limit
-            steps.push_back(MotorStep{
-                .msg = messages::LidStepperComplete(),
-                .lid_angle_increased = true,
-                .lid_overdrive = true,
-                .lid_rpm =
-                    motor_task::LidStepperState::PLATE_LIFT_VELOCITY_RPM});
-            // Return below switch
-            steps.push_back(MotorStep{
-                .msg = messages::LidStepperComplete(),
-                .lid_angle_increased = false,
-                .lid_angle_decreased = true,
-                .lid_overdrive = true,
-                .lid_rpm =
-                    motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM});
-            // Return to the switch
-            steps.push_back(MotorStep{
-                .msg = messages::LidStepperComplete(),
-                .lid_angle_increased = true,
-                .lid_overdrive = false,
-                .lid_rpm =
-                    motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM});
-            // Now BACK OUT of the switch
-            steps.push_back(MotorStep{
-                .msg = messages::LidStepperComplete(),
-                .lid_angle_increased = false,
-                .lid_angle_decreased = true,
-                .lid_overdrive = true,
-                .lid_rpm =
-                    motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM});
-            steps.push_back(
-                // an ack with error code NO_ERROR should follow
-                MotorStep{.msg = messages::LidStepperComplete(),
-                          .motor_state = MotorStep::MotorState::IDLE,
-                          .ack = messages::AcknowledgePrevious{
-                              .responding_to_id = 123,
-                              .with_error = errors::ErrorCode::NO_ERROR}});
-            steps[0].msg = messages::PlateLiftMessage{.id = 123};
-            steps[0].motor_state = MotorStep::MotorState::PLATE_LIFT;
-            test_motor_state_machine(tasks, steps);
-        }
-        GIVEN("seal retraction switch is triggered") {
-            motor_policy.set_retraction_switch_triggered(true);
-            WHEN("sending close lid command") {
-                std::vector<MotorStep> steps = {
-                    // First step closes hinge - skip seal movements
-                    {.msg = messages::CloseLidMessage{.id = 123},
-                     .lid_angle_decreased = true,
-                     .lid_overdrive = false,
-                     .lid_rpm =
-                         motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
-                    // Fourth step overdrives hinge
-                    {.msg = messages::LidStepperComplete(),
-                     .lid_angle_decreased = true,
-                     .lid_overdrive = true},
-                    // Now extend seal to switch
-                    {.msg = messages::LidStepperComplete(),
-                     .seal_on = true,
-                     .seal_direction = false,
-                     .seal_switch_armed = true}};
-                AND_WHEN("the closed switch is triggered") {
-                    motor_policy.set_lid_closed_switch(true);
-                    steps.push_back(
-                        // Retract seal from switch
-                        MotorStep{
-                            .msg =
-                                messages::SealStepperComplete{
-                                    .reason = messages::SealStepperComplete::
-                                        CompletionReason::LIMIT},
-                            .seal_on = true,
-                            .seal_direction = true,
-                            .seal_switch_armed = false});
-                    steps.push_back(
-                        // an ack with error code NO_ERROR should follow
-                        MotorStep{
-                            .msg =
-                                messages::SealStepperComplete{
-                                    .reason = messages::SealStepperComplete::
-                                        CompletionReason::DONE},
-                            .motor_state = MotorStep::MotorState::IDLE,
-                            .ack = messages::AcknowledgePrevious{
-                                .responding_to_id = 123,
-                                .with_error = errors::ErrorCode::NO_ERROR}});
-                    test_motor_state_machine(tasks, steps);
-                }
-                AND_WHEN("the closed switch is not triggered") {
-                    motor_policy.set_lid_closed_switch(false);
-                    steps.push_back(
-                        // Retract seal from switch
-                        MotorStep{
-                            .msg =
-                                messages::SealStepperComplete{
-                                    .reason = messages::SealStepperComplete::
-                                        CompletionReason::LIMIT},
-                            .ack = messages::AcknowledgePrevious{
-                                .responding_to_id = 123,
-                                .with_error =
-                                    errors::ErrorCode::UNEXPECTED_LID_STATE}});
-                    test_motor_state_machine(tasks, steps);
-                }
-            }
-        }
-        GIVEN("seal switches aren't shared") {
-            motor_policy.set_switch_lines_shared(false);
-            WHEN("sending close lid command") {
-                // Skip the 'backoff' steps
-                std::vector<MotorStep> steps = {
-                    // First step retracts seal to switch
-                    {.msg = messages::CloseLidMessage{.id = 123},
-                     .seal_on = true,
-                     .seal_direction = true,
-                     .seal_switch_armed = true,
-                     .motor_state = MotorStep::MotorState::OPENING_OR_CLOSING},
-                    // Second step closes hinge
-                    {.msg =
-                         messages::SealStepperComplete{
-                             .reason = messages::SealStepperComplete::
-                                 CompletionReason::DONE},
-                     .lid_angle_decreased = true,
-                     .lid_overdrive = false,
-                     .lid_rpm =
-                         motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
-                    // Fourth step overdrives hinge
-                    {.msg = messages::LidStepperComplete(),
-                     .lid_angle_decreased = true,
-                     .lid_overdrive = true},
-                    // Now extend seal to switch
-                    {.msg = messages::LidStepperComplete(),
-                     .seal_on = true,
-                     .seal_direction = false,
-                     .seal_switch_armed = true},
-                };
-                AND_WHEN("the closed switch is triggered") {
-                    motor_policy.set_lid_closed_switch(true);
-                    steps.push_back(
-                        // an ack with error code NO_ERROR should follow
-                        MotorStep{
-                            .msg =
-                                messages::SealStepperComplete{
-                                    .reason = messages::SealStepperComplete::
-                                        CompletionReason::DONE},
-                            .motor_state = MotorStep::MotorState::IDLE,
-                            .ack = messages::AcknowledgePrevious{
-                                .responding_to_id = 123,
-                                .with_error = errors::ErrorCode::NO_ERROR}});
-                    test_motor_state_machine(tasks, steps);
-                }
-                AND_WHEN("the closed switch is not triggered") {
-                    motor_policy.set_lid_closed_switch(false);
-                    steps.push_back(
-                        // an ack with error code UNEXPECTED_LID_STATE should
-                        // follow
-                        MotorStep{
-                            .msg =
-                                messages::SealStepperComplete{
-                                    .reason = messages::SealStepperComplete::
-                                        CompletionReason::DONE},
-                            .motor_state = MotorStep::MotorState::IDLE,
-                            .ack = messages::AcknowledgePrevious{
-                                .responding_to_id = 123,
-                                .with_error =
-                                    errors::ErrorCode::UNEXPECTED_LID_STATE}});
-                    test_motor_state_machine(tasks, steps);
-                }
-            }
-        }
-    }
-    GIVEN("lid is unknown at startup") {
-        motor_policy.set_lid_closed_switch(false);
-        motor_policy.set_lid_open_switch(false);
-        WHEN("sending open lid command") {
-            std::vector<MotorStep> steps = {
-                // First step retracts seal switch
-                {.msg = messages::OpenLidMessage{.id = 123},
-                 .seal_on = true,
-                 .seal_direction = true,
-                 .seal_switch_armed = true},
-                // Second step extends seeal switch
-                {.msg =
-                     messages::SealStepperComplete{
-                         .reason = messages::SealStepperComplete::
-                             CompletionReason::LIMIT},
-                 .seal_on = true,
-                 .seal_direction = false,
-                 .seal_switch_armed = false},
-                // Third step opens hinge
-                {.msg =
-                     messages::SealStepperComplete{
-                         .reason = messages::SealStepperComplete::
-                             CompletionReason::DONE},
-                 .lid_angle_increased = true,
-                 .lid_overdrive = false,
-                 .lid_rpm =
-                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM},
-                // Fourth step overdrives hinge
-                {.msg = messages::LidStepperComplete(),
-                 .lid_angle_decreased = true,
-                 .lid_overdrive = true},
-                // Should send ACK now
-                {.msg = messages::LidStepperComplete(),
-                 .ack =
-                     messages::AcknowledgePrevious{
-                         .responding_to_id = 123,
-                         .with_error = errors::ErrorCode::NO_ERROR}},
-            };
-            test_motor_state_machine(tasks, steps);
-        }
-        WHEN("sending close lid command") {
-            std::vector<MotorStep> steps = {
-                // First step retracts seal to switch
-                {.msg = messages::CloseLidMessage{.id = 123},
-                 .seal_on = true,
-                 .seal_direction = true,
-                 .seal_switch_armed = true},
-                // Second step extends seal from switch
-                {.msg =
-                     messages::SealStepperComplete{
-                         .reason = messages::SealStepperComplete::
-                             CompletionReason::LIMIT},
-                 .seal_on = true,
-                 .seal_direction = false,
-                 .seal_switch_armed = false},
-                // Third step closes hinge
-                {.msg =
-                     messages::SealStepperComplete{
-                         .reason = messages::SealStepperComplete::
-                             CompletionReason::DONE},
-                 .lid_angle_decreased = true,
-                 .lid_overdrive = false,
-                 .lid_rpm =
-                     motor_task::LidStepperState::LID_DEFAULT_VELOCITY_RPM}};
-            test_motor_state_machine(tasks, steps);
-            steps.clear();
-            AND_WHEN("the closed switch is triggered") {
-                motor_policy.set_lid_closed_switch(true);
-                // Fourth step overdrives hinge
-                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
-                                          .lid_angle_decreased = true,
-                                          .lid_overdrive = true});
-                // Now extend seal to switch
-                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
-                                          .seal_on = true,
-                                          .seal_direction = false,
-                                          .seal_switch_armed = true});
-                // Retract seal from switch
-                steps.push_back(
-                    MotorStep{.msg =
-                                  messages::SealStepperComplete{
-                                      .reason = messages::SealStepperComplete::
-                                          CompletionReason::LIMIT},
-                              .seal_on = true,
-                              .seal_direction = true,
-                              .seal_switch_armed = false});
-                steps.push_back(
-                    // an ack with error code NO_ERROR should follow
-                    MotorStep{.msg =
-                                  messages::SealStepperComplete{
-                                      .reason = messages::SealStepperComplete::
-                                          CompletionReason::DONE},
-                              .ack = messages::AcknowledgePrevious{
-                                  .responding_to_id = 123,
-                                  .with_error = errors::ErrorCode::NO_ERROR}});
-                test_motor_state_machine(tasks, steps);
-            }
-            AND_WHEN("the closed switch is not triggered") {
-                motor_policy.set_lid_closed_switch(false);
-                // Fourth step overdrives hinge
-                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
-                                          .lid_angle_decreased = true,
-                                          .lid_overdrive = true});
-                // Now extend seal to switch
-                steps.push_back(MotorStep{.msg = messages::LidStepperComplete(),
-                                          .seal_on = true,
-                                          .seal_direction = false,
-                                          .seal_switch_armed = true});
-                // Retract seal from switch
-                steps.push_back(MotorStep{
-                    .msg =
-                        messages::SealStepperComplete{
-                            .reason = messages::SealStepperComplete::
-                                CompletionReason::LIMIT},
-                    .ack = messages::AcknowledgePrevious{
-                        .responding_to_id = 123,
-                        .with_error =
-                            errors::ErrorCode::UNEXPECTED_LID_STATE}});
-                test_motor_state_machine(tasks, steps);
-            }
-        }
-        WHEN("sending plate lift command") {
-            std::vector<MotorStep> steps = {
-                // Command should end with error
-                {.msg = messages::PlateLiftMessage{.id = 123},
-                 .ack = messages::AcknowledgePrevious{
-                     .responding_to_id = 123,
-                     .with_error = errors::ErrorCode::LID_CLOSED}}};
-            test_motor_state_machine(tasks, steps);
         }
     }
 }

--- a/stm32-modules/thermocycler-gen2/tests/test_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_thermal_plate_task.cpp
@@ -69,6 +69,16 @@ SCENARIO("thermal plate task message passing") {
                     messages::UpdatePlateState::PlateState::IDLE);
         }
 
+        WHEN("sending a get-error-state message") {
+            auto message = messages::GetErrorStateMessage{.id=123};
+            plate_queue.backing_deque.push_back(message);
+            tasks->run_thermal_plate_task();
+            THEN("the task should get the message and respond") {
+                REQUIRE(plate_queue.backing_deque.empty());
+                tasks->require_has_ack_for(message);
+            }
+        }
+
         WHEN("sending a get-plate-temperature-debug message") {
             auto message = messages::GetPlateTemperatureDebugMessage{.id = 123};
             plate_queue.backing_deque.push_back(
@@ -626,7 +636,15 @@ SCENARIO("thermal plate task message passing") {
         }
 #endif
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
-
+        WHEN("sending a get-error-state message") {
+            auto message = messages::GetErrorStateMessage{.id=123};
+            plate_queue.backing_deque.push_back(message);
+            tasks->run_thermal_plate_task();
+            THEN("the task should get the message and respond") {
+                REQUIRE(plate_queue.backing_deque.empty());
+                tasks->require_has_ack_for(message, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT);
+            }
+        }
         THEN("the current error status was sent to system task") {
             REQUIRE(tasks->get_system_queue().has_message());
             auto sys_msg = tasks->get_system_queue().backing_deque.front();
@@ -753,6 +771,16 @@ SCENARIO("thermal plate task message passing") {
         }
 #endif
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
+        WHEN("sending a get-error-state message") {
+            auto message = messages::GetErrorStateMessage{.id=123};
+            plate_queue.backing_deque.push_back(message);
+            tasks->run_thermal_plate_task();
+            THEN("the task should get the message and respond") {
+                REQUIRE(plate_queue.backing_deque.empty());
+                tasks->require_has_ack_for(
+                    message, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_DISCONNECTED);
+            }
+        }
     }
 }
 

--- a/stm32-modules/thermocycler-gen2/tests/test_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_thermal_plate_task.cpp
@@ -70,7 +70,7 @@ SCENARIO("thermal plate task message passing") {
         }
 
         WHEN("sending a get-error-state message") {
-            auto message = messages::GetErrorStateMessage{.id=123};
+            auto message = messages::GetErrorStateMessage{.id = 123};
             plate_queue.backing_deque.push_back(message);
             tasks->run_thermal_plate_task();
             THEN("the task should get the message and respond") {
@@ -87,7 +87,8 @@ SCENARIO("thermal plate task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 AND_THEN("the task should respond to the messsage") {
-                    auto gettemp = tasks->get_latest_host_comms_message<messages::GetPlateTemperatureDebugResponse>();
+                    auto gettemp = tasks->get_latest_host_comms_message<
+                        messages::GetPlateTemperatureDebugResponse>();
 
                     REQUIRE(gettemp.responding_to_id == message.id);
 
@@ -146,7 +147,8 @@ SCENARIO("thermal plate task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 AND_THEN("the task should respond to the message") {
-                    auto gettemp = tasks->get_latest_host_comms_message<messages::GetPlateTempResponse>();
+                    auto gettemp = tasks->get_latest_host_comms_message<
+                        messages::GetPlateTempResponse>();
                     REQUIRE(gettemp.responding_to_id == message.id);
                     REQUIRE_THAT(gettemp.current_temp,
                                  Catch::Matchers::WithinAbs(_valid_temp, 0.1));
@@ -197,7 +199,8 @@ SCENARIO("thermal plate task message passing") {
                             offset_set_msg.const_a * _valid_temp +
                             ((offset_set_msg.const_b + 1.0F) * _valid_temp) +
                             offset_set_msg.const_c;
-                        auto gettemp = tasks->get_latest_host_comms_message<messages::GetPlateTemperatureDebugResponse>();
+                        auto gettemp = tasks->get_latest_host_comms_message<
+                            messages::GetPlateTemperatureDebugResponse>();
 
                         REQUIRE(gettemp.responding_to_id == message.id);
 
@@ -429,8 +432,9 @@ SCENARIO("thermal plate task message passing") {
                             messages::ThermalPlateMessage(tempMessage));
                         tasks->run_thermal_plate_task();
                         THEN("the response should have the new setpoint") {
-                            auto temperature_message = tasks->get_latest_host_comms_message<
-                                messages::GetPlateTempResponse>();
+                            auto temperature_message =
+                                tasks->get_latest_host_comms_message<
+                                    messages::GetPlateTempResponse>();
                             REQUIRE(temperature_message.set_temp ==
                                     message.setpoint);
                             REQUIRE_THAT(
@@ -500,8 +504,9 @@ SCENARIO("thermal plate task message passing") {
                             messages::ThermalPlateMessage(tempMessage));
                         tasks->run_thermal_plate_task();
                         THEN("the response should have no setpoint") {
-                            auto response = tasks->get_latest_host_comms_message<
-                                messages::GetPlateTempResponse>();
+                            auto response =
+                                tasks->get_latest_host_comms_message<
+                                    messages::GetPlateTempResponse>();
                             REQUIRE(response.set_temp == 0.0F);
                         }
                     }
@@ -529,7 +534,8 @@ SCENARIO("thermal plate task message passing") {
                     messages::ThermalPlateMessage(tempMessage));
                 tasks->run_thermal_plate_task();
                 THEN("the task should respond to the message") {
-                    auto response = tasks->get_latest_host_comms_message<messages::DeactivateAllResponse>();
+                    auto response = tasks->get_latest_host_comms_message<
+                        messages::DeactivateAllResponse>();
                     REQUIRE(response.responding_to_id == 321);
                     AND_WHEN("sending a GetPlateTemp query") {
                         auto tempMessage =
@@ -538,7 +544,9 @@ SCENARIO("thermal plate task message passing") {
                             messages::ThermalPlateMessage(tempMessage));
                         tasks->run_thermal_plate_task();
                         THEN("the response should have no setpoint") {
-                            auto plate_temp_response = tasks->get_latest_host_comms_message<messages::GetPlateTempResponse>();
+                            auto plate_temp_response =
+                                tasks->get_latest_host_comms_message<
+                                    messages::GetPlateTempResponse>();
                             REQUIRE(plate_temp_response.set_temp == 0.0F);
                         }
                     }
@@ -561,7 +569,8 @@ SCENARIO("thermal plate task message passing") {
                     REQUIRE(plate_queue.backing_deque.empty());
                     AND_THEN("the task should respond with a busy error") {
                         REQUIRE(plate_queue.backing_deque.empty());
-                        tasks->require_has_ack_for(message, errors::ErrorCode::THERMAL_PLATE_BUSY);
+                        tasks->require_has_ack_for(
+                            message, errors::ErrorCode::THERMAL_PLATE_BUSY);
                     }
                 }
             }
@@ -579,7 +588,8 @@ SCENARIO("thermal plate task message passing") {
                 plate_queue.backing_deque.push_back(message);
                 tasks->run_thermal_plate_task();
                 THEN("the powers are returned correctly") {
-                    auto response = tasks->get_latest_host_comms_message<messages::GetPlatePowerResponse>();
+                    auto response = tasks->get_latest_host_comms_message<
+                        messages::GetPlatePowerResponse>();
                     REQUIRE(response.responding_to_id == message.id);
                     REQUIRE_THAT(response.left,
                                  Catch::Matchers::WithinAbs(0.1, 0.01));
@@ -627,7 +637,8 @@ SCENARIO("thermal plate task message passing") {
         };
 
         while (!errors.empty()) {
-            auto error_msg = tasks->get_latest_host_comms_message<messages::ErrorMessage>();
+            auto error_msg =
+                tasks->get_latest_host_comms_message<messages::ErrorMessage>();
             auto error_itr =
                 std::find(std::begin(errors), std::end(errors), error_msg.code);
             CHECK(error_itr != std::end(errors));
@@ -637,12 +648,13 @@ SCENARIO("thermal plate task message passing") {
 #endif
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
         WHEN("sending a get-error-state message") {
-            auto message = messages::GetErrorStateMessage{.id=123};
+            auto message = messages::GetErrorStateMessage{.id = 123};
             plate_queue.backing_deque.push_back(message);
             tasks->run_thermal_plate_task();
             THEN("the task should get the message and respond") {
                 REQUIRE(plate_queue.backing_deque.empty());
-                tasks->require_has_ack_for(message, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT);
+                tasks->require_has_ack_for(
+                    message, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT);
             }
         }
         THEN("the current error status was sent to system task") {
@@ -697,7 +709,8 @@ SCENARIO("thermal plate task message passing") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 AND_THEN("the task should respond with an error") {
                     tasks->require_has_ack_for(
-                        message, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT);
+                        message,
+                        errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT);
                     REQUIRE(tasks->get_thermal_plate_policy()._fan_power ==
                             0.0);
                 }
@@ -713,7 +726,8 @@ SCENARIO("thermal plate task message passing") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 AND_THEN("the task should respond with an error") {
                     tasks->require_has_ack_for(
-                        message, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT);
+                        message,
+                        errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT);
                     AND_WHEN("sending a GetPlateTemp query") {
                         auto tempMessage =
                             messages::GetPlateTempMessage{.id = 555};
@@ -721,11 +735,50 @@ SCENARIO("thermal plate task message passing") {
                             messages::ThermalPlateMessage(tempMessage));
                         tasks->run_thermal_plate_task();
                         THEN("the response should have a setpoint of 0") {
-                            auto response = tasks->get_latest_host_comms_message<messages::GetPlateTempResponse>();
+                            auto response =
+                                tasks->get_latest_host_comms_message<
+                                    messages::GetPlateTempResponse>();
                             REQUIRE(response.set_temp == 0.0F);
                         }
                     }
                 }
+            }
+        }
+        WHEN("the thermistors fix themselves") {
+            auto valid_adc = _converter.backconvert(_valid_temp);
+            auto good_conversion = messages::ThermalPlateTempReadComplete{
+                .heat_sink = valid_adc,
+                .front_right = valid_adc,
+                .front_center = valid_adc,
+                .front_left = valid_adc,
+                .back_right = valid_adc,
+                .back_center = valid_adc,
+                .back_left = valid_adc,
+                .timestamp_ms = timestamp + 100};
+            plate_queue.backing_deque.push_back(good_conversion);
+            tasks->run_thermal_plate_task();
+            THEN("the error state is gone") {
+                REQUIRE(tasks->get_thermal_plate_task().most_relevant_error() ==
+                        errors::ErrorCode::NO_ERROR);
+            }
+            THEN("the system still reports the old error on first query") {
+                tasks->get_host_comms_queue().backing_deque.clear();
+                auto get_state = messages::GetErrorStateMessage{.id = 112};
+                plate_queue.backing_deque.push_back(get_state);
+                tasks->run_thermal_plate_task();
+                tasks->require_has_ack_for(
+                    get_state, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT);
+            }
+            THEN("the system does not report the old error on second query") {
+                auto get_state = messages::GetErrorStateMessage{.id = 112};
+                plate_queue.backing_deque.push_back(get_state);
+                tasks->run_thermal_plate_task();
+                tasks->get_host_comms_queue().backing_deque.clear();
+                get_state.id = 113;
+                plate_queue.backing_deque.push_back(get_state);
+                tasks->run_thermal_plate_task();
+                tasks->require_has_ack_for(get_state,
+                                           errors::ErrorCode::NO_ERROR);
             }
         }
     }
@@ -772,13 +825,14 @@ SCENARIO("thermal plate task message passing") {
 #endif
         CHECK(tasks->get_host_comms_queue().backing_deque.empty());
         WHEN("sending a get-error-state message") {
-            auto message = messages::GetErrorStateMessage{.id=123};
+            auto message = messages::GetErrorStateMessage{.id = 123};
             plate_queue.backing_deque.push_back(message);
             tasks->run_thermal_plate_task();
             THEN("the task should get the message and respond") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 tasks->require_has_ack_for(
-                    message, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_DISCONNECTED);
+                    message,
+                    errors::ErrorCode::THERMISTOR_FRONT_RIGHT_DISCONNECTED);
             }
         }
     }
@@ -802,12 +856,12 @@ SCENARIO("thermal plate drift error check") {
                                                    .back_center = adc_value,
                                                    .back_left = adc_value,
                                                    .timestamp_ms = timestamp};
-        static_cast<void>(plate_queue.try_send(read_message));
+        plate_queue.backing_deque.push_back(read_message);
         tasks->run_thermal_plate_task();
         WHEN("setting temperature and letting overshoot settle") {
             auto target_message = messages::SetPlateTemperatureMessage{
                 .id = 456, .setpoint = target_temp, .hold_time = 0.0F};
-            static_cast<void>(plate_queue.try_send(target_message));
+            plate_queue.backing_deque.push_back(target_message);
             // Move temperatures just above the base target
             adc_value = _converter.backconvert(target_temp + 1.0F);
             read_message.front_right = adc_value;
@@ -819,11 +873,11 @@ SCENARIO("thermal plate drift error check") {
             tasks->run_thermal_plate_task();
             timestamp += 1 * 1000;  // advance 1 second (enter overshoot)
             read_message.timestamp_ms = timestamp;
-            static_cast<void>(plate_queue.try_send(read_message));
+            plate_queue.backing_deque.push_back(read_message);
             tasks->run_thermal_plate_task();
             timestamp += 11 * 1000;  // advance 11 seconds (end overshoot)
             read_message.timestamp_ms = timestamp;
-            static_cast<void>(plate_queue.try_send(read_message));
+            plate_queue.backing_deque.push_back(read_message);
             tasks->run_thermal_plate_task();
             THEN("the peltiers are enabled") { REQUIRE(plate_policy._enabled); }
             AND_WHEN("a thermistor is out of spec after the settling time") {
@@ -840,14 +894,14 @@ SCENARIO("thermal plate drift error check") {
                      1.0F) *
                     1000;
                 read_message.timestamp_ms = timestamp;
-                static_cast<void>(plate_queue.try_send(read_message));
+                plate_queue.backing_deque.push_back(read_message);
                 tasks->run_thermal_plate_task();
                 timestamp +=
                     (plate_control::PlateControl::UNIFORMITY_CHECK_DELAY +
                      1.0F) *
                     1000;
                 read_message.timestamp_ms = timestamp;
-                static_cast<void>(plate_queue.try_send(read_message));
+                plate_queue.backing_deque.push_back(read_message);
                 tasks->run_thermal_plate_task();
 
                 THEN("the peltiers are disabled") {
@@ -856,7 +910,7 @@ SCENARIO("thermal plate drift error check") {
                 AND_WHEN("sending another Set Temperature message") {
                     host_queue.backing_deque.clear();
                     target_message.id = 999;
-                    static_cast<void>(plate_queue.try_send(target_message));
+                    plate_queue.backing_deque.push_back(target_message);
                     tasks->run_thermal_plate_task();
                     THEN("it is acked with an error") {
                         tasks->require_has_ack_for(
@@ -864,6 +918,31 @@ SCENARIO("thermal plate drift error check") {
                     }
                     THEN("control does not start") {
                         REQUIRE(!plate_policy._enabled);
+                    }
+                }
+                AND_WHEN("the thermistor error clears") {
+                    read_message.back_right = adc_value;
+                    read_message.timestamp_ms += 100;
+                    plate_queue.backing_deque.push_back(read_message);
+                    tasks->run_thermal_plate_task();
+                    THEN("the error is still latched") {
+                        REQUIRE(tasks->get_thermal_plate_task()
+                                    .most_relevant_error() ==
+                                errors::ErrorCode::THERMAL_DRIFT);
+                    }
+                    AND_WHEN("the error is subsequently cleared") {
+                        auto clear_message =
+                            messages::ClearErrorStateMessage{.id = 2232};
+                        plate_queue.backing_deque.push_back(clear_message);
+                        tasks->run_thermal_plate_task();
+                        read_message.timestamp_ms += 100;
+                        plate_queue.backing_deque.push_back(read_message);
+                        tasks->run_thermal_plate_task();
+                        THEN("the error is cleared") {
+                            REQUIRE(tasks->get_thermal_plate_task()
+                                        .most_relevant_error() ==
+                                    errors::ErrorCode::NO_ERROR);
+                        }
                     }
                 }
             }
@@ -874,10 +953,10 @@ SCENARIO("thermal plate drift error check") {
                     (plate_control::PlateControl::UNIFORMITY_CHECK_DELAY -
                      1.0F) *
                     1000;
-                static_cast<void>(plate_queue.try_send(read_message));
+                plate_queue.backing_deque.push_back(read_message);
                 tasks->run_thermal_plate_task();
                 read_message.timestamp_ms = timestamp;
-                static_cast<void>(plate_queue.try_send(read_message));
+                plate_queue.backing_deque.push_back(read_message);
                 tasks->run_thermal_plate_task();
                 THEN("the peltiers are not disabled") {
                     REQUIRE(plate_policy._enabled);
@@ -954,8 +1033,9 @@ SCENARIO("sending individual channel offset constants") {
                     THEN(
                         "the temperatures are compensated by each "
                         "channel's coefficients") {
-                        auto temperatures = tasks->get_latest_host_comms_message<
-                            messages::GetPlateTemperatureDebugResponse>();
+                        auto temperatures =
+                            tasks->get_latest_host_comms_message<
+                                messages::GetPlateTemperatureDebugResponse>();
                         double expected_left = (a * _valid_temp) +
                                                ((bl + 1.0F) * _valid_temp) + cl;
                         double expected_center = (a * _valid_temp) +
@@ -996,6 +1076,7 @@ SCENARIO("thermal plate error flag handling") {
         auto &plate_queue = tasks->get_thermal_plate_queue();
         auto &host_queue = tasks->get_host_comms_queue();
         auto invalid_adc = _converter.backconvert(130);
+
         auto read_message =
             messages::ThermalPlateTempReadComplete{.heat_sink = invalid_adc,
                                                    .front_right = invalid_adc,
@@ -1006,32 +1087,86 @@ SCENARIO("thermal plate error flag handling") {
                                                    .back_left = invalid_adc,
                                                    .timestamp_ms = timestamp};
         timestamp += TIME_DELTA;
-        REQUIRE(plate_queue.try_send(read_message));
+        plate_queue.backing_deque.push_back(read_message);
         tasks->run_thermal_plate_task();
         WHEN("sending a SetPlateTemperature message") {
             auto set_msg = messages::SetPlateTemperatureMessage{
                 .id = 123, .setpoint = 50, .hold_time = 0};
-            REQUIRE(plate_queue.try_send(set_msg));
+            plate_queue.backing_deque.push_back(set_msg);
             tasks->run_thermal_plate_task();
             THEN("the response shows an error") {
                 tasks->require_has_ack_for(
-                    set_msg, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_OVERTEMP);
+                    set_msg,
+                    errors::ErrorCode::THERMISTOR_FRONT_RIGHT_OVERTEMP);
             }
         }
         WHEN("sending a DeactivateAll message") {
             auto deactivate = messages::DeactivateAllMessage{.id = 444};
-            REQUIRE(plate_queue.try_send(deactivate));
+            plate_queue.backing_deque.push_back(deactivate);
             tasks->run_thermal_plate_task();
             host_queue.backing_deque.clear();
             AND_THEN("sending a SetPlateTemperature message") {
                 auto set_msg = messages::SetPlateTemperatureMessage{
                     .id = 123, .setpoint = 50, .hold_time = 0};
-                REQUIRE(plate_queue.try_send(set_msg));
+                plate_queue.backing_deque.push_back(set_msg);
                 tasks->run_thermal_plate_task();
                 THEN("the response shows an error") {
                     tasks->require_has_ack_for(
-                        set_msg, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_OVERTEMP);
+                        set_msg,
+                        errors::ErrorCode::THERMISTOR_FRONT_RIGHT_OVERTEMP);
                 }
+            }
+        }
+        WHEN("getting the state") {
+            auto get_state = messages::GetErrorStateMessage{.id = 321};
+            plate_queue.backing_deque.push_back(get_state);
+            tasks->run_thermal_plate_task();
+            THEN("the response has the error") {
+                tasks->require_has_ack_for(
+                    get_state,
+                    errors::ErrorCode::THERMISTOR_FRONT_RIGHT_OVERTEMP);
+            }
+        }
+        WHEN("the error goes away") {
+            auto valid_adc = _converter.backconvert(_valid_temp);
+            auto good_read = messages::ThermalPlateTempReadComplete{
+                .heat_sink = valid_adc,
+                .front_right = valid_adc,
+                .front_center = valid_adc,
+                .front_left = valid_adc,
+                .back_right = valid_adc,
+                .back_center = valid_adc,
+                .back_left = valid_adc,
+                .timestamp_ms = timestamp};
+            tasks->get_host_comms_queue().backing_deque.clear();
+            tasks->get_system_queue().backing_deque.clear();
+            plate_queue.backing_deque.push_back(good_read);
+            tasks->run_thermal_plate_task();
+            THEN("the system is back in the idle state") {
+                REQUIRE(tasks->get_thermal_plate_task().most_relevant_error() ==
+                        errors::ErrorCode::NO_ERROR);
+            }
+            THEN("one query shows the error and a second doesn't") {
+                auto get_state = messages::GetErrorStateMessage{.id = 322};
+                plate_queue.backing_deque.push_back(get_state);
+                tasks->run_thermal_plate_task();
+                tasks->require_has_ack_for(
+                    get_state,
+                    errors::ErrorCode::THERMISTOR_FRONT_RIGHT_OVERTEMP);
+                get_state.id = 323;
+                plate_queue.backing_deque.push_back(get_state);
+                tasks->run_thermal_plate_task();
+                tasks->require_has_ack_for(get_state);
+            }
+            THEN("the system task got a message to clear the error LEDs") {
+                REQUIRE_FALSE(tasks->get_system_queue().backing_deque.empty());
+                auto msg = tasks->get_system_queue().backing_deque.front();
+                tasks->get_system_queue().backing_deque.pop_front();
+                REQUIRE(
+                    std::holds_alternative<messages::UpdatePlateState>(msg));
+                auto plate_status = std::get<messages::UpdatePlateState>(msg);
+                REQUIRE(plate_status.state ==
+                        messages::UpdatePlateState::PlateState::IDLE);
             }
         }
     }
@@ -1056,7 +1191,7 @@ SCENARIO("thermal plate tick overflow handling") {
             .back_center = valid_adc,
             .back_left = valid_adc,
             .timestamp_ms = max_tick - 100};
-        std::ignore = plate_queue.try_send(read_message);
+        plate_queue.backing_deque.push_back(read_message);
         tasks->run_thermal_plate_task();
         auto command = messages::SetPlateTemperatureMessage{
             .id = 123,
@@ -1064,31 +1199,157 @@ SCENARIO("thermal plate tick overflow handling") {
             .hold_time = total_hold,
             .volume = 1,
         };
-        std::ignore = plate_queue.try_send(command);
+        plate_queue.backing_deque.push_back(command);
         tasks->run_thermal_plate_task();
 
         read_message.timestamp_ms = max_tick - 50;
-        std::ignore = plate_queue.try_send(read_message);
+        plate_queue.backing_deque.push_back(read_message);
         tasks->run_thermal_plate_task();
 
         read_message.timestamp_ms = max_tick - 25;
-        std::ignore = plate_queue.try_send(read_message);
+        plate_queue.backing_deque.push_back(read_message);
         tasks->run_thermal_plate_task();
 
         WHEN("sending a thermistor update that overflows the tick count") {
             read_message.timestamp_ms += ms_diff;
-            std::ignore = plate_queue.try_send(read_message);
+            plate_queue.backing_deque.push_back(read_message);
             tasks->run_thermal_plate_task();
             THEN("the new hold time makes sense") {
                 auto expected = total_hold - (ms_diff / 1000.0);
                 host_queue.backing_deque.clear();
                 auto get_message = messages::GetPlateTempMessage{.id = 321};
-                std::ignore = plate_queue.try_send(get_message);
+                plate_queue.backing_deque.push_back(get_message);
                 tasks->run_thermal_plate_task();
                 auto response = tasks->get_latest_host_comms_message<
                     messages::GetPlateTempResponse>();
                 REQUIRE_THAT(response.time_remaining,
                              Catch::Matchers::WithinAbs(expected, 0.01));
+            }
+        }
+    }
+}
+
+SCENARIO("thermal plate task error setting") {
+    GIVEN("a thermal plate task") {
+        auto tasks = TaskBuilder::build();
+        constexpr float temperature = 15;
+        auto valid_adc = _converter.backconvert(temperature);
+        constexpr uint32_t max_tick = std::numeric_limits<uint32_t>::max();
+        auto read_message = messages::ThermalPlateTempReadComplete{
+            .heat_sink = valid_adc,
+            .front_right = valid_adc,
+            .front_center = valid_adc,
+            .front_left = valid_adc,
+            .back_right = valid_adc,
+            .back_center = valid_adc,
+            .back_left = valid_adc,
+            .timestamp_ms = max_tick - 20000};
+        auto &plate_queue = tasks->get_thermal_plate_queue();
+        plate_queue.backing_deque.push_back(read_message);
+        tasks->run_thermal_plate_task();
+
+        WHEN("setting an error on a delay") {
+            auto set_message = messages::SetErrorStateMessage{
+                .id = 1233,
+                .error_to_set = errors::ErrorCode::THERMAL_DRIFT,
+                .delay_s = 10};
+            plate_queue.backing_deque.push_back(set_message);
+            tasks->run_thermal_plate_task();
+            tasks->require_has_ack_for(set_message);
+            THEN("after just less than the time the error is not set") {
+                read_message.timestamp_ms = max_tick - 10001;
+                plate_queue.backing_deque.push_back(read_message);
+                tasks->run_thermal_plate_task();
+                tasks->get_host_comms_queue().backing_deque.clear();
+                auto get_message = messages::GetErrorStateMessage{.id = 4444};
+                plate_queue.backing_deque.push_back(get_message);
+                tasks->run_thermal_plate_task();
+                tasks->require_has_ack_for(get_message);
+            }
+            THEN("after exactly the time the error is set") {
+                read_message.timestamp_ms = max_tick - 10000;
+                plate_queue.backing_deque.push_back(read_message);
+                tasks->run_thermal_plate_task();
+                tasks->get_host_comms_queue().backing_deque.clear();
+                auto get_message = messages::GetErrorStateMessage{.id = 4444};
+                plate_queue.backing_deque.push_back(get_message);
+                tasks->run_thermal_plate_task();
+                tasks->require_has_ack_for(get_message,
+                                           errors::ErrorCode::THERMAL_DRIFT);
+            }
+            THEN("after more than the time the error is set") {
+                read_message.timestamp_ms = max_tick - 9999;
+                plate_queue.backing_deque.push_back(read_message);
+                tasks->run_thermal_plate_task();
+                tasks->get_host_comms_queue().backing_deque.clear();
+                auto get_message = messages::GetErrorStateMessage{.id = 4444};
+                plate_queue.backing_deque.push_back(get_message);
+                tasks->run_thermal_plate_task();
+                tasks->require_has_ack_for(get_message,
+                                           errors::ErrorCode::THERMAL_DRIFT);
+            }
+        }
+
+        auto error =
+            GENERATE(errors::ErrorCode::THERMAL_PELTIER_ERROR,
+                     errors::ErrorCode::THERMAL_HEATSINK_FAN_ERROR,
+                     errors::ErrorCode::THERMAL_DRIFT,
+                     errors::ErrorCode::THERMISTOR_FRONT_RIGHT_DISCONNECTED,
+                     errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT,
+                     errors::ErrorCode::THERMISTOR_FRONT_RIGHT_OVERTEMP,
+                     errors::ErrorCode::THERMISTOR_FRONT_LEFT_DISCONNECTED,
+                     errors::ErrorCode::THERMISTOR_FRONT_LEFT_SHORT,
+                     errors::ErrorCode::THERMISTOR_FRONT_LEFT_OVERTEMP,
+                     errors::ErrorCode::THERMISTOR_FRONT_CENTER_DISCONNECTED,
+                     errors::ErrorCode::THERMISTOR_FRONT_CENTER_SHORT,
+                     errors::ErrorCode::THERMISTOR_FRONT_CENTER_OVERTEMP,
+                     errors::ErrorCode::THERMISTOR_BACK_RIGHT_DISCONNECTED,
+                     errors::ErrorCode::THERMISTOR_BACK_RIGHT_SHORT,
+                     errors::ErrorCode::THERMISTOR_BACK_RIGHT_OVERTEMP,
+                     errors::ErrorCode::THERMISTOR_BACK_LEFT_DISCONNECTED,
+                     errors::ErrorCode::THERMISTOR_BACK_LEFT_SHORT,
+                     errors::ErrorCode::THERMISTOR_BACK_LEFT_OVERTEMP,
+                     errors::ErrorCode::THERMISTOR_BACK_CENTER_DISCONNECTED,
+                     errors::ErrorCode::THERMISTOR_BACK_CENTER_SHORT,
+                     errors::ErrorCode::THERMISTOR_BACK_CENTER_OVERTEMP);
+        WHEN(std::string("Setting error ") +
+             std::to_string(static_cast<uint32_t>(error))) {
+            auto set_message = messages::SetErrorStateMessage{
+                .id = 1231, .error_to_set = error, .delay_s = 0};
+            plate_queue.backing_deque.push_back(set_message);
+            tasks->run_thermal_plate_task();
+            tasks->require_has_ack_for(set_message);
+            read_message.timestamp_ms = max_tick - 100;
+            plate_queue.backing_deque.push_back(read_message);
+            tasks->run_thermal_plate_task();
+#if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
+            THEN("the error is reported asynchronously") {
+                auto error_msg = tasks->get_latest_host_comms_message<
+                    messages::ErrorMessage>();
+                REQUIRE(error_msg.error == error);
+                plate_queue.backing_deque.pop_front();
+            }
+#endif
+            THEN("the error is reported by a get-error-state") {
+                auto get_state = messages::GetErrorStateMessage{.id = 2222};
+                plate_queue.backing_deque.push_back(get_state);
+                tasks->run_thermal_plate_task();
+                tasks->require_has_ack_for(get_state, error);
+            }
+            AND_WHEN("clearing the error and updating the state") {
+                auto clear = messages::ClearErrorStateMessage{.id = 99};
+                plate_queue.backing_deque.push_back(clear);
+                tasks->run_thermal_plate_task();
+                tasks->require_has_ack_for(clear);
+                read_message.timestamp_ms = max_tick - 90;
+                plate_queue.backing_deque.push_back(read_message);
+                tasks->run_thermal_plate_task();
+                THEN("the error is gone") {
+                    auto get_state = messages::GetErrorStateMessage{.id = 3333};
+                    plate_queue.backing_deque.push_back(get_state);
+                    tasks->run_thermal_plate_task();
+                    tasks->require_has_ack_for(get_state);
+                }
             }
         }
     }

--- a/stm32-modules/thermocycler-gen2/tests/test_thermal_plate_task.cpp
+++ b/stm32-modules/thermocycler-gen2/tests/test_thermal_plate_task.cpp
@@ -77,17 +77,7 @@ SCENARIO("thermal plate task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 AND_THEN("the task should respond to the messsage") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(std::holds_alternative<
-                            messages::GetPlateTemperatureDebugResponse>(
-                        response));
-                    auto gettemp =
-                        std::get<messages::GetPlateTemperatureDebugResponse>(
-                            response);
+                    auto gettemp = tasks->get_latest_host_comms_message<messages::GetPlateTemperatureDebugResponse>();
 
                     REQUIRE(gettemp.responding_to_id == message.id);
 
@@ -145,17 +135,8 @@ SCENARIO("thermal plate task message passing") {
             tasks->run_thermal_plate_task();
             THEN("the task should get the message") {
                 REQUIRE(plate_queue.backing_deque.empty());
-                AND_THEN("the task should respond to the messsage") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::GetPlateTempResponse>(
-                            response));
-                    auto gettemp =
-                        std::get<messages::GetPlateTempResponse>(response);
+                AND_THEN("the task should respond to the message") {
+                    auto gettemp = tasks->get_latest_host_comms_message<messages::GetPlateTempResponse>();
                     REQUIRE(gettemp.responding_to_id == message.id);
                     REQUIRE_THAT(gettemp.current_temp,
                                  Catch::Matchers::WithinAbs(_valid_temp, 0.1));
@@ -187,18 +168,8 @@ SCENARIO("thermal plate task message passing") {
             tasks->run_thermal_plate_task();
             THEN("the task should get the message") {
                 REQUIRE(plate_queue.backing_deque.empty());
-                AND_THEN("the task should respond to the messsage") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto ack_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(ack_msg.responding_to_id == offset_set_msg.id);
+                AND_THEN("the task should respond to the message") {
+                    tasks->require_has_ack_for(offset_set_msg);
                 }
             }
             AND_WHEN("sending a get-plate-temperature-debug message") {
@@ -216,17 +187,7 @@ SCENARIO("thermal plate task message passing") {
                             offset_set_msg.const_a * _valid_temp +
                             ((offset_set_msg.const_b + 1.0F) * _valid_temp) +
                             offset_set_msg.const_c;
-                        REQUIRE(!tasks->get_host_comms_queue()
-                                     .backing_deque.empty());
-                        auto response =
-                            tasks->get_host_comms_queue().backing_deque.front();
-                        tasks->get_host_comms_queue().backing_deque.pop_front();
-                        REQUIRE(std::holds_alternative<
-                                messages::GetPlateTemperatureDebugResponse>(
-                            response));
-                        auto gettemp = std::get<
-                            messages::GetPlateTemperatureDebugResponse>(
-                            response);
+                        auto gettemp = tasks->get_latest_host_comms_message<messages::GetPlateTemperatureDebugResponse>();
 
                         REQUIRE(gettemp.responding_to_id == message.id);
 
@@ -277,17 +238,8 @@ SCENARIO("thermal plate task message passing") {
                 THEN("the task should get the message") {
                     REQUIRE(plate_queue.backing_deque.empty());
                     AND_THEN("the response should have B=1 and C=6") {
-                        REQUIRE(!tasks->get_host_comms_queue()
-                                     .backing_deque.empty());
-                        auto response =
-                            tasks->get_host_comms_queue().backing_deque.front();
-                        tasks->get_host_comms_queue().backing_deque.pop_front();
-                        REQUIRE(std::holds_alternative<
-                                messages::GetOffsetConstantsResponse>(
-                            response));
-                        auto constants =
-                            std::get<messages::GetOffsetConstantsResponse>(
-                                response);
+                        auto constants = tasks->get_latest_host_comms_message<
+                            messages::GetOffsetConstantsResponse>();
                         REQUIRE(constants.responding_to_id == get_offsets.id);
                         REQUIRE_THAT(
                             constants.a,
@@ -317,16 +269,7 @@ SCENARIO("thermal plate task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(plate_queue.backing_deque.empty());
 
-                REQUIRE(!tasks->get_host_comms_queue().backing_deque.empty());
-                auto response =
-                    tasks->get_host_comms_queue().backing_deque.front();
-                tasks->get_host_comms_queue().backing_deque.pop_front();
-                REQUIRE(std::holds_alternative<messages::AcknowledgePrevious>(
-                    response));
-                REQUIRE(std::get<messages::AcknowledgePrevious>(response)
-                            .responding_to_id == 123);
-                REQUIRE(std::get<messages::AcknowledgePrevious>(response)
-                            .with_error == errors::ErrorCode::NO_ERROR);
+                tasks->require_has_ack_for(message);
                 auto policy = tasks->get_thermal_plate_policy();
                 REQUIRE(policy._enabled);
                 REQUIRE(policy._left.power == 0.5F);
@@ -401,19 +344,7 @@ SCENARIO("thermal plate task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 AND_THEN("the task should act on the message") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 123);
-                    REQUIRE(response_msg.with_error ==
-                            errors::ErrorCode::NO_ERROR);
+                    tasks->require_has_ack_for(message);
                     REQUIRE(tasks->get_thermal_plate_policy()._fan_power ==
                             0.5);
                 }
@@ -427,18 +358,7 @@ SCENARIO("thermal plate task message passing") {
                 THEN("the task should get the message") {
                     REQUIRE(plate_queue.backing_deque.empty());
                     AND_THEN("the task should act on the message") {
-                        REQUIRE(!tasks->get_host_comms_queue()
-                                     .backing_deque.empty());
-                        auto response =
-                            tasks->get_host_comms_queue().backing_deque.front();
-                        tasks->get_host_comms_queue().backing_deque.pop_front();
-                        REQUIRE(std::holds_alternative<
-                                messages::AcknowledgePrevious>(response));
-                        auto response_msg =
-                            std::get<messages::AcknowledgePrevious>(response);
-                        REQUIRE(response_msg.responding_to_id == 555);
-                        REQUIRE(response_msg.with_error ==
-                                errors::ErrorCode::NO_ERROR);
+                        tasks->require_has_ack_for(set_fan_auto);
                         REQUIRE(tasks->get_thermal_plate_policy()._fan_power ==
                                 0.0F);
                     }
@@ -458,21 +378,7 @@ SCENARIO("thermal plate task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 AND_THEN("the task should act on the message") {
-                    REQUIRE(plate_queue.backing_deque.empty());
-
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 123);
-                    REQUIRE(response_msg.with_error ==
-                            errors::ErrorCode::NO_ERROR);
+                    tasks->require_has_ack_for(message);
                 }
             }
         }
@@ -490,20 +396,9 @@ SCENARIO("thermal plate task message passing") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 AND_THEN("the task should act on the message") {
                     REQUIRE(plate_queue.backing_deque.empty());
-
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 555);
-                    REQUIRE(response_msg.with_error ==
-                            errors::ErrorCode::THERMAL_CONSTANT_OUT_OF_RANGE);
+                    tasks->require_has_ack_for(
+                        message,
+                        errors::ErrorCode::THERMAL_CONSTANT_OUT_OF_RANGE);
                 }
             }
         }
@@ -516,19 +411,7 @@ SCENARIO("thermal plate task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 AND_THEN("the task should respond to the message") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 123);
-                    REQUIRE(response_msg.with_error ==
-                            errors::ErrorCode::NO_ERROR);
+                    tasks->require_has_ack_for(message);
                     AND_WHEN("sending a GetPlateTemp query") {
                         auto tempMessage =
                             messages::GetPlateTempMessage{.id = 555};
@@ -536,12 +419,8 @@ SCENARIO("thermal plate task message passing") {
                             messages::ThermalPlateMessage(tempMessage));
                         tasks->run_thermal_plate_task();
                         THEN("the response should have the new setpoint") {
-                            REQUIRE(!tasks->get_host_comms_queue()
-                                         .backing_deque.empty());
-                            auto temperature_message =
-                                std::get<messages::GetPlateTempResponse>(
-                                    tasks->get_host_comms_queue()
-                                        .backing_deque.front());
+                            auto temperature_message = tasks->get_latest_host_comms_message<
+                                messages::GetPlateTempResponse>();
                             REQUIRE(temperature_message.set_temp ==
                                     message.setpoint);
                             REQUIRE_THAT(
@@ -603,13 +482,7 @@ SCENARIO("thermal plate task message passing") {
                     messages::ThermalPlateMessage(tempMessage));
                 tasks->run_thermal_plate_task();
                 THEN("the task should respond to the message") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    REQUIRE(
-                        std::get<messages::AcknowledgePrevious>(
-                            tasks->get_host_comms_queue().backing_deque.front())
-                            .responding_to_id == 321);
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
+                    tasks->require_has_ack_for(tempMessage);
                     AND_WHEN("sending a GetPlateTemp query") {
                         auto tempMessage =
                             messages::GetPlateTempMessage{.id = 555};
@@ -617,12 +490,9 @@ SCENARIO("thermal plate task message passing") {
                             messages::ThermalPlateMessage(tempMessage));
                         tasks->run_thermal_plate_task();
                         THEN("the response should have no setpoint") {
-                            REQUIRE(!tasks->get_host_comms_queue()
-                                         .backing_deque.empty());
-                            REQUIRE(std::get<messages::GetPlateTempResponse>(
-                                        tasks->get_host_comms_queue()
-                                            .backing_deque.front())
-                                        .set_temp == 0.0F);
+                            auto response = tasks->get_latest_host_comms_message<
+                                messages::GetPlateTempResponse>();
+                            REQUIRE(response.set_temp == 0.0F);
                         }
                     }
                 }
@@ -649,13 +519,8 @@ SCENARIO("thermal plate task message passing") {
                     messages::ThermalPlateMessage(tempMessage));
                 tasks->run_thermal_plate_task();
                 THEN("the task should respond to the message") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    REQUIRE(
-                        std::get<messages::DeactivateAllResponse>(
-                            tasks->get_host_comms_queue().backing_deque.front())
-                            .responding_to_id == 321);
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
+                    auto response = tasks->get_latest_host_comms_message<messages::DeactivateAllResponse>();
+                    REQUIRE(response.responding_to_id == 321);
                     AND_WHEN("sending a GetPlateTemp query") {
                         auto tempMessage =
                             messages::GetPlateTempMessage{.id = 555};
@@ -663,12 +528,8 @@ SCENARIO("thermal plate task message passing") {
                             messages::ThermalPlateMessage(tempMessage));
                         tasks->run_thermal_plate_task();
                         THEN("the response should have no setpoint") {
-                            REQUIRE(!tasks->get_host_comms_queue()
-                                         .backing_deque.empty());
-                            REQUIRE(std::get<messages::GetPlateTempResponse>(
-                                        tasks->get_host_comms_queue()
-                                            .backing_deque.front())
-                                        .set_temp == 0.0F);
+                            auto plate_temp_response = tasks->get_latest_host_comms_message<messages::GetPlateTempResponse>();
+                            REQUIRE(plate_temp_response.set_temp == 0.0F);
                         }
                     }
                 }
@@ -690,19 +551,7 @@ SCENARIO("thermal plate task message passing") {
                     REQUIRE(plate_queue.backing_deque.empty());
                     AND_THEN("the task should respond with a busy error") {
                         REQUIRE(plate_queue.backing_deque.empty());
-
-                        REQUIRE(!tasks->get_host_comms_queue()
-                                     .backing_deque.empty());
-                        auto response =
-                            tasks->get_host_comms_queue().backing_deque.front();
-                        tasks->get_host_comms_queue().backing_deque.pop_front();
-                        REQUIRE(std::holds_alternative<
-                                messages::AcknowledgePrevious>(response));
-                        auto response_msg =
-                            std::get<messages::AcknowledgePrevious>(response);
-                        REQUIRE(response_msg.responding_to_id == 808);
-                        REQUIRE(response_msg.with_error ==
-                                errors::ErrorCode::THERMAL_PLATE_BUSY);
+                        tasks->require_has_ack_for(message, errors::ErrorCode::THERMAL_PLATE_BUSY);
                     }
                 }
             }
@@ -720,10 +569,7 @@ SCENARIO("thermal plate task message passing") {
                 plate_queue.backing_deque.push_back(message);
                 tasks->run_thermal_plate_task();
                 THEN("the powers are returned correctly") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response = std::get<messages::GetPlatePowerResponse>(
-                        tasks->get_host_comms_queue().backing_deque.front());
+                    auto response = tasks->get_latest_host_comms_message<messages::GetPlatePowerResponse>();
                     REQUIRE(response.responding_to_id == message.id);
                     REQUIRE_THAT(response.left,
                                  Catch::Matchers::WithinAbs(0.1, 0.01));
@@ -754,6 +600,11 @@ SCENARIO("thermal plate task message passing") {
                                                    .back_left = _shorted_adc,
                                                    .timestamp_ms = timestamp};
         timestamp += TIME_DELTA;
+        plate_queue.backing_deque.push_back(
+            messages::ThermalPlateMessage(read_message));
+        tasks->run_thermal_plate_task();
+#if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
+        // Check that each error is reported
         // Order of errors doesn't care, so we use a list
         ErrorList errors = {
             errors::ErrorCode::THERMISTOR_HEATSINK_SHORT,
@@ -764,17 +615,9 @@ SCENARIO("thermal plate task message passing") {
             errors::ErrorCode::THERMISTOR_BACK_LEFT_SHORT,
             errors::ErrorCode::THERMISTOR_BACK_CENTER_SHORT,
         };
-        plate_queue.backing_deque.push_back(
-            messages::ThermalPlateMessage(read_message));
-        tasks->run_thermal_plate_task();
-        // Check that each error is reported
-#if defined(SYSTEM_ALLOW_ASYNC_ERRORS)
+
         while (!errors.empty()) {
-            CHECK(!tasks->get_host_comms_queue().backing_deque.empty());
-            CHECK(std::holds_alternative<messages::ErrorMessage>(
-                tasks->get_host_comms_queue().backing_deque.front()));
-            auto error_msg = std::get<messages::ErrorMessage>(
-                tasks->get_host_comms_queue().backing_deque.front());
+            auto error_msg = tasks->get_latest_host_comms_message<messages::ErrorMessage>();
             auto error_itr =
                 std::find(std::begin(errors), std::end(errors), error_msg.code);
             CHECK(error_itr != std::end(errors));
@@ -801,16 +644,8 @@ SCENARIO("thermal plate task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 AND_THEN("the task should respond with a temp of 0.0") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::GetPlateTempResponse>(
-                            response));
-                    auto gettemp =
-                        std::get<messages::GetPlateTempResponse>(response);
+                    auto gettemp = tasks->get_latest_host_comms_message<
+                        messages::GetPlateTempResponse>();
                     REQUIRE(gettemp.responding_to_id == message.id);
                     REQUIRE_THAT(gettemp.current_temp,
                                  Catch::Matchers::WithinAbs(0.0, 0.1));
@@ -830,17 +665,8 @@ SCENARIO("thermal plate task message passing") {
             tasks->run_thermal_plate_task();
             THEN("the task should respond with an error") {
                 REQUIRE(plate_queue.backing_deque.empty());
-
-                REQUIRE(!tasks->get_host_comms_queue().backing_deque.empty());
-                auto response =
-                    tasks->get_host_comms_queue().backing_deque.front();
-                tasks->get_host_comms_queue().backing_deque.pop_front();
-                REQUIRE(std::holds_alternative<messages::AcknowledgePrevious>(
-                    response));
-                REQUIRE(std::get<messages::AcknowledgePrevious>(response)
-                            .responding_to_id == 123);
-                REQUIRE(std::get<messages::AcknowledgePrevious>(response)
-                            .with_error != errors::ErrorCode::NO_ERROR);
+                tasks->require_has_ack_for(
+                    message, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT);
             }
         }
         WHEN("sending a SetFanManual message to turn on the fan") {
@@ -852,19 +678,8 @@ SCENARIO("thermal plate task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 AND_THEN("the task should respond with an error") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 123);
-                    REQUIRE(response_msg.with_error !=
-                            errors::ErrorCode::NO_ERROR);
+                    tasks->require_has_ack_for(
+                        message, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT);
                     REQUIRE(tasks->get_thermal_plate_policy()._fan_power ==
                             0.0);
                 }
@@ -879,19 +694,8 @@ SCENARIO("thermal plate task message passing") {
             THEN("the task should get the message") {
                 REQUIRE(plate_queue.backing_deque.empty());
                 AND_THEN("the task should respond with an error") {
-                    REQUIRE(
-                        !tasks->get_host_comms_queue().backing_deque.empty());
-                    auto response =
-                        tasks->get_host_comms_queue().backing_deque.front();
-                    tasks->get_host_comms_queue().backing_deque.pop_front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            response));
-                    auto response_msg =
-                        std::get<messages::AcknowledgePrevious>(response);
-                    REQUIRE(response_msg.responding_to_id == 123);
-                    REQUIRE(response_msg.with_error !=
-                            errors::ErrorCode::NO_ERROR);
+                    tasks->require_has_ack_for(
+                        message, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_SHORT);
                     AND_WHEN("sending a GetPlateTemp query") {
                         auto tempMessage =
                             messages::GetPlateTempMessage{.id = 555};
@@ -899,12 +703,8 @@ SCENARIO("thermal plate task message passing") {
                             messages::ThermalPlateMessage(tempMessage));
                         tasks->run_thermal_plate_task();
                         THEN("the response should have a setpoint of 0") {
-                            REQUIRE(!tasks->get_host_comms_queue()
-                                         .backing_deque.empty());
-                            REQUIRE(std::get<messages::GetPlateTempResponse>(
-                                        tasks->get_host_comms_queue()
-                                            .backing_deque.front())
-                                        .set_temp == 0.0F);
+                            auto response = tasks->get_latest_host_comms_message<messages::GetPlateTempResponse>();
+                            REQUIRE(response.set_temp == 0.0F);
                         }
                     }
                 }
@@ -956,7 +756,7 @@ SCENARIO("thermal plate task message passing") {
     }
 }
 
-TEST_CASE("thermal plate drift error check") {
+SCENARIO("thermal plate drift error check") {
     uint32_t timestamp = TIME_DELTA;
     GIVEN("thermal plate with good temperatures") {
         auto tasks = TaskBuilder::build();
@@ -1031,17 +831,8 @@ TEST_CASE("thermal plate drift error check") {
                     static_cast<void>(plate_queue.try_send(target_message));
                     tasks->run_thermal_plate_task();
                     THEN("it is acked with an error") {
-                        REQUIRE(host_queue.has_message());
-                        messages::HostCommsMessage response;
-                        host_queue.recv(&response);
-                        REQUIRE(std::holds_alternative<
-                                messages::AcknowledgePrevious>(response));
-                        auto response_ack =
-                            std::get<messages::AcknowledgePrevious>(response);
-                        REQUIRE(response_ack.responding_to_id ==
-                                target_message.id);
-                        REQUIRE(response_ack.with_error ==
-                                errors::ErrorCode::THERMAL_DRIFT);
+                        tasks->require_has_ack_for(
+                            target_message, errors::ErrorCode::THERMAL_DRIFT);
                     }
                     THEN("control does not start") {
                         REQUIRE(!plate_policy._enabled);
@@ -1068,7 +859,7 @@ TEST_CASE("thermal plate drift error check") {
     }
 }
 
-TEST_CASE("sending individual channel offset constants") {
+SCENARIO("sending individual channel offset constants") {
     uint32_t timestamp = TIME_DELTA;
     GIVEN("a thermal plate task") {
         auto tasks = TaskBuilder::build();
@@ -1135,13 +926,8 @@ TEST_CASE("sending individual channel offset constants") {
                     THEN(
                         "the temperatures are compensated by each "
                         "channel's coefficients") {
-                        REQUIRE(host_queue.has_message());
-                        auto msg = host_queue.backing_deque.front();
-                        REQUIRE(std::holds_alternative<
-                                messages::GetPlateTemperatureDebugResponse>(
-                            msg));
-                        auto temperatures = std::get<
-                            messages::GetPlateTemperatureDebugResponse>(msg);
+                        auto temperatures = tasks->get_latest_host_comms_message<
+                            messages::GetPlateTemperatureDebugResponse>();
                         double expected_left = (a * _valid_temp) +
                                                ((bl + 1.0F) * _valid_temp) + cl;
                         double expected_center = (a * _valid_temp) +
@@ -1175,7 +961,7 @@ TEST_CASE("sending individual channel offset constants") {
     }
 }
 
-TEST_CASE("thermal plate error flag handling") {
+SCENARIO("thermal plate error flag handling") {
     uint32_t timestamp = TIME_DELTA;
     GIVEN("a thermal plate task with invalid temperatures") {
         auto tasks = TaskBuilder::build();
@@ -1200,13 +986,8 @@ TEST_CASE("thermal plate error flag handling") {
             REQUIRE(plate_queue.try_send(set_msg));
             tasks->run_thermal_plate_task();
             THEN("the response shows an error") {
-                REQUIRE(host_queue.has_message());
-                auto rsp = host_queue.backing_deque.front();
-                REQUIRE(
-                    std::holds_alternative<messages::AcknowledgePrevious>(rsp));
-                auto response = std::get<messages::AcknowledgePrevious>(rsp);
-                REQUIRE(response.responding_to_id == 123);
-                REQUIRE(response.with_error != errors::ErrorCode::NO_ERROR);
+                tasks->require_has_ack_for(
+                    set_msg, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_OVERTEMP);
             }
         }
         WHEN("sending a DeactivateAll message") {
@@ -1220,22 +1001,15 @@ TEST_CASE("thermal plate error flag handling") {
                 REQUIRE(plate_queue.try_send(set_msg));
                 tasks->run_thermal_plate_task();
                 THEN("the response shows an error") {
-                    REQUIRE(host_queue.has_message());
-                    auto rsp = host_queue.backing_deque.front();
-                    REQUIRE(
-                        std::holds_alternative<messages::AcknowledgePrevious>(
-                            rsp));
-                    auto response =
-                        std::get<messages::AcknowledgePrevious>(rsp);
-                    REQUIRE(response.responding_to_id == 123);
-                    REQUIRE(response.with_error != errors::ErrorCode::NO_ERROR);
+                    tasks->require_has_ack_for(
+                        set_msg, errors::ErrorCode::THERMISTOR_FRONT_RIGHT_OVERTEMP);
                 }
             }
         }
     }
 }
 
-TEST_CASE("thermal plate tick overflow handling") {
+SCENARIO("thermal plate tick overflow handling") {
     constexpr uint32_t max_tick = std::numeric_limits<uint32_t>::max();
     const uint32_t ms_diff = GENERATE(10, 1000, 10000);
     constexpr float temperature = 15;
@@ -1283,8 +1057,8 @@ TEST_CASE("thermal plate tick overflow handling") {
                 auto get_message = messages::GetPlateTempMessage{.id = 321};
                 std::ignore = plate_queue.try_send(get_message);
                 tasks->run_thermal_plate_task();
-                auto response = std::get<messages::GetPlateTempResponse>(
-                    host_queue.backing_deque.front());
+                auto response = tasks->get_latest_host_comms_message<
+                    messages::GetPlateTempResponse>();
                 REQUIRE_THAT(response.time_remaining,
                              Catch::Matchers::WithinAbs(expected, 0.01));
             }


### PR DESCRIPTION
Implement some new gcodes as a followup to #533 but this time for the thermocycler.

As with that PR, M411 gets errors; M412.D Ennn Snnn sets with a delay; M413 clears.

This is a bit more particular and annoying because thermocycler errors are implemented a little unevenly; there's a lot of attention paid to how they work with the thermal task, and this work slots into there, but the lid errors are more ad-hoc and the motor errors don't really persist at all, so we just don't involve them at all.

Closes EXEC-1704