### PR TITLE
add usb transmission backpressure

### DIFF
--- a/stm32-modules/heater-shaker/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/host_comms_task/freertos_comms_task.cpp
@@ -162,6 +162,7 @@ void run(void *param) {  // NOLINT(misc-unused-parameters)
                         local_task->tx_buf.committed()->data()),
                     tx_end - local_task->tx_buf.committed()->data());
             }
+            vTaskDelay(1);
         }
     }
 }

--- a/stm32-modules/heater-shaker/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/host_comms_task/freertos_comms_task.cpp
@@ -152,7 +152,17 @@ void run(void *param) {  // NOLINT(misc-unused-parameters)
                 reinterpret_cast<uint8_t *>(
                     local_task->tx_buf.committed()->data()),
                 tx_end - local_task->tx_buf.committed()->data());
-            USBD_CDC_TransmitPacket(&_local_task.usb_handle);
+            uint8_t tx_result =
+                USBD_CDC_TransmitPacket(&_local_task.usb_handle);
+            while (tx_result == USBD_BUSY) {
+                vTaskDelay(1);
+                tx_result = USBD_CDC_TransmitPacket(&_local_task.usb_handle);
+            }
+
+            while (((USBD_CDC_HandleTypeDef *)_local_task.usb_handle.pClassData)
+                       ->TxState == 1) {
+                vTaskDelay(1);
+            }
             if (UartReady) {
                 UartReady = false;
                 HAL_UART_Transmit_IT(
@@ -162,7 +172,6 @@ void run(void *param) {  // NOLINT(misc-unused-parameters)
                         local_task->tx_buf.committed()->data()),
                     tx_end - local_task->tx_buf.committed()->data());
             }
-            vTaskDelay(1);
         }
     }
 }

--- a/stm32-modules/heater-shaker/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/stm32-modules/heater-shaker/firmware/host_comms_task/freertos_comms_task.cpp
@@ -158,10 +158,14 @@ void run(void *param) {  // NOLINT(misc-unused-parameters)
                 vTaskDelay(1);
                 tx_result = USBD_CDC_TransmitPacket(&_local_task.usb_handle);
             }
-
-            while (((USBD_CDC_HandleTypeDef *)_local_task.usb_handle.pClassData)
-                       ->TxState == 1) {
-                vTaskDelay(1);
+            if (tx_result != USBD_FAIL) {
+                uint8_t retries = 0;
+                while ((((USBD_CDC_HandleTypeDef *)
+                             _local_task.usb_handle.pClassData)
+                            ->TxState == 1) &&
+                       retries++ < 10) {
+                    vTaskDelay(1);
+                }
             }
             if (UartReady) {
                 UartReady = false;

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -162,7 +162,7 @@ struct GetResetReason {
         int res = 0;
         // print a hexadecimal representation of the reset flags
         res = snprintf(&*buf, (limit - buf),
-                       "M114 Last Reset Reason: %X h OK\n", reason);
+                       "M114 Last Reset Reason: %X OK\n", reason);
         if (res <= 0) {
             return buf;
         }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -161,8 +161,8 @@ struct GetResetReason {
         -> InputIt {
         int res = 0;
         // print a hexadecimal representation of the reset flags
-        res = snprintf(&*buf, (limit - buf), "M114 Last Reset Reason: %X OK\n",
-                       reason);
+        res = snprintf(&*buf, (limit - buf),
+                       "M114 Last Reset Reason: %X h OK\n", reason);
         if (res <= 0) {
             return buf;
         }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/gcodes.hpp
@@ -161,8 +161,8 @@ struct GetResetReason {
         -> InputIt {
         int res = 0;
         // print a hexadecimal representation of the reset flags
-        res = snprintf(&*buf, (limit - buf),
-                       "M114 Last Reset Reason: %X OK\n", reason);
+        res = snprintf(&*buf, (limit - buf), "M114 Last Reset Reason: %X OK\n",
+                       reason);
         if (res <= 0) {
             return buf;
         }

--- a/stm32-modules/thermocycler-gen2/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/stm32-modules/thermocycler-gen2/firmware/host_comms_task/freertos_comms_task.cpp
@@ -84,7 +84,6 @@ void run(void *param) {  // NOLINT(misc-unused-parameters)
                 reinterpret_cast<uint8_t *>(
                     local_task->tx_buf.committed()->data()),
                 tx_end - local_task->tx_buf.committed()->data());
-            vTaskDelay(1);
         }
     }
 }

--- a/stm32-modules/thermocycler-gen2/firmware/host_comms_task/usb_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/host_comms_task/usb_hardware.c
@@ -220,8 +220,12 @@ void usb_hw_send(uint8_t *buf, uint16_t len) {
         vTaskDelay(1);
         tx_result = USBD_CDC_TransmitPacket(&_local_config.usb_handle);
     }
+    if (tx_result == USBD_FAIL) {
+        return;
+    }
+    uint8_t retries = 0;
 
-    while (((USBD_CDC_HandleTypeDef*)_local_config.usb_handle.pClassData)->TxState == 1) {
+    while ((((USBD_CDC_HandleTypeDef*)_local_config.usb_handle.pClassData)->TxState == 1) && retries++ < 10) {
         vTaskDelay(1);
     }
 }

--- a/stm32-modules/thermocycler-gen2/firmware/host_comms_task/usb_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/host_comms_task/usb_hardware.c
@@ -215,5 +215,13 @@ void usb_hw_send(uint8_t *buf, uint16_t len) {
     USBD_CDC_SetTxBuffer(
         &_local_config.usb_handle,
         buf, len);
-    USBD_CDC_TransmitPacket(&_local_config.usb_handle);
+    uint8_t tx_result = USBD_CDC_TransmitPacket(&_local_config.usb_handle);
+    while (tx_result == USBD_BUSY) {
+        vTaskDelay(1);
+        tx_result = USBD_CDC_TransmitPacket(&_local_config.usb_handle);
+    }
+
+    while (((USBD_CDC_HandleTypeDef*)_local_config.usb_handle.pClassData)->TxState == 1) {
+        vTaskDelay(1);
+    }
 }


### PR DESCRIPTION
Sometimes the subsequent acks get lots (or, the first one does - there's one ack transmitted). My guess is that's because the acks are sent too fast and the usb hardware doesn't manage to actually send the buffer.

The usb middleware exposes status information; use that status information to wait on the data actually sending.

This change probably works; it definitely doesn't break anything.