### PR TITLE
fix(thermocycler-gen2): reset lid pos cache if err

### DIFF
--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1246,6 +1246,7 @@ class MotorTask {
                         : LidState::Status::IDLE;
                 if (!policy.lid_read_closed_switch()) {
                     error = errors::ErrorCode::UNEXPECTED_LID_STATE;
+                    _lid_stepper_state.position = motor_util::LidStepper::Position::BETWEEN;
                 } else {
                     error = handle_lid_state_enter(next_state, policy);
                 }

--- a/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
+++ b/stm32-modules/include/thermocycler-gen2/thermocycler-gen2/motor_task.hpp
@@ -1246,7 +1246,8 @@ class MotorTask {
                         : LidState::Status::IDLE;
                 if (!policy.lid_read_closed_switch()) {
                     error = errors::ErrorCode::UNEXPECTED_LID_STATE;
-                    _lid_stepper_state.position = motor_util::LidStepper::Position::BETWEEN;
+                    _lid_stepper_state.position =
+                        motor_util::LidStepper::Position::BETWEEN;
                 } else {
                     error = handle_lid_state_enter(next_state, policy);
                 }


### PR DESCRIPTION
Our fix to EXEC-1451 was to detect if the lid status switches detected that we weren't actually closed after the seal extended and return an error. This works great. The problem is that because this check happens in the lid state machine, the lid _hinge_ state machine has already done its work and cached that the lid is closed. Then, when the robot retries the command, the lid switches report in-between but we fall back to the cached value... which is "closed"... so we immediately and incorrectly succeed.

By clearing the position cache in the path that raises the error, we make sure that a subsequent close command will actually run (including raising the same error again if the error happens again) and thus the robot's retry and eventual error mechanisms will take us home.

Closes EXEC-1451