### PR TITLE
feat(vacuum-module): add support for the IS31FL LED driver and status bar animations and controls.

### DIFF
--- a/stm32-modules/include/vacuum-module/systemwide.h
+++ b/stm32-modules/include/vacuum-module/systemwide.h
@@ -1,5 +1,25 @@
 // included in c++ and c files
 #pragma once
 
+typedef enum StatusBarID {
+    Internal = 0,
+    External,
+} StatusBarID;
+
+typedef enum StatusBarColor {
+    White = 0,
+    Red,
+    Green,
+    Blue,
+    Yellow,
+} StatusBarColor;
+
+typedef enum StatusBarPattern {
+    Static = 0,
+    Flash,
+    Pulse,
+    Confirm,
+} StatusBarPattern;
+
 /* size of array for setting serial number */
 #define SYSTEM_WIDE_SERIAL_NUMBER_LENGTH 24

--- a/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
@@ -1,7 +1,6 @@
 /*
 ** Definitions of valid gcodes understood by the vacuum-module; intended to
-*work
-** with the gcode parser in gcode_parser.hpp
+*work with the gcode parser in gcode_parser.hpp
 */
 
 #pragma once
@@ -18,6 +17,14 @@
 #include "vacuum-module/errors.hpp"
 
 namespace gcode {
+
+template <typename ValueType, char... Chars>
+struct Arg {
+    static constexpr auto prefix = std::array{Chars...};
+    static constexpr bool required = false;
+    bool present = false;
+    ValueType value = ValueType{};
+};
 
 struct EnterBootloader {
     /**
@@ -211,6 +218,79 @@ struct SetSerialNumber {
         }
         auto ret = SetSerialNumber{.value = std::get<0>(arguments).value};
         return std::make_pair(ret, res.second);
+    }
+};
+
+struct SetStatusBarState {
+    std::optional<StatusBarID> bar_id;
+    std::optional<StatusBarColor> color;
+    std::optional<StatusBarPattern> pattern;
+    std::optional<uint32_t> duration;
+    std::optional<int8_t> reps;
+    float power;
+
+    using ParseResult = std::optional<SetStatusBarState>;
+    static constexpr auto prefix = std::array{'M', '2', '0', '0', ' '};
+    static constexpr const char* response = "M200 OK\n";
+
+    using PowerArg = Arg<float, 'P'>;
+    using ColorArg = Arg<uint8_t, 'C'>;
+    using KindArg = Arg<uint8_t, 'K'>;
+    using PatternArg = Arg<uint8_t, 'A'>;
+    using DurationArg = Arg<uint32_t, 'D'>;
+    using RepsArg = Arg<int8_t, 'R'>;
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto res =
+            gcode::SingleParser<PowerArg, ColorArg, KindArg, PatternArg,
+                                DurationArg, RepsArg>::parse_gcode(input, limit,
+                                                                   prefix);
+        if (!res.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+
+        auto ret = SetStatusBarState{.bar_id = std::nullopt,
+                                     .color = std::nullopt,
+                                     .pattern = std::nullopt,
+                                     .duration = std::nullopt,
+                                     .reps = std::nullopt,
+                                     .power = 0};
+
+        auto arguments = res.first.value();
+        if (std::get<0>(arguments).present) {
+            ret.power = static_cast<float>(std::get<0>(arguments).value);
+        }
+        if (std::get<1>(arguments).present) {
+            ret.color =
+                static_cast<StatusBarColor>(std::get<1>(arguments).value);
+        }
+        if (std::get<2>(arguments).present) {
+            ret.bar_id = static_cast<StatusBarID>(std::get<2>(arguments).value);
+        }
+        if (std::get<3>(arguments).present) {
+            ret.pattern =
+                static_cast<StatusBarPattern>(std::get<3>(arguments).value);
+        }
+        if (std::get<4>(arguments).present) {
+            ret.duration = static_cast<float>(std::get<4>(arguments).value);
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        if (std::get<5>(arguments).present) {
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+            ret.reps = static_cast<int8_t>(std::get<5>(arguments).value);
+        }
+        return std::make_pair(ret, res.second);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
     }
 };
 }  // namespace gcode

--- a/stm32-modules/include/vacuum-module/vacuum-module/host_comms_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/host_comms_task.hpp
@@ -38,10 +38,12 @@ class HostCommsTask {
   private:
     using GCodeParser =
         gcode::GroupParser<gcode::EnterBootloader, gcode::SetSerialNumber,
-                           gcode::GetSystemInfo, gcode::GetResetReason>;
+                           gcode::GetSystemInfo, gcode::GetResetReason,
+                           gcode::SetStatusBarState>;
 
     using AckOnlyCache =
-        AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber>;
+        AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
+                 gcode::SetStatusBarState>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetResetReasonCache = AckCache<8, gcode::GetResetReason>;
 
@@ -358,6 +360,36 @@ class HostCommsTask {
                                           errors::ErrorCode::GCODE_CACHE_FULL));
         }
         auto message = messages::EnterBootloaderMessage{.id = id};
+        if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::SetStatusBarState& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::SetStatusBarStateMessage{
+            .id = id,
+            .from_host = true,
+            .bar_id = gcode.bar_id,
+            .color = gcode.color,
+            .pattern = gcode.pattern,
+            .duration = gcode.duration,
+            .reps = gcode.reps,
+            .power = gcode.power,
+        };
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);

--- a/stm32-modules/include/vacuum-module/vacuum-module/messages.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/messages.hpp
@@ -99,6 +99,17 @@ struct ForceUSBDisconnect {
     size_t return_address;
 };
 
+struct SetStatusBarStateMessage {
+    uint32_t id = 0;
+    bool from_host = false;
+    std::optional<StatusBarID> bar_id = std::nullopt;
+    std::optional<StatusBarColor> color = std::nullopt;
+    std::optional<StatusBarPattern> pattern = std::nullopt;
+    std::optional<uint32_t> duration = std::nullopt;
+    std::optional<int8_t> reps = std::nullopt;
+    std::optional<float> power = std::nullopt;
+};
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, AcknowledgePrevious, GetSystemInfoResponse,
@@ -109,6 +120,6 @@ using SystemMessage =
                    SetSerialNumberMessage, EnterBootloaderMessage,
                    GetResetReasonMessage>;
 
-using UIMessage = ::std::variant<std::monostate>;
+using UIMessage = ::std::variant<std::monostate, SetStatusBarStateMessage>;
 
 };  // namespace messages

--- a/stm32-modules/include/vacuum-module/vacuum-module/ui_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/ui_task.hpp
@@ -353,12 +353,8 @@ class UITask {
 
     // Helper to get the StatusBarState given the bar id
     auto get_statusbar_state(StatusBarID bar) -> StatusBarState& {
-        switch (bar) {
-            case Internal:
-                return _led_bar_internal;
-            default:
-                return _led_bar_internal;
-        }
+        static_cast<void>(bar);
+        return _led_bar_internal;
     }
 
     auto get_default_period(StatusBarPattern pattern) -> uint32_t {

--- a/stm32-modules/include/vacuum-module/vacuum-module/ui_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/ui_task.hpp
@@ -1,11 +1,18 @@
 #pragma once
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
+#include <iterator>
+#include <optional>
 
 #include "core/is31fl_driver.hpp"
+#include "errors.hpp"
+#include "hal/message_queue.hpp"
+#include "messages.hpp"
 #include "ot_utils/freertos/freertos_timer.hpp"
+#include "systemwide.h"
 #include "ui_policy.hpp"
-#include "vacuum-module/messages.hpp"
 
 namespace ui_task {
 using namespace ot_utils::freertos_timer;
@@ -15,12 +22,88 @@ template <typename Policy>
 concept UIPolicyIface = requires(Policy& p) {
     // A function to set the heartbeat LED on or off
     {p.set_heartbeat_led(true)};
-};
+}
+&&is31fl::IS31FL_Policy<Policy>;
+
+// There are 4 channels per color and 4 LEDs for a total of 16 channels
+using ChannelMapping = std::array<size_t, 16>;
+static constexpr ChannelMapping white_channels{2, 3, 4, 5};
+static constexpr ChannelMapping red_channels{6, 9, 12, 15};
+static constexpr ChannelMapping green_channels{7, 10, 13, 16};
+static constexpr ChannelMapping blue_channels{8, 11, 14, 17};
+static constexpr ChannelMapping yellow_channels{6, 7, 9, 10, 12, 13, 15, 16};
+static constexpr int LED_CHANNEL_START = 2;
+static constexpr int LED_CHANNEL_END = 17;
+
+static auto color_to_channels(StatusBarColor color) -> const ChannelMapping& {
+    switch (color) {
+        case StatusBarColor::White:
+            return white_channels;
+        case StatusBarColor::Red:
+            return red_channels;
+        case StatusBarColor::Green:
+            return green_channels;
+        case StatusBarColor::Blue:
+            return blue_channels;
+        case StatusBarColor::Yellow:
+            return yellow_channels;
+        default:
+            return white_channels;
+    }
+}
 
 // The timer driving LED update frequency should run at this period
 static constexpr uint32_t UPDATE_PERIOD_MS = 10;
+static constexpr uint8_t LED_DRIVER0_I2C_ADDRESS = 0x6C << 1;  // Internal
+static constexpr auto DEFAULT_COLOR = StatusBarColor::White;
+static constexpr auto DEFAULT_POWER = 0.5F;
+static constexpr auto SYSTEM_LED_COUNT = 16;
+
+// Time between each write to the LED strip
+static constexpr uint32_t LED_UPDATE_PERIOD_MS = 1U * UPDATE_PERIOD_MS;
+// Time to fade from one color to the next
+static constexpr uint32_t LED_FADE_PERIOD_MS = 500U;
+// Time to flash the color on and off
+static constexpr uint32_t LED_FLASH_PERIOD_MS = 500U;
+// Time that each full "pulse" action should take (sine wave)
+static constexpr uint32_t LED_PULSE_PERIOD_MS = 1000U;
+// Time that it takes to fade from confirm color to original color
+static constexpr uint32_t LED_CONFIRM_FADE_PERIOD_MS = 5000U;
+// Time that it takes for the confirm color to flash
+static constexpr uint32_t LED_CONFIRM_PERIOD_MS = 300U;
+// Time that it takes for the confirm pattern to turn on the led
+static constexpr uint32_t LED_CONFIRM_ON_PERIOD_MS =
+    LED_CONFIRM_PERIOD_MS + 100;
 // Time to blink heartbeat LED
 static constexpr uint32_t HB_UPDATE_PERIOD_MS = 500U / UPDATE_PERIOD_MS;
+// Max duration of the animation in ms (10 seconds)
+static constexpr uint32_t MAX_UPDATE_PERIOD_MS = 10000U;
+// Min duration of the animation in ms (25 ms)
+static constexpr uint32_t MIN_UPDATE_PERIOD_MS = 25U;
+// Reps to signify runnning forever
+static constexpr int8_t FOREVER = -1;
+
+struct StatusBarState {
+    StatusBarID kind;
+    StatusBarColor color;
+    StatusBarColor old_color;
+    StatusBarPattern pattern = StatusBarPattern::Static;
+    float power;
+    float power_dt;
+    uint32_t duration = LED_PULSE_PERIOD_MS;
+    int8_t reps = FOREVER;
+    uint32_t counter = 0;
+    bool driver_ok = false;
+};
+
+const StatusBarState led_bar_internal = {
+
+    .kind = StatusBarID::Internal,
+    .color = DEFAULT_COLOR,
+    .old_color = DEFAULT_COLOR,
+    .power = DEFAULT_POWER,
+    .power_dt = 0,
+};
 
 using Message = messages::UIMessage;
 
@@ -57,6 +140,12 @@ class UITask {
 
         if (!_initialized) {
             _policy = &policy;
+
+            if (!_led_driver.initialized()) {
+                _led_driver.initialize(policy);
+                _led_bar_internal.driver_ok = true;
+                set_status_bar(Internal);
+            }
             _message_queue.set_ready();
             _initialized = true;
         }
@@ -79,6 +168,9 @@ class UITask {
             _policy->set_heartbeat_led(hb_led_state);
             hb_counter = 0;
         }
+
+        // tic the statusbar leds
+        update_ui();
     }
 
     template <UIPolicyIface Policy>
@@ -87,13 +179,274 @@ class UITask {
         static_cast<void>(policy);
     }
 
+    template <UIPolicyIface Policy>
+    auto visit_message(const messages::SetStatusBarStateMessage& m,
+                       Policy& policy) -> void {
+        static_cast<void>(policy);
+        for (auto bar_id : {StatusBarID::Internal}) {
+            bar_id = m.bar_id.value_or(bar_id);
+            auto& status_bar = get_statusbar_state(bar_id);
+            auto color = m.color.value_or(status_bar.color);
+            auto power = m.power.value_or(status_bar.power);
+            update_statusbar_state(bar_id, color, power, m.pattern, m.duration,
+                                   m.reps);
+            // Only set one status bar if one was given.
+            if (m.bar_id.has_value()) {
+                break;
+            }
+        }
+        if (m.from_host) {
+            // Only send ack if this was requested by the host
+            static_cast<void>(_task_registry->send_to_address(
+                messages::AcknowledgePrevious{.responding_to_id = m.id},
+                Queues::HostCommsAddress));
+        }
+    }
+
+    /*
+    Tics the statusbar leds to the next state.
+    */
+    // NOLINTNEXTLINE[readability-function-cognitive-complexity]
+    auto update_ui() -> void {
+        static constexpr double TWO = 2.0F;
+        for (auto bar_id : {StatusBarID::Internal}) {
+            _led_update_pending = false;
+            auto& status_bar = get_statusbar_state(bar_id);
+            // Skip if driver not initialized or reps reached 0
+            if (!status_bar.driver_ok) {
+                continue;
+            }
+            if (status_bar.reps != FOREVER && status_bar.reps < 1) {
+                continue;
+            }
+
+            // Turn off LEDs when power = 0
+            if (status_bar.power == 0) {
+                status_bar.reps = 0;
+                set_status_bar(bar_id);
+                continue;
+            }
+
+            status_bar.counter += LED_UPDATE_PERIOD_MS;
+            if (status_bar.counter > status_bar.duration) {
+                status_bar.counter = 0;
+            }
+
+            switch (status_bar.pattern) {
+                case StatusBarPattern::Static: {
+                    // Fade from current color to new color
+                    float power = status_bar.power;
+                    if (status_bar.counter < status_bar.duration) {
+                        power = static_cast<float>(status_bar.counter) /
+                                (static_cast<float>(status_bar.duration));
+                        power = std::clamp(power, 0.0F, status_bar.power);
+                        set_status_bar(bar_id, status_bar.color, power, true);
+                        status_bar.power_dt = power;
+                    } else {
+                        // Static only happens once
+                        status_bar.reps = 0;
+                        status_bar.power_dt = 0;
+                        return;
+                    }
+                    break;
+                }
+                case StatusBarPattern::Pulse: {
+                    // Set color as a triangle wave
+                    float power = status_bar.power;
+                    if (status_bar.counter < (status_bar.duration / TWO)) {
+                        power = static_cast<float>(status_bar.counter) /
+                                (static_cast<float>(status_bar.duration) / TWO);
+                    } else {
+                        auto inverse_count =
+                            std::abs(static_cast<int>(status_bar.duration) -
+                                     static_cast<int>(status_bar.counter));
+                        power = static_cast<float>(inverse_count) /
+                                (static_cast<float>(status_bar.duration) / TWO);
+                    }
+                    power = std::clamp(power, 0.0F, status_bar.power);
+                    set_status_bar(bar_id, status_bar.color, power);
+                    status_bar.power_dt = power;
+                    break;
+                }
+                case StatusBarPattern::Flash: {
+                    // Blink the statusbar by turning on/off by half the
+                    // duration.
+                    auto power =
+                        (status_bar.counter < (status_bar.duration / TWO))
+                            ? 0
+                            : status_bar.power;
+                    set_status_bar(bar_id, status_bar.color, power);
+                    status_bar.power_dt = power;
+                    break;
+                }
+                case StatusBarPattern::Confirm: {
+                    // turn on then off led to new color
+                    if (status_bar.counter < LED_CONFIRM_PERIOD_MS) {
+                        auto power =
+                            (status_bar.counter < LED_CONFIRM_PERIOD_MS / TWO)
+                                ? status_bar.power
+                                : 0;
+                        set_status_bar(bar_id, status_bar.color, power);
+                        status_bar.power_dt = power;
+                        // turn on led to new color
+                    } else if (status_bar.counter < LED_CONFIRM_ON_PERIOD_MS) {
+                        set_status_bar(bar_id, status_bar.color,
+                                       status_bar.power);
+                        // fade to old color
+                    } else {
+                        float power = status_bar.power;
+                        if (status_bar.counter < status_bar.duration) {
+                            power = static_cast<float>(status_bar.counter) /
+                                    (static_cast<float>(status_bar.duration));
+                            power = std::clamp(power, 0.0F, status_bar.power);
+                            set_status_bar(bar_id, status_bar.old_color, power,
+                                           true);
+                            status_bar.power_dt = power;
+                        } else {
+                            status_bar.reps = 0;
+                            status_bar.power_dt = 0;
+                            status_bar.color = status_bar.old_color;
+                            return;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            if (status_bar.counter >= status_bar.duration) {
+                if (status_bar.reps != FOREVER) {
+                    status_bar.reps -= 1;
+                }
+            }
+        }
+    }
+
+    /**
+     * @brief Set the power (separate from PWM) for a color. Each color has
+     * 4 channels, so this helper will set all of the channels.
+     */
+    auto set_color_power(StatusBarID bar, StatusBarColor color, float power,
+                         bool wipe = true) -> bool {
+        const auto& channels = color_to_channels(color);
+
+        // clear the LEDs not being set
+        if (wipe) {
+            for (int i = LED_CHANNEL_START; i <= LED_CHANNEL_END; i++) {
+                if (std::find(std::begin(channels), std::end(channels), i) !=
+                    std::end(channels)) {
+                    continue;
+                }
+                if (bar == Internal) {
+                    _led_driver.set_current(i, 0);
+                }
+            }
+        }
+
+        return std::ranges::all_of(
+            channels.cbegin(), channels.cend(), [bar, power, this](size_t c) {
+                if (bar == Internal) {
+                    return _led_driver.set_current(c, power);
+                }
+                return false;
+            });
+    }
+
+    // Helper to get the StatusBarState given the bar id
+    auto get_statusbar_state(StatusBarID bar) -> StatusBarState& {
+        switch (bar) {
+            case Internal:
+                return _led_bar_internal;
+            default:
+                return _led_bar_internal;
+        }
+    }
+
+    auto get_default_period(StatusBarPattern pattern) -> uint32_t {
+        switch (pattern) {
+            case Flash:
+                return LED_FLASH_PERIOD_MS;
+            case Static:
+                return LED_FADE_PERIOD_MS;
+            case Pulse:
+                return LED_PULSE_PERIOD_MS;
+            case Confirm:
+                return LED_CONFIRM_FADE_PERIOD_MS;
+            default:
+                return MAX_UPDATE_PERIOD_MS;
+        }
+    }
+
+    auto get_default_reps(StatusBarPattern pattern) -> int8_t {
+        switch (pattern) {
+            case Static:
+            case Confirm:
+                return 1;
+            case Flash:
+            case Pulse:
+                return FOREVER;
+            default:
+                return 1;
+        }
+    }
+
+    auto update_statusbar_state(
+        StatusBarID bar, StatusBarColor color, float power,
+        std::optional<StatusBarPattern> pattern = std::nullopt,
+        std::optional<uint32_t> duration = std::nullopt,
+        std::optional<int8_t> reps = std::nullopt) -> void {
+        auto& status_bar = get_statusbar_state(bar);
+        // If the old power was 0, set the old color to the new color
+        status_bar.old_color = status_bar.power == 0 ? color : status_bar.color;
+        status_bar.color = color;
+        status_bar.power = std::clamp(power, 0.0F, 1.0F);
+        status_bar.pattern = pattern.value_or(status_bar.pattern);
+        auto duration_ =
+            duration.value_or(get_default_period(status_bar.pattern));
+        status_bar.duration = std::clamp(
+            (uint32_t)duration_, MIN_UPDATE_PERIOD_MS, MAX_UPDATE_PERIOD_MS);
+        status_bar.reps = reps.value_or(get_default_reps(status_bar.pattern));
+        status_bar.counter = 0;
+    }
+
+    auto set_status_bar(StatusBarID bar,
+                        std::optional<StatusBarColor> color = std::nullopt,
+                        std::optional<float> power = std::nullopt,
+                        std::optional<bool> wipe = std::nullopt) -> bool {
+        // Skip if driver not initialized
+        auto status_bar = get_statusbar_state(bar);
+        if (!status_bar.driver_ok) {
+            return false;
+        }
+
+        // Skip if there is no state change
+        if (power.has_value() and color.has_value()) {
+            if (power.value() == status_bar.power_dt &&
+                color.value() == status_bar.color) {
+                return true;
+            }
+        }
+
+        auto power_ = power.value_or(status_bar.power);
+        auto color_ = color.value_or(status_bar.color);
+        auto wipe_ = wipe.value_or(true);
+        set_color_power(bar, color_, power_, wipe_);
+        if (bar == Internal) {
+            _led_driver.set_pwm(power_);
+            return _led_driver.send_update(*_policy);
+        }
+        return false;
+    }
+
     Queue& _message_queue;
     Aggregator* _task_registry;
     UIPolicy* _policy;
+    is31fl::IS31FL<LED_DRIVER0_I2C_ADDRESS> _led_driver{};
     FreeRTOSTimer _ui_timer;
 
+    StatusBarState _led_bar_internal = led_bar_internal;
     bool _initialized = false;
     bool hb_led_state = false;
     uint32_t hb_counter = 0;
+    bool _led_update_pending = false;
 };
 }  // namespace ui_task


### PR DESCRIPTION
# Overview

The Vacuum Module has a status bar LED based on the IS31FL, the same one used for the Flex Stacker project. Let's port that over to this project so we can use the same interface and GCODES.

Closes: [EXEC-1908](https://opentrons.atlassian.net/browse/EXEC-1908)

```
M200
Set Status Bar Color and Power:

Power, float 0 through 1.0; >0 turns ON
*C: Color, int 0 - 3; 0: White, 1: Red, 2: Green, 3: Blue 
*K: Kind, int (0 or 1); 0 = internal, 1 = external status bar.
*A: Pattern, 0 - Static, 1 - Flash, 2 - Pulse, 3 - Confirm
*D: Duration, int 25-10000 ms
*R: Repetitions, -1 (forever), 10
*: optional params, default/previously set values will be used if unspecified. 
```
Example usage
```
M200 P1 C0   # Turns the statusbar on to white
M200 OK

M200 P1 C0 A2  # pulse the statusbar
M200 OK

M200 P0.5 C1 A1  # flash the statusbar red at 50% (0.5) power
M200 OK

M200 P0.5 C1 A1 D500 # flash the statusbar red at 50% (0.5) and cycle every 500ms
M200 OK
```

# Changelog

- Adds support for the IS31FL LED driver
- Expands the UI task to handle animations + state changes of the status bar
- Adds M200 SetStatusBarState GCode to let you set the statusbar state

# Testing

- [x] Make sure you can change the status bar LED colors and animations using the M200 GCODE via serial


[EXEC-1908]: https://opentrons.atlassian.net/browse/EXEC-1908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ