### PR TITLE
feat(reference/vacuum-module): Fix gpio init issues with i2c3 + add hal_i2c_master_read and hal_i2c_master_write

### DIFF
--- a/stm32-modules/include/reference-module/firmware/hardware_iface.hpp
+++ b/stm32-modules/include/reference-module/firmware/hardware_iface.hpp
@@ -23,6 +23,10 @@ class I2CBase {
                           uint16_t size) -> RxTxReturn;
     virtual auto i2c_write(uint16_t dev_addr, uint16_t reg, uint8_t* data,
                            uint16_t size) -> RxTxReturn;
+    virtual auto i2c_master_write(uint16_t dev_addr, uint8_t* data,
+                                  uint16_t size) -> RxTxReturn;
+    virtual auto i2c_master_read(uint16_t dev_addr, uint8_t* data,
+                                 uint16_t size) -> RxTxReturn;
 };
 
 }  // namespace i2c::hardware

--- a/stm32-modules/include/reference-module/firmware/i2c_comms.hpp
+++ b/stm32-modules/include/reference-module/firmware/i2c_comms.hpp
@@ -18,11 +18,15 @@ class I2C : public I2CBase {
     auto operator=(const I2C &) = delete;
     auto operator=(const I2C &&) = delete;
 
+    auto set_handle(HAL_I2C_HANDLE i2c_handle, I2C_BUS bus) -> void;
     auto i2c_read(uint16_t dev_addr, uint16_t reg, uint8_t *data, uint16_t size)
         -> RxTxReturn final;
     auto i2c_write(uint16_t dev_addr, uint16_t reg, uint8_t *data,
                    uint16_t size) -> RxTxReturn final;
-    auto set_handle(HAL_I2C_HANDLE i2c_handle, I2C_BUS bus) -> void;
+    auto i2c_master_write(uint16_t dev_addr, uint8_t *data, uint16_t size)
+        -> RxTxReturn final;
+    auto i2c_master_read(uint16_t dev_addr, uint8_t *data, uint16_t size)
+        -> RxTxReturn final;
 
   private:
     I2C_BUS bus = NO_BUS;

--- a/stm32-modules/include/reference-module/firmware/i2c_hardware.h
+++ b/stm32-modules/include/reference-module/firmware/i2c_hardware.h
@@ -28,6 +28,10 @@ uint8_t hal_i2c_write(I2C_BUS bus, uint16_t DevAddress, uint8_t reg,
                       uint8_t *data, uint16_t size);
 uint8_t hal_i2c_read(I2C_BUS bus, uint16_t DevAddress, uint16_t reg,
                      uint8_t *data, uint16_t size);
+uint8_t hal_i2c_master_write(I2C_BUS bus, uint16_t DevAddress, uint8_t *data,
+                             uint16_t size);
+uint8_t hal_i2c_master_read(I2C_BUS bus, uint16_t DevAddress, uint8_t *data,
+                            uint16_t size);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/stm32-modules/include/vacuum-module/firmware/hardware_iface.hpp
+++ b/stm32-modules/include/vacuum-module/firmware/hardware_iface.hpp
@@ -23,6 +23,10 @@ class I2CBase {
                           uint16_t size) -> RxTxReturn;
     virtual auto i2c_write(uint16_t dev_addr, uint16_t reg, uint8_t* data,
                            uint16_t size) -> RxTxReturn;
+    virtual auto i2c_master_write(uint16_t dev_addr, uint8_t* data,
+                                  uint16_t size) -> RxTxReturn;
+    virtual auto i2c_master_read(uint16_t dev_addr, uint8_t* data,
+                                 uint16_t size) -> RxTxReturn;
 };
 
 }  // namespace i2c::hardware

--- a/stm32-modules/include/vacuum-module/firmware/i2c_comms.hpp
+++ b/stm32-modules/include/vacuum-module/firmware/i2c_comms.hpp
@@ -18,11 +18,15 @@ class I2C : public I2CBase {
     auto operator=(const I2C &) = delete;
     auto operator=(const I2C &&) = delete;
 
+    auto set_handle(HAL_I2C_HANDLE i2c_handle, I2C_BUS bus) -> void;
     auto i2c_read(uint16_t dev_addr, uint16_t reg, uint8_t *data, uint16_t size)
         -> RxTxReturn final;
     auto i2c_write(uint16_t dev_addr, uint16_t reg, uint8_t *data,
                    uint16_t size) -> RxTxReturn final;
-    auto set_handle(HAL_I2C_HANDLE i2c_handle, I2C_BUS bus) -> void;
+    auto i2c_master_write(uint16_t dev_addr, uint8_t *data, uint16_t size)
+        -> RxTxReturn final;
+    auto i2c_master_read(uint16_t dev_addr, uint8_t *data, uint16_t size)
+        -> RxTxReturn final;
 
   private:
     I2C_BUS bus = NO_BUS;

--- a/stm32-modules/include/vacuum-module/firmware/i2c_hardware.h
+++ b/stm32-modules/include/vacuum-module/firmware/i2c_hardware.h
@@ -28,6 +28,10 @@ uint8_t hal_i2c_write(I2C_BUS bus, uint16_t DevAddress, uint8_t reg,
                       uint8_t *data, uint16_t size);
 uint8_t hal_i2c_read(I2C_BUS bus, uint16_t DevAddress, uint16_t reg,
                      uint8_t *data, uint16_t size);
+uint8_t hal_i2c_master_write(I2C_BUS bus, uint16_t DevAddress, uint8_t *data,
+                             uint16_t size);
+uint8_t hal_i2c_master_read(I2C_BUS bus, uint16_t DevAddress, uint8_t *data,
+                            uint16_t size);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/stm32-modules/reference-module/firmware/system/i2c_comms.cpp
+++ b/stm32-modules/reference-module/firmware/system/i2c_comms.cpp
@@ -24,3 +24,15 @@ auto I2C::i2c_read(uint16_t dev_addr, uint16_t reg, uint8_t* data,
     auto ret = hal_i2c_read(bus, dev_addr, reg, data, size);
     return RxTxReturn(ret);
 }
+
+auto I2C::i2c_master_write(uint16_t dev_addr, uint8_t* data, uint16_t size)
+    -> RxTxReturn {
+    auto ret = hal_i2c_master_write(bus, dev_addr, data, size);
+    return RxTxReturn(ret);
+}
+
+auto I2C::i2c_master_read(uint16_t dev_addr, uint8_t* data, uint16_t size)
+    -> RxTxReturn {
+    auto ret = hal_i2c_master_read(bus, dev_addr, data, size);
+    return RxTxReturn(ret);
+}

--- a/stm32-modules/reference-module/firmware/system/i2c_hardware.c
+++ b/stm32-modules/reference-module/firmware/system/i2c_hardware.c
@@ -234,6 +234,58 @@ uint8_t hal_i2c_read(I2C_BUS bus, uint16_t DevAddress, uint16_t reg, uint8_t *da
     return rx_result;
 }
 
+uint8_t hal_i2c_master_write(I2C_BUS bus, uint16_t DevAddress, uint8_t *data, uint16_t size) {
+    uint32_t notification_val = 0;
+    NotificationHandle_t *notification_handle = lookup_handle(bus);
+    I2C_HandleTypeDef* i2c_handle = (I2C_HandleTypeDef*)notification_handle->i2c_handle;
+
+    // Bus was not registered
+    if(notification_handle == NULL) return NO_HANDLE_ERROR;
+
+    uint8_t retries = 0;
+    HAL_StatusTypeDef rx_result = HAL_OK;
+    do {
+        // Setup task handle and send message
+        notification_handle->task_to_notify = xTaskGetCurrentTaskHandle();
+        rx_result = HAL_I2C_Master_Transmit_IT(i2c_handle, DevAddress, data, size);
+
+        // Wait for callback and check result.
+        notification_val = ulTaskNotifyTake(pdTRUE, MAX_TIMEOUT);
+        if (rx_result == HAL_OK) break;
+        if (notification_handle->should_retry) rx_result = HAL_BUSY;
+        if (notification_val != 1) rx_result = HAL_TIMEOUT;
+
+        retries += 1;
+    } while (retries < MAX_RETRIES);
+    return rx_result;
+}
+
+uint8_t hal_i2c_master_read(I2C_BUS bus, uint16_t DevAddress, uint8_t *data, uint16_t size) {
+    uint32_t notification_val = 0;
+    NotificationHandle_t *notification_handle = lookup_handle(bus);
+    I2C_HandleTypeDef* i2c_handle = (I2C_HandleTypeDef*)notification_handle->i2c_handle;
+
+    // Bus was not registered
+    if(notification_handle == NULL) return NO_HANDLE_ERROR;
+
+    uint8_t retries = 0;
+    HAL_StatusTypeDef rx_result = HAL_OK;
+    do {
+        // Setup task handle and send message
+        notification_handle->task_to_notify = xTaskGetCurrentTaskHandle();
+        rx_result = HAL_I2C_Master_Receive_IT(i2c_handle, DevAddress, data, size);
+
+        // Wait for callback and check result.
+        notification_val = ulTaskNotifyTake(pdTRUE, MAX_TIMEOUT);
+        if (rx_result == HAL_OK) break;
+        if (notification_handle->should_retry) rx_result = HAL_BUSY;
+        if (notification_val != 1) rx_result = HAL_TIMEOUT;
+
+        retries += 1;
+    } while (retries < MAX_RETRIES);
+    return rx_result;
+}
+
 void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *i2c_handle) {
     handle_i2c_callback(i2c_handle, false);
 }

--- a/stm32-modules/reference-module/firmware/system/main.h
+++ b/stm32-modules/reference-module/firmware/system/main.h
@@ -37,10 +37,16 @@ void Error_Handler(void);
 #define n48V_FAULT_Pin GPIO_PIN_6
 #define n48V_FAULT_GPIO_Port GPIOC
 
-#define EEPROM_I2C2_SDA_Pin GPIO_PIN_8
-#define EEPROM_I2C2_SDA_GPIO_Port GPIOA
-#define EEPOM_I2C2_SCL_Pin GPIO_PIN_9
-#define EEPOM_I2C2_SCL_GPIO_Port GPIOA
+#define I2C2_SDA_Pin GPIO_PIN_8
+#define I2C2_SDA_GPIO_Port GPIOA
+#define I2C2_SCL_Pin GPIO_PIN_9
+#define I2C2_SCL_GPIO_Port GPIOA
+
+#define I2C3_SCL_Pin GPIO_PIN_8
+#define I2C3_SCL_GPIO_Port GPIOC
+#define I2C3_SDA_Pin GPIO_PIN_9
+#define I2C3_SDA_GPIO_Port GPIOC
+
 #define EEPROM_WP_PIN GPIO_PIN_10
 #define EEPROM_WP_PORT GPIOA
 

--- a/stm32-modules/reference-module/firmware/system/stm32g4xx_hal_msp.c
+++ b/stm32-modules/reference-module/firmware/system/stm32g4xx_hal_msp.c
@@ -76,7 +76,7 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c)
         PA8     ------> I2C2_SDA
         PA9     ------> I2C2_SCL
         */
-        GPIO_InitStruct.Pin = EEPROM_I2C2_SDA_Pin|EEPOM_I2C2_SCL_Pin;
+        GPIO_InitStruct.Pin = I2C2_SDA_Pin|I2C2_SCL_Pin;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
@@ -90,7 +90,29 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c)
         HAL_NVIC_SetPriority(I2C2_ER_IRQn, 7, 0);
         HAL_NVIC_EnableIRQ(I2C2_EV_IRQn);
         HAL_NVIC_EnableIRQ(I2C2_ER_IRQn);
+    } else if(hi2c->Instance==I2C3)
+    {
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        /**I2C3 GPIO Configuration
+        PC8     ------> I2C3_SCL
+        PC9     ------> I2C3_SDA
+        */
+        GPIO_InitStruct.Pin = I2C3_SCL_Pin|I2C3_SDA_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF8_I2C3;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+        /* Peripheral clock enable */
+        __HAL_RCC_I2C3_CLK_ENABLE();
+
+        HAL_NVIC_SetPriority(I2C3_EV_IRQn, 7, 0);
+        HAL_NVIC_SetPriority(I2C3_ER_IRQn, 7, 0);
+        HAL_NVIC_EnableIRQ(I2C3_EV_IRQn);
+        HAL_NVIC_EnableIRQ(I2C3_ER_IRQn);
     }
+
 }
 
 /**
@@ -110,9 +132,20 @@ void HAL_I2C_MspDeInit(I2C_HandleTypeDef* hi2c)
         PA8     ------> I2C2_SDA
         PA9     ------> I2C2_SCL
         */
-        HAL_GPIO_DeInit(EEPROM_I2C2_SDA_GPIO_Port, EEPROM_I2C2_SDA_Pin);
+        HAL_GPIO_DeInit(I2C2_SDA_GPIO_Port, I2C2_SDA_Pin);
+        HAL_GPIO_DeInit(I2C2_SCL_GPIO_Port, I2C2_SCL_Pin);
+    }
+    else if(hi2c->Instance==I2C3)
+    {
+        /* Peripheral clock disable */
+        __HAL_RCC_I2C3_CLK_DISABLE();
 
-        HAL_GPIO_DeInit(EEPOM_I2C2_SCL_GPIO_Port, EEPOM_I2C2_SCL_Pin);
+        /**I2C3 GPIO Configuration
+        PC8     ------> I2C3_SCL
+        PC9     ------> I2C3_SDA
+        */
+        HAL_GPIO_DeInit(I2C3_SCL_GPIO_Port, I2C3_SCL_Pin);
+        HAL_GPIO_DeInit(I2C3_SDA_GPIO_Port, I2C3_SDA_Pin);
     }
 }
 

--- a/stm32-modules/reference-module/firmware/ui/ui_policy.cpp
+++ b/stm32-modules/reference-module/firmware/ui/ui_policy.cpp
@@ -1,6 +1,8 @@
 #include "firmware/ui_policy.hpp"
 
+#include "FreeRTOS.h"
 #include "firmware/ui_hardware.h"
+#include "task.h"
 
 namespace ui_policy {
 
@@ -8,4 +10,5 @@ namespace ui_policy {
 auto UIPolicy::set_heartbeat_led(bool value) -> void {
     ui_hardware_set_heartbeat_led(value);
 }
+
 }  // namespace ui_policy

--- a/stm32-modules/vacuum-module/firmware/system/i2c_comms.cpp
+++ b/stm32-modules/vacuum-module/firmware/system/i2c_comms.cpp
@@ -24,3 +24,15 @@ auto I2C::i2c_read(uint16_t dev_addr, uint16_t reg, uint8_t* data,
     auto ret = hal_i2c_read(bus, dev_addr, reg, data, size);
     return RxTxReturn(ret);
 }
+
+auto I2C::i2c_master_write(uint16_t dev_addr, uint8_t* data, uint16_t size)
+    -> RxTxReturn {
+    auto ret = hal_i2c_master_write(bus, dev_addr, data, size);
+    return RxTxReturn(ret);
+}
+
+auto I2C::i2c_master_read(uint16_t dev_addr, uint8_t* data, uint16_t size)
+    -> RxTxReturn {
+    auto ret = hal_i2c_master_read(bus, dev_addr, data, size);
+    return RxTxReturn(ret);
+}

--- a/stm32-modules/vacuum-module/firmware/system/i2c_hardware.c
+++ b/stm32-modules/vacuum-module/firmware/system/i2c_hardware.c
@@ -234,6 +234,58 @@ uint8_t hal_i2c_read(I2C_BUS bus, uint16_t DevAddress, uint16_t reg, uint8_t *da
     return rx_result;
 }
 
+uint8_t hal_i2c_master_write(I2C_BUS bus, uint16_t DevAddress, uint8_t *data, uint16_t size) {
+    uint32_t notification_val = 0;
+    NotificationHandle_t *notification_handle = lookup_handle(bus);
+    I2C_HandleTypeDef* i2c_handle = (I2C_HandleTypeDef*)notification_handle->i2c_handle;
+
+    // Bus was not registered
+    if(notification_handle == NULL) return NO_HANDLE_ERROR;
+
+    uint8_t retries = 0;
+    HAL_StatusTypeDef rx_result = HAL_OK;
+    do {
+        // Setup task handle and send message
+        notification_handle->task_to_notify = xTaskGetCurrentTaskHandle();
+        rx_result = HAL_I2C_Master_Transmit_IT(i2c_handle, DevAddress, data, size);
+
+        // Wait for callback and check result.
+        notification_val = ulTaskNotifyTake(pdTRUE, MAX_TIMEOUT);
+        if (rx_result == HAL_OK) break;
+        if (notification_handle->should_retry) rx_result = HAL_BUSY;
+        if (notification_val != 1) rx_result = HAL_TIMEOUT;
+
+        retries += 1;
+    } while (retries < MAX_RETRIES);
+    return rx_result;
+}
+
+uint8_t hal_i2c_master_read(I2C_BUS bus, uint16_t DevAddress, uint8_t *data, uint16_t size) {
+    uint32_t notification_val = 0;
+    NotificationHandle_t *notification_handle = lookup_handle(bus);
+    I2C_HandleTypeDef* i2c_handle = (I2C_HandleTypeDef*)notification_handle->i2c_handle;
+
+    // Bus was not registered
+    if(notification_handle == NULL) return NO_HANDLE_ERROR;
+
+    uint8_t retries = 0;
+    HAL_StatusTypeDef rx_result = HAL_OK;
+    do {
+        // Setup task handle and send message
+        notification_handle->task_to_notify = xTaskGetCurrentTaskHandle();
+        rx_result = HAL_I2C_Master_Receive_IT(i2c_handle, DevAddress, data, size);
+
+        // Wait for callback and check result.
+        notification_val = ulTaskNotifyTake(pdTRUE, MAX_TIMEOUT);
+        if (rx_result == HAL_OK) break;
+        if (notification_handle->should_retry) rx_result = HAL_BUSY;
+        if (notification_val != 1) rx_result = HAL_TIMEOUT;
+
+        retries += 1;
+    } while (retries < MAX_RETRIES);
+    return rx_result;
+}
+
 void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *i2c_handle) {
     handle_i2c_callback(i2c_handle, false);
 }

--- a/stm32-modules/vacuum-module/firmware/system/main.h
+++ b/stm32-modules/vacuum-module/firmware/system/main.h
@@ -37,10 +37,16 @@ void Error_Handler(void);
 #define n48V_FAULT_Pin GPIO_PIN_6
 #define n48V_FAULT_GPIO_Port GPIOC
 
-#define EEPROM_I2C2_SDA_Pin GPIO_PIN_8
-#define EEPROM_I2C2_SDA_GPIO_Port GPIOA
-#define EEPOM_I2C2_SCL_Pin GPIO_PIN_9
-#define EEPOM_I2C2_SCL_GPIO_Port GPIOA
+#define I2C2_SDA_Pin GPIO_PIN_8
+#define I2C2_SDA_GPIO_Port GPIOA
+#define I2C2_SCL_Pin GPIO_PIN_9
+#define I2C2_SCL_GPIO_Port GPIOA
+
+#define I2C3_SCL_Pin GPIO_PIN_8
+#define I2C3_SCL_GPIO_Port GPIOC
+#define I2C3_SDA_Pin GPIO_PIN_9
+#define I2C3_SDA_GPIO_Port GPIOC
+
 #define EEPROM_WP_PIN GPIO_PIN_10
 #define EEPROM_WP_PORT GPIOA
 

--- a/stm32-modules/vacuum-module/firmware/system/stm32g4xx_hal_msp.c
+++ b/stm32-modules/vacuum-module/firmware/system/stm32g4xx_hal_msp.c
@@ -76,7 +76,7 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c)
         PA8     ------> I2C2_SDA
         PA9     ------> I2C2_SCL
         */
-        GPIO_InitStruct.Pin = EEPROM_I2C2_SDA_Pin|EEPOM_I2C2_SCL_Pin;
+        GPIO_InitStruct.Pin = I2C2_SDA_Pin|I2C2_SCL_Pin;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
@@ -90,7 +90,29 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c)
         HAL_NVIC_SetPriority(I2C2_ER_IRQn, 7, 0);
         HAL_NVIC_EnableIRQ(I2C2_EV_IRQn);
         HAL_NVIC_EnableIRQ(I2C2_ER_IRQn);
+    } else if(hi2c->Instance==I2C3)
+    {
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        /**I2C3 GPIO Configuration
+        PC8     ------> I2C3_SCL
+        PC9     ------> I2C3_SDA
+        */
+        GPIO_InitStruct.Pin = I2C3_SCL_Pin|I2C3_SDA_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF8_I2C3;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+        /* Peripheral clock enable */
+        __HAL_RCC_I2C3_CLK_ENABLE();
+
+        HAL_NVIC_SetPriority(I2C3_EV_IRQn, 7, 0);
+        HAL_NVIC_SetPriority(I2C3_ER_IRQn, 7, 0);
+        HAL_NVIC_EnableIRQ(I2C3_EV_IRQn);
+        HAL_NVIC_EnableIRQ(I2C3_ER_IRQn);
     }
+
 }
 
 /**
@@ -110,9 +132,20 @@ void HAL_I2C_MspDeInit(I2C_HandleTypeDef* hi2c)
         PA8     ------> I2C2_SDA
         PA9     ------> I2C2_SCL
         */
-        HAL_GPIO_DeInit(EEPROM_I2C2_SDA_GPIO_Port, EEPROM_I2C2_SDA_Pin);
+        HAL_GPIO_DeInit(I2C2_SDA_GPIO_Port, I2C2_SDA_Pin);
+        HAL_GPIO_DeInit(I2C2_SCL_GPIO_Port, I2C2_SCL_Pin);
+    }
+    else if(hi2c->Instance==I2C3)
+    {
+        /* Peripheral clock disable */
+        __HAL_RCC_I2C3_CLK_DISABLE();
 
-        HAL_GPIO_DeInit(EEPOM_I2C2_SCL_GPIO_Port, EEPOM_I2C2_SCL_Pin);
+        /**I2C3 GPIO Configuration
+        PC8     ------> I2C3_SCL
+        PC9     ------> I2C3_SDA
+        */
+        HAL_GPIO_DeInit(I2C3_SCL_GPIO_Port, I2C3_SCL_Pin);
+        HAL_GPIO_DeInit(I2C3_SDA_GPIO_Port, I2C3_SDA_Pin);
     }
 }
 

--- a/stm32-modules/vacuum-module/firmware/ui/ui_policy.cpp
+++ b/stm32-modules/vacuum-module/firmware/ui/ui_policy.cpp
@@ -1,6 +1,8 @@
 #include "firmware/ui_policy.hpp"
 
+#include "FreeRTOS.h"
 #include "firmware/ui_hardware.h"
+#include "task.h"
 
 namespace ui_policy {
 
@@ -8,4 +10,5 @@ namespace ui_policy {
 auto UIPolicy::set_heartbeat_led(bool value) -> void {
     ui_hardware_set_heartbeat_led(value);
 }
+
 }  // namespace ui_policy


### PR DESCRIPTION
# Overview

The GPIO init was not initiated properly for I2C3 because it was not set up. So, let's fix that by adding the corresponding instance to the HAL_I2C_MspInit and HAL_I2C_MspDeInit functions. Let's also add a hal_i2c_master_read and hal_i2c_master_write functions that can be used for sending raw data through the i2c bus, where a specific transaction is required.

# Changes

- Add `hal_i2c_master_read` and `hal_i2c_master_write` functions and expose them through the I2C class
- Fix an issue when initializing the GPIO for the I2C3 bus

# Testing

- [x] Talk to a device on the i2c3 line using the `hal_i2c_master_read` and `hal_i2c_master_write` functions.