### PR TITLE
feat(vacuum-module): set up FIR filtering for vacuum pressure sensor readings

### DIFF
--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -41,7 +41,6 @@ constexpr uint8_t PRESSURE_FRAME_LEN = 10;
 constexpr int UNFILTERED_PRESSURE_BUFFER_LEN = 13;
 constexpr int FILTER_LEN = 13;
 constexpr int FILTERED_PRESSURE_BUFFER_LEN = 13;
-//constexpr double FILTER[FILTER_LEN] = {(1.0 / FILTER_LEN)};
 constexpr std::array<double, FILTER_LEN> FILTER = {(1.0 / FILTER_LEN)};
 
 // Frame retry defaults
@@ -70,12 +69,6 @@ class MPRLL0025PA00001 {
             // check device status
             ok = _policy->is_device_ready(device_address << 1);
         }
-        // initialize filter buffer to be an unweighted moving average
-        // TODO: optimize these filter coefficients
-//        double moving_average_coefficient = 1.0 / FILTER_LEN;
-//        for (int i = 0; i < FILTER_LEN; i++) {
-//            FILTER.at(i) = moving_average_coefficient;
-//        }
 
         return ok;
     }
@@ -103,10 +96,8 @@ class MPRLL0025PA00001 {
                 static_cast<bool>(status_byte & STATUS_BUSY_FLAG);
             if (!sensor_busy) {
                 pressure_mbar = parse_pressure(RD_BUFF.data());
-                return pressure_mbar;
-//                filter_pressure(pressure_mbar);
-//                return FILTERED_PRESSURE_MBAR[
-//                    filtered_pressure_buffer_index];
+                filter_pressure(pressure_mbar);
+                return FILTERED_PRESSURE_MBAR[filtered_pressure_buffer_index];
             }
         }
 
@@ -124,7 +115,6 @@ class MPRLL0025PA00001 {
         WR_BUFF[0] = cmd;
         // Copy data to the buffer starting from the header len.
         for (uint8_t i = 1; i < len; i++) {
-            // NOLINTNEXTLINE
             WR_BUFF[i] = data[i - 1];
         }
         return len + 1;
@@ -136,7 +126,6 @@ class MPRLL0025PA00001 {
         // The pressure counts are in big-endian (most significant byte first)
         // order, not little-endian.
         auto press_counts =
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             static_cast<double>(raw[1] << 16 | raw[2] << 8 | raw[3]);
         auto pressure_psi = (((press_counts - OUTPUT_MIN) * (PMAX - PMIN)) /
                              (OUTPUT_MAX - OUTPUT_MIN)) +
@@ -152,36 +141,27 @@ class MPRLL0025PA00001 {
         double filter_output = 0;
 
         for (int i = 0; i < UNFILTERED_PRESSURE_BUFFER_LEN; i++) {
-            int p_index = (unfiltered_pressure_buffer_index + i) % UNFILTERED_PRESSURE_BUFFER_LEN; 
+            int p_index = (unfiltered_pressure_buffer_index + i) %
+                          UNFILTERED_PRESSURE_BUFFER_LEN;
             double pressure_sample = UNFILTERED_PRESSURE_BUFFER_MBAR[p_index];
             for (int j = 0; j < FILTER_LEN; j++) {
                 filter_output += pressure_sample * FILTER[j];
             }
         }
 
-//        for (int i = 0; i < FILTER_LEN; i++) {
-//            int current_term = (unfiltered_pressure_buffer_index - i + UNFILTERED_PRESSURE_BUFFER_LEN) %
-//                       UNFILTERED_PRESSURE_BUFFER_LEN;
-//            filter_output +=
-//                UNFILTERED_PRESSURE_BUFFER_MBAR[current_term] * FILTER[i];
-//        }
-        FILTERED_PRESSURE_MBAR[filtered_pressure_buffer_index] =
-            filter_output;
+        FILTERED_PRESSURE_MBAR[filtered_pressure_buffer_index] = filter_output;
     }
 
     Policy* _policy{nullptr};
     std::array<uint8_t, PRESSURE_FRAME_LEN> RD_BUFF = {0};
     std::array<uint8_t, PRESSURE_FRAME_LEN> WR_BUFF = {0};
     PressureSensorID _sensor_id{};
-//    std::array<double, FILTER_LEN> FILTER = {};
     uint8_t device_address{};
 
     std::array<double, FILTERED_PRESSURE_BUFFER_LEN> FILTERED_PRESSURE_MBAR = {
         0};
     std::array<double, UNFILTERED_PRESSURE_BUFFER_LEN>
         UNFILTERED_PRESSURE_BUFFER_MBAR = {0};
-//    double FILTERED_PRESSURE_MBAR[FILTERED_PRESSURE_BUFFER_LEN] = {0};
-//    double UNFILTERED_PRESSURE_BUFFER_MBAR[UNFILTERED_PRESSURE_BUFFER_LEN] = {0};
     int filtered_pressure_buffer_index = -1;
     int unfiltered_pressure_buffer_index = -1;
     double pressure_mbar = 0;

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -41,7 +41,6 @@ constexpr uint8_t PRESSURE_FRAME_LEN = 10;
 constexpr int UNFILTERED_PRESSURE_BUFFER_LEN = 13;
 constexpr int FILTER_LEN = 13;
 constexpr int FILTERED_PRESSURE_BUFFER_LEN = 13;
-double FILTER[FILTER_LEN] = {};
 
 // Frame retry defaults
 constexpr uint8_t DEFAULT_RETRIES = 3;
@@ -71,9 +70,9 @@ class MPRLL0025PA00001 {
         }
         // initialize filter buffer to be an unweighted moving average
         // TODO: optimize these filter coefficients
-        double moving_average_coefficient = 1 / FILTER_LEN;
+        double moving_average_coefficient = 1.0 / FILTER_LEN;
         for (int i = 0; i < FILTER_LEN; i++) {
-            FILTER[i] = moving_average_coefficient;
+            FILTER.at(i) = moving_average_coefficient;
         }
 
         return ok;
@@ -103,7 +102,8 @@ class MPRLL0025PA00001 {
             if (!sensor_busy) {
                 pressure_mbar = parse_pressure(RD_BUFF.data());
                 filter_pressure(pressure_mbar);
-                return FILTERED_PRESSURE_MBAR[filtered_pressure_buffer_index];
+                return FILTERED_PRESSURE_MBAR.at(
+                    filtered_pressure_buffer_index);
             }
         }
 
@@ -148,27 +148,30 @@ class MPRLL0025PA00001 {
         filtered_pressure_buffer_index %= FILTERED_PRESSURE_BUFFER_LEN;
         unfiltered_pressure_buffer_index %= UNFILTERED_PRESSURE_BUFFER_LEN;
 
-        UNFILTERED_PRESSURE_BUFFER_MBAR[unfiltered_pressure_buffer_index] =
+        UNFILTERED_PRESSURE_BUFFER_MBAR.at(unfiltered_pressure_buffer_index) =
             input_pressure_mbar;
         double filter_output = 0;
         for (int i = 0; i < FILTER_LEN; i++) {
             int current_term = (unfiltered_pressure_buffer_index - i) %
                                UNFILTERED_PRESSURE_BUFFER_LEN;
             filter_output +=
-                UNFILTERED_PRESSURE_BUFFER_MBAR[current_term] * FILTER[i];
+                UNFILTERED_PRESSURE_BUFFER_MBAR.at(current_term) * FILTER.at(i);
         }
-        FILTERED_PRESSURE_MBAR[filtered_pressure_buffer_index] = filter_output;
+        FILTERED_PRESSURE_MBAR.at(filtered_pressure_buffer_index) =
+            filter_output;
     }
 
     Policy* _policy{nullptr};
     std::array<uint8_t, PRESSURE_FRAME_LEN> RD_BUFF = {0};
     std::array<uint8_t, PRESSURE_FRAME_LEN> WR_BUFF = {0};
     PressureSensorID _sensor_id{};
+    std::array<double, FILTER_LEN> FILTER = {};
     uint8_t device_address{};
 
-    double FILTERED_PRESSURE_MBAR[FILTERED_PRESSURE_BUFFER_LEN] = {0};
-    double UNFILTERED_PRESSURE_BUFFER_MBAR[UNFILTERED_PRESSURE_BUFFER_LEN] = {
+    std::array<double, FILTERED_PRESSURE_BUFFER_LEN> FILTERED_PRESSURE_MBAR = {
         0};
+    std::array<double, UNFILTERED_PRESSURE_BUFFER_LEN>
+        UNFILTERED_PRESSURE_BUFFER_MBAR = {0};
     int filtered_pressure_buffer_index = -1;
     int unfiltered_pressure_buffer_index = -1;
     double pressure_mbar = 0;

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cmath>
 #include <cstdint>
 
 namespace vacuum_pressure_sensor {
@@ -42,8 +43,11 @@ constexpr int PRESSURE_BUFFER_LEN = 5;
 // TODO: currently this filter acts as an unweighted moving average. Find
 // coefficient values that optimize sensor output behavior for closed-loop
 // control
+constexpr double moving_avg_coefficient =
+    1.0 / std::pow((PRESSURE_BUFFER_LEN - 0.75), 2);
 constexpr std::array<double, PRESSURE_BUFFER_LEN> FILTER = {
-    (1.0 / PRESSURE_BUFFER_LEN)};
+    moving_avg_coefficient, moving_avg_coefficient, moving_avg_coefficient,
+    moving_avg_coefficient};
 
 // Frame retry defaults
 constexpr uint8_t DEFAULT_RETRIES = 3;
@@ -141,7 +145,7 @@ class MPRLL0025PA00001 {
     auto filter_pressure(double input_pressure_mbar) -> void {
         ++filtered_pressure_buffer_index %= PRESSURE_BUFFER_LEN;
         ++unfiltered_pressure_buffer_index %= PRESSURE_BUFFER_LEN;
-        unfiltered_pressure_mbar.at(filtered_pressure_buffer_index) =
+        unfiltered_pressure_mbar.at(unfiltered_pressure_buffer_index) =
             input_pressure_mbar;
         double filter_output = 0;
 

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -152,7 +152,7 @@ class MPRLL0025PA00001 {
             input_pressure_mbar;
         double filter_output = 0;
         for (int i = 0; i < FILTER_LEN; i++) {
-            int current_term = (unfiltered_pressure_buffer_index + i) %
+            int current_term = (unfiltered_pressure_buffer_index - i) %
                                UNFILTERED_PRESSURE_BUFFER_LEN;
             filter_output +=
                 UNFILTERED_PRESSURE_BUFFER_MBAR[current_term] * FILTER[i];

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -97,7 +97,7 @@ class MPRLL0025PA00001 {
             if (!sensor_busy) {
                 pressure_mbar = parse_pressure(RD_BUFF.data());
                 filter_pressure(pressure_mbar);
-                return FILTERED_PRESSURE_MBAR[filtered_pressure_buffer_index];
+                return FILTERED_PRESSURE_MBAR.at(filtered_pressure_buffer_index);
             }
         }
 
@@ -136,20 +136,20 @@ class MPRLL0025PA00001 {
     auto filter_pressure(double input_pressure_mbar) -> void {
         ++filtered_pressure_buffer_index %= FILTERED_PRESSURE_BUFFER_LEN;
         ++unfiltered_pressure_buffer_index %= UNFILTERED_PRESSURE_BUFFER_LEN;
-        UNFILTERED_PRESSURE_BUFFER_MBAR[filtered_pressure_buffer_index] =
+        UNFILTERED_PRESSURE_BUFFER_MBAR.at(filtered_pressure_buffer_index) =
             input_pressure_mbar;
         double filter_output = 0;
 
         for (int i = 0; i < UNFILTERED_PRESSURE_BUFFER_LEN; i++) {
             int p_index = (unfiltered_pressure_buffer_index + i) %
                           UNFILTERED_PRESSURE_BUFFER_LEN;
-            double pressure_sample = UNFILTERED_PRESSURE_BUFFER_MBAR[p_index];
+            double pressure_sample = UNFILTERED_PRESSURE_BUFFER_MBAR.at(p_index);
             for (int j = 0; j < FILTER_LEN; j++) {
                 filter_output += pressure_sample * FILTER[j];
             }
         }
 
-        FILTERED_PRESSURE_MBAR[filtered_pressure_buffer_index] = filter_output;
+        FILTERED_PRESSURE_MBAR.at(filtered_pressure_buffer_index) = filter_output;
     }
 
     Policy* _policy{nullptr};

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -39,6 +39,9 @@ constexpr double PMIN = 0;
 constexpr double PSI2MBAR = 68.9475729318;
 constexpr uint8_t PRESSURE_FRAME_LEN = 10;
 constexpr int PRESSURE_BUFFER_LEN = 13;
+// TODO: currently this filter acts as an unweighted moving average. Find
+// coefficient values that optimize sensor output behavior for closed-loop
+// control
 constexpr std::array<double, PRESSURE_BUFFER_LEN> FILTER = {
     (1.0 / PRESSURE_BUFFER_LEN)};
 
@@ -127,7 +130,7 @@ class MPRLL0025PA00001 {
         // The pressure counts are in big-endian (most significant byte first)
         // order, not little-endian.
         auto press_counts =
-            // NOLINTNEXTLINE
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             static_cast<double>(raw[1] << 16 | raw[2] << 8 | raw[3]);
         auto pressure_psi = (((press_counts - OUTPUT_MIN) * (PMAX - PMIN)) /
                              (OUTPUT_MAX - OUTPUT_MIN)) +

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -38,10 +38,9 @@ constexpr double PMAX = 25;
 constexpr double PMIN = 0;
 constexpr double PSI2MBAR = 68.9475729318;
 constexpr uint8_t PRESSURE_FRAME_LEN = 10;
-constexpr int UNFILTERED_PRESSURE_BUFFER_LEN = 13;
-constexpr int FILTER_LEN = 13;
-constexpr int FILTERED_PRESSURE_BUFFER_LEN = 13;
-constexpr std::array<double, FILTER_LEN> FILTER = {(1.0 / FILTER_LEN)};
+constexpr int PRESSURE_BUFFER_LEN = 13;
+constexpr std::array<double, PRESSURE_BUFFER_LEN> FILTER = {
+    (1.0 / PRESSURE_BUFFER_LEN)};
 
 // Frame retry defaults
 constexpr uint8_t DEFAULT_RETRIES = 3;
@@ -137,18 +136,17 @@ class MPRLL0025PA00001 {
     }
 
     auto filter_pressure(double input_pressure_mbar) -> void {
-        ++filtered_pressure_buffer_index %= FILTERED_PRESSURE_BUFFER_LEN;
-        ++unfiltered_pressure_buffer_index %= UNFILTERED_PRESSURE_BUFFER_LEN;
-        UNFILTERED_PRESSURE_BUFFER_MBAR.at(filtered_pressure_buffer_index) =
+        ++filtered_pressure_buffer_index %= PRESSURE_BUFFER_LEN;
+        ++unfiltered_pressure_buffer_index %= PRESSURE_BUFFER_LEN;
+        UNFILTERED_PRESSURE_MBAR.at(filtered_pressure_buffer_index) =
             input_pressure_mbar;
         double filter_output = 0;
 
-        for (int i = 0; i < UNFILTERED_PRESSURE_BUFFER_LEN; i++) {
-            int p_index = (unfiltered_pressure_buffer_index + i) %
-                          UNFILTERED_PRESSURE_BUFFER_LEN;
-            double pressure_sample =
-                UNFILTERED_PRESSURE_BUFFER_MBAR.at(p_index);
-            for (int j = 0; j < FILTER_LEN; j++) {
+        for (int i = 0; i < PRESSURE_BUFFER_LEN; i++) {
+            int p_index =
+                (unfiltered_pressure_buffer_index + i) % PRESSURE_BUFFER_LEN;
+            double pressure_sample = UNFILTERED_PRESSURE_MBAR.at(p_index);
+            for (int j = 0; j < PRESSURE_BUFFER_LEN; j++) {
                 filter_output += pressure_sample * FILTER.at(j);
             }
         }
@@ -163,10 +161,8 @@ class MPRLL0025PA00001 {
     PressureSensorID _sensor_id{};
     uint8_t device_address{};
 
-    std::array<double, FILTERED_PRESSURE_BUFFER_LEN> FILTERED_PRESSURE_MBAR = {
-        0};
-    std::array<double, UNFILTERED_PRESSURE_BUFFER_LEN>
-        UNFILTERED_PRESSURE_BUFFER_MBAR = {0};
+    std::array<double, PRESSURE_BUFFER_LEN> FILTERED_PRESSURE_MBAR = {0};
+    std::array<double, PRESSURE_BUFFER_LEN> UNFILTERED_PRESSURE_MBAR = {0};
     size_t filtered_pressure_buffer_index = 0;
     size_t unfiltered_pressure_buffer_index = 0;
     double pressure_mbar = 0;

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -37,8 +37,11 @@ constexpr double PMAX = 25;
 // minimum value of pressure range [bar, psi, kPa, etc.]
 constexpr double PMIN = 0;
 constexpr double PSI2MBAR = 68.9475729318;
-
 constexpr uint8_t PRESSURE_FRAME_LEN = 10;
+constexpr int UNFILTERED_PRESSURE_BUFFER_LEN = 13;
+constexpr int FILTER_LEN = 13;
+constexpr int FILTERED_PRESSURE_BUFFER_LEN = 13;
+double FILTER[FILTER_LEN] = {};
 
 // Frame retry defaults
 constexpr uint8_t DEFAULT_RETRIES = 3;
@@ -65,6 +68,12 @@ class MPRLL0025PA00001 {
 
             // check device status
             ok = _policy->is_device_ready(device_address << 1);
+        }
+        // initialize filter buffer to be an unweighted moving average
+        // TODO: optimize these filter coefficients
+        double moving_average_coefficient = 1 / FILTER_LEN;
+        for (int i = 0; i < FILTER_LEN; i++) {
+            FILTER[i] = moving_average_coefficient;
         }
 
         return ok;
@@ -93,7 +102,8 @@ class MPRLL0025PA00001 {
                 static_cast<bool>(status_byte & STATUS_BUSY_FLAG);
             if (!sensor_busy) {
                 pressure_mbar = parse_pressure(RD_BUFF.data());
-                return pressure_mbar;
+                filter_pressure(pressure_mbar);
+                return FILTERED_PRESSURE_MBAR[filtered_pressure_buffer_index];
             }
         }
 
@@ -131,13 +141,37 @@ class MPRLL0025PA00001 {
         return pressure_psi * PSI2MBAR;
     }
 
+    auto filter_pressure(double input_pressure_mbar) -> void {
+        filtered_pressure_buffer_index++;
+        unfiltered_pressure_buffer_index++;
+
+        filtered_pressure_buffer_index %= FILTERED_PRESSURE_BUFFER_LEN;
+        unfiltered_pressure_buffer_index %= UNFILTERED_PRESSURE_BUFFER_LEN;
+
+        UNFILTERED_PRESSURE_BUFFER_MBAR[unfiltered_pressure_buffer_index] =
+            input_pressure_mbar;
+        double filter_output = 0;
+        for (int i = 0; i < FILTER_LEN; i++) {
+            int current_term = (unfiltered_pressure_buffer_index + i) %
+                               UNFILTERED_PRESSURE_BUFFER_LEN;
+            filter_output +=
+                UNFILTERED_PRESSURE_BUFFER_MBAR[current_term] * FILTER[i];
+        }
+        FILTERED_PRESSURE_MBAR[filtered_pressure_buffer_index] = filter_output;
+    }
+
     Policy* _policy{nullptr};
     std::array<uint8_t, PRESSURE_FRAME_LEN> RD_BUFF = {0};
     std::array<uint8_t, PRESSURE_FRAME_LEN> WR_BUFF = {0};
     PressureSensorID _sensor_id{};
     uint8_t device_address{};
 
-    double pressure_mbar = {0};
+    double FILTERED_PRESSURE_MBAR[FILTERED_PRESSURE_BUFFER_LEN] = {0};
+    double UNFILTERED_PRESSURE_BUFFER_MBAR[UNFILTERED_PRESSURE_BUFFER_LEN] = {
+        0};
+    int filtered_pressure_buffer_index = -1;
+    int unfiltered_pressure_buffer_index = -1;
+    double pressure_mbar = 0;
     uint8_t last_status = 0;
 };
 

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -97,7 +97,8 @@ class MPRLL0025PA00001 {
             if (!sensor_busy) {
                 pressure_mbar = parse_pressure(RD_BUFF.data());
                 filter_pressure(pressure_mbar);
-                return FILTERED_PRESSURE_MBAR.at(filtered_pressure_buffer_index);
+                return FILTERED_PRESSURE_MBAR.at(
+                    filtered_pressure_buffer_index);
             }
         }
 
@@ -115,6 +116,7 @@ class MPRLL0025PA00001 {
         WR_BUFF[0] = cmd;
         // Copy data to the buffer starting from the header len.
         for (uint8_t i = 1; i < len; i++) {
+            // NOLINTNEXTLINE
             WR_BUFF[i] = data[i - 1];
         }
         return len + 1;
@@ -126,6 +128,7 @@ class MPRLL0025PA00001 {
         // The pressure counts are in big-endian (most significant byte first)
         // order, not little-endian.
         auto press_counts =
+        // NOLINTNEXTLINE
             static_cast<double>(raw[1] << 16 | raw[2] << 8 | raw[3]);
         auto pressure_psi = (((press_counts - OUTPUT_MIN) * (PMAX - PMIN)) /
                              (OUTPUT_MAX - OUTPUT_MIN)) +
@@ -143,13 +146,15 @@ class MPRLL0025PA00001 {
         for (int i = 0; i < UNFILTERED_PRESSURE_BUFFER_LEN; i++) {
             int p_index = (unfiltered_pressure_buffer_index + i) %
                           UNFILTERED_PRESSURE_BUFFER_LEN;
-            double pressure_sample = UNFILTERED_PRESSURE_BUFFER_MBAR.at(p_index);
+            double pressure_sample =
+                UNFILTERED_PRESSURE_BUFFER_MBAR.at(p_index);
             for (int j = 0; j < FILTER_LEN; j++) {
-                filter_output += pressure_sample * FILTER[j];
+                filter_output += pressure_sample * FILTER.at(j);
             }
         }
 
-        FILTERED_PRESSURE_MBAR.at(filtered_pressure_buffer_index) = filter_output;
+        FILTERED_PRESSURE_MBAR.at(filtered_pressure_buffer_index) =
+            filter_output;
     }
 
     Policy* _policy{nullptr};

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -38,7 +38,7 @@ constexpr double PMAX = 25;
 constexpr double PMIN = 0;
 constexpr double PSI2MBAR = 68.9475729318;
 constexpr uint8_t PRESSURE_FRAME_LEN = 10;
-constexpr int PRESSURE_BUFFER_LEN = 13;
+constexpr int PRESSURE_BUFFER_LEN = 5;
 // TODO: currently this filter acts as an unweighted moving average. Find
 // coefficient values that optimize sensor output behavior for closed-loop
 // control

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -41,6 +41,8 @@ constexpr uint8_t PRESSURE_FRAME_LEN = 10;
 constexpr int UNFILTERED_PRESSURE_BUFFER_LEN = 13;
 constexpr int FILTER_LEN = 13;
 constexpr int FILTERED_PRESSURE_BUFFER_LEN = 13;
+//constexpr double FILTER[FILTER_LEN] = {(1.0 / FILTER_LEN)};
+constexpr std::array<double, FILTER_LEN> FILTER = {(1.0 / FILTER_LEN)};
 
 // Frame retry defaults
 constexpr uint8_t DEFAULT_RETRIES = 3;
@@ -70,10 +72,10 @@ class MPRLL0025PA00001 {
         }
         // initialize filter buffer to be an unweighted moving average
         // TODO: optimize these filter coefficients
-        double moving_average_coefficient = 1.0 / FILTER_LEN;
-        for (int i = 0; i < FILTER_LEN; i++) {
-            FILTER.at(i) = moving_average_coefficient;
-        }
+//        double moving_average_coefficient = 1.0 / FILTER_LEN;
+//        for (int i = 0; i < FILTER_LEN; i++) {
+//            FILTER.at(i) = moving_average_coefficient;
+//        }
 
         return ok;
     }
@@ -101,9 +103,10 @@ class MPRLL0025PA00001 {
                 static_cast<bool>(status_byte & STATUS_BUSY_FLAG);
             if (!sensor_busy) {
                 pressure_mbar = parse_pressure(RD_BUFF.data());
-                filter_pressure(pressure_mbar);
-                return FILTERED_PRESSURE_MBAR.at(
-                    filtered_pressure_buffer_index);
+                return pressure_mbar;
+//                filter_pressure(pressure_mbar);
+//                return FILTERED_PRESSURE_MBAR[
+//                    filtered_pressure_buffer_index];
             }
         }
 
@@ -142,22 +145,18 @@ class MPRLL0025PA00001 {
     }
 
     auto filter_pressure(double input_pressure_mbar) -> void {
-        filtered_pressure_buffer_index++;
-        unfiltered_pressure_buffer_index++;
-
-        filtered_pressure_buffer_index %= FILTERED_PRESSURE_BUFFER_LEN;
-        unfiltered_pressure_buffer_index %= UNFILTERED_PRESSURE_BUFFER_LEN;
-
-        UNFILTERED_PRESSURE_BUFFER_MBAR.at(unfiltered_pressure_buffer_index) =
+        ++filtered_pressure_buffer_index %= FILTERED_PRESSURE_BUFFER_LEN;
+        ++unfiltered_pressure_buffer_index %= UNFILTERED_PRESSURE_BUFFER_LEN;
+        UNFILTERED_PRESSURE_BUFFER_MBAR[filtered_pressure_buffer_index] =
             input_pressure_mbar;
         double filter_output = 0;
         for (int i = 0; i < FILTER_LEN; i++) {
-            int current_term = (unfiltered_pressure_buffer_index - i) %
-                               UNFILTERED_PRESSURE_BUFFER_LEN;
+            int current_term = (unfiltered_pressure_buffer_index - i + UNFILTERED_PRESSURE_BUFFER_LEN) %
+                       UNFILTERED_PRESSURE_BUFFER_LEN;
             filter_output +=
-                UNFILTERED_PRESSURE_BUFFER_MBAR.at(current_term) * FILTER.at(i);
+                UNFILTERED_PRESSURE_BUFFER_MBAR[current_term] * FILTER[i];
         }
-        FILTERED_PRESSURE_MBAR.at(filtered_pressure_buffer_index) =
+        FILTERED_PRESSURE_MBAR[filtered_pressure_buffer_index] =
             filter_output;
     }
 
@@ -165,13 +164,15 @@ class MPRLL0025PA00001 {
     std::array<uint8_t, PRESSURE_FRAME_LEN> RD_BUFF = {0};
     std::array<uint8_t, PRESSURE_FRAME_LEN> WR_BUFF = {0};
     PressureSensorID _sensor_id{};
-    std::array<double, FILTER_LEN> FILTER = {};
+//    std::array<double, FILTER_LEN> FILTER = {};
     uint8_t device_address{};
 
     std::array<double, FILTERED_PRESSURE_BUFFER_LEN> FILTERED_PRESSURE_MBAR = {
         0};
     std::array<double, UNFILTERED_PRESSURE_BUFFER_LEN>
         UNFILTERED_PRESSURE_BUFFER_MBAR = {0};
+//    double FILTERED_PRESSURE_MBAR[FILTERED_PRESSURE_BUFFER_LEN] = {0};
+//    double UNFILTERED_PRESSURE_BUFFER_MBAR[UNFILTERED_PRESSURE_BUFFER_LEN] = {0};
     int filtered_pressure_buffer_index = -1;
     int unfiltered_pressure_buffer_index = -1;
     double pressure_mbar = 0;

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -43,9 +43,9 @@ constexpr int PRESSURE_BUFFER_LEN = 5;
 // TODO: currently this filter acts as an unweighted moving average. Find
 // coefficient values that optimize sensor output behavior for closed-loop
 // control
-constexpr double moving_avg_coefficient =
+const double moving_avg_coefficient =
     1.0 / std::pow((PRESSURE_BUFFER_LEN - 0.75), 2);
-constexpr std::array<double, PRESSURE_BUFFER_LEN> FILTER = {
+const std::array<double, PRESSURE_BUFFER_LEN> FILTER = {
     moving_avg_coefficient, moving_avg_coefficient, moving_avg_coefficient,
     moving_avg_coefficient};
 
@@ -148,11 +148,12 @@ class MPRLL0025PA00001 {
         unfiltered_pressure_mbar.at(unfiltered_pressure_buffer_index) =
             input_pressure_mbar;
         double filter_output = 0;
-
+        double pressure_sample = 0;
+        int p_index = unfiltered_pressure_buffer_index;
         for (int i = 0; i < PRESSURE_BUFFER_LEN; i++) {
-            int p_index =
+            p_index =
                 (unfiltered_pressure_buffer_index + i) % PRESSURE_BUFFER_LEN;
-            double pressure_sample = unfiltered_pressure_mbar.at(p_index);
+            pressure_sample = unfiltered_pressure_mbar.at(p_index);
             for (int j = 0; j < PRESSURE_BUFFER_LEN; j++) {
                 filter_output += pressure_sample * FILTER.at(j);
             }

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -128,7 +128,7 @@ class MPRLL0025PA00001 {
         // The pressure counts are in big-endian (most significant byte first)
         // order, not little-endian.
         auto press_counts =
-        // NOLINTNEXTLINE
+            // NOLINTNEXTLINE
             static_cast<double>(raw[1] << 16 | raw[2] << 8 | raw[3]);
         auto pressure_psi = (((press_counts - OUTPUT_MIN) * (PMAX - PMIN)) /
                              (OUTPUT_MAX - OUTPUT_MIN)) +
@@ -167,8 +167,8 @@ class MPRLL0025PA00001 {
         0};
     std::array<double, UNFILTERED_PRESSURE_BUFFER_LEN>
         UNFILTERED_PRESSURE_BUFFER_MBAR = {0};
-    int filtered_pressure_buffer_index = -1;
-    int unfiltered_pressure_buffer_index = -1;
+    size_t filtered_pressure_buffer_index = 0;
+    size_t unfiltered_pressure_buffer_index = 0;
     double pressure_mbar = 0;
     uint8_t last_status = 0;
 };

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -99,7 +99,7 @@ class MPRLL0025PA00001 {
             if (!sensor_busy) {
                 pressure_mbar = parse_pressure(RD_BUFF.data());
                 filter_pressure(pressure_mbar);
-                return FILTERED_PRESSURE_MBAR.at(
+                return filtered_pressure_mbar.at(
                     filtered_pressure_buffer_index);
             }
         }
@@ -141,20 +141,20 @@ class MPRLL0025PA00001 {
     auto filter_pressure(double input_pressure_mbar) -> void {
         ++filtered_pressure_buffer_index %= PRESSURE_BUFFER_LEN;
         ++unfiltered_pressure_buffer_index %= PRESSURE_BUFFER_LEN;
-        UNFILTERED_PRESSURE_MBAR.at(filtered_pressure_buffer_index) =
+        unfiltered_pressure_mbar.at(filtered_pressure_buffer_index) =
             input_pressure_mbar;
         double filter_output = 0;
 
         for (int i = 0; i < PRESSURE_BUFFER_LEN; i++) {
             int p_index =
                 (unfiltered_pressure_buffer_index + i) % PRESSURE_BUFFER_LEN;
-            double pressure_sample = UNFILTERED_PRESSURE_MBAR.at(p_index);
+            double pressure_sample = unfiltered_pressure_mbar.at(p_index);
             for (int j = 0; j < PRESSURE_BUFFER_LEN; j++) {
                 filter_output += pressure_sample * FILTER.at(j);
             }
         }
 
-        FILTERED_PRESSURE_MBAR.at(filtered_pressure_buffer_index) =
+        filtered_pressure_mbar.at(filtered_pressure_buffer_index) =
             filter_output;
     }
 
@@ -164,8 +164,8 @@ class MPRLL0025PA00001 {
     PressureSensorID _sensor_id{};
     uint8_t device_address{};
 
-    std::array<double, PRESSURE_BUFFER_LEN> FILTERED_PRESSURE_MBAR = {0};
-    std::array<double, PRESSURE_BUFFER_LEN> UNFILTERED_PRESSURE_MBAR = {0};
+    std::array<double, PRESSURE_BUFFER_LEN> filtered_pressure_mbar = {0};
+    std::array<double, PRESSURE_BUFFER_LEN> unfiltered_pressure_mbar = {0};
     size_t filtered_pressure_buffer_index = 0;
     size_t unfiltered_pressure_buffer_index = 0;
     double pressure_mbar = 0;

--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -150,12 +150,21 @@ class MPRLL0025PA00001 {
         UNFILTERED_PRESSURE_BUFFER_MBAR[filtered_pressure_buffer_index] =
             input_pressure_mbar;
         double filter_output = 0;
-        for (int i = 0; i < FILTER_LEN; i++) {
-            int current_term = (unfiltered_pressure_buffer_index - i + UNFILTERED_PRESSURE_BUFFER_LEN) %
-                       UNFILTERED_PRESSURE_BUFFER_LEN;
-            filter_output +=
-                UNFILTERED_PRESSURE_BUFFER_MBAR[current_term] * FILTER[i];
+
+        for (int i = 0; i < UNFILTERED_PRESSURE_BUFFER_LEN; i++) {
+            int p_index = (unfiltered_pressure_buffer_index + i) % UNFILTERED_PRESSURE_BUFFER_LEN; 
+            double pressure_sample = UNFILTERED_PRESSURE_BUFFER_MBAR[p_index];
+            for (int j = 0; j < FILTER_LEN; j++) {
+                filter_output += pressure_sample * FILTER[j];
+            }
         }
+
+//        for (int i = 0; i < FILTER_LEN; i++) {
+//            int current_term = (unfiltered_pressure_buffer_index - i + UNFILTERED_PRESSURE_BUFFER_LEN) %
+//                       UNFILTERED_PRESSURE_BUFFER_LEN;
+//            filter_output +=
+//                UNFILTERED_PRESSURE_BUFFER_MBAR[current_term] * FILTER[i];
+//        }
         FILTERED_PRESSURE_MBAR[filtered_pressure_buffer_index] =
             filter_output;
     }

--- a/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
@@ -73,7 +73,6 @@ static constexpr const uint32_t CONTROL_PERIOD_MS =
 static constexpr const double MS_TO_SECONDS = 0.001F;
 static constexpr const double ATM_PRESSURE_MBAR = 1013.25;
 static constexpr const double DEFAULT_RAMP_RATE = 400.0F;
-static constexpr const double SENSOR_ALPHA = 0.2F;  // Pressure Sensor EMA Alpha
 // Velocity Gain:
 // How much RPM to add for every 1 mbar/sec drop requested.
 static constexpr const float K_VELOCITY = 20.0F;

--- a/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
@@ -264,11 +264,7 @@ class PressureTask {
             }
         }
 
-        // Use EMA pressure filter. TODO: change this to FIR filter
-        auto raw_pressure = _pressure_control.pressure_abs_b;
-        auto previous_pressure = _pressure_control.current_pressure;
-        auto current_pressure = (SENSOR_ALPHA * raw_pressure) +
-                                ((1.0F - SENSOR_ALPHA) * previous_pressure);
+        auto current_pressure = _pressure_control.pressure_abs_b;
         _pressure_control.current_pressure = current_pressure;
 
         // Run Slew Limiter to get smooth trajectory in mbar


### PR DESCRIPTION
## Overview
This code implements the structure for a finite-impulse response filter, to be used on the vacuum pressure sensor. 

This sets up a buffer of filter coefficient values, and after each pressure sensor reading, convolves the most recent set of unfiltered pressure readings with the filter's coefficients. Currently, the coefficients are configured to make the filter function as a simple unweighted moving average, but this is with the expectation that we’ll optimize and update these values later on. 