### PR TITLE
feat(vacuum-module): add product id for vacuum module.

### DIFF
--- a/stm32-modules/vacuum-module/firmware/host_comms_task/usbd_desc.c
+++ b/stm32-modules/vacuum-module/firmware/host_comms_task/usbd_desc.c
@@ -27,7 +27,7 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 #define USBD_VID                      0x0483
-#define USBD_PID                      0xffff  /* Replace '0xfff' with your device product ID */
+#define USBD_PID                      0xef40  /* Replace '0xfff' with your device product ID */
 #define USBD_LANGID_STRING            0x0409  /* Replace '0xbbb' with your device language ID */
 #define USBD_MANUFACTURER_STRING      "Opentrons" /* Add your manufacturer string */
 #define USBD_PRODUCT_HS_STRING        "Vacuum HS" /* Add your product High Speed string */


### PR DESCRIPTION
Add the corresponding product id `0xEF40` for the vacuum module, so udev can correctly identify this device when plugged into the Flex.