### PR TITLE
feat(vacuum-module): add gcodes to tune the pressure control PID parameters.

### DIFF
--- a/stm32-modules/common/src/pid.cpp
+++ b/stm32-modules/common/src/pid.cpp
@@ -72,3 +72,13 @@ auto PID::arm_integrator_reset(double error, double threshold) -> void {
     }
     _reset_threshold = std::abs(threshold);
 }
+
+auto PID::set_tunings(double kp, double ki, double kd, bool reset_system)
+    -> void {
+    _kp = kp;
+    _ki = ki;
+    _kd = kd;
+    if (reset_system) {
+        reset();
+    }
+}

--- a/stm32-modules/include/common/core/pid.hpp
+++ b/stm32-modules/include/common/core/pid.hpp
@@ -57,6 +57,8 @@ class PID {
     [[nodiscard]] auto last_error() const -> double;
     [[nodiscard]] auto last_iterm() const -> double;
     auto arm_integrator_reset(double error, double threshold = 0.0F) -> void;
+    auto set_tunings(double kp, double ki, double kd, bool reset_system = false)
+        -> void;
 
   private:
     enum IntegratorResetTrigger : uint8_t { RISING, FALLING, NONE };

--- a/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
@@ -535,4 +535,117 @@ struct SetVentState {
     }
 };
 
+struct SetPressurePID {
+    /*
+     * M125- SetPressurePID tune the pressure regulation parameters
+     * */
+    std::optional<double> kp;
+    std::optional<double> ki;
+    std::optional<double> kd;
+    std::optional<double> overshoot;
+    std::optional<double> k_velocity;
+    std::optional<double> k_holding;
+    bool reset = false;
+
+    using ParseResult = std::optional<SetPressurePID>;
+    static constexpr auto prefix = std::array{'M', '1', '2', '5', ' '};
+    static constexpr const char* response = "M125 OK\n";
+
+    using P = Arg<float, 'P'>;
+    using I = Arg<float, 'I'>;
+    using D = Arg<float, 'D'>;
+    using O = Arg<float, 'O'>;
+    using V = Arg<float, 'V'>;
+    using H = Arg<float, 'H'>;
+    using R = Arg<uint8_t, 'R'>;
+
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto res = gcode::SingleParser<P, I, D, O, V, H, R>::parse_gcode(
+            input, limit, prefix);
+        if (!res.first.has_value()) {
+            return std::make_pair(ParseResult(), input);
+        }
+
+        auto ret = SetPressurePID{.reset = false};
+
+        auto arguments = res.first.value();
+        if (std::get<0>(arguments).present) {
+            ret.kp = static_cast<double>(std::get<0>(arguments).value);
+        }
+        if (std::get<1>(arguments).present) {
+            ret.ki = static_cast<double>(std::get<1>(arguments).value);
+        }
+        if (std::get<2>(arguments).present) {
+            ret.kd = static_cast<double>(std::get<2>(arguments).value);
+        }
+        if (std::get<3>(arguments).present) {
+            ret.overshoot = static_cast<double>(std::get<3>(arguments).value);
+        }
+        if (std::get<4>(arguments).present) {
+            ret.k_velocity = static_cast<double>(std::get<4>(arguments).value);
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        if (std::get<5>(arguments).present) {
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+            ret.k_holding = static_cast<double>(std::get<5>(arguments).value);
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        if (std::get<6>(arguments).present) {
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+            ret.reset = static_cast<bool>(std::get<6>(arguments).value);
+        }
+        return std::make_pair(ret, res.second);
+    }
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit) -> InputIt {
+        return write_string_to_iterpair(buf, limit, response);
+    }
+};
+
+struct GetPressurePID {
+    /*
+     * M126- GetPressurePID get the pressure control PID tunings
+     * */
+    using ParseResult = std::optional<GetPressurePID>;
+    static constexpr auto prefix = std::array{'M', '1', '2', '6'};
+
+    template <typename InputIt, typename InLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputIt, InLimit>
+    static auto write_response_into(InputIt buf, InLimit limit, double kp,
+                                    double ki, double kd, double overshoot,
+                                    double k_velocity, double k_holding)
+        -> InputIt {
+        int res = 0;
+        res = snprintf(&*buf, (limit - buf),
+                       "M126 P:%.1f I:%.1f D:%.1f O:%.1f V:%.1f H:%.1f OK\n",
+                       kp, ki, kd, overshoot, k_velocity, k_holding);
+        if (res <= 0) {
+            return buf;
+        }
+        return buf + res;
+    }
+    template <typename InputIt, typename Limit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<Limit, InputIt>
+    static auto parse(const InputIt& input, Limit limit)
+        -> std::pair<ParseResult, InputIt> {
+        auto working = prefix_matches(input, limit, prefix);
+        if (working == input) {
+            return std::make_pair(ParseResult(), input);
+        }
+        if (working != limit && !std::isspace(*working)) {
+            return std::make_pair(ParseResult(), input);
+        }
+        return std::make_pair(ParseResult(GetPressurePID()), working);
+    }
+};
+
 }  // namespace gcode

--- a/stm32-modules/include/vacuum-module/vacuum-module/host_comms_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/host_comms_task.hpp
@@ -37,21 +37,22 @@ class HostCommsTask {
     using Queues = typename tasks::Tasks<QueueImpl>;
 
   private:
-    using GCodeParser =
-        gcode::GroupParser<gcode::EnterBootloader, gcode::SetSerialNumber,
-                           gcode::GetSystemInfo, gcode::GetResetReason,
-                           gcode::SetStatusBarState, gcode::GetPumpState,
-                           gcode::GetPressureState, gcode::SetPressureState,
-                           gcode::SetPumpState, gcode::SetVentState>;
+    using GCodeParser = gcode::GroupParser<
+        gcode::EnterBootloader, gcode::SetSerialNumber, gcode::GetSystemInfo,
+        gcode::GetResetReason, gcode::SetStatusBarState, gcode::GetPumpState,
+        gcode::GetPressureState, gcode::SetPressureState, gcode::SetPumpState,
+        gcode::SetVentState, gcode::SetPressurePID, gcode::GetPressurePID>;
 
     using AckOnlyCache =
         AckCache<8, gcode::EnterBootloader, gcode::SetSerialNumber,
                  gcode::SetStatusBarState, gcode::SetPressureState,
-                 gcode::SetPumpState, gcode::SetVentState>;
+                 gcode::SetPumpState, gcode::SetVentState,
+                 gcode::SetPressurePID>;
     using GetSystemInfoCache = AckCache<8, gcode::GetSystemInfo>;
     using GetResetReasonCache = AckCache<8, gcode::GetResetReason>;
     using GetPumpStateCache = AckCache<8, gcode::GetPumpState>;
     using GetPressureStateCache = AckCache<8, gcode::GetPressureState>;
+    using GetPressurePIDCache = AckCache<8, gcode::GetPressurePID>;
 
   public:
     static constexpr size_t TICKS_TO_WAIT_ON_SEND = 10;
@@ -341,6 +342,30 @@ class HostCommsTask {
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(const messages::GetPressurePIDResponseMessage& response,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto cache_entry =
+            get_pressure_pid_cache.remove_if_present(response.responding_to_id);
+        return std::visit(
+            [tx_into, tx_limit, response](auto cache_element) {
+                using T = std::decay_t<decltype(cache_element)>;
+                if constexpr (std::is_same_v<std::monostate, T>) {
+                    return errors::write_into(
+                        tx_into, tx_limit,
+                        errors::ErrorCode::BAD_MESSAGE_ACKNOWLEDGEMENT);
+                } else {
+                    return cache_element.write_response_into(
+                        tx_into, tx_limit, response.kp, response.ki,
+                        response.kd, response.overshoot, response.k_velocity,
+                        response.k_holding);
+                }
+            },
+            cache_entry);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_gcode(const std::monostate& ignore, InputIt tx_into,
                      InputLimit tx_limit) -> std::pair<bool, InputIt> {
         static_cast<void>(ignore);
@@ -586,6 +611,58 @@ class HostCommsTask {
         return std::make_pair(true, tx_into);
     }
 
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::GetPressurePID& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = get_pressure_pid_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::GetPressurePIDMessage{.id = id};
+
+        if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            get_pressure_pid_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_gcode(const gcode::SetPressurePID& gcode, InputIt tx_into,
+                     InputLimit tx_limit) -> std::pair<bool, InputIt> {
+        auto id = ack_only_cache.add(gcode);
+        if (id == 0) {
+            return std::make_pair(
+                false, errors::write_into(tx_into, tx_limit,
+                                          errors::ErrorCode::GCODE_CACHE_FULL));
+        }
+        auto message = messages::SetPressurePIDMessage{
+            .id = id,
+            .kp = gcode.kp,
+            .ki = gcode.ki,
+            .kd = gcode.kd,
+            .overshoot = gcode.overshoot,
+            .k_velocity = gcode.k_velocity,
+            .k_holding = gcode.k_holding,
+            .reset = gcode.reset,
+        };
+        if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
+            auto wrote_to = errors::write_into(
+                tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);
+            ack_only_cache.remove_if_present(id);
+            return std::make_pair(false, wrote_to);
+        }
+        return std::make_pair(true, tx_into);
+    }
+
     // Our error handler just writes an error and bails
     template <typename InputIt, typename InputLimit>
     requires std::forward_iterator<InputIt> &&
@@ -605,6 +682,7 @@ class HostCommsTask {
     GetResetReasonCache get_reset_reason_cache;
     GetPumpStateCache get_pump_state_cache;
     GetPressureStateCache get_pressure_state_cache;
+    GetPressurePIDCache get_pressure_pid_cache;
     bool may_connect_latch = true;
 };
 

--- a/stm32-modules/include/vacuum-module/vacuum-module/messages.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/messages.hpp
@@ -171,12 +171,37 @@ struct SetVentMessage {
     bool vent = false;
 };
 
+struct SetPressurePIDMessage {
+    uint32_t id = 0;
+    std::optional<double> kp = std::nullopt;
+    std::optional<double> ki = std::nullopt;
+    std::optional<double> kd = std::nullopt;
+    std::optional<double> overshoot = std::nullopt;
+    std::optional<double> k_velocity = std::nullopt;
+    std::optional<double> k_holding = std::nullopt;
+    bool reset = false;
+};
+
+struct GetPressurePIDMessage {
+    uint32_t id = 0;
+};
+
+struct GetPressurePIDResponseMessage {
+    uint32_t responding_to_id;
+    double kp;
+    double ki;
+    double kd;
+    double overshoot;
+    double k_velocity;
+    double k_holding;
+};
+
 using HostCommsMessage =
     ::std::variant<std::monostate, IncomingMessageFromHost, ForceUSBDisconnect,
                    ErrorMessage, DebugMessage, AcknowledgePrevious,
                    GetSystemInfoResponse, GetResetReasonResponse,
-                   GetPressureStateResponseMessage,
-                   GetPumpStateResponseMessage>;
+                   GetPressureStateResponseMessage, GetPumpStateResponseMessage,
+                   GetPressurePIDResponseMessage>;
 
 using SystemMessage =
     ::std::variant<std::monostate, AcknowledgePrevious, GetSystemInfoMessage,
@@ -185,9 +210,11 @@ using SystemMessage =
 
 using UIMessage = ::std::variant<std::monostate, SetStatusBarStateMessage>;
 
-using PressureMessage = ::std::variant<std::monostate, PressureControlMessage,
-                                       SetPressureStateMessage,
-                                       GetPressureStateMessage, SetVentMessage>;
+using PressureMessage =
+    ::std::variant<std::monostate, PressureControlMessage,
+                   SetPressureStateMessage, GetPressureStateMessage,
+                   SetVentMessage, SetPressurePIDMessage,
+                   GetPressurePIDMessage>;
 
 using PumpMessage = ::std::variant<std::monostate, PumpControlMessage,
                                    SetPumpStateMessage, GetPumpStateMessage>;

--- a/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
@@ -75,10 +75,10 @@ static constexpr const double ATM_PRESSURE_MBAR = 1013.25;
 static constexpr const double DEFAULT_RAMP_RATE = 400.0F;
 // Velocity Gain:
 // How much RPM to add for every 1 mbar/sec drop requested.
-static constexpr const float K_VELOCITY = 20.0F;
+static constexpr const double K_VELOCITY = 20.0F;
 // Holding Gain:
 // Max RPM required to hold a deep vacuum against leaks.
-static constexpr const float K_HOLDING = 43.0F;
+static constexpr const double K_HOLDING = 43.0F;
 // Disables Velocity and Holding Gain if target is overshot
 static constexpr const double OVERSHOOT_ERROR = -2.0F;
 
@@ -119,6 +119,9 @@ struct PressureControl {
     double ramp_rate = 0;
     double target_rpm = 0;
     uint32_t duration_s = 0;
+    float k_velocity = 0;
+    float k_holding = 0;
+    double overshoot_error = 0;
     bool vent_after = false;
 
     double pressure_abs_a = 0;
@@ -138,7 +141,9 @@ const PressureControl pressure_control = {
                CONTROL_PERIOD_MS,  // sampletime
                MAX_RPM,            // windup_limit_high
                0),                 // windup_limit_low
-};
+    .k_velocity = K_VELOCITY,
+    .k_holding = K_HOLDING,
+    .overshoot_error = OVERSHOOT_ERROR};
 
 template <typename P>
 concept PressureControlPolicy = requires(P p) {
@@ -280,10 +285,11 @@ class PressureTask {
         // FF. If we are Overshot (Error is very negative), we want 0 FF.
         auto total_ff_rpm = 0.F;
         auto is_relaxing = (rate_mbar_s < 0.0F);
-        auto is_overshot = (error < OVERSHOOT_ERROR);
+        auto is_overshot = (error < _pressure_control.overshoot_error);
         if (!is_relaxing && !is_overshot) {
             // Calculate RPM needed to achieve this flow rate (Pumping)
-            auto ff_velocity = std::max<double>(0.0F, rate_mbar_s * K_VELOCITY);
+            auto ff_velocity = std::max<double>(
+                0.0F, rate_mbar_s * _pressure_control.k_velocity);
 
             // Calculate Holding Feed-Forward (Static Load)
             // Calculate how "deep" the vacuum is as a percentage (0.0 to 1.0)
@@ -291,7 +297,7 @@ class PressureTask {
             auto ratio =
                 (ATM_PRESSURE_MBAR - smooth_target) / ATM_PRESSURE_MBAR;
             ratio = std::clamp<double>(ratio, 0.0F, 1.0F);
-            auto ff_holding = ratio * K_HOLDING;
+            auto ff_holding = ratio * _pressure_control.k_holding;
             total_ff_rpm = ff_velocity + ff_holding;
         }
 
@@ -375,6 +381,38 @@ class PressureTask {
         auto ret =
             vent_state == m.vent ? Error::NO_ERROR : Error::VENT_FAILED_ERROR;
         send_ack_message(m.id, ret);
+    }
+
+    template <PressureControlPolicy Policy>
+    auto visit_message(const messages::SetPressurePIDMessage& m, Policy& policy)
+        -> void {
+        static_cast<void>(policy);
+        auto& pc = _pressure_control;
+        pc.overshoot_error = m.overshoot.value_or(pc.overshoot_error);
+        pc.k_velocity = m.k_velocity.value_or(pc.k_velocity);
+        pc.k_holding = m.k_holding.value_or(pc.k_holding);
+        auto kp = m.kp.value_or(pc.pid.kp());
+        auto ki = m.ki.value_or(pc.pid.ki());
+        auto kd = m.kd.value_or(pc.pid.kd());
+        pc.pid.set_tunings(kp, ki, kd, m.reset);
+        send_ack_message(m.id);
+    }
+
+    template <PressureControlPolicy Policy>
+    auto visit_message(const messages::GetPressurePIDMessage& m, Policy& policy)
+        -> void {
+        static_cast<void>(policy);
+        auto msg = messages::GetPressurePIDResponseMessage{
+            .responding_to_id = m.id,
+            .kp = _pressure_control.pid.kp(),
+            .ki = _pressure_control.pid.ki(),
+            .kd = _pressure_control.pid.kd(),
+            .overshoot = _pressure_control.overshoot_error,
+            .k_velocity = _pressure_control.k_velocity,
+            .k_holding = _pressure_control.k_holding,
+        };
+        static_cast<void>(
+            _task_registry->send_to_address(msg, Queues::HostCommsAddress));
     }
 
     auto get_sensor(PressureSensorID sensor_id) -> PressureSensor& {


### PR DESCRIPTION
# Overview

Hardware testing needs to tune the pressure regulation for smoother performance, so let's expose the pressure-control parameters that directly affect it. Those parameters are

- The PID parameters (Proportional, Integral, Derivative)
- The `K_Velocity` Feed-Forward Gain, How much RPM to add for every 1 mbar/sec drop requested
- The `K_Holding` Feed-Forward Gain, Max RPM required to hold a deep vacuum against leaks.
- The Overshoot error Determines the threshold when the k_velocity and k_holding are ignored if we overshoot

# Changelog

- Adds M125 SetPressurePID GCode
- Adds M126 GetPressurePID GCode
