### PR TITLE
fix(build): add vacuum-module to set_build_vars script to deploy the firmware to aws.

### DIFF
--- a/scripts/set_build_vars.sh
+++ b/scripts/set_build_vars.sh
@@ -37,6 +37,11 @@ case $TRAVIS_TAG in
     export RELEASE_UPLOAD_DIR="flex-stacker/${RELEASE_VERSION}"
     ;;
 
+  vacuum-module@v*)
+    export RELEASE_LOCAL_DIR="${DIST_DIR}/vacuum-module"
+    export RELEASE_UPLOAD_DIR="vacuum-module/${RELEASE_VERSION}"
+    ;;
+
   *)
     export RELEASE_LOCAL_DIR=$DIST_DIR
     export RELEASE_UPLOAD_DIR="modules-${THIS_BUILD_TAG}-${TRAVIS_BRANCH}"


### PR DESCRIPTION
We need this so we can deploy the vacuum module firmware binaries to the correct directory in aws