### PR TITLE
fix(vacuum-module): convert unweighted filter to EMI when filtering mprll0025pa00001a pressure readings.

### DIFF
--- a/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/mprll0025pa00001a.hpp
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <cstdint>
 
+#include "firmware/hardware_iface.hpp"
+
 namespace vacuum_pressure_sensor {
 using i2c::hardware::RxTxReturn;
 
@@ -39,15 +41,18 @@ constexpr double PMAX = 25;
 constexpr double PMIN = 0;
 constexpr double PSI2MBAR = 68.9475729318;
 constexpr uint8_t PRESSURE_FRAME_LEN = 10;
-constexpr int PRESSURE_BUFFER_LEN = 5;
-// TODO: currently this filter acts as an unweighted moving average. Find
-// coefficient values that optimize sensor output behavior for closed-loop
-// control
-const double moving_avg_coefficient =
-    1.0 / std::pow((PRESSURE_BUFFER_LEN - 0.75), 2);
+constexpr int PRESSURE_BUFFER_LEN = 8;
+// These coefficients act as an EMI (Exponential Moving Average) filter.
+// Ci = alpha(1 - alpha)^i
+// clang-format off
 const std::array<double, PRESSURE_BUFFER_LEN> FILTER = {
-    moving_avg_coefficient, moving_avg_coefficient, moving_avg_coefficient,
-    moving_avg_coefficient};
+    // 0.1756, 0.1580, 0.1422, 0.1280, 0.1152, 0.1037, 0.0933, 0.0840  // a=0.1
+    0.2403, 0.1923, 0.1538, 0.1231, 0.0985, 0.0788, 0.0630, 0.0504  // a=0.2
+    // 0.3133, 0.2193, 0.1535, 0.1075, 0.0752, 0.0527, 0.0369, 0.0258  // a=0.3
+    // 0.5020, 0.2510, 0.1255, 0.0627, 0.0314, 0.0157, 0.0078, 0.0039  // a=0.5
+    // 0.8000, 0.1600, 0.0320, 0.0064, 0.0013, 0.0003, 0.0001, 0.0000  // a=0.8
+};
+// clang-format on
 
 // Frame retry defaults
 constexpr uint8_t DEFAULT_RETRIES = 3;
@@ -71,6 +76,7 @@ class MPRLL0025PA00001 {
         if (_policy == nullptr) {
             _policy = policy;
             _sensor_id = sensor_id;
+            is_first_read = true;
 
             // check device status
             ok = _policy->is_device_ready(device_address << 1);
@@ -101,10 +107,16 @@ class MPRLL0025PA00001 {
             auto sensor_busy =
                 static_cast<bool>(status_byte & STATUS_BUSY_FLAG);
             if (!sensor_busy) {
-                pressure_mbar = parse_pressure(RD_BUFF.data());
-                filter_pressure(pressure_mbar);
-                return filtered_pressure_mbar.at(
-                    filtered_pressure_buffer_index);
+                auto raw_pressure = parse_pressure(RD_BUFF.data());
+                // Pre-fill the buffer if this is the first read so we dont
+                // calculate the filtered pressure from 1 reading where the
+                // rest of the buffer is holding 0.
+                if (is_first_read) {
+                    unfiltered_pressure_mbar.fill(raw_pressure);
+                    is_first_read = false;
+                }
+                pressure_mbar = filter_pressure(raw_pressure);
+                return pressure_mbar;
             }
         }
 
@@ -142,25 +154,19 @@ class MPRLL0025PA00001 {
         return pressure_psi * PSI2MBAR;
     }
 
-    auto filter_pressure(double input_pressure_mbar) -> void {
-        ++filtered_pressure_buffer_index %= PRESSURE_BUFFER_LEN;
-        ++unfiltered_pressure_buffer_index %= PRESSURE_BUFFER_LEN;
-        unfiltered_pressure_mbar.at(unfiltered_pressure_buffer_index) =
-            input_pressure_mbar;
+    auto filter_pressure(double pressure_mbar) -> double {
         double filter_output = 0;
-        double pressure_sample = 0;
-        int p_index = unfiltered_pressure_buffer_index;
+        unfiltered_pressure_mbar.at(pressure_buffer_index) = pressure_mbar;
         for (int i = 0; i < PRESSURE_BUFFER_LEN; i++) {
-            p_index =
-                (unfiltered_pressure_buffer_index + i) % PRESSURE_BUFFER_LEN;
-            pressure_sample = unfiltered_pressure_mbar.at(p_index);
-            for (int j = 0; j < PRESSURE_BUFFER_LEN; j++) {
-                filter_output += pressure_sample * FILTER.at(j);
-            }
+            const int p_index =
+                (pressure_buffer_index - i + PRESSURE_BUFFER_LEN) %
+                PRESSURE_BUFFER_LEN;
+            filter_output +=
+                unfiltered_pressure_mbar.at(p_index) * FILTER.at(i);
         }
-
-        filtered_pressure_mbar.at(filtered_pressure_buffer_index) =
-            filter_output;
+        pressure_buffer_index =
+            (pressure_buffer_index + 1) % PRESSURE_BUFFER_LEN;
+        return filter_output;
     }
 
     Policy* _policy{nullptr};
@@ -169,12 +175,11 @@ class MPRLL0025PA00001 {
     PressureSensorID _sensor_id{};
     uint8_t device_address{};
 
-    std::array<double, PRESSURE_BUFFER_LEN> filtered_pressure_mbar = {0};
     std::array<double, PRESSURE_BUFFER_LEN> unfiltered_pressure_mbar = {0};
-    size_t filtered_pressure_buffer_index = 0;
-    size_t unfiltered_pressure_buffer_index = 0;
+    uint8_t pressure_buffer_index = 0;
     double pressure_mbar = 0;
     uint8_t last_status = 0;
+    bool is_first_read = true;
 };
 
 }  // namespace vacuum_pressure_sensor

--- a/stm32-modules/vacuum-module/tests/CMakeLists.txt
+++ b/stm32-modules/vacuum-module/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ include(AddBuildAndTestTarget)
 add_executable(${TARGET_MODULE_NAME}
         test_main.cpp
         test_errors.cpp
+        test_mprll0025pa00001a.cpp
     )
 
 target_include_directories(${TARGET_MODULE_NAME}

--- a/stm32-modules/vacuum-module/tests/test_mprll0025pa00001a.cpp
+++ b/stm32-modules/vacuum-module/tests/test_mprll0025pa00001a.cpp
@@ -1,0 +1,135 @@
+#include <array>
+#include <cmath>
+
+#include "catch2/catch.hpp"
+#include "firmware/hardware_iface.hpp"
+#include "systemwide.h"
+#include "vacuum-module/mprll0025pa00001a.hpp"
+
+namespace vacuum_pressure_sensor {
+
+using RxTxReturn = uint8_t;
+
+struct MockPolicy {
+    uint32_t press_counts = 0;
+    uint8_t status = 0;
+
+    void sleep_ms(uint32_t) {}
+
+    bool is_device_ready(uint16_t) { return true; }
+
+    RxTxReturn i2c_master_write(uint16_t, const uint8_t *, uint16_t) {
+        return 0;
+    }
+
+    RxTxReturn i2c_master_read(uint16_t, uint8_t *data, uint16_t len) {
+        if (len == 4) {
+            data[0] = status;
+            data[1] = (press_counts >> 16) & 0xFF;
+            data[2] = (press_counts >> 8) & 0xFF;
+            data[3] = press_counts & 0xFF;
+        }
+        return 0;
+    }
+
+    RxTxReturn i2c_read(uint16_t dev_addr, uint16_t reg, uint8_t *data,
+                        uint16_t size) {
+        return 0;
+    }
+
+    RxTxReturn i2c_write(uint16_t dev_addr, uint16_t reg, uint8_t *data,
+                         uint16_t size) {
+        return 0;
+    }
+};
+
+auto get_counts(double mbar) -> uint32_t {
+    double psi = mbar / PSI2MBAR;
+    double counts = psi * (OUTPUT_MAX - OUTPUT_MIN) / PMAX + OUTPUT_MIN;
+    return static_cast<uint32_t>(std::round(counts));
+}
+
+}  // namespace vacuum_pressure_sensor
+
+using namespace vacuum_pressure_sensor;
+
+SCENARIO("MPRLL0025PA00001 pressure filtering works", "[vacuum][filter]") {
+    GIVEN("a mock policy and initialized sensor") {
+        MockPolicy policy;
+        MPRLL0025PA00001<MockPolicy> sensor(DEV_ADDRESS);
+        sensor.initialize(&policy, PressureSensorID::ABS_PRESSURE_A);
+        policy.status = 0;
+
+        WHEN("first read with pressure 10.0") {
+            policy.press_counts = get_counts(10.0);
+            auto result = sensor.read_pressure();
+            THEN("returns approximately 10.0") {
+                REQUIRE_THAT(result, Catch::Matchers::WithinAbs(10.0, 0.01));
+            }
+        }
+
+        GIVEN("after first read with constant pressure 10.0") {
+            policy.press_counts = get_counts(10.0);
+            sensor.read_pressure();
+
+            WHEN("multiple subsequent reads with same pressure") {
+                bool all_constant = true;
+                for (int i = 0; i < 10; ++i) {
+                    auto result = sensor.read_pressure();
+                    if (!Catch::Matchers::Floating::WithinAbsMatcher(10.0, 0.01)
+                             .match(result)) {
+                        all_constant = false;
+                        break;
+                    }
+                }
+                THEN("all return approximately 10.0") { REQUIRE(all_constant); }
+            }
+        }
+
+        GIVEN("after first read with 10.0") {
+            policy.press_counts = get_counts(10.0);
+            sensor.read_pressure();
+
+            WHEN("second read with 20.0") {
+                policy.press_counts = get_counts(20.0);
+                auto result = sensor.read_pressure();
+                THEN("returns approximately 12.405") {
+                    REQUIRE_THAT(result,
+                                 Catch::Matchers::WithinAbs(12.405, 0.001));
+                }
+
+                AND_WHEN("third read with 30.0") {
+                    policy.press_counts = get_counts(30.0);
+                    auto result = sensor.read_pressure();
+                    THEN("returns approximately 16.731") {
+                        REQUIRE_THAT(result,
+                                     Catch::Matchers::WithinAbs(16.731, 0.001));
+                    }
+                }
+            }
+        }
+
+        GIVEN("after sequence of reads to fill and wrap the buffer") {
+            std::array<double, 9> inputs = {10.0, 20.0, 30.0, 40.0, 50.0,
+                                            60.0, 70.0, 80.0, 90.0};
+            std::array<double, 9> expected = {10.0,   12.405, 16.731,
+                                              22.595, 29.69,  37.77,
+                                              46.638, 56.136, 66.138};
+
+            bool all_match = true;
+            for (size_t i = 0; i < inputs.size(); ++i) {
+                policy.press_counts = get_counts(inputs[i]);
+                auto result = sensor.read_pressure();
+                if (!Catch::Matchers::Floating::WithinAbsMatcher(expected[i],
+                                                                 0.003)
+                         .match(result)) {
+                    all_match = false;
+                    break;
+                }
+            }
+            THEN("filtered values match expected after wrap-around") {
+                REQUIRE(all_match);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Overview

Let's convert the unweighted moving average filter to an exponential moving average filter that prioritizes newer values so we can filter out noise from the pump oscillations. Let's also fix an issue when calculating the filtered pressure the first time we take a reading, where the mostly zeroed buffer is used to calculate the pressure. This caused the system to output much lower pressure, resulting in the pump overcompensating on startup.
# Changelog

- Convert Unweighted Moving Average to Exponential Moving Average (EMI) filter with coefficients producing alpha = 0.2 for greater smoothing.
- Fill the pressure buffer with the first pressure it reads, so we don't generate artificially low values.
