### PR TITLE
fix: correct reset reason logic

### DIFF
--- a/stm32-modules/flex-stacker/firmware/system/system_hardware.c
+++ b/stm32-modules/flex-stacker/firmware/system/system_hardware.c
@@ -1,52 +1,39 @@
+#include "firmware/system_hardware.h"
+
+#include "main.h"
 #include "stm32g4xx_hal.h"
-#include "stm32g4xx_hal_rcc.h"
 #include "stm32g4xx_hal_cortex.h"
+#include "stm32g4xx_hal_rcc.h"
 #include "stm32g4xx_hal_tim.h"
 
-#include "firmware/system_hardware.h"
-#include "main.h"
-
 /** Local defines */
-// This is the start of the sys memory region for the STM32G491 
+// This is the start of the sys memory region for the STM32G491
 // from the reference manual and STM application note AN2606
 #define SYSMEM_START 0x1fff0000
 #define SYSMEM_BOOT (SYSMEM_START + 4)
 
 // address 4 in the bootable region is the address of the first instruction that
 // should run, aka the data that should be loaded into $pc.
-const uint32_t *const sysmem_boot_loc = (uint32_t*)SYSMEM_BOOT;
+const uint32_t *const sysmem_boot_loc = (uint32_t *)SYSMEM_BOOT;
 uint16_t reset_reason;
 
 enum RCC_FLAGS {
-    _NONE,
-    // high speed internal clock ready
-    HSIRDY, // = 1
-    // high speed external clock ready
-    HSERDY, // = 2
-    // main phase-locked loop clock ready
-    PLLRDY, // = 3
-    // hsi48 clock ready
-    HSI48RDY, // = 4
-    // low-speed external clock ready
-    LSERDY, // = 5
     // lse clock security system failure
-    LSECSSD, // = 6
-    // low-speed internal clock ready
-    LSIRDY, // = 7
+    LSECSSD,  // = 0
     // brown out
-    BORRST, // = 8
+    BORRST,  // = 1
     // option byte-loader reset
-    OBLRST, // = 9
+    OBLRST,  // = 2
     // pin reset
-    PINRST, // = 10
+    PINRST,  // = 3
     // software reset
-    SFTRST, // = 11
+    SFTRST,  // = 4
     // independent watchdog
-    IWDGRST, // = 12
+    IWDGRST,  // = 5
     // window watchdog
-    WWDGRST, // = 13
+    WWDGRST,  // = 6
     // low power reset
-    LPWRRST, // = 14
+    LPWRRST,  // = 7
 };
 
 static void save_reset_reason() {
@@ -54,76 +41,46 @@ static void save_reset_reason() {
     // reset flag matches any of them
     reset_reason = 0;
 
-    // high speed internal clock ready
-    if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY)) {
-        reset_reason |= HSIRDY;
-    }
-    // high speed external clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY)) {
-        reset_reason |= HSERDY;
-    }
-    // main phase-locked loop clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY)) {
-        reset_reason |= PLLRDY;
-    }
-    // hsi48 clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY)) {
-        reset_reason |= HSI48RDY;
-    }
-    // low-speed external clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY)) {
-        reset_reason |= LSERDY;
-    }
-    // lse clock security system failure
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY)) {
-        reset_reason |= LSECSSD;
-    }
-    // low-speed internal clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY)) {
-        reset_reason |= LSIRDY;
-    }
     // brown out
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
-        reset_reason |= BORRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
+        reset_reason |= (1 << BORRST);
     }
     // option byte-loader reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST)) {
-        reset_reason |= OBLRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST)) {
+        reset_reason |= (1 << OBLRST);
     }
     // pin reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
-        reset_reason |= PINRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
+        reset_reason |= (1 << PINRST);
     }
     // software reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
-        reset_reason |= SFTRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
+        reset_reason |= (1 << SFTRST);
     }
     // independent watchdog
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
-        reset_reason |= IWDGRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
+        reset_reason |= (1 << IWDGRST);
     }
     // window watchdog
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
-        reset_reason |= WWDGRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
+        reset_reason |= (1 << WWDGRST);
     }
     // low power reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
-        reset_reason |= LPWRRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
+        reset_reason |= (1 << LPWRRST);
     }
 }
 
-uint16_t system_hardware_reset_reason() {
-    return reset_reason;
-}
+uint16_t system_hardware_reset_reason() { return reset_reason; }
 
 /** PUBLIC FUNCTION IMPLEMENTATION */
 
 void system_hardware_enter_bootloader(void) {
+    // We have to uninitialize as many of the peripherals as possible, because
+    // the bootloader expects to start as the system comes up
 
-    // We have to uninitialize as many of the peripherals as possible, because the bootloader
-    // expects to start as the system comes up
-
-    // The HAL has ways to turn off all the core clocking and the clock security system
+    // The HAL has ways to turn off all the core clocking and the clock security
+    // system
     HAL_RCC_DisableLSECSS();
     HAL_RCC_DeInit();
 
@@ -133,32 +90,31 @@ void system_hardware_enter_bootloader(void) {
     SysTick->VAL = 0;
 
     /* Clear Interrupt Enable Register & Interrupt Pending Register */
-    for (int i=0;i<8;i++)
-    {
-        NVIC->ICER[i]=0xFFFFFFFF;
-        NVIC->ICPR[i]=0xFFFFFFFF;
+    for (int i = 0; i < 8; i++) {
+        NVIC->ICER[i] = 0xFFFFFFFF;
+        NVIC->ICPR[i] = 0xFFFFFFFF;
     }
 
-    // We have to make sure that the processor is mapping the system memory region to address 0,
-    // which the bootloader expects
+    // We have to make sure that the processor is mapping the system memory
+    // region to address 0, which the bootloader expects
     __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH();
     // and now we're ready to set the system up to start executing system flash.
     // arm cortex initialization means that
-    // address 0 in the bootable region is the address where the processor should start its stack
-    // which we have to do as late as possible because as soon as we do this the c and c++ runtime
-    // environment is no longer valid
-    __set_MSP(*((uint32_t*)SYSMEM_START));
+    // address 0 in the bootable region is the address where the processor
+    // should start its stack which we have to do as late as possible because as
+    // soon as we do this the c and c++ runtime environment is no longer valid
+    __set_MSP(*((uint32_t *)SYSMEM_START));
 
     // finally, jump to the bootloader. we do this in inline asm because we need
-    // this to be a naked call (no caller-side prep like stacking return addresses)
-    // and to have a naked function you need to define it as a function, not a
-    // function pointer, and we don't statically know the address here since it is
-    // whatever's contained in that second word of the bsystem memory region.
-    asm volatile (
-        "bx %0"
-        : // no outputs
-        : "r" (*sysmem_boot_loc)
-        : "memory"  );
+    // this to be a naked call (no caller-side prep like stacking return
+    // addresses) and to have a naked function you need to define it as a
+    // function, not a function pointer, and we don't statically know the
+    // address here since it is whatever's contained in that second word of the
+    // bsystem memory region.
+    asm volatile("bx %0"
+                 :  // no outputs
+                 : "r"(*sysmem_boot_loc)
+                 : "memory");
 }
 
 /**
@@ -207,7 +163,8 @@ void install_detection_pin_init(void) {
  * enable/disable writing to the eeprom.
  */
 void enable_eeprom_write(bool enable) {
-    HAL_GPIO_WritePin(EEPROM_WP_PORT, EEPROM_WP_PIN, enable ? GPIO_PIN_RESET : GPIO_PIN_SET);
+    HAL_GPIO_WritePin(EEPROM_WP_PORT, EEPROM_WP_PIN,
+                      enable ? GPIO_PIN_RESET : GPIO_PIN_SET);
 }
 
 void system_hardware_gpio_init(void) {
@@ -220,13 +177,15 @@ void system_hardware_gpio_init(void) {
 }
 
 bool system_hardware_read_door_closed(void) {
-    return HAL_GPIO_ReadPin(HOPPER_DOOR_CLOSED_GPIO_PORT, HOPPER_DOOR_CLOSED_PIN) == GPIO_PIN_SET;
+    return HAL_GPIO_ReadPin(HOPPER_DOOR_CLOSED_GPIO_PORT,
+                            HOPPER_DOOR_CLOSED_PIN) == GPIO_PIN_SET;
 }
 
 bool system_hardware_read_install_detected(void) {
 #if PRIMARY_REVISION == 'a'
     return false;
 #else
-    return HAL_GPIO_ReadPin(INSTALL_DETECTION_PORT, INSTALL_DETECTION_PIN) == GPIO_PIN_SET;
+    return HAL_GPIO_ReadPin(INSTALL_DETECTION_PORT, INSTALL_DETECTION_PIN) ==
+           GPIO_PIN_SET;
 #endif
 }

--- a/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/motor_task/motor_hardware.c
@@ -1,527 +1,478 @@
-#include "stm32f3xx_hal.h"
-#include "parameters_conversion.h"
 #include "motor_hardware.h"
-#include "mc_tuning.h"
+
+#include <math.h>    // for fabs
+#include <string.h>  // for memset
+
+#include "mc_config.h"
 #include "mc_interface.h"
 #include "mc_tasks.h"
-#include "mc_config.h"
-#include <string.h>  // for memset
-#include <math.h> // for fabs
+#include "mc_tuning.h"
+#include "parameters_conversion.h"
+#include "stm32f3xx_hal.h"
 
 #ifdef __cplusplus
 extern "C" {
-#endif // __cplusplus
-
+#endif  // __cplusplus
 
 static void Error_Handler();
 
-motor_hardware_handles *MOTOR_HW_HANDLE = NULL;
+motor_hardware_handles* MOTOR_HW_HANDLE = NULL;
 
 static _Atomic int16_t motor_speed_buffer[MOTOR_SPEED_BUFFER_SIZE];
 static _Atomic size_t motor_speed_buffer_itr = 0;
 uint16_t reset_reason;
 
 enum RCC_FLAGS {
-    _NONE,
-    // high speed internal clock ready
-    HSIRDY, // = 1
-    // high speed external clock ready
-    HSERDY, // = 2
-    // main phase-locked loop clock ready
-    PLLRDY, // = 3
-    // hsi48 clock ready
-    HSI48RDY, // = 4
-    // low-speed external clock ready
-    LSERDY, // = 5
-    // lse clock security system failure
-    LSECSSD, // = 6
-    // low-speed internal clock ready
-    LSIRDY, // = 7
-    // brown out
-    BORRST, // = 8
+    _NONE,  // f3 has no LSE security
+    // power-on (f3 has no dedicated brown-out detection)
+    PORRST,  // = 1
     // option byte-loader reset
-    OBLRST, // = 9
+    OBLRST,  // = 2
     // pin reset
-    PINRST, // = 10
+    PINRST,  // = 3
     // software reset
-    SFTRST, // = 11
+    SFTRST,  // = 4
     // independent watchdog
-    IWDGRST, // = 12
+    IWDGRST,  // = 5
     // window watchdog
-    WWDGRST, // = 13
+    WWDGRST,  // = 6
     // low power reset
-    LPWRRST, // = 14
+    LPWRRST,  // = 7
 };
 
-static void MX_NVIC_Init(void)
-{
-  /* TIM1_BRK_TIM15_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(TIM1_BRK_TIM15_IRQn, 9, 0);
-  HAL_NVIC_EnableIRQ(TIM1_BRK_TIM15_IRQn);
-  /* TIM1_UP_TIM16_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(TIM1_UP_TIM16_IRQn, 3, 0);
-  HAL_NVIC_EnableIRQ(TIM1_UP_TIM16_IRQn);
-  /* ADC1_2_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(ADC1_2_IRQn, 4, 0);
-  HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
-  /* TIM2_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(TIM2_IRQn, 8, 0);
-  HAL_NVIC_EnableIRQ(TIM2_IRQn);
+static void MX_NVIC_Init(void) {
+    /* TIM1_BRK_TIM15_IRQn interrupt configuration */
+    HAL_NVIC_SetPriority(TIM1_BRK_TIM15_IRQn, 9, 0);
+    HAL_NVIC_EnableIRQ(TIM1_BRK_TIM15_IRQn);
+    /* TIM1_UP_TIM16_IRQn interrupt configuration */
+    HAL_NVIC_SetPriority(TIM1_UP_TIM16_IRQn, 3, 0);
+    HAL_NVIC_EnableIRQ(TIM1_UP_TIM16_IRQn);
+    /* ADC1_2_IRQn interrupt configuration */
+    HAL_NVIC_SetPriority(ADC1_2_IRQn, 4, 0);
+    HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
+    /* TIM2_IRQn interrupt configuration */
+    HAL_NVIC_SetPriority(TIM2_IRQn, 8, 0);
+    HAL_NVIC_EnableIRQ(TIM2_IRQn);
 }
 
 /**
-  * @brief ADC1 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_ADC1_Init(ADC_HandleTypeDef* adc1)
-{
+ * @brief ADC1 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_ADC1_Init(ADC_HandleTypeDef* adc1) {
+    /* USER CODE BEGIN ADC1_Init 0 */
 
-  /* USER CODE BEGIN ADC1_Init 0 */
+    /* USER CODE END ADC1_Init 0 */
 
-  /* USER CODE END ADC1_Init 0 */
+    ADC_MultiModeTypeDef multimode = {0};
+    ADC_InjectionConfTypeDef sConfigInjected = {0};
 
-  ADC_MultiModeTypeDef multimode = {0};
-  ADC_InjectionConfTypeDef sConfigInjected = {0};
+    /* USER CODE BEGIN ADC1_Init 1 */
 
-  /* USER CODE BEGIN ADC1_Init 1 */
+    /* USER CODE END ADC1_Init 1 */
+    /** Common config
+     */
+    adc1->Instance = ADC1;
+    adc1->Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV1;
+    adc1->Init.Resolution = ADC_RESOLUTION_12B;
+    adc1->Init.ScanConvMode = ADC_SCAN_ENABLE;
+    adc1->Init.ContinuousConvMode = DISABLE;
+    adc1->Init.DiscontinuousConvMode = DISABLE;
+    adc1->Init.DataAlign = ADC_DATAALIGN_LEFT;
+    adc1->Init.NbrOfConversion = 1;
+    adc1->Init.DMAContinuousRequests = DISABLE;
+    adc1->Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+    adc1->Init.LowPowerAutoWait = DISABLE;
+    adc1->Init.Overrun = ADC_OVR_DATA_PRESERVED;
+    if (HAL_ADC_Init(adc1) != HAL_OK) {
+        Error_Handler();
+    }
+    /** Configure the ADC multi-mode
+     */
+    multimode.Mode = ADC_MODE_INDEPENDENT;
+    if (HAL_ADCEx_MultiModeConfigChannel(adc1, &multimode) != HAL_OK) {
+        Error_Handler();
+    }
+    /** Configure Injected Channel
+     */
+    sConfigInjected.InjectedChannel = ADC_CHANNEL_2;
+    sConfigInjected.InjectedRank = ADC_INJECTED_RANK_1;
+    sConfigInjected.InjectedSingleDiff = ADC_SINGLE_ENDED;
+    sConfigInjected.InjectedNbrOfConversion = 2;
+    sConfigInjected.InjectedSamplingTime = ADC_SAMPLETIME_19CYCLES_5;
+    sConfigInjected.ExternalTrigInjecConvEdge =
+        ADC_EXTERNALTRIGINJECCONV_EDGE_RISING;
+    sConfigInjected.ExternalTrigInjecConv = ADC_EXTERNALTRIGINJECCONV_T1_TRGO;
+    sConfigInjected.AutoInjectedConv = DISABLE;
+    sConfigInjected.InjectedDiscontinuousConvMode = DISABLE;
+    sConfigInjected.QueueInjectedContext = ENABLE;
+    sConfigInjected.InjectedOffset = 0;
+    sConfigInjected.InjectedOffsetNumber = ADC_OFFSET_NONE;
+    if (HAL_ADCEx_InjectedConfigChannel(adc1, &sConfigInjected) != HAL_OK) {
+        Error_Handler();
+    }
+    /** Configure Injected Channel
+     */
+    sConfigInjected.InjectedChannel = ADC_CHANNEL_14;
+    sConfigInjected.InjectedRank = ADC_INJECTED_RANK_2;
+    if (HAL_ADCEx_InjectedConfigChannel(adc1, &sConfigInjected) != HAL_OK) {
+        Error_Handler();
+    }
+    /* USER CODE BEGIN ADC1_Init 2 */
 
-  /* USER CODE END ADC1_Init 1 */
-  /** Common config
-  */
-  adc1->Instance = ADC1;
-  adc1->Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV1;
-  adc1->Init.Resolution = ADC_RESOLUTION_12B;
-  adc1->Init.ScanConvMode = ADC_SCAN_ENABLE;
-  adc1->Init.ContinuousConvMode = DISABLE;
-  adc1->Init.DiscontinuousConvMode = DISABLE;
-  adc1->Init.DataAlign = ADC_DATAALIGN_LEFT;
-  adc1->Init.NbrOfConversion = 1;
-  adc1->Init.DMAContinuousRequests = DISABLE;
-  adc1->Init.EOCSelection = ADC_EOC_SINGLE_CONV;
-  adc1->Init.LowPowerAutoWait = DISABLE;
-  adc1->Init.Overrun = ADC_OVR_DATA_PRESERVED;
-  if (HAL_ADC_Init(adc1) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure the ADC multi-mode
-  */
-  multimode.Mode = ADC_MODE_INDEPENDENT;
-  if (HAL_ADCEx_MultiModeConfigChannel(adc1, &multimode) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure Injected Channel
-  */
-  sConfigInjected.InjectedChannel = ADC_CHANNEL_2;
-  sConfigInjected.InjectedRank = ADC_INJECTED_RANK_1;
-  sConfigInjected.InjectedSingleDiff = ADC_SINGLE_ENDED;
-  sConfigInjected.InjectedNbrOfConversion = 2;
-  sConfigInjected.InjectedSamplingTime = ADC_SAMPLETIME_19CYCLES_5;
-  sConfigInjected.ExternalTrigInjecConvEdge = ADC_EXTERNALTRIGINJECCONV_EDGE_RISING;
-  sConfigInjected.ExternalTrigInjecConv = ADC_EXTERNALTRIGINJECCONV_T1_TRGO;
-  sConfigInjected.AutoInjectedConv = DISABLE;
-  sConfigInjected.InjectedDiscontinuousConvMode = DISABLE;
-  sConfigInjected.QueueInjectedContext = ENABLE;
-  sConfigInjected.InjectedOffset = 0;
-  sConfigInjected.InjectedOffsetNumber = ADC_OFFSET_NONE;
-  if (HAL_ADCEx_InjectedConfigChannel(adc1, &sConfigInjected) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure Injected Channel
-  */
-  sConfigInjected.InjectedChannel = ADC_CHANNEL_14;
-  sConfigInjected.InjectedRank = ADC_INJECTED_RANK_2;
-  if (HAL_ADCEx_InjectedConfigChannel(adc1, &sConfigInjected) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN ADC1_Init 2 */
-
-  /* USER CODE END ADC1_Init 2 */
-
+    /* USER CODE END ADC1_Init 2 */
 }
 
 /**
-  * @brief ADC2 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_ADC2_Init(ADC_HandleTypeDef* adc2)
-{
+ * @brief ADC2 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_ADC2_Init(ADC_HandleTypeDef* adc2) {
+    /* USER CODE BEGIN ADC2_Init 0 */
 
-  /* USER CODE BEGIN ADC2_Init 0 */
+    /* USER CODE END ADC2_Init 0 */
 
-  /* USER CODE END ADC2_Init 0 */
+    ADC_InjectionConfTypeDef sConfigInjected = {0};
+    ADC_ChannelConfTypeDef sConfig = {0};
 
-  ADC_InjectionConfTypeDef sConfigInjected = {0};
-  ADC_ChannelConfTypeDef sConfig = {0};
+    /* USER CODE BEGIN ADC2_Init 1 */
 
-  /* USER CODE BEGIN ADC2_Init 1 */
+    /* USER CODE END ADC2_Init 1 */
+    /** Common config
+     */
+    adc2->Instance = ADC2;
+    adc2->Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV1;
+    adc2->Init.Resolution = ADC_RESOLUTION_12B;
+    adc2->Init.ScanConvMode = ADC_SCAN_ENABLE;
+    adc2->Init.ContinuousConvMode = DISABLE;
+    adc2->Init.DiscontinuousConvMode = DISABLE;
+    adc2->Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
+    adc2->Init.ExternalTrigConv = ADC_SOFTWARE_START;
+    adc2->Init.DataAlign = ADC_DATAALIGN_LEFT;
+    adc2->Init.NbrOfConversion = 2;
+    adc2->Init.DMAContinuousRequests = DISABLE;
+    adc2->Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+    adc2->Init.LowPowerAutoWait = DISABLE;
+    adc2->Init.Overrun = ADC_OVR_DATA_PRESERVED;
+    if (HAL_ADC_Init(adc2) != HAL_OK) {
+        Error_Handler();
+    }
+    /** Configure Injected Channel
+     */
+    sConfigInjected.InjectedChannel = ADC_CHANNEL_14;
+    sConfigInjected.InjectedRank = ADC_INJECTED_RANK_1;
+    sConfigInjected.InjectedSingleDiff = ADC_SINGLE_ENDED;
+    sConfigInjected.InjectedNbrOfConversion = 2;
+    sConfigInjected.InjectedSamplingTime = ADC_SAMPLETIME_19CYCLES_5;
+    sConfigInjected.ExternalTrigInjecConvEdge =
+        ADC_EXTERNALTRIGINJECCONV_EDGE_RISING;
+    sConfigInjected.ExternalTrigInjecConv = ADC_EXTERNALTRIGINJECCONV_T1_TRGO;
+    sConfigInjected.AutoInjectedConv = DISABLE;
+    sConfigInjected.InjectedDiscontinuousConvMode = DISABLE;
+    sConfigInjected.QueueInjectedContext = ENABLE;
+    sConfigInjected.InjectedOffset = 0;
+    sConfigInjected.InjectedOffsetNumber = ADC_OFFSET_NONE;
+    if (HAL_ADCEx_InjectedConfigChannel(adc2, &sConfigInjected) != HAL_OK) {
+        Error_Handler();
+    }
+    /** Configure Injected Channel
+     */
+    sConfigInjected.InjectedChannel = ADC_CHANNEL_4;
+    sConfigInjected.InjectedRank = ADC_INJECTED_RANK_2;
+    if (HAL_ADCEx_InjectedConfigChannel(adc2, &sConfigInjected) != HAL_OK) {
+        Error_Handler();
+    }
+    /** Configure Regular Channel
+     */
+    sConfig.Channel = ADC_CHANNEL_11;
+    sConfig.Rank = ADC_REGULAR_RANK_1;
+    sConfig.SingleDiff = ADC_SINGLE_ENDED;
+    sConfig.SamplingTime = ADC_SAMPLETIME_7CYCLES_5;
+    sConfig.OffsetNumber = ADC_OFFSET_NONE;
+    sConfig.Offset = 0;
+    if (HAL_ADC_ConfigChannel(adc2, &sConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    /** Configure Regular Channel
+     */
+    sConfig.Channel = ADC_CHANNEL_5;
+    sConfig.Rank = ADC_REGULAR_RANK_2;
+    if (HAL_ADC_ConfigChannel(adc2, &sConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    /* USER CODE BEGIN ADC2_Init 2 */
 
-  /* USER CODE END ADC2_Init 1 */
-  /** Common config
-  */
-  adc2->Instance = ADC2;
-  adc2->Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV1;
-  adc2->Init.Resolution = ADC_RESOLUTION_12B;
-  adc2->Init.ScanConvMode = ADC_SCAN_ENABLE;
-  adc2->Init.ContinuousConvMode = DISABLE;
-  adc2->Init.DiscontinuousConvMode = DISABLE;
-  adc2->Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
-  adc2->Init.ExternalTrigConv = ADC_SOFTWARE_START;
-  adc2->Init.DataAlign = ADC_DATAALIGN_LEFT;
-  adc2->Init.NbrOfConversion = 2;
-  adc2->Init.DMAContinuousRequests = DISABLE;
-  adc2->Init.EOCSelection = ADC_EOC_SINGLE_CONV;
-  adc2->Init.LowPowerAutoWait = DISABLE;
-  adc2->Init.Overrun = ADC_OVR_DATA_PRESERVED;
-  if (HAL_ADC_Init(adc2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure Injected Channel
-  */
-  sConfigInjected.InjectedChannel = ADC_CHANNEL_14;
-  sConfigInjected.InjectedRank = ADC_INJECTED_RANK_1;
-  sConfigInjected.InjectedSingleDiff = ADC_SINGLE_ENDED;
-  sConfigInjected.InjectedNbrOfConversion = 2;
-  sConfigInjected.InjectedSamplingTime = ADC_SAMPLETIME_19CYCLES_5;
-  sConfigInjected.ExternalTrigInjecConvEdge = ADC_EXTERNALTRIGINJECCONV_EDGE_RISING;
-  sConfigInjected.ExternalTrigInjecConv = ADC_EXTERNALTRIGINJECCONV_T1_TRGO;
-  sConfigInjected.AutoInjectedConv = DISABLE;
-  sConfigInjected.InjectedDiscontinuousConvMode = DISABLE;
-  sConfigInjected.QueueInjectedContext = ENABLE;
-  sConfigInjected.InjectedOffset = 0;
-  sConfigInjected.InjectedOffsetNumber = ADC_OFFSET_NONE;
-  if (HAL_ADCEx_InjectedConfigChannel(adc2, &sConfigInjected) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure Injected Channel
-  */
-  sConfigInjected.InjectedChannel = ADC_CHANNEL_4;
-  sConfigInjected.InjectedRank = ADC_INJECTED_RANK_2;
-  if (HAL_ADCEx_InjectedConfigChannel(adc2, &sConfigInjected) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure Regular Channel
-  */
-  sConfig.Channel = ADC_CHANNEL_11;
-  sConfig.Rank = ADC_REGULAR_RANK_1;
-  sConfig.SingleDiff = ADC_SINGLE_ENDED;
-  sConfig.SamplingTime = ADC_SAMPLETIME_7CYCLES_5;
-  sConfig.OffsetNumber = ADC_OFFSET_NONE;
-  sConfig.Offset = 0;
-  if (HAL_ADC_ConfigChannel(adc2, &sConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure Regular Channel
-  */
-  sConfig.Channel = ADC_CHANNEL_5;
-  sConfig.Rank = ADC_REGULAR_RANK_2;
-  if (HAL_ADC_ConfigChannel(adc2, &sConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN ADC2_Init 2 */
-
-  /* USER CODE END ADC2_Init 2 */
-
+    /* USER CODE END ADC2_Init 2 */
 }
 
 /**
-  * @brief TIM1 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_TIM1_Init(TIM_HandleTypeDef* tim1)
-{
+ * @brief TIM1 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_TIM1_Init(TIM_HandleTypeDef* tim1) {
+    /* USER CODE BEGIN TIM1_Init 0 */
 
-  /* USER CODE BEGIN TIM1_Init 0 */
+    /* USER CODE END TIM1_Init 0 */
 
-  /* USER CODE END TIM1_Init 0 */
+    TIM_SlaveConfigTypeDef sSlaveConfig = {0};
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    TIM_OC_InitTypeDef sConfigOC = {0};
+    TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
 
-  TIM_SlaveConfigTypeDef sSlaveConfig = {0};
-  TIM_MasterConfigTypeDef sMasterConfig = {0};
-  TIM_OC_InitTypeDef sConfigOC = {0};
-  TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
+    /* USER CODE BEGIN TIM1_Init 1 */
 
-  /* USER CODE BEGIN TIM1_Init 1 */
+    /* USER CODE END TIM1_Init 1 */
+    tim1->State = HAL_TIM_STATE_RESET;
+    tim1->Instance = TIM1;
+    tim1->Init.Prescaler = ((TIM_CLOCK_DIVIDER)-1);
+    tim1->Init.CounterMode = TIM_COUNTERMODE_CENTERALIGNED1;
+    tim1->Init.Period = ((PWM_PERIOD_CYCLES) / 2);
+    tim1->Init.ClockDivision = TIM_CLOCKDIVISION_DIV2;
+    tim1->Init.RepetitionCounter = (REP_COUNTER);
+    tim1->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    if (HAL_TIM_Base_Init(tim1) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_TIM_PWM_Init(tim1) != HAL_OK) {
+        Error_Handler();
+    }
+    sSlaveConfig.SlaveMode = TIM_SLAVEMODE_TRIGGER;
+    sSlaveConfig.InputTrigger = TIM_TS_ITR1;
+    if (HAL_TIM_SlaveConfigSynchro(tim1, &sSlaveConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_OC4REF;
+    sMasterConfig.MasterOutputTrigger2 = TIM_TRGO2_RESET;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(tim1, &sMasterConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    sConfigOC.OCMode = TIM_OCMODE_PWM1;
+    sConfigOC.Pulse = ((PWM_PERIOD_CYCLES) / 4);
+    sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+    sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
+    sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
+    sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
+    sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
+    if (HAL_TIM_PWM_ConfigChannel(tim1, &sConfigOC, TIM_CHANNEL_1) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_TIM_PWM_ConfigChannel(tim1, &sConfigOC, TIM_CHANNEL_2) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_TIM_PWM_ConfigChannel(tim1, &sConfigOC, TIM_CHANNEL_3) != HAL_OK) {
+        Error_Handler();
+    }
+    sConfigOC.OCMode = TIM_OCMODE_PWM2;
+    sConfigOC.Pulse = (((PWM_PERIOD_CYCLES) / 2) - (HTMIN));
+    if (HAL_TIM_PWM_ConfigChannel(tim1, &sConfigOC, TIM_CHANNEL_4) != HAL_OK) {
+        Error_Handler();
+    }
+    sBreakDeadTimeConfig.OffStateRunMode = TIM_OSSR_ENABLE;
+    sBreakDeadTimeConfig.OffStateIDLEMode = TIM_OSSI_ENABLE;
+    sBreakDeadTimeConfig.LockLevel = TIM_LOCKLEVEL_1;
+    sBreakDeadTimeConfig.DeadTime = 0;
+    sBreakDeadTimeConfig.BreakState = TIM_BREAK_DISABLE;
+    sBreakDeadTimeConfig.BreakPolarity = TIM_BREAKPOLARITY_HIGH;
+    sBreakDeadTimeConfig.BreakFilter = 0;
+    sBreakDeadTimeConfig.Break2State = TIM_BREAK2_ENABLE;
+    sBreakDeadTimeConfig.Break2Polarity = TIM_BREAK2POLARITY_LOW;
+    sBreakDeadTimeConfig.Break2Filter = 3;
+    sBreakDeadTimeConfig.AutomaticOutput = TIM_AUTOMATICOUTPUT_DISABLE;
+    if (HAL_TIMEx_ConfigBreakDeadTime(tim1, &sBreakDeadTimeConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    /* USER CODE BEGIN TIM1_Init 2 */
 
-  /* USER CODE END TIM1_Init 1 */
-  tim1->State = HAL_TIM_STATE_RESET;
-  tim1->Instance = TIM1;
-  tim1->Init.Prescaler = ((TIM_CLOCK_DIVIDER) - 1);
-  tim1->Init.CounterMode = TIM_COUNTERMODE_CENTERALIGNED1;
-  tim1->Init.Period = ((PWM_PERIOD_CYCLES) / 2);
-  tim1->Init.ClockDivision = TIM_CLOCKDIVISION_DIV2;
-  tim1->Init.RepetitionCounter = (REP_COUNTER);
-  tim1->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-  if (HAL_TIM_Base_Init(tim1) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  if (HAL_TIM_PWM_Init(tim1) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sSlaveConfig.SlaveMode = TIM_SLAVEMODE_TRIGGER;
-  sSlaveConfig.InputTrigger = TIM_TS_ITR1;
-  if (HAL_TIM_SlaveConfigSynchro(tim1, &sSlaveConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sMasterConfig.MasterOutputTrigger = TIM_TRGO_OC4REF;
-  sMasterConfig.MasterOutputTrigger2 = TIM_TRGO2_RESET;
-  sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-  if (HAL_TIMEx_MasterConfigSynchronization(tim1, &sMasterConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sConfigOC.OCMode = TIM_OCMODE_PWM1;
-  sConfigOC.Pulse = ((PWM_PERIOD_CYCLES) / 4);
-  sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
-  sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
-  sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
-  sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
-  sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
-  if (HAL_TIM_PWM_ConfigChannel(tim1, &sConfigOC, TIM_CHANNEL_1) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  if (HAL_TIM_PWM_ConfigChannel(tim1, &sConfigOC, TIM_CHANNEL_2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  if (HAL_TIM_PWM_ConfigChannel(tim1, &sConfigOC, TIM_CHANNEL_3) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sConfigOC.OCMode = TIM_OCMODE_PWM2;
-  sConfigOC.Pulse = (((PWM_PERIOD_CYCLES) / 2) - (HTMIN));
-  if (HAL_TIM_PWM_ConfigChannel(tim1, &sConfigOC, TIM_CHANNEL_4) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sBreakDeadTimeConfig.OffStateRunMode = TIM_OSSR_ENABLE;
-  sBreakDeadTimeConfig.OffStateIDLEMode = TIM_OSSI_ENABLE;
-  sBreakDeadTimeConfig.LockLevel = TIM_LOCKLEVEL_1;
-  sBreakDeadTimeConfig.DeadTime = 0;
-  sBreakDeadTimeConfig.BreakState = TIM_BREAK_DISABLE;
-  sBreakDeadTimeConfig.BreakPolarity = TIM_BREAKPOLARITY_HIGH;
-  sBreakDeadTimeConfig.BreakFilter = 0;
-  sBreakDeadTimeConfig.Break2State = TIM_BREAK2_ENABLE;
-  sBreakDeadTimeConfig.Break2Polarity = TIM_BREAK2POLARITY_LOW;
-  sBreakDeadTimeConfig.Break2Filter = 3;
-  sBreakDeadTimeConfig.AutomaticOutput = TIM_AUTOMATICOUTPUT_DISABLE;
-  if (HAL_TIMEx_ConfigBreakDeadTime(tim1, &sBreakDeadTimeConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN TIM1_Init 2 */
-
-  /* USER CODE END TIM1_Init 2 */
-  HAL_TIM_MspPostInit(tim1);
-
+    /* USER CODE END TIM1_Init 2 */
+    HAL_TIM_MspPostInit(tim1);
 }
 
 /**
-  * @brief TIM2 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_TIM2_Init(TIM_HandleTypeDef* tim2)
-{
+ * @brief TIM2 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_TIM2_Init(TIM_HandleTypeDef* tim2) {
+    /* USER CODE BEGIN TIM2_Init 0 */
 
-  /* USER CODE BEGIN TIM2_Init 0 */
+    /* USER CODE END TIM2_Init 0 */
 
-  /* USER CODE END TIM2_Init 0 */
+    TIM_ClockConfigTypeDef sClockSourceConfig = {0};
+    TIM_HallSensor_InitTypeDef sConfig = {0};
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
 
-  TIM_ClockConfigTypeDef sClockSourceConfig = {0};
-  TIM_HallSensor_InitTypeDef sConfig = {0};
-  TIM_MasterConfigTypeDef sMasterConfig = {0};
+    /* USER CODE BEGIN TIM2_Init 1 */
 
-  /* USER CODE BEGIN TIM2_Init 1 */
+    /* USER CODE END TIM2_Init 1 */
+    tim2->State = HAL_TIM_STATE_RESET;
+    tim2->Instance = TIM2;
+    tim2->Init.Prescaler = 0;
+    tim2->Init.CounterMode = TIM_COUNTERMODE_UP;
+    tim2->Init.Period = M1_HALL_TIM_PERIOD;
+    tim2->Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    tim2->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    if (HAL_TIM_Base_Init(tim2) != HAL_OK) {
+        Error_Handler();
+    }
+    sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
+    if (HAL_TIM_ConfigClockSource(tim2, &sClockSourceConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    sConfig.IC1Polarity = TIM_ICPOLARITY_RISING;
+    sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
+    sConfig.IC1Filter = M1_HALL_IC_FILTER;
+    sConfig.Commutation_Delay = 0;
+    if (HAL_TIMEx_HallSensor_Init(tim2, &sConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_OC2REF;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(tim2, &sMasterConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    /* USER CODE BEGIN TIM2_Init 2 */
 
-  /* USER CODE END TIM2_Init 1 */
-  tim2->State = HAL_TIM_STATE_RESET;
-  tim2->Instance = TIM2;
-  tim2->Init.Prescaler = 0;
-  tim2->Init.CounterMode = TIM_COUNTERMODE_UP;
-  tim2->Init.Period = M1_HALL_TIM_PERIOD;
-  tim2->Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
-  tim2->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-  if (HAL_TIM_Base_Init(tim2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
-  if (HAL_TIM_ConfigClockSource(tim2, &sClockSourceConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sConfig.IC1Polarity = TIM_ICPOLARITY_RISING;
-  sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC1Filter = M1_HALL_IC_FILTER;
-  sConfig.Commutation_Delay = 0;
-  if (HAL_TIMEx_HallSensor_Init(tim2, &sConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sMasterConfig.MasterOutputTrigger = TIM_TRGO_OC2REF;
-  sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-  if (HAL_TIMEx_MasterConfigSynchronization(tim2, &sMasterConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN TIM2_Init 2 */
-
-  /* USER CODE END TIM2_Init 2 */
-
+    /* USER CODE END TIM2_Init 2 */
 }
 
 static void PlateLockTIM_Init(TIM_HandleTypeDef* tim3) {
-  __HAL_RCC_TIM3_CLK_ENABLE();
-  tim3->State = HAL_TIM_STATE_RESET;
-  tim3->Instance = PLATE_LOCK_TIM;
-  tim3->Init.Prescaler = 0;
-  tim3->Init.CounterMode = TIM_COUNTERMODE_UP;
-  tim3->Init.Period = PLATE_LOCK_PWM_GRANULARITY;
-  tim3->Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
-  tim3->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
-  HAL_TIM_PWM_Init(tim3);
+    __HAL_RCC_TIM3_CLK_ENABLE();
+    tim3->State = HAL_TIM_STATE_RESET;
+    tim3->Instance = PLATE_LOCK_TIM;
+    tim3->Init.Prescaler = 0;
+    tim3->Init.CounterMode = TIM_COUNTERMODE_UP;
+    tim3->Init.Period = PLATE_LOCK_PWM_GRANULARITY;
+    tim3->Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    tim3->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
+    HAL_TIM_PWM_Init(tim3);
 
-  motor_hardware_plate_lock_off(tim3);
+    motor_hardware_plate_lock_off(tim3);
 }
 
 /**
-  * @brief  Configures EXTI Line0 (connected to PE0 pin) in interrupt mode
-  * @param  None
-  * @retval None
-  */
-static void EXTI0_Config(void)
-{
-  GPIO_InitTypeDef   GPIO_InitStructure;
+ * @brief  Configures EXTI Line0 (connected to PE0 pin) in interrupt mode
+ * @param  None
+ * @retval None
+ */
+static void EXTI0_Config(void) {
+    GPIO_InitTypeDef GPIO_InitStructure;
 
-  /* Enable GPIOE clock */
-  __HAL_RCC_GPIOE_CLK_ENABLE();
-  
-  /* Configure plate lock engaged optical switch*/
-  GPIO_InitStructure.Pin = PLATE_LOCK_ENGAGED_Pin;
-  GPIO_InitStructure.Mode = GPIO_MODE_IT_FALLING;
-  GPIO_InitStructure.Pull = GPIO_PULLUP;
-  GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_HIGH;
-  HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStructure);
+    /* Enable GPIOE clock */
+    __HAL_RCC_GPIOE_CLK_ENABLE();
 
-  /* Enable and set EXTI0 Interrupt to the lowest priority */
-  HAL_NVIC_SetPriority(EXTI0_IRQn, 10, 0);
-  HAL_NVIC_EnableIRQ(EXTI0_IRQn);
+    /* Configure plate lock engaged optical switch*/
+    GPIO_InitStructure.Pin = PLATE_LOCK_ENGAGED_Pin;
+    GPIO_InitStructure.Mode = GPIO_MODE_IT_FALLING;
+    GPIO_InitStructure.Pull = GPIO_PULLUP;
+    GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_HIGH;
+    HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStructure);
+
+    /* Enable and set EXTI0 Interrupt to the lowest priority */
+    HAL_NVIC_SetPriority(EXTI0_IRQn, 10, 0);
+    HAL_NVIC_EnableIRQ(EXTI0_IRQn);
 }
 
 /**
-  * @brief  Configures EXTI Line4 (connected to PE4 pin) in interrupt mode
-  * @param  None
-  * @retval None
-  */
-static void EXTI4_Config(void)
-{
-  GPIO_InitTypeDef   GPIO_InitStructure;
+ * @brief  Configures EXTI Line4 (connected to PE4 pin) in interrupt mode
+ * @param  None
+ * @retval None
+ */
+static void EXTI4_Config(void) {
+    GPIO_InitTypeDef GPIO_InitStructure;
 
-  /* Enable GPIOE clock */
-  __HAL_RCC_GPIOE_CLK_ENABLE();
-  
-  /* Configure plate lock released optical switch*/
-  GPIO_InitStructure.Pin = PLATE_LOCK_RELEASED_Pin;
-  GPIO_InitStructure.Mode = GPIO_MODE_IT_FALLING;
-  GPIO_InitStructure.Pull = GPIO_PULLUP;
-  GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_HIGH;
-  HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStructure);
+    /* Enable GPIOE clock */
+    __HAL_RCC_GPIOE_CLK_ENABLE();
 
-  /* Enable and set EXTI4 Interrupt to the lowest priority */
-  HAL_NVIC_SetPriority(EXTI4_IRQn, 10, 0);
-  HAL_NVIC_EnableIRQ(EXTI4_IRQn);
+    /* Configure plate lock released optical switch*/
+    GPIO_InitStructure.Pin = PLATE_LOCK_RELEASED_Pin;
+    GPIO_InitStructure.Mode = GPIO_MODE_IT_FALLING;
+    GPIO_InitStructure.Pull = GPIO_PULLUP;
+    GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_HIGH;
+    HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStructure);
+
+    /* Enable and set EXTI4 Interrupt to the lowest priority */
+    HAL_NVIC_SetPriority(EXTI4_IRQn, 10, 0);
+    HAL_NVIC_EnableIRQ(EXTI4_IRQn);
 }
 
 /**
-  * @brief GPIO Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_GPIO_Init(void)
-{
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
+ * @brief GPIO Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_GPIO_Init(void) {
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
 
-  /* GPIO Ports Clock Enable */
-  __HAL_RCC_GPIOF_CLK_ENABLE();
-  __HAL_RCC_GPIOA_CLK_ENABLE();
-  __HAL_RCC_GPIOC_CLK_ENABLE();
-  __HAL_RCC_GPIOD_CLK_ENABLE();
-  __HAL_RCC_GPIOB_CLK_ENABLE();
-  __HAL_RCC_GPIOE_CLK_ENABLE();
+    /* GPIO Ports Clock Enable */
+    __HAL_RCC_GPIOF_CLK_ENABLE();
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOD_CLK_ENABLE();
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOE_CLK_ENABLE();
 
+    /*Configure GPIO pin Output Level */
+    HAL_GPIO_WritePin(M1_PWM_EN_W_GPIO_Port,
+                      M1_PWM_EN_U_Pin | M1_PWM_EN_V_Pin | M1_PWM_EN_W_Pin,
+                      GPIO_PIN_RESET);
 
-  /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(M1_PWM_EN_W_GPIO_Port,
-                    M1_PWM_EN_U_Pin|M1_PWM_EN_V_Pin|M1_PWM_EN_W_Pin,
-                    GPIO_PIN_RESET);
+    /*Configure GPIO pins : M1_PWM_EN_U_Pin M1_PWM_EN_V_Pin M1_PWM_EN_W_Pin */
+    GPIO_InitStruct.Pin = M1_PWM_EN_U_Pin | M1_PWM_EN_V_Pin | M1_PWM_EN_W_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+    HAL_GPIO_Init(M1_PWM_EN_W_GPIO_Port, &GPIO_InitStruct);
 
-  /*Configure GPIO pins : M1_PWM_EN_U_Pin M1_PWM_EN_V_Pin M1_PWM_EN_W_Pin */
-  GPIO_InitStruct.Pin = M1_PWM_EN_U_Pin|M1_PWM_EN_V_Pin|M1_PWM_EN_W_Pin;
-  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-  GPIO_InitStruct.Pull = GPIO_PULLDOWN;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
-  HAL_GPIO_Init(M1_PWM_EN_W_GPIO_Port, &GPIO_InitStruct);
+    memset(&GPIO_InitStruct, 0, sizeof(GPIO_InitStruct));
+    GPIO_InitStruct.Pin = DRIVER_NSLEEP_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    HAL_GPIO_Init(DRIVER_NSLEEP_Port, &GPIO_InitStruct);
+    HAL_GPIO_WritePin(DRIVER_NSLEEP_Port, DRIVER_NSLEEP_Pin, GPIO_PIN_SET);
+    GPIO_InitStruct.Pin = SOLENOID_1_Pin | SOLENOID_2_Pin;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(SOLENOID_1_Port, &GPIO_InitStruct);
+    HAL_GPIO_WritePin(SOLENOID_1_Port, SOLENOID_1_Pin | SOLENOID_2_Pin,
+                      GPIO_PIN_RESET);
+    GPIO_InitStruct.Pin = SOLENOID_VREF_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(SOLENOID_VREF_Port, &GPIO_InitStruct);
 
-  memset(&GPIO_InitStruct, 0, sizeof(GPIO_InitStruct));
-  GPIO_InitStruct.Pin = DRIVER_NSLEEP_Pin;
-  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-  HAL_GPIO_Init(DRIVER_NSLEEP_Port, &GPIO_InitStruct);
-  HAL_GPIO_WritePin(DRIVER_NSLEEP_Port, DRIVER_NSLEEP_Pin, GPIO_PIN_SET);
-  GPIO_InitStruct.Pin = SOLENOID_1_Pin | SOLENOID_2_Pin;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  HAL_GPIO_Init(SOLENOID_1_Port, &GPIO_InitStruct);
-  HAL_GPIO_WritePin(SOLENOID_1_Port, SOLENOID_1_Pin | SOLENOID_2_Pin, GPIO_PIN_RESET);
-  GPIO_InitStruct.Pin = SOLENOID_VREF_Pin;
-  GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  HAL_GPIO_Init(SOLENOID_VREF_Port, &GPIO_InitStruct);
+    GPIO_InitStruct.Pin = PLATE_LOCK_IN_1_Pin | PLATE_LOCK_IN_2_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Alternate = GPIO_AF2_TIM3;
+    HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStruct);
 
-  GPIO_InitStruct.Pin = PLATE_LOCK_IN_1_Pin | PLATE_LOCK_IN_2_Pin;
-  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Alternate = GPIO_AF2_TIM3;
-  HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStruct);
+    GPIO_InitStruct.Pin = PLATE_LOCK_NSLEEP_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStruct);
+    HAL_GPIO_WritePin(PLATE_LOCK_Port, PLATE_LOCK_NSLEEP_Pin, GPIO_PIN_SET);
 
-  GPIO_InitStruct.Pin = PLATE_LOCK_NSLEEP_Pin;
-  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStruct);
-  HAL_GPIO_WritePin(PLATE_LOCK_Port, PLATE_LOCK_NSLEEP_Pin, GPIO_PIN_SET);
-
-  GPIO_InitStruct.Pin = PLATE_LOCK_NFAULT_Pin;
-  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStruct);
+    GPIO_InitStruct.Pin = PLATE_LOCK_NFAULT_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(PLATE_LOCK_Port, &GPIO_InitStruct);
 }
 
 static void DAC_Init(DAC_HandleTypeDef* dac) {
-  __HAL_RCC_DAC1_CLK_ENABLE();
-  dac->Instance = DAC1;
-  if (HAL_OK != HAL_DAC_Init(dac)) {
-    Error_Handler();
-  }
-  DAC_ChannelConfTypeDef chan_config = {
-     .DAC_Trigger = DAC_TRIGGER_NONE,
-     .DAC_OutputBuffer = DAC_OUTPUTBUFFER_ENABLE,
-  };
-  HAL_DAC_ConfigChannel(dac, &chan_config, SOLENOID_DAC_CHANNEL);
-  HAL_DAC_Start(dac, SOLENOID_DAC_CHANNEL);
-  HAL_DAC_SetValue(dac, SOLENOID_DAC_CHANNEL, DAC_ALIGN_8B_R, 0);
+    __HAL_RCC_DAC1_CLK_ENABLE();
+    dac->Instance = DAC1;
+    if (HAL_OK != HAL_DAC_Init(dac)) {
+        Error_Handler();
+    }
+    DAC_ChannelConfTypeDef chan_config = {
+        .DAC_Trigger = DAC_TRIGGER_NONE,
+        .DAC_OutputBuffer = DAC_OUTPUTBUFFER_ENABLE,
+    };
+    HAL_DAC_ConfigChannel(dac, &chan_config, SOLENOID_DAC_CHANNEL);
+    HAL_DAC_Start(dac, SOLENOID_DAC_CHANNEL);
+    HAL_DAC_SetValue(dac, SOLENOID_DAC_CHANNEL, DAC_ALIGN_8B_R, 0);
 }
 
 static void save_reset_reason() {
@@ -529,402 +480,351 @@ static void save_reset_reason() {
     // reset flag matches any of them
     reset_reason = 0;
 
-    // high speed internal clock ready
-    if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY)) {
-        reset_reason |= HSIRDY;
-    }
-    // high speed external clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY)) {
-        reset_reason |= HSERDY;
-    }
-    // main phase-locked loop clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY)) {
-        reset_reason |= PLLRDY;
-    }
-    // hsi48 clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY)) {
-        reset_reason |= HSI48RDY;
-    }
-    // low-speed external clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY)) {
-        reset_reason |= LSERDY;
-    }
-    // lse clock security system failure
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY)) {
-        reset_reason |= LSECSSD;
-    }
-    // low-speed internal clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY)) {
-        reset_reason |= LSIRDY;
-    }
     // brown out
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PORRST)) {
-        reset_reason |= BORRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_PORRST)) {
+        reset_reason |= (1 << PORRST);
     }
     // option byte-loader reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST)) {
-        reset_reason |= OBLRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST)) {
+        reset_reason |= (1 << OBLRST);
     }
     // pin reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
-        reset_reason |= PINRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
+        reset_reason |= (1 << PINRST);
     }
     // software reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
-        reset_reason |= SFTRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
+        reset_reason |= (1 << SFTRST);
     }
     // independent watchdog
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
-        reset_reason |= IWDGRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
+        reset_reason |= (1 << IWDGRST);
     }
     // window watchdog
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
-        reset_reason |= WWDGRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
+        reset_reason |= (1 << WWDGRST);
     }
     // low power reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
-        reset_reason |= LPWRRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
+        reset_reason |= (1 << LPWRRST);
     }
 }
 
 /**
-  * Initializes the Global MSP.
-  */
-void Hal_MspInit(void)
-{
-  /* USER CODE BEGIN MspInit 0 */
+ * Initializes the Global MSP.
+ */
+void Hal_MspInit(void) {
+    /* USER CODE BEGIN MspInit 0 */
 
-  /* USER CODE END MspInit 0 */
+    /* USER CODE END MspInit 0 */
 
-  __HAL_RCC_SYSCFG_CLK_ENABLE();
-  __HAL_RCC_PWR_CLK_ENABLE();
+    __HAL_RCC_SYSCFG_CLK_ENABLE();
+    __HAL_RCC_PWR_CLK_ENABLE();
 
-  /* System interrupt init*/
+    /* System interrupt init*/
 
-  /* USER CODE BEGIN MspInit 1 */
+    /* USER CODE BEGIN MspInit 1 */
 
-  /* USER CODE END MspInit 1 */
+    /* USER CODE END MspInit 1 */
 }
 
-static uint32_t HAL_RCC_ADC12_CLK_ENABLED=0;
+static uint32_t HAL_RCC_ADC12_CLK_ENABLED = 0;
 
 /**
-* @brief ADC MSP Initialization
-* This function configures the hardware resources used in this example
-* @param hadc: ADC handle pointer
-* @retval None
-*/
-void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)
-{
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
-  if(hadc->Instance==ADC1)
-  {
-  /* USER CODE BEGIN ADC1_MspInit 0 */
+ * @brief ADC MSP Initialization
+ * This function configures the hardware resources used in this example
+ * @param hadc: ADC handle pointer
+ * @retval None
+ */
+void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc) {
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    if (hadc->Instance == ADC1) {
+        /* USER CODE BEGIN ADC1_MspInit 0 */
 
-  /* USER CODE END ADC1_MspInit 0 */
-    /* Peripheral clock enable */
-    HAL_RCC_ADC12_CLK_ENABLED++;
-    if(HAL_RCC_ADC12_CLK_ENABLED==1){
-      __HAL_RCC_ADC12_CLK_ENABLE();
+        /* USER CODE END ADC1_MspInit 0 */
+        /* Peripheral clock enable */
+        HAL_RCC_ADC12_CLK_ENABLED++;
+        if (HAL_RCC_ADC12_CLK_ENABLED == 1) {
+            __HAL_RCC_ADC12_CLK_ENABLE();
+        }
+
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        /**ADC1 GPIO Configuration
+        PA1     ------> ADC1_IN2
+        PB11     ------> ADC1_IN14
+        */
+        GPIO_InitStruct.Pin = M1_CURR_AMPL_U_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        HAL_GPIO_Init(M1_CURR_AMPL_U_GPIO_Port, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = M1_CURR_AMPL_V_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        HAL_GPIO_Init(M1_CURR_AMPL_V_GPIO_Port, &GPIO_InitStruct);
+
+        /* USER CODE BEGIN ADC1_MspInit 1 */
+
+        /* USER CODE END ADC1_MspInit 1 */
+    } else if (hadc->Instance == ADC2) {
+        /* USER CODE BEGIN ADC2_MspInit 0 */
+
+        /* USER CODE END ADC2_MspInit 0 */
+        /* Peripheral clock enable */
+        HAL_RCC_ADC12_CLK_ENABLED++;
+        if (HAL_RCC_ADC12_CLK_ENABLED == 1) {
+            __HAL_RCC_ADC12_CLK_ENABLE();
+        }
+
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        /**ADC2 GPIO Configuration
+        PA7     ------> ADC2_IN4
+        PC4     ------> ADC2_IN5
+        PC5     ------> ADC2_IN11
+        PB11     ------> ADC2_IN14
+        */
+        GPIO_InitStruct.Pin = M1_CURR_AMPL_W_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        HAL_GPIO_Init(M1_CURR_AMPL_W_GPIO_Port, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = /*M1_TEMPERATURE_Pin|*/ M1_BUS_VOLTAGE_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = M1_CURR_AMPL_V_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        HAL_GPIO_Init(M1_CURR_AMPL_V_GPIO_Port, &GPIO_InitStruct);
+
+        /* USER CODE BEGIN ADC2_MspInit 1 */
+
+        /* USER CODE END ADC2_MspInit 1 */
     }
-
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-    /**ADC1 GPIO Configuration
-    PA1     ------> ADC1_IN2
-    PB11     ------> ADC1_IN14
-    */
-    GPIO_InitStruct.Pin = M1_CURR_AMPL_U_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    HAL_GPIO_Init(M1_CURR_AMPL_U_GPIO_Port, &GPIO_InitStruct);
-
-    GPIO_InitStruct.Pin = M1_CURR_AMPL_V_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    HAL_GPIO_Init(M1_CURR_AMPL_V_GPIO_Port, &GPIO_InitStruct);
-
-  /* USER CODE BEGIN ADC1_MspInit 1 */
-
-  /* USER CODE END ADC1_MspInit 1 */
-  }
-  else if(hadc->Instance==ADC2)
-  {
-  /* USER CODE BEGIN ADC2_MspInit 0 */
-
-  /* USER CODE END ADC2_MspInit 0 */
-    /* Peripheral clock enable */
-    HAL_RCC_ADC12_CLK_ENABLED++;
-    if(HAL_RCC_ADC12_CLK_ENABLED==1){
-      __HAL_RCC_ADC12_CLK_ENABLE();
-    }
-
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    __HAL_RCC_GPIOC_CLK_ENABLE();
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-    /**ADC2 GPIO Configuration
-    PA7     ------> ADC2_IN4
-    PC4     ------> ADC2_IN5
-    PC5     ------> ADC2_IN11
-    PB11     ------> ADC2_IN14
-    */
-    GPIO_InitStruct.Pin = M1_CURR_AMPL_W_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    HAL_GPIO_Init(M1_CURR_AMPL_W_GPIO_Port, &GPIO_InitStruct);
-
-    GPIO_InitStruct.Pin = /*M1_TEMPERATURE_Pin|*/M1_BUS_VOLTAGE_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-
-    GPIO_InitStruct.Pin = M1_CURR_AMPL_V_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    HAL_GPIO_Init(M1_CURR_AMPL_V_GPIO_Port, &GPIO_InitStruct);
-
-  /* USER CODE BEGIN ADC2_MspInit 1 */
-
-  /* USER CODE END ADC2_MspInit 1 */
-  }
-
 }
 
 /**
-* @brief ADC MSP De-Initialization
-* This function freeze the hardware resources used in this example
-* @param hadc: ADC handle pointer
-* @retval None
-*/
-void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
-{
-  if(hadc->Instance==ADC1)
-  {
-  /* USER CODE BEGIN ADC1_MspDeInit 0 */
+ * @brief ADC MSP De-Initialization
+ * This function freeze the hardware resources used in this example
+ * @param hadc: ADC handle pointer
+ * @retval None
+ */
+void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc) {
+    if (hadc->Instance == ADC1) {
+        /* USER CODE BEGIN ADC1_MspDeInit 0 */
 
-  /* USER CODE END ADC1_MspDeInit 0 */
-    /* Peripheral clock disable */
-    HAL_RCC_ADC12_CLK_ENABLED--;
-    if(HAL_RCC_ADC12_CLK_ENABLED==0){
-      __HAL_RCC_ADC12_CLK_DISABLE();
+        /* USER CODE END ADC1_MspDeInit 0 */
+        /* Peripheral clock disable */
+        HAL_RCC_ADC12_CLK_ENABLED--;
+        if (HAL_RCC_ADC12_CLK_ENABLED == 0) {
+            __HAL_RCC_ADC12_CLK_DISABLE();
+        }
+
+        /**ADC1 GPIO Configuration
+        PA1     ------> ADC1_IN2
+        PB11     ------> ADC1_IN14
+        */
+        HAL_GPIO_DeInit(M1_CURR_AMPL_U_GPIO_Port, M1_CURR_AMPL_U_Pin);
+
+        HAL_GPIO_DeInit(M1_CURR_AMPL_V_GPIO_Port, M1_CURR_AMPL_V_Pin);
+
+        /* ADC1 interrupt DeInit */
+        /* USER CODE BEGIN ADC1:ADC1_2_IRQn disable */
+        /**
+         * Uncomment the line below to disable the "ADC1_2_IRQn" interrupt
+         * Be aware, disabling shared interrupt may affect other IPs
+         */
+        /* HAL_NVIC_DisableIRQ(ADC1_2_IRQn); */
+        /* USER CODE END ADC1:ADC1_2_IRQn disable */
+
+        /* USER CODE BEGIN ADC1_MspDeInit 1 */
+
+        /* USER CODE END ADC1_MspDeInit 1 */
+    } else if (hadc->Instance == ADC2) {
+        /* USER CODE BEGIN ADC2_MspDeInit 0 */
+
+        /* USER CODE END ADC2_MspDeInit 0 */
+        /* Peripheral clock disable */
+        HAL_RCC_ADC12_CLK_ENABLED--;
+        if (HAL_RCC_ADC12_CLK_ENABLED == 0) {
+            __HAL_RCC_ADC12_CLK_DISABLE();
+        }
+
+        /**ADC2 GPIO Configuration
+        PA7     ------> ADC2_IN4
+        PC4     ------> ADC2_IN5
+        PC5     ------> ADC2_IN11
+        PB11     ------> ADC2_IN14
+        */
+        HAL_GPIO_DeInit(M1_CURR_AMPL_W_GPIO_Port, M1_CURR_AMPL_W_Pin);
+
+        HAL_GPIO_DeInit(GPIOC, /*M1_TEMPERATURE_Pin|*/ M1_BUS_VOLTAGE_Pin);
+
+        HAL_GPIO_DeInit(M1_CURR_AMPL_V_GPIO_Port, M1_CURR_AMPL_V_Pin);
+
+        /* ADC2 interrupt DeInit */
+        /* USER CODE BEGIN ADC2:ADC1_2_IRQn disable */
+        /**
+         * Uncomment the line below to disable the "ADC1_2_IRQn" interrupt
+         * Be aware, disabling shared interrupt may affect other IPs
+         */
+        /* HAL_NVIC_DisableIRQ(ADC1_2_IRQn); */
+        /* USER CODE END ADC2:ADC1_2_IRQn disable */
+
+        /* USER CODE BEGIN ADC2_MspDeInit 1 */
+
+        /* USER CODE END ADC2_MspDeInit 1 */
     }
-
-    /**ADC1 GPIO Configuration
-    PA1     ------> ADC1_IN2
-    PB11     ------> ADC1_IN14
-    */
-    HAL_GPIO_DeInit(M1_CURR_AMPL_U_GPIO_Port, M1_CURR_AMPL_U_Pin);
-
-    HAL_GPIO_DeInit(M1_CURR_AMPL_V_GPIO_Port, M1_CURR_AMPL_V_Pin);
-
-    /* ADC1 interrupt DeInit */
-  /* USER CODE BEGIN ADC1:ADC1_2_IRQn disable */
-    /**
-    * Uncomment the line below to disable the "ADC1_2_IRQn" interrupt
-    * Be aware, disabling shared interrupt may affect other IPs
-    */
-    /* HAL_NVIC_DisableIRQ(ADC1_2_IRQn); */
-  /* USER CODE END ADC1:ADC1_2_IRQn disable */
-
-  /* USER CODE BEGIN ADC1_MspDeInit 1 */
-
-  /* USER CODE END ADC1_MspDeInit 1 */
-  }
-  else if(hadc->Instance==ADC2)
-  {
-  /* USER CODE BEGIN ADC2_MspDeInit 0 */
-
-  /* USER CODE END ADC2_MspDeInit 0 */
-    /* Peripheral clock disable */
-    HAL_RCC_ADC12_CLK_ENABLED--;
-    if(HAL_RCC_ADC12_CLK_ENABLED==0){
-      __HAL_RCC_ADC12_CLK_DISABLE();
-    }
-
-    /**ADC2 GPIO Configuration
-    PA7     ------> ADC2_IN4
-    PC4     ------> ADC2_IN5
-    PC5     ------> ADC2_IN11
-    PB11     ------> ADC2_IN14
-    */
-    HAL_GPIO_DeInit(M1_CURR_AMPL_W_GPIO_Port, M1_CURR_AMPL_W_Pin);
-
-    HAL_GPIO_DeInit(GPIOC, /*M1_TEMPERATURE_Pin|*/M1_BUS_VOLTAGE_Pin);
-
-    HAL_GPIO_DeInit(M1_CURR_AMPL_V_GPIO_Port, M1_CURR_AMPL_V_Pin);
-
-    /* ADC2 interrupt DeInit */
-  /* USER CODE BEGIN ADC2:ADC1_2_IRQn disable */
-    /**
-    * Uncomment the line below to disable the "ADC1_2_IRQn" interrupt
-    * Be aware, disabling shared interrupt may affect other IPs
-    */
-    /* HAL_NVIC_DisableIRQ(ADC1_2_IRQn); */
-  /* USER CODE END ADC2:ADC1_2_IRQn disable */
-
-  /* USER CODE BEGIN ADC2_MspDeInit 1 */
-
-  /* USER CODE END ADC2_MspDeInit 1 */
-  }
-
 }
 
 /**
-* @brief TIM_Base MSP Initialization
-* This function configures the hardware resources used in this example
-* @param htim_base: TIM_Base handle pointer
-* @retval None
-*/
-void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim_base)
-{
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
-  if(htim_base->Instance==TIM1)
-  {
-  /* USER CODE BEGIN TIM1_MspInit 0 */
+ * @brief TIM_Base MSP Initialization
+ * This function configures the hardware resources used in this example
+ * @param htim_base: TIM_Base handle pointer
+ * @retval None
+ */
+void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim_base) {
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    if (htim_base->Instance == TIM1) {
+        /* USER CODE BEGIN TIM1_MspInit 0 */
 
-  /* USER CODE END TIM1_MspInit 0 */
-    /* Peripheral clock enable */
-    __HAL_RCC_TIM1_CLK_ENABLE();
+        /* USER CODE END TIM1_MspInit 0 */
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM1_CLK_ENABLE();
 
-    __HAL_RCC_GPIOC_CLK_ENABLE();
-    /**TIM1 GPIO Configuration
-    PA11     ------> TIM1_BKIN2
-    */
-    GPIO_InitStruct.Pin = M1_OCP_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-    GPIO_InitStruct.Alternate = GPIO_AF6_TIM1;
-    HAL_GPIO_Init(M1_OCP_GPIO_Port, &GPIO_InitStruct);
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        /**TIM1 GPIO Configuration
+        PA11     ------> TIM1_BKIN2
+        */
+        GPIO_InitStruct.Pin = M1_OCP_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF6_TIM1;
+        HAL_GPIO_Init(M1_OCP_GPIO_Port, &GPIO_InitStruct);
 
-  /* USER CODE BEGIN TIM1_MspInit 1 */
+        /* USER CODE BEGIN TIM1_MspInit 1 */
 
-  /* USER CODE END TIM1_MspInit 1 */
-  }
-  else if(htim_base->Instance==TIM2)
-  {
-  /* USER CODE BEGIN TIM2_MspInit 0 */
+        /* USER CODE END TIM1_MspInit 1 */
+    } else if (htim_base->Instance == TIM2) {
+        /* USER CODE BEGIN TIM2_MspInit 0 */
 
-  /* USER CODE END TIM2_MspInit 0 */
-    /* Peripheral clock enable */
-    __HAL_RCC_TIM2_CLK_ENABLE();
+        /* USER CODE END TIM2_MspInit 0 */
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM2_CLK_ENABLE();
 
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    GPIO_InitStruct.Pin = M1_HALL_H3_Pin|M1_HALL_H2_Pin|M1_HALL_H1_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF2_TIM2;
-    HAL_GPIO_Init(M1_HALL_H3_GPIO_Port, &GPIO_InitStruct);
-  /* USER CODE BEGIN TIM2_MspInit 1 */
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        GPIO_InitStruct.Pin = M1_HALL_H3_Pin | M1_HALL_H2_Pin | M1_HALL_H1_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF2_TIM2;
+        HAL_GPIO_Init(M1_HALL_H3_GPIO_Port, &GPIO_InitStruct);
+        /* USER CODE BEGIN TIM2_MspInit 1 */
 
-  /* USER CODE END TIM2_MspInit 1 */
-  }
-
+        /* USER CODE END TIM2_MspInit 1 */
+    }
 }
 
-void HAL_TIM_MspPostInit(TIM_HandleTypeDef* htim)
-{
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
-  if(htim->Instance==TIM1)
-  {
-  /* USER CODE BEGIN TIM1_MspPostInit 0 */
+void HAL_TIM_MspPostInit(TIM_HandleTypeDef* htim) {
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    if (htim->Instance == TIM1) {
+        /* USER CODE BEGIN TIM1_MspPostInit 0 */
 
-  /* USER CODE END TIM1_MspPostInit 0 */
+        /* USER CODE END TIM1_MspPostInit 0 */
 
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    /**TIM1 GPIO Configuration
-    PA8     ------> TIM1_CH1
-    PA9     ------> TIM1_CH2
-    PA10     ------> TIM1_CH3
-    */
-    GPIO_InitStruct.Pin = M1_PWM_UH_Pin|M1_PWM_VH_Pin|M1_PWM_WH_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitStruct.Pull = GPIO_PULLDOWN;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF6_TIM1;
-    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        /**TIM1 GPIO Configuration
+        PA8     ------> TIM1_CH1
+        PA9     ------> TIM1_CH2
+        PA10     ------> TIM1_CH3
+        */
+        GPIO_InitStruct.Pin = M1_PWM_UH_Pin | M1_PWM_VH_Pin | M1_PWM_WH_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF6_TIM1;
+        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-  /* USER CODE BEGIN TIM1_MspPostInit 1 */
+        /* USER CODE BEGIN TIM1_MspPostInit 1 */
 
-  /* USER CODE END TIM1_MspPostInit 1 */
-  }
-
+        /* USER CODE END TIM1_MspPostInit 1 */
+    }
 }
 /**
-* @brief TIM_Base MSP De-Initialization
-* This function freeze the hardware resources used in this example
-* @param htim_base: TIM_Base handle pointer
-* @retval None
-*/
-void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* htim_base)
-{
-  if(htim_base->Instance==TIM1)
-  {
-  /* USER CODE BEGIN TIM1_MspDeInit 0 */
+ * @brief TIM_Base MSP De-Initialization
+ * This function freeze the hardware resources used in this example
+ * @param htim_base: TIM_Base handle pointer
+ * @retval None
+ */
+void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* htim_base) {
+    if (htim_base->Instance == TIM1) {
+        /* USER CODE BEGIN TIM1_MspDeInit 0 */
 
-  /* USER CODE END TIM1_MspDeInit 0 */
-    /* Peripheral clock disable */
-    __HAL_RCC_TIM1_CLK_DISABLE();
+        /* USER CODE END TIM1_MspDeInit 0 */
+        /* Peripheral clock disable */
+        __HAL_RCC_TIM1_CLK_DISABLE();
 
-    /**TIM1 GPIO Configuration
-    PA8     ------> TIM1_CH1
-    PA9     ------> TIM1_CH2
-    PA10     ------> TIM1_CH3
-    PA11     ------> TIM1_BKIN2
-    */
-    HAL_GPIO_DeInit(GPIOA, M1_PWM_UH_Pin|M1_PWM_VH_Pin|M1_PWM_WH_Pin|M1_OCP_Pin);
+        /**TIM1 GPIO Configuration
+        PA8     ------> TIM1_CH1
+        PA9     ------> TIM1_CH2
+        PA10     ------> TIM1_CH3
+        PA11     ------> TIM1_BKIN2
+        */
+        HAL_GPIO_DeInit(
+            GPIOA, M1_PWM_UH_Pin | M1_PWM_VH_Pin | M1_PWM_WH_Pin | M1_OCP_Pin);
 
-    /* TIM1 interrupt DeInit */
-    HAL_NVIC_DisableIRQ(TIM1_BRK_TIM15_IRQn);
-    HAL_NVIC_DisableIRQ(TIM1_UP_TIM16_IRQn);
-  /* USER CODE BEGIN TIM1_MspDeInit 1 */
+        /* TIM1 interrupt DeInit */
+        HAL_NVIC_DisableIRQ(TIM1_BRK_TIM15_IRQn);
+        HAL_NVIC_DisableIRQ(TIM1_UP_TIM16_IRQn);
+        /* USER CODE BEGIN TIM1_MspDeInit 1 */
 
-  /* USER CODE END TIM1_MspDeInit 1 */
-  }
-  else if(htim_base->Instance==TIM2)
-  {
-  /* USER CODE BEGIN TIM2_MspDeInit 0 */
+        /* USER CODE END TIM1_MspDeInit 1 */
+    } else if (htim_base->Instance == TIM2) {
+        /* USER CODE BEGIN TIM2_MspDeInit 0 */
 
-  /* USER CODE END TIM2_MspDeInit 0 */
-    /* Peripheral clock disable */
-    __HAL_RCC_TIM2_CLK_DISABLE();
+        /* USER CODE END TIM2_MspDeInit 0 */
+        /* Peripheral clock disable */
+        __HAL_RCC_TIM2_CLK_DISABLE();
 
-    /**TIM2 GPIO Configuration
-    PB10     ------> TIM2_CH3
-    PA15     ------> TIM2_CH1
-    PB3     ------> TIM2_CH2
-    */
-    HAL_GPIO_DeInit(GPIOB, M1_HALL_H3_Pin|M1_HALL_H2_Pin);
+        /**TIM2 GPIO Configuration
+        PB10     ------> TIM2_CH3
+        PA15     ------> TIM2_CH1
+        PB3     ------> TIM2_CH2
+        */
+        HAL_GPIO_DeInit(GPIOB, M1_HALL_H3_Pin | M1_HALL_H2_Pin);
 
-    HAL_GPIO_DeInit(M1_HALL_H1_GPIO_Port, M1_HALL_H1_Pin);
+        HAL_GPIO_DeInit(M1_HALL_H1_GPIO_Port, M1_HALL_H1_Pin);
 
-    /* TIM2 interrupt DeInit */
-    HAL_NVIC_DisableIRQ(TIM2_IRQn);
-  /* USER CODE BEGIN TIM2_MspDeInit 1 */
+        /* TIM2 interrupt DeInit */
+        HAL_NVIC_DisableIRQ(TIM2_IRQn);
+        /* USER CODE BEGIN TIM2_MspDeInit 1 */
 
-  /* USER CODE END TIM2_MspDeInit 1 */
-  }
-
+        /* USER CODE END TIM2_MspDeInit 1 */
+    }
 }
 
 void motor_hardware_setup(motor_hardware_handles* handles) {
-  save_reset_reason();
-  MOTOR_HW_HANDLE = handles;
-  memset(motor_speed_buffer, 0, sizeof(motor_speed_buffer));
-  MX_GPIO_Init();
-  MX_ADC1_Init(&handles->adc1);
-  MX_ADC2_Init(&handles->adc2);
-  MX_TIM1_Init(&handles->tim1);
-  MX_TIM2_Init(&handles->tim2);
-  DAC_Init(&handles->dac1);
-  MCboot(handles->mci, handles->mct);
-  PlateLockTIM_Init(&handles->tim3);
-  EXTI0_Config();
-  EXTI4_Config();
-  /* Initialize interrupts */
-  MX_NVIC_Init();
+    save_reset_reason();
+    MOTOR_HW_HANDLE = handles;
+    memset(motor_speed_buffer, 0, sizeof(motor_speed_buffer));
+    MX_GPIO_Init();
+    MX_ADC1_Init(&handles->adc1);
+    MX_ADC2_Init(&handles->adc2);
+    MX_TIM1_Init(&handles->tim1);
+    MX_TIM2_Init(&handles->tim2);
+    DAC_Init(&handles->dac1);
+    MCboot(handles->mci, handles->mct);
+    PlateLockTIM_Init(&handles->tim3);
+    EXTI0_Config();
+    EXTI4_Config();
+    /* Initialize interrupts */
+    MX_NVIC_Init();
 }
 
 void motor_hardware_solenoid_drive(DAC_HandleTypeDef* dac1, uint8_t dacval) {
@@ -933,80 +833,76 @@ void motor_hardware_solenoid_drive(DAC_HandleTypeDef* dac1, uint8_t dacval) {
 }
 
 void motor_hardware_solenoid_release(DAC_HandleTypeDef* dac1) {
-  HAL_GPIO_WritePin(SOLENOID_1_Port, SOLENOID_1_Pin, GPIO_PIN_RESET);
-  HAL_DAC_SetValue(dac1, SOLENOID_DAC_CHANNEL, DAC_ALIGN_8B_R, 0);
+    HAL_GPIO_WritePin(SOLENOID_1_Port, SOLENOID_1_Pin, GPIO_PIN_RESET);
+    HAL_DAC_SetValue(dac1, SOLENOID_DAC_CHANNEL, DAC_ALIGN_8B_R, 0);
 }
 
-uint16_t motor_hardware_reset_reason() {
-    return reset_reason;
-}
+uint16_t motor_hardware_reset_reason() { return reset_reason; }
 
 void motor_hardware_plate_lock_on(TIM_HandleTypeDef* tim3, float power) {
-  float power_scale = fabs(power);
-  if (power_scale > 1.f) {
-    power_scale = 1.f;
-  }
-  TIM_OC_InitTypeDef chan_config = {
-     .OCMode = TIM_OCMODE_PWM1,
-     .Pulse = (uint16_t)(PLATE_LOCK_PWM_GRANULARITY * power_scale),
-     .OCPolarity = TIM_OCPOLARITY_HIGH,
-     .OCIdleState = TIM_OCIDLESTATE_RESET
-};
-  uint32_t active_channel = ((power < 0) ? PLATE_LOCK_IN_1_Chan : PLATE_LOCK_IN_2_Chan);
-  uint32_t passive_channel = ((power < 0) ? PLATE_LOCK_IN_2_Chan : PLATE_LOCK_IN_1_Chan);
-  HAL_TIM_PWM_Stop(tim3, active_channel);
-  HAL_TIM_PWM_Stop(tim3, passive_channel);
-  HAL_TIM_PWM_ConfigChannel(tim3, &chan_config, active_channel);
-  chan_config.OCMode = TIM_OCMODE_FORCED_INACTIVE;
-  HAL_TIM_PWM_ConfigChannel(tim3, &chan_config, passive_channel);
-  HAL_TIM_GenerateEvent(tim3, TIM_EVENTSOURCE_UPDATE);
-  HAL_TIM_PWM_Start(tim3, passive_channel);
-  HAL_TIM_PWM_Start(tim3,  active_channel);
+    float power_scale = fabs(power);
+    if (power_scale > 1.f) {
+        power_scale = 1.f;
+    }
+    TIM_OC_InitTypeDef chan_config = {
+        .OCMode = TIM_OCMODE_PWM1,
+        .Pulse = (uint16_t)(PLATE_LOCK_PWM_GRANULARITY * power_scale),
+        .OCPolarity = TIM_OCPOLARITY_HIGH,
+        .OCIdleState = TIM_OCIDLESTATE_RESET};
+    uint32_t active_channel =
+        ((power < 0) ? PLATE_LOCK_IN_1_Chan : PLATE_LOCK_IN_2_Chan);
+    uint32_t passive_channel =
+        ((power < 0) ? PLATE_LOCK_IN_2_Chan : PLATE_LOCK_IN_1_Chan);
+    HAL_TIM_PWM_Stop(tim3, active_channel);
+    HAL_TIM_PWM_Stop(tim3, passive_channel);
+    HAL_TIM_PWM_ConfigChannel(tim3, &chan_config, active_channel);
+    chan_config.OCMode = TIM_OCMODE_FORCED_INACTIVE;
+    HAL_TIM_PWM_ConfigChannel(tim3, &chan_config, passive_channel);
+    HAL_TIM_GenerateEvent(tim3, TIM_EVENTSOURCE_UPDATE);
+    HAL_TIM_PWM_Start(tim3, passive_channel);
+    HAL_TIM_PWM_Start(tim3, active_channel);
 }
 
 void motor_hardware_plate_lock_off(TIM_HandleTypeDef* tim3) {
-  TIM_OC_InitTypeDef chan_config = {
-     .OCMode = TIM_OCMODE_FORCED_INACTIVE,
-     .Pulse = 0,
-     .OCPolarity = TIM_OCPOLARITY_HIGH,
-     .OCIdleState = TIM_OCIDLESTATE_RESET
-};
-  HAL_TIM_PWM_Stop(tim3, PLATE_LOCK_IN_1_Chan);
-  HAL_TIM_PWM_Stop(tim3, PLATE_LOCK_IN_2_Chan);
-  HAL_TIM_OC_ConfigChannel(tim3, &chan_config, PLATE_LOCK_IN_1_Chan);
-  HAL_TIM_OC_ConfigChannel(tim3, &chan_config, PLATE_LOCK_IN_2_Chan);
-  HAL_TIM_GenerateEvent(tim3, TIM_EVENTSOURCE_UPDATE);
-  HAL_TIM_PWM_Start(tim3, PLATE_LOCK_IN_1_Chan);
-  HAL_TIM_PWM_Start(tim3, PLATE_LOCK_IN_2_Chan);
+    TIM_OC_InitTypeDef chan_config = {.OCMode = TIM_OCMODE_FORCED_INACTIVE,
+                                      .Pulse = 0,
+                                      .OCPolarity = TIM_OCPOLARITY_HIGH,
+                                      .OCIdleState = TIM_OCIDLESTATE_RESET};
+    HAL_TIM_PWM_Stop(tim3, PLATE_LOCK_IN_1_Chan);
+    HAL_TIM_PWM_Stop(tim3, PLATE_LOCK_IN_2_Chan);
+    HAL_TIM_OC_ConfigChannel(tim3, &chan_config, PLATE_LOCK_IN_1_Chan);
+    HAL_TIM_OC_ConfigChannel(tim3, &chan_config, PLATE_LOCK_IN_2_Chan);
+    HAL_TIM_GenerateEvent(tim3, TIM_EVENTSOURCE_UPDATE);
+    HAL_TIM_PWM_Start(tim3, PLATE_LOCK_IN_1_Chan);
+    HAL_TIM_PWM_Start(tim3, PLATE_LOCK_IN_2_Chan);
 }
 
 void motor_hardware_plate_lock_brake(TIM_HandleTypeDef* tim3) {
-  float power_scale = 1.f;
-  TIM_OC_InitTypeDef chan_config = {
-     .OCMode = TIM_OCMODE_PWM1,
-     .Pulse = (uint16_t)(PLATE_LOCK_PWM_GRANULARITY * power_scale),
-     .OCPolarity = TIM_OCPOLARITY_HIGH,
-     .OCIdleState = TIM_OCIDLESTATE_RESET
-};
-  HAL_TIM_PWM_Stop(tim3, PLATE_LOCK_IN_1_Chan);
-  HAL_TIM_PWM_Stop(tim3, PLATE_LOCK_IN_2_Chan);
-  HAL_TIM_OC_ConfigChannel(tim3, &chan_config, PLATE_LOCK_IN_1_Chan);
-  HAL_TIM_OC_ConfigChannel(tim3, &chan_config, PLATE_LOCK_IN_2_Chan);
-  HAL_TIM_GenerateEvent(tim3, TIM_EVENTSOURCE_UPDATE);
-  HAL_TIM_PWM_Start(tim3, PLATE_LOCK_IN_1_Chan);
-  HAL_TIM_PWM_Start(tim3, PLATE_LOCK_IN_2_Chan);
+    float power_scale = 1.f;
+    TIM_OC_InitTypeDef chan_config = {
+        .OCMode = TIM_OCMODE_PWM1,
+        .Pulse = (uint16_t)(PLATE_LOCK_PWM_GRANULARITY * power_scale),
+        .OCPolarity = TIM_OCPOLARITY_HIGH,
+        .OCIdleState = TIM_OCIDLESTATE_RESET};
+    HAL_TIM_PWM_Stop(tim3, PLATE_LOCK_IN_1_Chan);
+    HAL_TIM_PWM_Stop(tim3, PLATE_LOCK_IN_2_Chan);
+    HAL_TIM_OC_ConfigChannel(tim3, &chan_config, PLATE_LOCK_IN_1_Chan);
+    HAL_TIM_OC_ConfigChannel(tim3, &chan_config, PLATE_LOCK_IN_2_Chan);
+    HAL_TIM_GenerateEvent(tim3, TIM_EVENTSOURCE_UPDATE);
+    HAL_TIM_PWM_Start(tim3, PLATE_LOCK_IN_1_Chan);
+    HAL_TIM_PWM_Start(tim3, PLATE_LOCK_IN_2_Chan);
 }
 
 void motor_hardware_add_rpm_measurement(int16_t speed) {
     motor_speed_buffer[motor_speed_buffer_itr++] = speed;
-    if(motor_speed_buffer_itr == MOTOR_SPEED_BUFFER_SIZE) {
+    if (motor_speed_buffer_itr == MOTOR_SPEED_BUFFER_SIZE) {
         motor_speed_buffer_itr = 0;
     }
 }
 
 int16_t motor_hardware_get_smoothed_rpm() {
     int64_t sum = 0;
-    for(uint8_t itr = 0; itr < MOTOR_SPEED_BUFFER_SIZE; ++itr) {
+    for (uint8_t itr = 0; itr < MOTOR_SPEED_BUFFER_SIZE; ++itr) {
         sum += (int64_t)motor_speed_buffer[itr];
     }
     return (int16_t)(sum / MOTOR_SPEED_BUFFER_SIZE);
@@ -1020,57 +916,54 @@ int16_t motor_hardware_get_smoothed_rpm() {
 /******************************************************************************/
 
 /**
-  * @brief  This function handles External line 0 interrupt request.
-  * @param  None
-  * @retval None
-  */
-void EXTI0_IRQHandler(void)
-{
-  HAL_GPIO_EXTI_IRQHandler(PLATE_LOCK_ENGAGED_Pin);
+ * @brief  This function handles External line 0 interrupt request.
+ * @param  None
+ * @retval None
+ */
+void EXTI0_IRQHandler(void) {
+    HAL_GPIO_EXTI_IRQHandler(PLATE_LOCK_ENGAGED_Pin);
 }
 
 /**
-  * @brief  This function handles External line 4 interrupt request.
-  * @param  None
-  * @retval None
-  */
-void EXTI4_IRQHandler(void)
-{
-  HAL_GPIO_EXTI_IRQHandler(PLATE_LOCK_RELEASED_Pin);
+ * @brief  This function handles External line 4 interrupt request.
+ * @param  None
+ * @retval None
+ */
+void EXTI4_IRQHandler(void) {
+    HAL_GPIO_EXTI_IRQHandler(PLATE_LOCK_RELEASED_Pin);
 }
 
 /**
-  * @brief EXTI line detection callbacks
-  * @param GPIO_Pin: Specifies the pins connected EXTI line
-  * @retval None
-  */
-void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
-{
-  optical_switch_results results;
-  if (GPIO_Pin == PLATE_LOCK_ENGAGED_Pin) {
-    results.closed = true;
-    results.open = false;
-  }
-  if (GPIO_Pin == PLATE_LOCK_RELEASED_Pin) {
-    results.open = true;
-    results.closed = false;
-  }
-  MOTOR_HW_HANDLE->plate_lock_complete(&results);
+ * @brief EXTI line detection callbacks
+ * @param GPIO_Pin: Specifies the pins connected EXTI line
+ * @retval None
+ */
+void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
+    optical_switch_results results;
+    if (GPIO_Pin == PLATE_LOCK_ENGAGED_Pin) {
+        results.closed = true;
+        results.open = false;
+    }
+    if (GPIO_Pin == PLATE_LOCK_RELEASED_Pin) {
+        results.open = true;
+        results.closed = false;
+    }
+    MOTOR_HW_HANDLE->plate_lock_complete(&results);
 }
 
-bool motor_hardware_plate_lock_sensor_read(uint16_t GPIO_Pin)
-{
-  if (GPIO_PIN_RESET == HAL_GPIO_ReadPin(PLATE_LOCK_Port, GPIO_Pin)) {
-    return true;
-  } else {
-    return false;
-  }
+bool motor_hardware_plate_lock_sensor_read(uint16_t GPIO_Pin) {
+    if (GPIO_PIN_RESET == HAL_GPIO_ReadPin(PLATE_LOCK_Port, GPIO_Pin)) {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 void Error_Handler() {
-  while (true) {}
+    while (true) {
+    }
 }
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/stm32-modules/reference-module/firmware/system/system_hardware.c
+++ b/stm32-modules/reference-module/firmware/system/system_hardware.c
@@ -1,52 +1,39 @@
+#include "firmware/system_hardware.h"
+
+#include "main.h"
 #include "stm32g4xx_hal.h"
-#include "stm32g4xx_hal_rcc.h"
 #include "stm32g4xx_hal_cortex.h"
+#include "stm32g4xx_hal_rcc.h"
 #include "stm32g4xx_hal_tim.h"
 
-#include "firmware/system_hardware.h"
-#include "main.h"
-
 /** Local defines */
-// This is the start of the sys memory region for the STM32G491 
+// This is the start of the sys memory region for the STM32G491
 // from the reference manual and STM application note AN2606
 #define SYSMEM_START 0x1fff0000
 #define SYSMEM_BOOT (SYSMEM_START + 4)
 
 // address 4 in the bootable region is the address of the first instruction that
 // should run, aka the data that should be loaded into $pc.
-const uint32_t *const sysmem_boot_loc = (uint32_t*)SYSMEM_BOOT;
+const uint32_t *const sysmem_boot_loc = (uint32_t *)SYSMEM_BOOT;
 uint16_t reset_reason;
 
 enum RCC_FLAGS {
-    _NONE,
-    // high speed internal clock ready
-    HSIRDY, // = 1
-    // high speed external clock ready
-    HSERDY, // = 2
-    // main phase-locked loop clock ready
-    PLLRDY, // = 3
-    // hsi48 clock ready
-    HSI48RDY, // = 4
-    // low-speed external clock ready
-    LSERDY, // = 5
     // lse clock security system failure
-    LSECSSD, // = 6
-    // low-speed internal clock ready
-    LSIRDY, // = 7
+    LSECSSD,  // = 0
     // brown out
-    BORRST, // = 8
+    BORRST,  // = 1
     // option byte-loader reset
-    OBLRST, // = 9
+    OBLRST,  // = 2
     // pin reset
-    PINRST, // = 10
+    PINRST,  // = 3
     // software reset
-    SFTRST, // = 11
+    SFTRST,  // = 4
     // independent watchdog
-    IWDGRST, // = 12
+    IWDGRST,  // = 5
     // window watchdog
-    WWDGRST, // = 13
+    WWDGRST,  // = 6
     // low power reset
-    LPWRRST, // = 14
+    LPWRRST,  // = 7
 };
 
 static void save_reset_reason() {
@@ -54,76 +41,50 @@ static void save_reset_reason() {
     // reset flag matches any of them
     reset_reason = 0;
 
-    // high speed internal clock ready
-    if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY)) {
-        reset_reason |= HSIRDY;
-    }
-    // high speed external clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY)) {
-        reset_reason |= HSERDY;
-    }
-    // main phase-locked loop clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY)) {
-        reset_reason |= PLLRDY;
-    }
-    // hsi48 clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY)) {
-        reset_reason |= HSI48RDY;
-    }
-    // low-speed external clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY)) {
-        reset_reason |= LSERDY;
-    }
     // lse clock security system failure
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY)) {
-        reset_reason |= LSECSSD;
-    }
-    // low-speed internal clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY)) {
-        reset_reason |= LSIRDY;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSECSSD)) {
+        reset_reason |= (1 << LSECSSD);
     }
     // brown out
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
-        reset_reason |= BORRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
+        reset_reason |= (1 << BORRST);
     }
     // option byte-loader reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST)) {
-        reset_reason |= OBLRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST)) {
+        reset_reason |= (1 << OBLRST);
     }
     // pin reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
-        reset_reason |= PINRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
+        reset_reason |= (1 << PINRST);
     }
     // software reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
-        reset_reason |= SFTRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
+        reset_reason |= (1 << SFTRST);
     }
     // independent watchdog
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
-        reset_reason |= IWDGRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
+        reset_reason |= (1 << IWDGRST);
     }
     // window watchdog
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
-        reset_reason |= WWDGRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
+        reset_reason |= (1 << WWDGRST);
     }
     // low power reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
-        reset_reason |= LPWRRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
+        reset_reason |= (1 << LPWRRST);
     }
 }
 
-uint16_t system_hardware_reset_reason() {
-    return reset_reason;
-}
+uint16_t system_hardware_reset_reason() { return reset_reason; }
 
 /** PUBLIC FUNCTION IMPLEMENTATION */
 
 void system_hardware_enter_bootloader(void) {
+    // We have to uninitialize as many of the peripherals as possible, because
+    // the bootloader expects to start as the system comes up
 
-    // We have to uninitialize as many of the peripherals as possible, because the bootloader
-    // expects to start as the system comes up
-
-    // The HAL has ways to turn off all the core clocking and the clock security system
+    // The HAL has ways to turn off all the core clocking and the clock security
+    // system
     HAL_RCC_DisableLSECSS();
     HAL_RCC_DeInit();
 
@@ -133,32 +94,31 @@ void system_hardware_enter_bootloader(void) {
     SysTick->VAL = 0;
 
     /* Clear Interrupt Enable Register & Interrupt Pending Register */
-    for (int i=0;i<8;i++)
-    {
-        NVIC->ICER[i]=0xFFFFFFFF;
-        NVIC->ICPR[i]=0xFFFFFFFF;
+    for (int i = 0; i < 8; i++) {
+        NVIC->ICER[i] = 0xFFFFFFFF;
+        NVIC->ICPR[i] = 0xFFFFFFFF;
     }
 
-    // We have to make sure that the processor is mapping the system memory region to address 0,
-    // which the bootloader expects
+    // We have to make sure that the processor is mapping the system memory
+    // region to address 0, which the bootloader expects
     __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH();
     // and now we're ready to set the system up to start executing system flash.
     // arm cortex initialization means that
-    // address 0 in the bootable region is the address where the processor should start its stack
-    // which we have to do as late as possible because as soon as we do this the c and c++ runtime
-    // environment is no longer valid
-    __set_MSP(*((uint32_t*)SYSMEM_START));
+    // address 0 in the bootable region is the address where the processor
+    // should start its stack which we have to do as late as possible because as
+    // soon as we do this the c and c++ runtime environment is no longer valid
+    __set_MSP(*((uint32_t *)SYSMEM_START));
 
     // finally, jump to the bootloader. we do this in inline asm because we need
-    // this to be a naked call (no caller-side prep like stacking return addresses)
-    // and to have a naked function you need to define it as a function, not a
-    // function pointer, and we don't statically know the address here since it is
-    // whatever's contained in that second word of the bsystem memory region.
-    asm volatile (
-        "bx %0"
-        : // no outputs
-        : "r" (*sysmem_boot_loc)
-        : "memory"  );
+    // this to be a naked call (no caller-side prep like stacking return
+    // addresses) and to have a naked function you need to define it as a
+    // function, not a function pointer, and we don't statically know the
+    // address here since it is whatever's contained in that second word of the
+    // bsystem memory region.
+    asm volatile("bx %0"
+                 :  // no outputs
+                 : "r"(*sysmem_boot_loc)
+                 : "memory");
 }
 
 /**
@@ -181,7 +141,8 @@ void eeprom_write_protect_init(void) {
  * enable/disable writing to the eeprom.
  */
 void enable_eeprom_write(bool enable) {
-    HAL_GPIO_WritePin(EEPROM_WP_PORT, EEPROM_WP_PIN, enable ? GPIO_PIN_RESET : GPIO_PIN_SET);
+    HAL_GPIO_WritePin(EEPROM_WP_PORT, EEPROM_WP_PIN,
+                      enable ? GPIO_PIN_RESET : GPIO_PIN_SET);
 }
 
 void system_hardware_gpio_init(void) {
@@ -190,4 +151,3 @@ void system_hardware_gpio_init(void) {
     // Disable eeprom write
     enable_eeprom_write(false);
 }
-

--- a/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
+++ b/stm32-modules/tempdeck-gen3/firmware/thermal_control/thermal_hardware.c
@@ -18,7 +18,8 @@
 // Given a desired frequency of 500kHz, we do not need to prescale the timer
 #define TIM2_PRESCALER (0)
 // Calculates out to 339
-#define TIM2_RELOAD ((TIMER_CLOCK_FREQ / (PULSE_WIDTH_FREQ * (TIM2_PRESCALER + 1))) - 1)
+#define TIM2_RELOAD \
+    ((TIMER_CLOCK_FREQ / (PULSE_WIDTH_FREQ * (TIM2_PRESCALER + 1))) - 1)
 // PWM should be scaled from 0 to MAX_PWM, inclusive
 #define MAX_PWM (TIM2_RELOAD + 1)
 
@@ -44,7 +45,8 @@
 
 #define TIM16_PRESCALER (67)
 // Calculates out to 2499
-#define TIM16_RELOAD ((TIMER_CLOCK_FREQ / (FAN_PULSE_WIDTH_FREQ * (TIM16_PRESCALER + 1))) - 1)
+#define TIM16_RELOAD \
+    ((TIMER_CLOCK_FREQ / (FAN_PULSE_WIDTH_FREQ * (TIM16_PRESCALER + 1))) - 1)
 
 // PWM should be scaled from 0 to FAN_MAX_PWM, inclusive
 #define FAN_MAX_PWM (TIM16_RELOAD + 1)
@@ -67,7 +69,6 @@ struct thermal_hardware {
     double hot_side_power;
 };
 
-
 // ***************************************************************************
 // Local variables
 
@@ -81,35 +82,22 @@ static struct thermal_hardware hardware = {
 };
 
 enum RCC_FLAGS {
-    _NONE,
-    // high speed internal clock ready
-    HSIRDY, // = 1
-    // high speed external clock ready
-    HSERDY, // = 2
-    // main phase-locked loop clock ready
-    PLLRDY, // = 3
-    // hsi48 clock ready
-    HSI48RDY, // = 4
-    // low-speed external clock ready
-    LSERDY, // = 5
     // lse clock security system failure
-    LSECSSD, // = 6
-    // low-speed internal clock ready
-    LSIRDY, // = 7
+    LSECSSD,  // = 0
     // brown out
-    BORRST, // = 8
+    BORRST,  // = 1
     // option byte-loader reset
-    OBLRST, // = 9
+    OBLRST,  // = 2
     // pin reset
-    PINRST, // = 10
+    PINRST,  // = 3
     // software reset
-    SFTRST, // = 11
+    SFTRST,  // = 4
     // independent watchdog
-    IWDGRST, // = 12
+    IWDGRST,  // = 5
     // window watchdog
-    WWDGRST, // = 13
+    WWDGRST,  // = 6
     // low power reset
-    LPWRRST, // = 14
+    LPWRRST,  // = 7
 };
 
 // ***************************************************************************
@@ -135,7 +123,7 @@ static void save_reset_reason();
 
 void thermal_hardware_init() {
     save_reset_reason();
-    if(!hardware.initialized) {
+    if (!hardware.initialized) {
         init_gpio();
         init_peltier_timer();
         init_fan_timer();
@@ -150,12 +138,10 @@ void thermal_hardware_init() {
 
 uint16_t reset_reason;
 
-uint16_t thermal_hardware_reset_reason() {
-    return reset_reason;
-}
+uint16_t thermal_hardware_reset_reason() { return reset_reason; }
 
 void thermal_hardware_enable_peltiers() {
-    if(!hardware.initialized) {
+    if (!hardware.initialized) {
         return;
     }
     hardware.enabled = true;
@@ -163,12 +149,12 @@ void thermal_hardware_enable_peltiers() {
 }
 
 void thermal_hardware_disable_peltiers() {
-    if(!hardware.initialized) {
+    if (!hardware.initialized) {
         return;
     }
     hardware.enabled = false;
     HAL_GPIO_WritePin(PELTIER_ENABLE_PORT, PELTIER_ENABLE_PIN, GPIO_PIN_RESET);
-    
+
     __HAL_TIM_SET_COMPARE(&hardware.peltier_timer, HEATING_CHANNEL, 0);
     __HAL_TIM_SET_COMPARE(&hardware.peltier_timer, COOLING_CHANNEL, 0);
 
@@ -177,24 +163,24 @@ void thermal_hardware_disable_peltiers() {
 }
 
 bool thermal_hardware_set_peltier_heat(double power) {
-    if((!hardware.initialized) || (!hardware.enabled)) {
+    if ((!hardware.initialized) || (!hardware.enabled)) {
         return false;
     }
 
-    if(power < MIN_PELTIER_POWER && power > 0.0F) {
+    if (power < MIN_PELTIER_POWER && power > 0.0F) {
         power = MIN_PELTIER_POWER;
     }
-    if(power < 0.0F) {
+    if (power < 0.0F) {
         power = 0.0F;
     }
-    if(power > MAX_PELTIER_POWER) {
+    if (power > MAX_PELTIER_POWER) {
         power = MAX_PELTIER_POWER;
     }
 
     uint32_t pwm = power * (double)MAX_PWM;
     __HAL_TIM_SET_COMPARE(&hardware.peltier_timer, COOLING_CHANNEL, 0);
     __HAL_TIM_SET_COMPARE(&hardware.peltier_timer, HEATING_CHANNEL, pwm);
-    
+
     hardware.hot_side_power = power;
     hardware.cool_side_power = 0.0F;
 
@@ -202,24 +188,24 @@ bool thermal_hardware_set_peltier_heat(double power) {
 }
 
 bool thermal_hardware_set_peltier_cool(double power) {
-    if((!hardware.initialized) || (!hardware.enabled)) {
+    if ((!hardware.initialized) || (!hardware.enabled)) {
         return false;
     }
 
-    if(power < MIN_PELTIER_POWER && power > 0.0F) {
+    if (power < MIN_PELTIER_POWER && power > 0.0F) {
         power = MIN_PELTIER_POWER;
     }
-    if(power < 0.0F) {
+    if (power < 0.0F) {
         power = 0.0F;
     }
-    if(power > MAX_PELTIER_POWER) {
+    if (power > MAX_PELTIER_POWER) {
         power = MAX_PELTIER_POWER;
     }
-    
+
     uint32_t pwm = power * (double)MAX_PWM;
     __HAL_TIM_SET_COMPARE(&hardware.peltier_timer, HEATING_CHANNEL, 0);
     __HAL_TIM_SET_COMPARE(&hardware.peltier_timer, COOLING_CHANNEL, pwm);
-    
+
     hardware.hot_side_power = 0.0F;
     hardware.cool_side_power = power;
 
@@ -227,26 +213,28 @@ bool thermal_hardware_set_peltier_cool(double power) {
 }
 
 bool thermal_hardware_set_fan_power(double power) {
-    if(!hardware.initialized) {
+    if (!hardware.initialized) {
         return false;
     }
-    if(power > 1.0F) {
+    if (power > 1.0F) {
         return false;
     }
     uint32_t pwm = power * (double)FAN_MAX_PWM;
-    
+
     // The fan controller will default to full power if it thinks the
     // control line is disconnected, and unfortunately it thinks a 0% PWM
-    // is a disconnection. So the lowest allowable PWM is 0.01, which 
+    // is a disconnection. So the lowest allowable PWM is 0.01, which
     // still results in the fan staying still.
-    if(pwm == 0) { pwm = 1; }
+    if (pwm == 0) {
+        pwm = 1;
+    }
     __HAL_TIM_SET_COMPARE(&hardware.fan_timer, FAN_CHANNEL, pwm);
     return true;
 }
 
 void thermal_hardware_set_eeprom_write_protect(bool set) {
     HAL_GPIO_WritePin(EEPROM_WP_PORT, EEPROM_WP_PIN,
-        set ? GPIO_PIN_SET : GPIO_PIN_RESET);
+                      set ? GPIO_PIN_SET : GPIO_PIN_RESET);
 }
 
 // ***************************************************************************
@@ -265,14 +253,16 @@ static void init_peltier_timer() {
     hardware.peltier_timer.Init.Period = TIM2_RELOAD;
     hardware.peltier_timer.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
     hardware.peltier_timer.Init.RepetitionCounter = 0;
-    hardware.peltier_timer.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    hardware.peltier_timer.Init.AutoReloadPreload =
+        TIM_AUTORELOAD_PRELOAD_DISABLE;
     hal_ret = HAL_TIM_PWM_Init(&hardware.peltier_timer);
     configASSERT(hal_ret == HAL_OK);
 
     sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
     sMasterConfig.MasterOutputTrigger2 = TIM_TRGO2_RESET;
     sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-    hal_ret = HAL_TIMEx_MasterConfigSynchronization(&hardware.peltier_timer, &sMasterConfig);
+    hal_ret = HAL_TIMEx_MasterConfigSynchronization(&hardware.peltier_timer,
+                                                    &sMasterConfig);
     configASSERT(hal_ret == HAL_OK);
 
     // PWM1 means the output is enabled if the current timer count is LESS THAN
@@ -287,17 +277,15 @@ static void init_peltier_timer() {
     sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
     sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
 
-    hal_ret = HAL_TIM_PWM_ConfigChannel(&hardware.peltier_timer,
-                                        &sConfigOC,
+    hal_ret = HAL_TIM_PWM_ConfigChannel(&hardware.peltier_timer, &sConfigOC,
                                         HEATING_CHANNEL);
     configASSERT(hal_ret == HAL_OK);
 
-    hal_ret = HAL_TIM_PWM_ConfigChannel(&hardware.peltier_timer,
-                                        &sConfigOC,
+    hal_ret = HAL_TIM_PWM_ConfigChannel(&hardware.peltier_timer, &sConfigOC,
                                         COOLING_CHANNEL);
     configASSERT(hal_ret == HAL_OK);
-    
-    // Set up the PWM GPIO pins 
+
+    // Set up the PWM GPIO pins
 
     __HAL_RCC_GPIOB_CLK_ENABLE();
     /**TIM2 GPIO Configuration
@@ -326,7 +314,6 @@ static void init_fan_timer() {
     TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
     GPIO_InitTypeDef GPIO_InitStruct = {0};
 
-
     // Configure timer 16 for PWMN control on channel 1
     hardware.fan_timer.State = HAL_TIM_STATE_RESET;
     hardware.fan_timer.Instance = TIM16;
@@ -347,7 +334,8 @@ static void init_fan_timer() {
     sConfigOC.OCFastMode = TIM_OCFAST_ENABLE;
     sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
     sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
-    hal_ret = HAL_TIM_PWM_ConfigChannel(&hardware.fan_timer, &sConfigOC, FAN_CHANNEL);
+    hal_ret =
+        HAL_TIM_PWM_ConfigChannel(&hardware.fan_timer, &sConfigOC, FAN_CHANNEL);
     configASSERT(hal_ret == HAL_OK);
     sBreakDeadTimeConfig.OffStateRunMode = TIM_OSSR_DISABLE;
     sBreakDeadTimeConfig.OffStateIDLEMode = TIM_OSSI_DISABLE;
@@ -357,7 +345,8 @@ static void init_fan_timer() {
     sBreakDeadTimeConfig.BreakPolarity = TIM_BREAKPOLARITY_HIGH;
     sBreakDeadTimeConfig.BreakFilter = 0;
     sBreakDeadTimeConfig.AutomaticOutput = TIM_AUTOMATICOUTPUT_DISABLE;
-    hal_ret = HAL_TIMEx_ConfigBreakDeadTime(&hardware.fan_timer, &sBreakDeadTimeConfig);
+    hal_ret = HAL_TIMEx_ConfigBreakDeadTime(&hardware.fan_timer,
+                                            &sBreakDeadTimeConfig);
     configASSERT(hal_ret == HAL_OK);
 
     __GPIOA_CLK_ENABLE();
@@ -395,60 +384,36 @@ static void save_reset_reason() {
     // reset flag matches any of them
     reset_reason = 0;
 
-    // high speed internal clock ready
-    if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY)) {
-        reset_reason |= HSIRDY;
-    }
-    // high speed external clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY)) {
-        reset_reason |= HSERDY;
-    }
-    // main phase-locked loop clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY)) {
-        reset_reason |= PLLRDY;
-    }
-    // hsi48 clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY)) {
-        reset_reason |= HSI48RDY;
-    }
-    // low-speed external clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY)) {
-        reset_reason |= LSERDY;
-    }
     // lse clock security system failure
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY)) {
-        reset_reason |= LSECSSD;
-    }
-    // low-speed internal clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY)) {
-        reset_reason |= LSIRDY;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSECSSD)) {
+        reset_reason |= (1 << LSECSSD);
     }
     // brown out
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
-        reset_reason |= BORRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
+        reset_reason |= (1 << BORRST);
     }
     // option byte-loader reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST)) {
-        reset_reason |= OBLRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST)) {
+        reset_reason |= (1 << OBLRST);
     }
     // pin reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
-        reset_reason |= PINRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
+        reset_reason |= (1 << PINRST);
     }
     // software reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
-        reset_reason |= SFTRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
+        reset_reason |= (1 << SFTRST);
     }
     // independent watchdog
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
-        reset_reason |= IWDGRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
+        reset_reason |= (1 << IWDGRST);
     }
     // window watchdog
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
-        reset_reason |= WWDGRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
+        reset_reason |= (1 << WWDGRST);
     }
     // low power reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
-        reset_reason |= LPWRRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
+        reset_reason |= (1 << LPWRRST);
     }
 }

--- a/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_hardware.c
+++ b/stm32-modules/thermocycler-gen2/firmware/motor_task/motor_hardware.c
@@ -5,20 +5,18 @@
 #include "firmware/motor_hardware.h"
 
 #include <stdatomic.h>
+#include <stdlib.h>  // for abs
 #include <string.h>  // for memset
-#include <stdlib.h> // for abs
 
 #include "FreeRTOS.h"
-#include "task.h"
-
+#include "firmware/motor_spi_hardware.h"
 #include "stm32g4xx_hal.h"
 #include "stm32g4xx_hal_tim.h"
-
-#include "firmware/motor_spi_hardware.h"
+#include "task.h"
 
 #ifdef __cplusplus
 extern "C" {
-#endif // __cplusplus
+#endif  // __cplusplus
 
 // ----------------------------------------------------------------------------
 // Local definitions
@@ -49,12 +47,12 @@ extern "C" {
 /** Port for Seal Extension Limit Switch input.*/
 #define SEAL_EXTENSION_SWITCH_PORT (GPIOD)
 /** Pin for Seal Extension Limit Switch input.*/
-#define SEAL_EXTENSION_SWITCH_PIN  (GPIO_PIN_6)
+#define SEAL_EXTENSION_SWITCH_PIN (GPIO_PIN_6)
 
 /** Port for Seal Retraction Limit Switch input.*/
 #define SEAL_RETRACTION_SWITCH_PORT (GPIOC)
 /** Pin for Seal Retraction Limit Switch input.*/
-#define SEAL_RETRACTION_SWITCH_PIN  (GPIO_PIN_12)
+#define SEAL_RETRACTION_SWITCH_PIN (GPIO_PIN_12)
 
 /** Port for the Photointerrupt Enable line.*/
 #define PHOTOINTERRUPT_ENABLE_PORT (GPIOE)
@@ -91,7 +89,8 @@ extern "C" {
 /** Preload for APB to give a 10MHz clock.*/
 #define TIM6_PRELOAD (16)
 /** Calculated TIM6 period.*/
-#define TIM6_PERIOD (((TIM6_APB_FREQ/(TIM6_PRELOAD + 1)) / MOTOR_INTERRUPT_FREQ) - 1)
+#define TIM6_PERIOD \
+    (((TIM6_APB_FREQ / (TIM6_PRELOAD + 1)) / MOTOR_INTERRUPT_FREQ) - 1)
 
 /**
  * @brief Calculates the frequency of ticks to get a Lid Motor RPM. The ratio
@@ -159,61 +158,41 @@ typedef struct motor_hardware_struct {
 
 static motor_hardware_t _motor_hardware = {
     .initialized = false,
-    .callbacks = {
-        .lid_stepper_complete = NULL,
-        .seal_stepper_tick = NULL,
-        .seal_stepper_error = NULL,
-        .seal_stepper_limit_switch = NULL
-    },
-    .lid_stepper = {
-        .moving = false,
-        .direction = true,
-        .overdrive = false,
-        .step_count = 0,
-        .step_target = 0,
-        .timer = {0},
-        .dac = {0}
-    },
-    .seal = {
-        .enabled = false,
-        .moving = false,
-        .direction = false,
-        .extension_switch_armed = false,
-        .retraction_switch_armed = false,
-        .timer = {0}
-    }
-};
+    .callbacks = {.lid_stepper_complete = NULL,
+                  .seal_stepper_tick = NULL,
+                  .seal_stepper_error = NULL,
+                  .seal_stepper_limit_switch = NULL},
+    .lid_stepper = {.moving = false,
+                    .direction = true,
+                    .overdrive = false,
+                    .step_count = 0,
+                    .step_target = 0,
+                    .timer = {0},
+                    .dac = {0}},
+    .seal = {.enabled = false,
+             .moving = false,
+             .direction = false,
+             .extension_switch_armed = false,
+             .retraction_switch_armed = false,
+             .timer = {0}}};
 
 enum RCC_FLAGS {
-    NONE,
-    // high speed internal clock ready
-    HSIRDY, // = 1
-    // high speed external clock ready
-    HSERDY, // = 2
-    // main phase-locked loop clock ready
-    PLLRDY, // = 3
-    // hsi48 clock ready
-    HSI48RDY, // = 4
-    // low-speed external clock ready
-    LSERDY, // = 5
     // lse clock security system failure
-    LSECSSD, // = 6
-    // low-speed internal clock ready
-    LSIRDY, // = 7
+    LSECSSD,  // = 0
     // brown out
-    BORRST, // = 8
+    BORRST,  // = 1
     // option byte-loader reset
-    OBLRST, // = 9
+    OBLRST,  // = 2
     // pin reset
-    PINRST, // = 10
+    PINRST,  // = 3
     // software reset
-    SFTRST, // = 11
+    SFTRST,  // = 4
     // independent watchdog
-    IWDGRST, // = 12
+    IWDGRST,  // = 5
     // window watchdog
-    WWDGRST, // = 13
+    WWDGRST,  // = 6
     // low power reset
-    LPWRRST, // = 14
+    LPWRRST,  // = 7
 };
 
 // ----------------------------------------------------------------------------
@@ -239,9 +218,10 @@ void motor_hardware_setup(const motor_hardware_callbacks* callbacks) {
     configASSERT(callbacks->seal_stepper_error != NULL);
     configASSERT(callbacks->seal_stepper_limit_switch != NULL);
 
-    memcpy(&_motor_hardware.callbacks, callbacks, sizeof(_motor_hardware.callbacks));
+    memcpy(&_motor_hardware.callbacks, callbacks,
+           sizeof(_motor_hardware.callbacks));
 
-    if(!_motor_hardware.initialized) {
+    if (!_motor_hardware.initialized) {
         init_motor_gpio();
         init_dac1(&_motor_hardware.lid_stepper.dac);
         init_tim2(&_motor_hardware.lid_stepper.timer);
@@ -255,13 +235,14 @@ void motor_hardware_setup(const motor_hardware_callbacks* callbacks) {
     _motor_hardware.initialized = true;
 }
 
-//PA0/PA1/PB10/PB11 = TIM2CH1/2/3/4 (all GPIO_AF1_TIM2)
-//control via increment_step in motor_task.hpp?
-//handle end switch IT start and stop
+// PA0/PA1/PB10/PB11 = TIM2CH1/2/3/4 (all GPIO_AF1_TIM2)
+// control via increment_step in motor_task.hpp?
+// handle end switch IT start and stop
 void motor_hardware_lid_stepper_start(int32_t steps, bool overdrive) {
-    //check for fault
+    // check for fault
     _motor_hardware.lid_stepper.step_count = 0;
-    // Multiply number of steps by 2 because the timer is in toggle mode (2 interrupts = 1 microstep)
+    // Multiply number of steps by 2 because the timer is in toggle mode (2
+    // interrupts = 1 microstep)
     _motor_hardware.lid_stepper.step_target = abs(steps) * 2;
     // Set overdrive flag
     _motor_hardware.lid_stepper.overdrive = overdrive;
@@ -269,104 +250,120 @@ void motor_hardware_lid_stepper_start(int32_t steps, bool overdrive) {
     // True = opening
     _motor_hardware.lid_stepper.direction = (steps > 0);
     if (steps > 0) {
-        HAL_GPIO_WritePin(LID_STEPPER_CONTROL_Port, LID_STEPPER_DIR_Pin, GPIO_PIN_SET);
+        HAL_GPIO_WritePin(LID_STEPPER_CONTROL_Port, LID_STEPPER_DIR_Pin,
+                          GPIO_PIN_SET);
     } else {
-        HAL_GPIO_WritePin(LID_STEPPER_CONTROL_Port, LID_STEPPER_DIR_Pin, GPIO_PIN_RESET);
+        HAL_GPIO_WritePin(LID_STEPPER_CONTROL_Port, LID_STEPPER_DIR_Pin,
+                          GPIO_PIN_RESET);
     }
 
-    HAL_TIM_OC_Start_IT(&_motor_hardware.lid_stepper.timer, LID_STEPPER_STEP_Channel);
+    HAL_TIM_OC_Start_IT(&_motor_hardware.lid_stepper.timer,
+                        LID_STEPPER_STEP_Channel);
 }
 
 void motor_hardware_lid_stepper_stop() {
-    HAL_TIM_OC_Stop_IT(&_motor_hardware.lid_stepper.timer, LID_STEPPER_STEP_Channel);
+    HAL_TIM_OC_Stop_IT(&_motor_hardware.lid_stepper.timer,
+                       LID_STEPPER_STEP_Channel);
 }
 
 void motor_hardware_lid_increment() {
     bool done = false;
     _motor_hardware.lid_stepper.step_count++;
     // Only check stop switches if this is NOT an overdrive
-    if(!_motor_hardware.lid_stepper.overdrive) {
-        if(_motor_hardware.lid_stepper.direction) {
+    if (!_motor_hardware.lid_stepper.overdrive) {
+        if (_motor_hardware.lid_stepper.direction) {
             // Check if lid is open
-            if(motor_hardware_lid_read_open()) {
+            if (motor_hardware_lid_read_open()) {
                 done = true;
             }
         } else {
             // Check if lid is closed
-            if(motor_hardware_lid_read_closed()) {
+            if (motor_hardware_lid_read_closed()) {
                 done = true;
             }
         }
     }
-    
-    // If the lid hit a limit switch, 
-    if (_motor_hardware.lid_stepper.step_count > (_motor_hardware.lid_stepper.step_target - 1)) {
+
+    // If the lid hit a limit switch,
+    if (_motor_hardware.lid_stepper.step_count >
+        (_motor_hardware.lid_stepper.step_target - 1)) {
         done = true;
     }
 
-    if(done) {
+    if (done) {
         motor_hardware_lid_stepper_stop();
         _motor_hardware.callbacks.lid_stepper_complete();
     }
 }
 
 void motor_hardware_lid_stepper_set_dac(uint8_t dacval) {
-    HAL_DAC_SetValue(&_motor_hardware.lid_stepper.dac, LID_STEPPER_VREF_CHANNEL, DAC_ALIGN_8B_R, dacval);
+    HAL_DAC_SetValue(&_motor_hardware.lid_stepper.dac, LID_STEPPER_VREF_CHANNEL,
+                     DAC_ALIGN_8B_R, dacval);
 }
 
 bool motor_hardware_lid_stepper_check_fault(void) {
-    return (HAL_GPIO_ReadPin(LID_STEPPER_ENABLE_Port, LID_STEPPER_FAULT_Pin) == GPIO_PIN_RESET) ? true : false;
+    return (HAL_GPIO_ReadPin(LID_STEPPER_ENABLE_Port, LID_STEPPER_FAULT_Pin) ==
+            GPIO_PIN_RESET)
+               ? true
+               : false;
 }
 
 bool motor_hardware_lid_stepper_reset(void) {
-    //if fault, try resetting
+    // if fault, try resetting
     if (motor_hardware_lid_stepper_check_fault()) {
-        HAL_GPIO_WritePin(LID_STEPPER_ENABLE_Port, LID_STEPPER_RESET_Pin, GPIO_PIN_RESET);
+        HAL_GPIO_WritePin(LID_STEPPER_ENABLE_Port, LID_STEPPER_RESET_Pin,
+                          GPIO_PIN_RESET);
         vTaskDelay(pdMS_TO_TICKS(100));
-        HAL_GPIO_WritePin(LID_STEPPER_ENABLE_Port, LID_STEPPER_RESET_Pin, GPIO_PIN_SET);
+        HAL_GPIO_WritePin(LID_STEPPER_ENABLE_Port, LID_STEPPER_RESET_Pin,
+                          GPIO_PIN_SET);
     }
-    //return false if fault persists
+    // return false if fault persists
     return (motor_hardware_lid_stepper_check_fault() == true) ? false : true;
 }
 
 bool motor_hardware_lid_stepper_set_rpm(double rpm) {
-    if(lid_active()) {
+    if (lid_active()) {
         return false;
     }
-    if(rpm < LID_RPM_MIN || rpm > LID_RPM_MAX) {
+    if (rpm < LID_RPM_MIN || rpm > LID_RPM_MAX) {
         return false;
     }
 
     /* Compute TIM2 clock */
     uint32_t uwTimClock = HAL_RCC_GetPCLK1Freq();
     uint32_t uwPeriodValue = __HAL_TIM_CALC_PERIOD(
-                uwTimClock, 
-                _motor_hardware.lid_stepper.timer.Init.Prescaler, 
-                LID_RPM_TO_FREQ(rpm));
+        uwTimClock, _motor_hardware.lid_stepper.timer.Init.Prescaler,
+        LID_RPM_TO_FREQ(rpm));
     __HAL_TIM_SET_AUTORELOAD(&_motor_hardware.lid_stepper.timer, uwPeriodValue);
-    
+
     return true;
 }
 
 bool motor_hardware_lid_read_closed(void) {
-    return (HAL_GPIO_ReadPin(LID_CLOSED_SWITCH_PORT, LID_CLOSED_SWITCH_PIN) == GPIO_PIN_RESET) ? true : false;
+    return (HAL_GPIO_ReadPin(LID_CLOSED_SWITCH_PORT, LID_CLOSED_SWITCH_PIN) ==
+            GPIO_PIN_RESET)
+               ? true
+               : false;
 }
 
 bool motor_hardware_lid_read_open(void) {
-    return (HAL_GPIO_ReadPin(LID_OPEN_SWITCH_PORT, LID_OPEN_SWITCH_PIN) == GPIO_PIN_SET) ? true : false;
+    return (HAL_GPIO_ReadPin(LID_OPEN_SWITCH_PORT, LID_OPEN_SWITCH_PIN) ==
+            GPIO_PIN_SET)
+               ? true
+               : false;
 }
 
 bool motor_hardware_set_seal_enable(bool enable) {
     // Active low
-    HAL_GPIO_WritePin(SEAL_STEPPER_ENABLE_PORT, SEAL_STEPPER_ENABLE_PIN, 
-        (enable) ? GPIO_PIN_RESET : GPIO_PIN_SET);
+    HAL_GPIO_WritePin(SEAL_STEPPER_ENABLE_PORT, SEAL_STEPPER_ENABLE_PIN,
+                      (enable) ? GPIO_PIN_RESET : GPIO_PIN_SET);
     return true;
 }
 
 bool motor_hardware_set_seal_direction(bool direction) {
     _motor_hardware.seal.direction = direction;
-    HAL_GPIO_WritePin(SEAL_STEPPER_DIRECTION_PORT, SEAL_STEPPER_DIRECTION_PIN, 
-        direction ? GPIO_PIN_SET : GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(SEAL_STEPPER_DIRECTION_PORT, SEAL_STEPPER_DIRECTION_PIN,
+                      direction ? GPIO_PIN_SET : GPIO_PIN_RESET);
     return true;
 }
 
@@ -383,14 +380,15 @@ void motor_hardware_seal_interrupt(void) {
 }
 
 void motor_hardware_seal_step_pulse(void) {
-    HAL_GPIO_WritePin(SEAL_STEPPER_STEP_PORT, SEAL_STEPPER_STEP_PIN, 
+    HAL_GPIO_WritePin(SEAL_STEPPER_STEP_PORT, SEAL_STEPPER_STEP_PIN,
                       GPIO_PIN_SET);
-    HAL_GPIO_WritePin(SEAL_STEPPER_STEP_PORT, SEAL_STEPPER_STEP_PIN, 
+    HAL_GPIO_WritePin(SEAL_STEPPER_STEP_PORT, SEAL_STEPPER_STEP_PIN,
                       GPIO_PIN_RESET);
 }
 
-void motor_hardware_solenoid_engage() { //engage to clear/unlock sliding locking plate
-    //check to confirm lid closed before engaging solenoid
+void motor_hardware_solenoid_engage() {  // engage to clear/unlock sliding
+                                         // locking plate
+    // check to confirm lid closed before engaging solenoid
     HAL_GPIO_WritePin(SOLENOID_Port, SOLENOID_Pin, GPIO_PIN_SET);
 }
 
@@ -400,29 +398,33 @@ void motor_hardware_solenoid_release() {
 
 bool motor_hardware_seal_extension_switch_triggered() {
     // Active low - the switches pull to ground when triggered
-    return (HAL_GPIO_ReadPin(SEAL_EXTENSION_SWITCH_PORT, SEAL_EXTENSION_SWITCH_PIN)
-             == GPIO_PIN_RESET) ? true : false; 
+    return (HAL_GPIO_ReadPin(SEAL_EXTENSION_SWITCH_PORT,
+                             SEAL_EXTENSION_SWITCH_PIN) == GPIO_PIN_RESET)
+               ? true
+               : false;
 }
 
 bool motor_hardware_seal_retraction_switch_triggered() {
     // Active low - the switches pull to ground when triggered
-    return (HAL_GPIO_ReadPin(SEAL_RETRACTION_SWITCH_PORT, SEAL_RETRACTION_SWITCH_PIN)
-             == GPIO_PIN_RESET) ? true : false; 
+    return (HAL_GPIO_ReadPin(SEAL_RETRACTION_SWITCH_PORT,
+                             SEAL_RETRACTION_SWITCH_PIN) == GPIO_PIN_RESET)
+               ? true
+               : false;
 }
 
 void motor_hardware_seal_switch_interrupt() {
-    if(__HAL_GPIO_EXTI_GET_IT(SEAL_EXTENSION_SWITCH_PIN) != 0x00u) {
+    if (__HAL_GPIO_EXTI_GET_IT(SEAL_EXTENSION_SWITCH_PIN) != 0x00u) {
         __HAL_GPIO_EXTI_CLEAR_IT(SEAL_EXTENSION_SWITCH_PIN);
-        if(atomic_exchange(&_motor_hardware.seal.extension_switch_armed, 0)) {
-            if(_motor_hardware.callbacks.seal_stepper_limit_switch != NULL) {
+        if (atomic_exchange(&_motor_hardware.seal.extension_switch_armed, 0)) {
+            if (_motor_hardware.callbacks.seal_stepper_limit_switch != NULL) {
                 _motor_hardware.callbacks.seal_stepper_limit_switch();
             }
         }
     }
-    if(__HAL_GPIO_EXTI_GET_IT(SEAL_RETRACTION_SWITCH_PIN) != 0x00u) {
+    if (__HAL_GPIO_EXTI_GET_IT(SEAL_RETRACTION_SWITCH_PIN) != 0x00u) {
         __HAL_GPIO_EXTI_CLEAR_IT(SEAL_RETRACTION_SWITCH_PIN);
-        if(atomic_exchange(&_motor_hardware.seal.retraction_switch_armed, 0)) {
-            if(_motor_hardware.callbacks.seal_stepper_limit_switch != NULL) {
+        if (atomic_exchange(&_motor_hardware.seal.retraction_switch_armed, 0)) {
+            if (_motor_hardware.callbacks.seal_stepper_limit_switch != NULL) {
                 _motor_hardware.callbacks.seal_stepper_limit_switch();
             }
         }
@@ -442,22 +444,19 @@ void motor_hardware_seal_switch_set_disarmed() {
     _motor_hardware.seal.retraction_switch_armed = false;
 }
 
-uint16_t motor_hardware_reset_reason() {
-    return reset_reason;
-}
+uint16_t motor_hardware_reset_reason() { return reset_reason; }
 
 // ----------------------------------------------------------------------------
 // Local function implementation
 
 /**
-  * @brief GPIO Initialization Function
-  * @param None
-  * @retval None
-  */
-static void init_motor_gpio(void)
-{
+ * @brief GPIO Initialization Function
+ * @param None
+ * @retval None
+ */
+static void init_motor_gpio(void) {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
-    
+
     /* Enable GPIOx clocks */
     __HAL_RCC_GPIOA_CLK_ENABLE();
     __HAL_RCC_GPIOB_CLK_ENABLE();
@@ -473,12 +472,14 @@ static void init_motor_gpio(void)
     GPIO_InitStruct.Pin = LID_STEPPER_RESET_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
     HAL_GPIO_Init(LID_STEPPER_ENABLE_Port, &GPIO_InitStruct);
-    HAL_GPIO_WritePin(LID_STEPPER_ENABLE_Port, LID_STEPPER_RESET_Pin, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(LID_STEPPER_ENABLE_Port, LID_STEPPER_RESET_Pin,
+                      GPIO_PIN_SET);
 
     GPIO_InitStruct.Pin = LID_STEPPER_ENABLE_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
     HAL_GPIO_Init(LID_STEPPER_ENABLE_Port, &GPIO_InitStruct);
-    HAL_GPIO_WritePin(LID_STEPPER_ENABLE_Port, LID_STEPPER_ENABLE_Pin, GPIO_PIN_RESET); //enable output at init
+    HAL_GPIO_WritePin(LID_STEPPER_ENABLE_Port, LID_STEPPER_ENABLE_Pin,
+                      GPIO_PIN_RESET);  // enable output at init
 
     GPIO_InitStruct.Pin = LID_STEPPER_FAULT_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
@@ -506,7 +507,7 @@ static void init_motor_gpio(void)
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Alternate = 0;
     HAL_GPIO_Init(LID_CLOSED_SWITCH_PORT, &GPIO_InitStruct);
-    
+
     GPIO_InitStruct.Pin = LID_OPEN_SWITCH_PIN;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FAST;
@@ -519,15 +520,16 @@ static void init_motor_gpio(void)
     GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_LOW;
-	GPIO_InitStruct.Alternate = 0;
+    GPIO_InitStruct.Alternate = 0;
     HAL_GPIO_Init(PHOTOINTERRUPT_ENABLE_PORT, &GPIO_InitStruct);
-    HAL_GPIO_WritePin(PHOTOINTERRUPT_ENABLE_PORT, PHOTOINTERRUPT_ENABLE_PIN, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(PHOTOINTERRUPT_ENABLE_PORT, PHOTOINTERRUPT_ENABLE_PIN,
+                      GPIO_PIN_SET);
 
     GPIO_InitStruct.Pin = SEAL_STEPPER_ENABLE_PIN;
     GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_LOW;
-	GPIO_InitStruct.Alternate = 0;
+    GPIO_InitStruct.Alternate = 0;
     HAL_GPIO_Init(SEAL_STEPPER_ENABLE_PORT, &GPIO_InitStruct);
 
     GPIO_InitStruct.Pin = SEAL_STEPPER_DIRECTION_PIN;
@@ -554,7 +556,7 @@ static void init_motor_gpio(void)
     GPIO_InitStruct.Speed = GPIO_SPEED_LOW;
     HAL_GPIO_Init(SEAL_STEPPER_DIAG1_PORT, &GPIO_InitStruct);
 
-    // The IRQ for this line (EXTI 5 through 9) is enabled by 
+    // The IRQ for this line (EXTI 5 through 9) is enabled by
     // the thermal subsystem.
     GPIO_InitStruct.Pin = SEAL_EXTENSION_SWITCH_PIN;
     GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
@@ -598,11 +600,13 @@ static void init_dac1(DAC_HandleTypeDef* hdac) {
         .DAC_Trigger = DAC_TRIGGER_NONE,
         .DAC_OutputBuffer = DAC_OUTPUTBUFFER_ENABLE,
     };
-    hal_ret = HAL_DAC_ConfigChannel(hdac, &chan_config, LID_STEPPER_VREF_CHANNEL);
+    hal_ret =
+        HAL_DAC_ConfigChannel(hdac, &chan_config, LID_STEPPER_VREF_CHANNEL);
     configASSERT(hal_ret == HAL_OK);
     hal_ret = HAL_DAC_Start(hdac, LID_STEPPER_VREF_CHANNEL);
     configASSERT(hal_ret == HAL_OK);
-    hal_ret = HAL_DAC_SetValue(hdac, LID_STEPPER_VREF_CHANNEL, DAC_ALIGN_8B_R, 0);
+    hal_ret =
+        HAL_DAC_SetValue(hdac, LID_STEPPER_VREF_CHANNEL, DAC_ALIGN_8B_R, 0);
     configASSERT(hal_ret == HAL_OK);
 }
 
@@ -613,9 +617,10 @@ static void init_tim2(TIM_HandleTypeDef* htim) {
     /* Compute TIM2 clock */
     uint32_t uwTimClock = HAL_RCC_GetPCLK1Freq();
     /* Compute the prescaler value to have TIM2 counter clock equal to 1MHz */
-    uint32_t uwPrescalerValue = (uint32_t) ((uwTimClock / 1000000U) - 1U);
-    uint32_t uwPeriodValue = __HAL_TIM_CALC_PERIOD(uwTimClock, uwPrescalerValue, LID_RPM_TO_FREQ(125));
-    
+    uint32_t uwPrescalerValue = (uint32_t)((uwTimClock / 1000000U) - 1U);
+    uint32_t uwPeriodValue = __HAL_TIM_CALC_PERIOD(uwTimClock, uwPrescalerValue,
+                                                   LID_RPM_TO_FREQ(125));
+
     htim->Instance = TIM2;
     htim->Init.Prescaler = uwPrescalerValue;
     htim->Init.CounterMode = TIM_COUNTERMODE_UP;
@@ -626,15 +631,15 @@ static void init_tim2(TIM_HandleTypeDef* htim) {
     htim->State = HAL_TIM_STATE_RESET;
     hal_ret = HAL_TIM_OC_Init(htim);
     configASSERT(hal_ret == HAL_OK);
-    
+
     htim_oc.OCMode = TIM_OCMODE_TOGGLE;
     htim_oc.OCPolarity = TIM_OCPOLARITY_HIGH;
     htim_oc.OCFastMode = TIM_OCFAST_DISABLE;
     htim_oc.OCIdleState = TIM_OCIDLESTATE_RESET;
-    hal_ret = HAL_TIM_OC_ConfigChannel(htim, &htim_oc, LID_STEPPER_STEP_Channel);
+    hal_ret =
+        HAL_TIM_OC_ConfigChannel(htim, &htim_oc, LID_STEPPER_STEP_Channel);
     configASSERT(hal_ret == HAL_OK);
 }
-
 
 static void init_tim6(TIM_HandleTypeDef* htim) {
     HAL_StatusTypeDef hal_ret;
@@ -657,9 +662,9 @@ static void init_tim6(TIM_HandleTypeDef* htim) {
 }
 
 static bool lid_active() {
-    return TIM_CHANNEL_STATE_GET
-        (&(_motor_hardware.lid_stepper.timer), LID_STEPPER_STEP_Channel) 
-        != HAL_TIM_CHANNEL_STATE_READY;
+    return TIM_CHANNEL_STATE_GET(&(_motor_hardware.lid_stepper.timer),
+                                 LID_STEPPER_STEP_Channel) !=
+           HAL_TIM_CHANNEL_STATE_READY;
 }
 
 static void save_reset_reason() {
@@ -667,61 +672,37 @@ static void save_reset_reason() {
     // reset flag matches any of them
     reset_reason = 0;
 
-    // high speed internal clock ready
-    if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY)) {
-        reset_reason |= HSIRDY;
-    }
-    // high speed external clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY)) {
-        reset_reason |= HSERDY;
-    }
-    // main phase-locked loop clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY)) {
-        reset_reason |= PLLRDY;
-    }
-    // hsi48 clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSI48RDY)) {
-        reset_reason |= HSI48RDY;
-    }
-    // low-speed external clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY)) {
-        reset_reason |= LSERDY;
-    }
     // lse clock security system failure
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSECSSD)) {
-        reset_reason |= LSECSSD;
-    }
-    // low-speed internal clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY)) {
-        reset_reason |= LSIRDY;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSECSSD)) {
+        reset_reason |= (1 << LSECSSD);
     }
     // brown out
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
-        reset_reason |= BORRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
+        reset_reason |= (1 << BORRST);
     }
     // option byte-loader reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST)) {
-        reset_reason |= OBLRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST)) {
+        reset_reason |= (1 << OBLRST);
     }
     // pin reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
-        reset_reason |= PINRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
+        reset_reason |= (1 << PINRST);
     }
     // software reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
-        reset_reason |= SFTRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
+        reset_reason |= (1 << SFTRST);
     }
     // independent watchdog
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
-        reset_reason |= IWDGRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
+        reset_reason |= (1 << IWDGRST);
     }
     // window watchdog
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
-        reset_reason |= WWDGRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
+        reset_reason |= (1 << WWDGRST);
     }
     // low power reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
-        reset_reason |= LPWRRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
+        reset_reason |= (1 << LPWRRST);
     }
 }
 
@@ -729,16 +710,16 @@ static void save_reset_reason() {
 // Overwritten HAL functions
 
 /**
-  * @brief This function handles TIM2 global interrupt (used for
-  * Lid Stepper control)
-  */
-void TIM2_IRQHandler(void) { 
-    HAL_TIM_IRQHandler(&_motor_hardware.lid_stepper.timer); 
+ * @brief This function handles TIM2 global interrupt (used for
+ * Lid Stepper control)
+ */
+void TIM2_IRQHandler(void) {
+    HAL_TIM_IRQHandler(&_motor_hardware.lid_stepper.timer);
 }
 
 /**
-  * @brief This function handles TIM6 global interrupt.
-  */
+ * @brief This function handles TIM6 global interrupt.
+ */
 void TIM6_DAC_IRQHandler(void) {
     HAL_TIM_IRQHandler(&_motor_hardware.seal.timer);
 }
@@ -748,12 +729,12 @@ void TIM6_DAC_IRQHandler(void) {
  * This flags a seal stepper error event
  */
 void EXTI3_IRQHandler(void) {
-	if(__HAL_GPIO_EXTI_GET_IT(SEAL_STEPPER_DIAG0_PIN) != 0x00u) {
-		__HAL_GPIO_EXTI_CLEAR_IT(SEAL_STEPPER_DIAG0_PIN);
-		if(_motor_hardware.callbacks.seal_stepper_error) {
-			_motor_hardware.callbacks.seal_stepper_error(MOTOR_ERROR);
-		}	
-	}
+    if (__HAL_GPIO_EXTI_GET_IT(SEAL_STEPPER_DIAG0_PIN) != 0x00u) {
+        __HAL_GPIO_EXTI_CLEAR_IT(SEAL_STEPPER_DIAG0_PIN);
+        if (_motor_hardware.callbacks.seal_stepper_error) {
+            _motor_hardware.callbacks.seal_stepper_error(MOTOR_ERROR);
+        }
+    }
 }
 
 /**
@@ -761,14 +742,14 @@ void EXTI3_IRQHandler(void) {
  * This flags a seal stepper stall event.
  */
 void EXTI4_IRQHandler(void) {
-	if(__HAL_GPIO_EXTI_GET_IT(SEAL_STEPPER_DIAG1_PIN) != 0x00u) {
-		__HAL_GPIO_EXTI_CLEAR_IT(SEAL_STEPPER_DIAG1_PIN);
-		if(_motor_hardware.callbacks.seal_stepper_error) {
-			_motor_hardware.callbacks.seal_stepper_error(MOTOR_STALL);
-		}
-	}
+    if (__HAL_GPIO_EXTI_GET_IT(SEAL_STEPPER_DIAG1_PIN) != 0x00u) {
+        __HAL_GPIO_EXTI_CLEAR_IT(SEAL_STEPPER_DIAG1_PIN);
+        if (_motor_hardware.callbacks.seal_stepper_error) {
+            _motor_hardware.callbacks.seal_stepper_error(MOTOR_STALL);
+        }
+    }
 }
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/stm32-modules/vacuum-module/firmware/system/system_hardware.c
+++ b/stm32-modules/vacuum-module/firmware/system/system_hardware.c
@@ -1,52 +1,39 @@
+#include "firmware/system_hardware.h"
+
+#include "main.h"
 #include "stm32g4xx_hal.h"
-#include "stm32g4xx_hal_rcc.h"
 #include "stm32g4xx_hal_cortex.h"
+#include "stm32g4xx_hal_rcc.h"
 #include "stm32g4xx_hal_tim.h"
 
-#include "firmware/system_hardware.h"
-#include "main.h"
-
 /** Local defines */
-// This is the start of the sys memory region for the STM32G491 
+// This is the start of the sys memory region for the STM32G491
 // from the reference manual and STM application note AN2606
 #define SYSMEM_START 0x1fff0000
 #define SYSMEM_BOOT (SYSMEM_START + 4)
 
 // address 4 in the bootable region is the address of the first instruction that
 // should run, aka the data that should be loaded into $pc.
-const uint32_t *const sysmem_boot_loc = (uint32_t*)SYSMEM_BOOT;
+const uint32_t *const sysmem_boot_loc = (uint32_t *)SYSMEM_BOOT;
 uint16_t reset_reason;
 
 enum RCC_FLAGS {
-    _NONE,
-    // high speed internal clock ready
-    HSIRDY, // = 1
-    // high speed external clock ready
-    HSERDY, // = 2
-    // main phase-locked loop clock ready
-    PLLRDY, // = 3
-    // hsi48 clock ready
-    HSI48RDY, // = 4
-    // low-speed external clock ready
-    LSERDY, // = 5
     // lse clock security system failure
-    LSECSSD, // = 6
-    // low-speed internal clock ready
-    LSIRDY, // = 7
+    LSECSSD,  // = 0
     // brown out
-    BORRST, // = 8
+    BORRST,  // = 1
     // option byte-loader reset
-    OBLRST, // = 9
+    OBLRST,  // = 2
     // pin reset
-    PINRST, // = 10
+    PINRST,  // = 3
     // software reset
-    SFTRST, // = 11
+    SFTRST,  // = 4
     // independent watchdog
-    IWDGRST, // = 12
+    IWDGRST,  // = 5
     // window watchdog
-    WWDGRST, // = 13
+    WWDGRST,  // = 6
     // low power reset
-    LPWRRST, // = 14
+    LPWRRST,  // = 7
 };
 
 static void save_reset_reason() {
@@ -54,76 +41,46 @@ static void save_reset_reason() {
     // reset flag matches any of them
     reset_reason = 0;
 
-    // high speed internal clock ready
-    if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY)) {
-        reset_reason |= HSIRDY;
-    }
-    // high speed external clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY)) {
-        reset_reason |= HSERDY;
-    }
-    // main phase-locked loop clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY)) {
-        reset_reason |= PLLRDY;
-    }
-    // hsi48 clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY)) {
-        reset_reason |= HSI48RDY;
-    }
-    // low-speed external clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY)) {
-        reset_reason |= LSERDY;
-    }
-    // lse clock security system failure
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY)) {
-        reset_reason |= LSECSSD;
-    }
-    // low-speed internal clock ready
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY)) {
-        reset_reason |= LSIRDY;
-    }
     // brown out
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
-        reset_reason |= BORRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
+        reset_reason |= (1 << BORRST);
     }
     // option byte-loader reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST)) {
-        reset_reason |= OBLRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST)) {
+        reset_reason |= (1 << OBLRST);
     }
     // pin reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
-        reset_reason |= PINRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
+        reset_reason |= (1 << PINRST);
     }
     // software reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
-        reset_reason |= SFTRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
+        reset_reason |= (1 << SFTRST);
     }
     // independent watchdog
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
-        reset_reason |= IWDGRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
+        reset_reason |= (1 << IWDGRST);
     }
     // window watchdog
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
-        reset_reason |= WWDGRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
+        reset_reason |= (1 << WWDGRST);
     }
     // low power reset
-    else if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
-        reset_reason |= LPWRRST;
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
+        reset_reason |= (1 << LPWRRST);
     }
 }
 
-uint16_t system_hardware_reset_reason() {
-    return reset_reason;
-}
+uint16_t system_hardware_reset_reason() { return reset_reason; }
 
 /** PUBLIC FUNCTION IMPLEMENTATION */
 
 void system_hardware_enter_bootloader(void) {
+    // We have to uninitialize as many of the peripherals as possible, because
+    // the bootloader expects to start as the system comes up
 
-    // We have to uninitialize as many of the peripherals as possible, because the bootloader
-    // expects to start as the system comes up
-
-    // The HAL has ways to turn off all the core clocking and the clock security system
+    // The HAL has ways to turn off all the core clocking and the clock security
+    // system
     HAL_RCC_DisableLSECSS();
     HAL_RCC_DeInit();
 
@@ -133,32 +90,31 @@ void system_hardware_enter_bootloader(void) {
     SysTick->VAL = 0;
 
     /* Clear Interrupt Enable Register & Interrupt Pending Register */
-    for (int i=0;i<8;i++)
-    {
-        NVIC->ICER[i]=0xFFFFFFFF;
-        NVIC->ICPR[i]=0xFFFFFFFF;
+    for (int i = 0; i < 8; i++) {
+        NVIC->ICER[i] = 0xFFFFFFFF;
+        NVIC->ICPR[i] = 0xFFFFFFFF;
     }
 
-    // We have to make sure that the processor is mapping the system memory region to address 0,
-    // which the bootloader expects
+    // We have to make sure that the processor is mapping the system memory
+    // region to address 0, which the bootloader expects
     __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH();
     // and now we're ready to set the system up to start executing system flash.
     // arm cortex initialization means that
-    // address 0 in the bootable region is the address where the processor should start its stack
-    // which we have to do as late as possible because as soon as we do this the c and c++ runtime
-    // environment is no longer valid
-    __set_MSP(*((uint32_t*)SYSMEM_START));
+    // address 0 in the bootable region is the address where the processor
+    // should start its stack which we have to do as late as possible because as
+    // soon as we do this the c and c++ runtime environment is no longer valid
+    __set_MSP(*((uint32_t *)SYSMEM_START));
 
     // finally, jump to the bootloader. we do this in inline asm because we need
-    // this to be a naked call (no caller-side prep like stacking return addresses)
-    // and to have a naked function you need to define it as a function, not a
-    // function pointer, and we don't statically know the address here since it is
-    // whatever's contained in that second word of the bsystem memory region.
-    asm volatile (
-        "bx %0"
-        : // no outputs
-        : "r" (*sysmem_boot_loc)
-        : "memory"  );
+    // this to be a naked call (no caller-side prep like stacking return
+    // addresses) and to have a naked function you need to define it as a
+    // function, not a function pointer, and we don't statically know the
+    // address here since it is whatever's contained in that second word of the
+    // bsystem memory region.
+    asm volatile("bx %0"
+                 :  // no outputs
+                 : "r"(*sysmem_boot_loc)
+                 : "memory");
 }
 
 /**
@@ -181,7 +137,8 @@ void eeprom_write_protect_init(void) {
  * enable/disable writing to the eeprom.
  */
 void enable_eeprom_write(bool enable) {
-    HAL_GPIO_WritePin(EEPROM_WP_PORT, EEPROM_WP_PIN, enable ? GPIO_PIN_RESET : GPIO_PIN_SET);
+    HAL_GPIO_WritePin(EEPROM_WP_PORT, EEPROM_WP_PIN,
+                      enable ? GPIO_PIN_RESET : GPIO_PIN_SET);
 }
 
 void system_hardware_gpio_init(void) {
@@ -190,4 +147,3 @@ void system_hardware_gpio_init(void) {
     // Disable eeprom write
     enable_eeprom_write(false);
 }
-


### PR DESCRIPTION
The reset reason logic had a couple issues
- Not all the RCC flags are about reset reasons; some of them are more in the CC than the R (of Reset and Clock Control) and are about monitoring the readiness of internal clock sources. Omit these
- The logic would only emit the first positive flag it found, which in the current implementation was always one of the clock readiness flags. Instead, emit all positive flags
- There are slightly different reset-reason flags available on the F3 (which is used in the heater-shaker) and the G4 (which is used everywhere else); adapt the code on the heater-shaker to that

## testing
- can't really unit test this one since it's all about parsing HAL flags
- put this on the specified modules; restart them; and see what M114 says. it should say 2, 8, or 128 (or possibly a mix of those - this is a bitflag field and it's possible that power-on reset and low power reset may collide, so 130)