### PR TITLE
fix(vacuum-module): fix init issue with lps22hb resulting in bad pressure values.

### DIFF
--- a/stm32-modules/include/vacuum-module/vacuum-module/lps22hb.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/lps22hb.hpp
@@ -108,7 +108,7 @@ class LPS22HB {
             auto status_byte = RD_BUFF[0];
             pres_ready = static_cast<bool>(status_byte & PRESSURE_READY_FLAG);
             temp_ready = static_cast<bool>(status_byte & TEMP_READY_FLAG);
-            if (pres_ready || temp_ready) {
+            if (pres_ready && temp_ready) {
                 break;
             }
         }

--- a/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
@@ -361,7 +361,7 @@ class PressureTask {
         // Convert to guage pressure
         auto target_pressure = 0.0F;
         auto current_pressure = 0.0F;
-        if (_control_state.target_pressure > 0) {
+        if (_control_state.target_pressure != 0) {
             target_pressure =
                 _control_state.target_pressure - _control_state.pressure_atm;
             current_pressure =


### PR DESCRIPTION
We need to wait for both the pressure AND temperature states to be ready when initializing the LPS22HB atmospheric pressure sensor.