### PR TITLE
fix(vacuum-module): Increase the max pwm of the vacuum module to 100

### DIFF
--- a/stm32-modules/include/vacuum-module/systemwide.h
+++ b/stm32-modules/include/vacuum-module/systemwide.h
@@ -54,6 +54,6 @@ typedef enum VentState { CLOSED = 0, OPENED = 1 } VentState;
 typedef void* TaskHandle;
 
 #define MIN_PWM 0
-#define MAX_PWM 95
+#define MAX_PWM 100
 #define MIN_RPM 0.0f
 #define MAX_RPM 3500.0f


### PR DESCRIPTION
We had to limit the max duty cycle pre-EVT due to electrical issues where the board would lose power when the pump came to a hard stop. This has since been fixed, so we no longer need to limit it.