### PR TITLE
feat(vacuum-module): add vacuum duration to GetPressureState.

### DIFF
--- a/cpp-utils/include/ot_utils/freertos/freertos_timer.hpp
+++ b/cpp-utils/include/ot_utils/freertos/freertos_timer.hpp
@@ -6,6 +6,15 @@
 #include "task.h"
 #include "timers.h"
 
+constexpr auto ROUNDED_DIV(uint32_t A, uint32_t B) noexcept -> uint32_t {
+    return (((A) + ((B) / 2)) / (B));
+}
+
+constexpr auto TICKS_TO_MS(uint32_t ticks) noexcept -> uint32_t {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    return ROUNDED_DIV((ticks) * 1000, (uint32_t)configTICK_RATE_HZ);
+}
+
 namespace ot_utils::freertos_timer {
 
 class FreeRTOSTimer {
@@ -54,6 +63,15 @@ class FreeRTOSTimer {
             vTaskDelay(1);
         }
     }
+
+    auto get_remaining_time() -> uint32_t {
+        /*
+        The time in ms remaining before this timer expires and the callback is executed.
+        */
+        if (!is_running()) { return uint32_t(0); }
+        return TICKS_TO_MS(xTimerGetExpiryTime( timer ) - xTaskGetTickCount());
+    }
+
 
     void start() { xTimerStart(timer, 1); }
 

--- a/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
@@ -386,14 +386,14 @@ struct GetPressureState {
                                     double current_pressure,
                                     double pressure_abs_a,
                                     double pressure_abs_b, double pressure_atm,
-                                    bool vacuum_enabled, VentState vent_state)
-        -> InputIt {
+                                    bool vacuum_enabled, uint32_t duration_s,
+                                    VentState vent_state) -> InputIt {
         int res = 0;
-        res =
-            snprintf(&*buf, (limit - buf),
-                     "M121 T:%.1f C:%.1f A:%.1f B:%.1f H:%.1f E:%d V:%d OK\n",
-                     target_pressure, current_pressure, pressure_abs_a,
-                     pressure_abs_b, pressure_atm, vacuum_enabled, vent_state);
+        res = snprintf(
+            &*buf, (limit - buf),
+            "M121 T:%.1f C:%.1f A:%.1f B:%.1f H:%.1f E:%d D:%ld V:%d OK\n",
+            target_pressure, current_pressure, pressure_abs_a, pressure_abs_b,
+            pressure_atm, vacuum_enabled, duration_s, vent_state);
         if (res <= 0) {
             return buf;
         }

--- a/stm32-modules/include/vacuum-module/vacuum-module/host_comms_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/host_comms_task.hpp
@@ -335,7 +335,8 @@ class HostCommsTask {
                         tx_into, tx_limit, response.target_pressure,
                         response.current_pressure, response.pressure_abs_a,
                         response.pressure_abs_b, response.pressure_atm,
-                        response.vacuum_enabled, response.vent_state);
+                        response.vacuum_enabled, response.duration_s,
+                        response.vent_state);
                 }
             },
             cache_entry);

--- a/stm32-modules/include/vacuum-module/vacuum-module/messages.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/messages.hpp
@@ -149,6 +149,7 @@ struct GetPressureStateResponseMessage {
     double pressure_abs_b;
     double pressure_atm;
     bool vacuum_enabled;
+    uint32_t duration_s;
     VentState vent_state;
 };
 

--- a/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
@@ -375,6 +375,8 @@ class PressureTask {
             .pressure_abs_b = _control_state.pressure_abs_b,
             .pressure_atm = _control_state.pressure_atm,
             .vacuum_enabled = _control_state.enable_vacuum,
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+            .duration_s = _vacuum_timer.get_remaining_time() / 1000,
             .vent_state = _control_state.vent_state,
         };
         static_cast<void>(


### PR DESCRIPTION
We need to know how much time we have left under vacuum so we can monitor the task on the python side.