### PR TITLE
fix(vacuum-module): set correct 8-bit DAC range of 256 instead of 4096 when setting the vent voltage.

### DIFF
--- a/stm32-modules/include/vacuum-module/firmware/vent_hardware.h
+++ b/stm32-modules/include/vacuum-module/firmware/vent_hardware.h
@@ -11,7 +11,7 @@ extern "C" {
 #include "systemwide.h"
 
 #define REF_VOLTAGE 3.3
-#define DAC_FULLRANGE 4096
+#define DAC_FULLRANGE 256
 
 void vent_hardware_init(void);
 void hw_set_vent_state(VentState state);


### PR DESCRIPTION
We are using an 8-bit DAC, so the full range is 256 instead of 4096.