### PR TITLE
feat(vacuum-module): add notify mechanism to the pump_task so we can use duration + waste detection logic of the pressure task.

### DIFF
--- a/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
@@ -479,7 +479,9 @@ struct SetPumpState {
         if (std::get<4>(arguments).present) {
             ret.timeout_s = static_cast<uint32_t>(std::get<4>(arguments).value);
         }
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if (std::get<5>(arguments).present) {
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
             ret.ramp_rate = static_cast<double>(std::get<5>(arguments).value);
         }
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)

--- a/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
@@ -418,11 +418,16 @@ struct GetPressureState {
 struct SetPumpState {
     /*
      * M122- SetPumpState set state of pump control (start pump, target rpm,
-     * on/off)
+     * on/off). Supports E:<duration_s> T:<timeout_s> (D: is duty) to enable
+     * duration tracking and waste detection via notification to PressureTask.
      * */
     double target_rpm = 0;
     uint8_t duty_cycle = 0;
     bool start_pump = false;
+    uint32_t duration_s = 0;
+    uint32_t timeout_s = 0;
+    double ramp_rate = 0;
+    bool vent_after = true;
 
     using ParseResult = std::optional<SetPumpState>;
     static constexpr auto prefix = std::array{'M', '1', '2', '2', ' '};
@@ -431,20 +436,31 @@ struct SetPumpState {
     using StartArg = Arg<uint8_t, 'S'>;
     using RPMArg = Arg<uint16_t, 'R'>;
     using DutyArg = Arg<uint8_t, 'D'>;
+    using DurationArg = Arg<uint32_t, 'E'>;
+    using TimeoutArg = Arg<uint32_t, 'T'>;
+    using RampArg = Arg<float, 'A'>;
+    using VentArg = Arg<uint8_t, 'V'>;
 
     template <typename InputIt, typename Limit>
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<Limit, InputIt>
     static auto parse(const InputIt& input, Limit limit)
         -> std::pair<ParseResult, InputIt> {
-        auto res = gcode::SingleParser<StartArg, RPMArg, DutyArg>::parse_gcode(
-            input, limit, prefix);
+        auto res =
+            gcode::SingleParser<StartArg, RPMArg, DutyArg, DurationArg,
+                                TimeoutArg, RampArg,
+                                VentArg>::parse_gcode(input, limit, prefix);
         if (!res.first.has_value()) {
             return std::make_pair(ParseResult(), input);
         }
 
-        auto ret =
-            SetPumpState{.target_rpm = 0, .duty_cycle = 0, .start_pump = false};
+        auto ret = SetPumpState{.target_rpm = 0,
+                                .duty_cycle = 0,
+                                .start_pump = false,
+                                .duration_s = 0,
+                                .timeout_s = 0,
+                                .ramp_rate = 0.0,
+                                .vent_after = true};
 
         auto arguments = res.first.value();
         if (std::get<0>(arguments).present) {
@@ -455,6 +471,21 @@ struct SetPumpState {
         }
         if (std::get<2>(arguments).present) {
             ret.duty_cycle = static_cast<uint8_t>(std::get<2>(arguments).value);
+        }
+        if (std::get<3>(arguments).present) {
+            ret.duration_s =
+                static_cast<uint32_t>(std::get<3>(arguments).value);
+        }
+        if (std::get<4>(arguments).present) {
+            ret.timeout_s = static_cast<uint32_t>(std::get<4>(arguments).value);
+        }
+        if (std::get<5>(arguments).present) {
+            ret.ramp_rate = static_cast<double>(std::get<5>(arguments).value);
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        if (std::get<6>(arguments).present) {
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+            ret.vent_after = static_cast<bool>(std::get<6>(arguments).value);
         }
         return std::make_pair(ret, res.second);
     }

--- a/stm32-modules/include/vacuum-module/vacuum-module/host_comms_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/host_comms_task.hpp
@@ -589,6 +589,10 @@ class HostCommsTask {
             .rpm_setpoint = gcode.target_rpm,
             .duty_cycle = gcode.duty_cycle,
             .run_pump = gcode.start_pump,
+            .duration_s = gcode.duration_s,
+            .timeout_s = gcode.timeout_s,
+            .ramp_rate = gcode.ramp_rate,
+            .vent_after = gcode.vent_after,
         };
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(

--- a/stm32-modules/include/vacuum-module/vacuum-module/messages.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/messages.hpp
@@ -135,6 +135,24 @@ struct SetPumpStateMessage {
     double rpm_setpoint = 0;
     uint8_t duty_cycle = 0;
     bool run_pump = false;
+    uint32_t duration_s = 0;
+    uint32_t timeout_s = 0;
+    double ramp_rate = 0;
+    bool vent_after = true;
+};
+
+/*
+ * Internal notification from PumpTask to PressureTask when a direct/from_host
+ * SetPumpState is received. This lets PressureTask run its duration tracking
+ * and waste detection logic without sending pump control commands back.
+ */
+struct NotifyPumpRunMessage {
+    bool run_pump = false;
+    uint8_t pressure_percent = 0;
+    uint32_t duration_s = 0;
+    uint32_t timeout_s = 0;
+    double ramp_rate = 0;
+    bool vent_after = true;
 };
 
 struct GetPressureStateMessage {
@@ -252,7 +270,7 @@ using PressureMessage =
                    SetPressureStateMessage, GetPressureStateMessage,
                    SetVentMessage, SetPressurePIDMessage, GetPressurePIDMessage,
                    SetWasteDetectionConfigMessage,
-                   GetWasteDetectionConfigMessage>;
+                   GetWasteDetectionConfigMessage, NotifyPumpRunMessage>;
 
 using PumpMessage = ::std::variant<std::monostate, PumpControlMessage,
                                    SetPumpStateMessage, GetPumpStateMessage>;

--- a/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
@@ -367,7 +367,7 @@ class PressureTask {
 
             // Calculate target pressure as a percent
             auto p_atm = _control_state.pressure_atm;
-            auto p_percent = std::clamp<int>(m.pressure_percent, 0, 100);
+            auto p_percent = std::clamp<int>(m.pressure_percent, 0, 100.0);
             _control_state.target_pressure = p_atm * p_percent / 100.0;
 
             _control_state.duration_s = m.duration_s;

--- a/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
@@ -142,6 +142,8 @@ struct PressureControlState {
     bool enable_vacuum = false;
     VentState vent_state = VentState::CLOSED;
     bool vent_after = true;
+    // if false, pump is driven externally; monitor only, no SetPump msgs sent
+    bool control_pump = true;
 };
 
 const PressureControlState pressure_control_state;
@@ -289,9 +291,12 @@ class PressureTask {
             return;
         }
 
-        auto rpm = _controller.update(dt, current_pressure_b, target_pressure);
-        _control_state.target_rpm = rpm;
-        set_pump_state(true, rpm);
+        if (_control_state.control_pump) {
+            auto rpm =
+                _controller.update(dt, current_pressure_b, target_pressure);
+            _control_state.target_rpm = rpm;
+            set_pump_state(true, rpm);
+        }
     }
 
     template <PressureControlPolicy Policy>
@@ -334,6 +339,7 @@ class PressureTask {
 
         // Start the pressure control loop
         if (!_control_state.enable_vacuum && m.start_pump) {
+            _control_state.control_pump = true;
             reset_pressure_state_buffer();
             _detector.reset();
             _controller.configure_slew(current_pressure, m.ramp_rate);
@@ -344,6 +350,47 @@ class PressureTask {
         _control_state.enable_vacuum = m.start_pump;
 
         send_ack_message(m.id);
+    }
+
+    template <PressureControlPolicy Policy>
+    auto visit_message(const messages::NotifyPumpRunMessage& m, Policy& policy)
+        -> void {
+        static_cast<void>(policy);
+        // PumpTask received direct SetPump (from_host); enable our
+        // monitoring (periodic pressure reads, waste detection, duration
+        // timer, target monitoring) so PumpTask can "use" this
+        // functionality. We must not send any SetPumpState control messages
+        // back to PumpTask.
+        // Convert target guage presure to abs pressure
+        if (m.run_pump) {
+            update_pressures(policy, true);
+
+            // Calculate target pressure as a percent
+            auto p_atm = _control_state.pressure_atm;
+            auto p_percent = std::clamp<int>(m.pressure_percent, 0, 100);
+            _control_state.target_pressure = p_atm * p_percent / 100.0;
+
+            _control_state.duration_s = m.duration_s;
+            _control_state.timeout_s = m.timeout_s;
+            _control_state.target_pressure_reached = false;
+            _control_state.control_pump = false;
+
+            if (!_control_state.enable_vacuum) {
+                reset_pressure_state_buffer();
+                _detector.reset();
+                policy.start_pressure_control(true);
+            }
+
+            if (m.duration_s > 0) {
+                _vacuum_timer.stop();
+                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+                _vacuum_timer.update_period(m.duration_s * 1000);
+                _vacuum_timer.start();
+            }
+            // No ack sent here; the originating SetPump from host was already
+            // acked by PumpTask.
+        }
+        _control_state.enable_vacuum = m.run_pump;
     }
 
     template <PressureControlPolicy Policy>
@@ -584,7 +631,9 @@ class PressureTask {
     auto stop_vacuum() -> void {
         _vacuum_timer.stop();
         _policy->start_pressure_control(false);
-        set_pump_state(false, 0);
+        if (_control_state.control_pump) {
+            set_pump_state(false, 0);
+        }
 
         _detector.reset();
         _controller.reset();
@@ -597,6 +646,7 @@ class PressureTask {
         _control_state.timeout_s = 0;
         _control_state.enable_vacuum = false;
         _control_state.target_pressure_reached = false;
+        _control_state.control_pump = true;
     }
 
     auto maintaining_target_pressure() -> bool {

--- a/stm32-modules/include/vacuum-module/vacuum-module/pump_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/pump_task.hpp
@@ -214,8 +214,21 @@ class PumpTask {
         }
 
         if (m.from_host) {
-            send_ack_message(m.id);
+            // Send notification to PressureTask so it can track vacuum duration
+            // and perform waste detection using its sensor access and logic.
+            // PressureTask will run monitoring but must not send control msgs
+            // (SetPumpState) back in this mode.
+            auto notify =
+                messages::NotifyPumpRunMessage{.run_pump = m.run_pump,
+                                               .pressure_percent = m.duty_cycle,
+                                               .duration_s = m.duration_s,
+                                               .timeout_s = m.timeout_s,
+                                               .ramp_rate = m.ramp_rate,
+                                               .vent_after = m.vent_after};
+            static_cast<void>(_task_registry->send_to_address(
+                notify, Queues::PressureAddress));
         }
+        send_ack_message(m.id);
     }
 
     template <PumpControlPolicy Policy>


### PR DESCRIPTION
# Overview

The PressureTask is responsible for tracking how long the vacuum should run when duration > 0, as well as for the waste detection mechanism. The pump task needs access to this logic, so let's create a new internal `NotifyPumpRunMessage` that the PumpTask can send to the PressureTask to enable monitor-only mode, so it does NOT send control messages to the pump since it's being controlled "manually".

# Changelog

- Add `duration`, `timeout`, `rate`, and `vent_after` args to the SetPumpState (M122) GCODE message.
- Add `NotifyPumpRunMessage` message so we can notify the PressureTask to go into `monitor-only` mode.
- When in `monitor-only` mode, set the target pressure by using the duty cycle 0-100 as a percent of the atmospheric pressure.