### PR TITLE
fix(heater-shaker): fix PWM deadlock

### DIFF
--- a/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
+++ b/stm32-modules/heater-shaker/firmware/heater_task/heater_hardware.c
@@ -294,6 +294,9 @@ void heater_hardware_power_disable(heater_hardware* hardware, uint8_t task_conte
     HAL_TIM_PWM_Stop_IT(&internal->pad_tim, HEATER_PAD_SHORT_CHECK_TIM_CHANNEL);
     HAL_TIM_PWM_Stop_IT(&internal->pad_tim, HEATER_PAD_OPEN_CHECK_TIM_CHANNEL);
     internal->heater_started = false;
+    internal->update_lock = false;
+    internal->update_while_locked = false;
+    internal->period_count = 0;
     if (!heatpad_in_error_state()) {
         internal->heatpad_cs_status = IDLE;
     }


### PR DESCRIPTION
# Overview

Fixes a bug where the HS permanently stops heating after a `deactivate_heater()` call, requiring a hard power cycle to recover. The heater firmware reports no error (`M411 OK`) and retains its setpoint (`M105` shows `T:target`), but the PWM hardware is never activated.

The heater pad circuit check ISR (`HAL_TIM_OC_DelayElapsedCallback`) uses an `update_lock` flag to prevent PWM changes during open/short circuit checks. This check is a multi-step state machine spread across several ISR invocations:

- ISR invocation 1: sets `update_lock = true`, transitions state machine to `OPEN_CHECK_STARTED`
- ISR invocations 2-3: performs open/short checks, transitions to `PREP_RUNNING`
- ISR invocation 4: clears `update_lock = false`, restores overcurrent detection

If `heater_hardware_power_disable()` is called between steps 1 and 4 (ex., from an `M106` DeactivateHeater GCODE while the heater is actively running), the PWM channels are stopped and the ISR can never fire again. `update_lock` remains permanently stuck true.

When a subsequent `M104` (SetTemperature) re-enables heating, `heater_hardware_power_set()` sees `update_lock == true` and caches the PWM setting instead of starting the PWM hardware. The PID controller keeps computing, the task reports no error, but the heater pad never receives power.

It seems reasonable to assume timing window is approximately 1-3ms out of every ~1 second circuit check cycle, consistent with the observed rare occurrence rate.

## Test Plan

It's possible to validate the fix using a script sending an enormous amount of GCODES (see Seth's comment). One can also validate by running the following protocol enough times, each run has roughly a 95% chance of catching the bug. A few clean runs is sufficient for proving the fix:

```
from opentrons import protocol_api

metadata = {
    "protocolName": "HS Heater Race Condition Repro",
}

requirements = {"apiLevel": "2.28", "robotType": "Flex"}


def run(protocol: protocol_api.ProtocolContext) -> None:
    hs = protocol.load_module("heaterShakerModuleV1", "D1")
    plate = hs.load_labware("nest_96_wellplate_200ul_pcr_full_skirt")
    hs.close_labware_latch()

    target_temp = 65
    settle_seconds = 10
    max_cycles = 1000

    for i in range(1, max_cycles + 1):
        hs.set_and_wait_for_temperature(target_temp)

        protocol.delay(seconds=settle_seconds)

        hs.deactivate_heater()
        protocol.delay(seconds=5)

    hs.deactivate_heater()
    hs.open_labware_latch()

```