### PR TITLE
fix(vacuum-module): fixes an issue with NotifyPumpRunMessage not working correctly for SetPumpMessage.

### DIFF
--- a/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
@@ -372,6 +372,7 @@ class PressureTask {
 
             _control_state.duration_s = m.duration_s;
             _control_state.timeout_s = m.timeout_s;
+            _control_state.vent_after = m.vent_after;
             _control_state.target_pressure_reached = false;
             _control_state.control_pump = false;
 
@@ -631,9 +632,7 @@ class PressureTask {
     auto stop_vacuum() -> void {
         _vacuum_timer.stop();
         _policy->start_pressure_control(false);
-        if (_control_state.control_pump) {
-            set_pump_state(false, 0);
-        }
+        set_pump_state(false, 0);
 
         _detector.reset();
         _controller.reset();


### PR DESCRIPTION

- Forgot to set vent_after in NotifyPumpRunMessage
- Make sure we always call set_pump_state(false, 0) when we stop the vacuum_pump so the vacuum is stopped when running in "manual" mode via the `SetVacuumPower` command.