### PR TITLE
fix(vacuum-module): enter DFU via option bytes

### DIFF
--- a/stm32-modules/include/vacuum-module/firmware/system_hardware.h
+++ b/stm32-modules/include/vacuum-module/firmware/system_hardware.h
@@ -9,8 +9,19 @@ extern "C" {
 
 /**
  * @brief Enter the bootloader. This function never returns.
+ *
+ * Disconnects USB and reprograms nSWBOOT0/nBOOT0 so the next reset boots the
+ * STM system-memory DFU bootloader (verified working path on this hardware;
+ * a pure software jump does not enumerate USB DFU on the vacuum module).
  */
 void system_hardware_enter_bootloader(void);
+
+/**
+ * @brief If option bytes still select system-memory boot (left over from DFU
+ * entry), restore main-flash boot. Call early in HardwareInit. May reset.
+ */
+void system_hardware_handle_bootloader_request(void);
+
 void system_hardware_gpio_init(void);
 uint16_t system_hardware_reset_reason(void);
 void enable_eeprom_write(bool enable);

--- a/stm32-modules/include/vacuum-module/vacuum-module/system_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/system_task.hpp
@@ -115,7 +115,15 @@ class SystemTask {
     template <SystemExecutionPolicy Policy>
     auto visit_message(const messages::EnterBootloaderMessage& message,
                        Policy& policy) {
-        // Must disconnect USB before restarting
+        // Acknowledge first so host_comms can TX "dfu OK" while USB is still
+        // connected. ForceUSBDisconnect must come after that response is
+        // queued; otherwise may_connect is cleared and the OK is never sent.
+        auto response =
+            messages::AcknowledgePrevious{.responding_to_id = message.id};
+        static_cast<void>(_task_registry->send_to_address(
+            response, Queues::HostCommsAddress));
+
+        // Must disconnect USB before restarting into the system bootloader
         auto id = _prep_cache.add(0);
         auto usb_msg = messages::ForceUSBDisconnect{
             .id = id, .return_address = MY_ADDRESS};
@@ -125,14 +133,9 @@ class SystemTask {
         }
 
         if (_prep_cache.empty()) {
-            // Couldn't send any messages? Enter bootloader anyways
+            // Couldn't send disconnect? Enter bootloader anyways
             policy.enter_bootloader();
         }
-
-        auto response =
-            messages::AcknowledgePrevious{.responding_to_id = message.id};
-        static_cast<void>(_task_registry->send_to_address(
-            response, Queues::HostCommsAddress));
     }
 
     // Any Ack messages should be in response to bootloader prep messages

--- a/stm32-modules/vacuum-module/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/stm32-modules/vacuum-module/firmware/host_comms_task/freertos_comms_task.cpp
@@ -10,6 +10,7 @@
 #include "firmware/freertos_message_queue.hpp"
 #include "firmware/usb_hardware.h"
 #include "hal/double_buffer.hpp"
+#include "projdefs.h"
 #include "task.h"
 #include "vacuum-module/host_comms_task.hpp"
 #include "vacuum-module/messages.hpp"
@@ -66,16 +67,22 @@ auto run(tasks::FirmwareTasks::QueueAggregator *aggregator) -> void {
         char *tx_end =
             top_task->run_once(local_task->tx_buf.accessible()->begin(),
                                local_task->tx_buf.accessible()->end());
-        if (!top_task->may_connect()) {
-            usb_hw_stop();
-        } else if (tx_end != local_task->tx_buf.accessible()->data()) {
+        // Always flush any response first (e.g. "dfu OK") before optionally
+        // stopping USB. Previously may_connect was checked first, which dropped
+        // the bootloader acknowledgement on the floor.
+        if (tx_end != local_task->tx_buf.accessible()->data()) {
             local_task->tx_buf.swap();
             usb_hw_send(
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
                 reinterpret_cast<uint8_t *>(
                     local_task->tx_buf.committed()->data()),
                 tx_end - local_task->tx_buf.committed()->data());
-            vTaskDelay(1);
+            // Allow the CDC transfer to finish on the wire before a possible
+            // USB disconnect (enter-DFU path kills the peripheral quickly).
+            vTaskDelay(pdMS_TO_TICKS(10));
+        }
+        if (!top_task->may_connect()) {
+            usb_hw_stop();
         }
     }
 }

--- a/stm32-modules/vacuum-module/firmware/system/system_hardware.c
+++ b/stm32-modules/vacuum-module/firmware/system/system_hardware.c
@@ -3,6 +3,8 @@
 #include "main.h"
 #include "stm32g4xx_hal.h"
 #include "stm32g4xx_hal_cortex.h"
+#include "stm32g4xx_hal_flash.h"
+#include "stm32g4xx_hal_flash_ex.h"
 #include "stm32g4xx_hal_rcc.h"
 #include "stm32g4xx_hal_tim.h"
 
@@ -73,48 +75,124 @@ static void save_reset_reason() {
 
 uint16_t system_hardware_reset_reason() { return reset_reason; }
 
+/**
+ * Program nSWBOOT0 / nBOOT0 and optionally launch (resets the MCU).
+ *
+ * @param system_memory_boot  true  -> boot system-memory DFU (nSWBOOT0=0,nBOOT0=0)
+ *                            false -> normal boot from pin/flash (nSWBOOT0=1,nBOOT0=1)
+ * @param launch              if true, HAL_FLASH_OB_Launch() (does not return on success)
+ * @return true if the option-byte program step succeeded
+ */
+static bool program_boot_option_bytes(bool system_memory_boot, bool launch) {
+    FLASH_OBProgramInitTypeDef ob_init = {0};
+
+    // Clear sticky flash errors left by prior ops / bootloader (required or
+    // OPTSTRT can fail and leave nSWBOOT0 stuck selecting system memory).
+    __HAL_RCC_FLASH_CLK_ENABLE();
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
+
+    if (HAL_FLASH_Unlock() != HAL_OK) {
+        return false;
+    }
+    if (HAL_FLASH_OB_Unlock() != HAL_OK) {
+        HAL_FLASH_Lock();
+        return false;
+    }
+
+    ob_init.OptionType = OPTIONBYTE_USER;
+    ob_init.USERType = OB_USER_nSWBOOT0 | OB_USER_nBOOT0;
+    if (system_memory_boot) {
+        // nSWBOOT0=0 (boot mode from option bit), nBOOT0=0 (system memory)
+        ob_init.USERConfig = OB_BOOT0_FROM_OB | OB_nBOOT0_RESET;
+    } else {
+        // Match factory-ish default OPTR=0xFFEFF8AA: boot from BOOT0 pin,
+        // nBOOT0 set.
+        ob_init.USERConfig = OB_BOOT0_FROM_PIN | OB_nBOOT0_SET;
+    }
+
+    const bool programmed = (HAL_FLASHEx_OBProgram(&ob_init) == HAL_OK);
+    if (programmed && launch) {
+        // Reloads option bytes and resets. Does not return on success.
+        HAL_FLASH_OB_Launch();
+    }
+
+    HAL_FLASH_OB_Lock();
+    HAL_FLASH_Lock();
+    return programmed;
+}
+
+/**
+ * Force a clean boot of the STM system-memory DFU bootloader by programming
+ * the nSWBOOT0/nBOOT0 option bytes and launching them (resets the chip).
+ *
+ * Why not a software jump? Jumping to 0x1FFF0000 from the application does not
+ * bring up USB DFU consistently (device fails enumeration). I think this
+ * has to do with the state the device is left in when it enters dfu mode
+ * from a software jump, anyway booting system memory via option bytes works
+ * so lets do that.
+ */
+static void boot_system_memory_via_option_bytes(void) {
+    (void)program_boot_option_bytes(true, true);
+}
+
+/**
+ * If a previous DFU entry left the MCU configured to boot system memory,
+ * restore normal main-flash boot so the next power cycle runs the application.
+ * HAL_FLASH_OB_Launch() resets the chip when a change is applied.
+ */
+void system_hardware_handle_bootloader_request(void) {
+    // FLASH_OPTR_nSWBOOT0 == 0 means boot mode comes from nBOOT0 option bit
+    // (the state we enter for DFU). Restore pin/main-flash boot.
+    if ((FLASH->OPTR & FLASH_OPTR_nSWBOOT0) == 0U) {
+        (void)program_boot_option_bytes(false, true);
+    }
+}
+
 /** PUBLIC FUNCTION IMPLEMENTATION */
 
 void system_hardware_enter_bootloader(void) {
-    // We have to uninitialize as many of the peripherals as possible, because
-    // the bootloader expects to start as the system comes up
+    // Drop the CDC interface so the host detaches before DFU re-enumerates.
+    __HAL_RCC_USB_CLK_ENABLE();
+    USB->BCDR &= (uint16_t)(~USB_BCDR_DPPU);
+    USB->CNTR = (uint16_t)(USB_CNTR_FRES | USB_CNTR_PDWN);
+    __HAL_RCC_USB_FORCE_RESET();
+    __HAL_RCC_USB_RELEASE_RESET();
+    __HAL_RCC_USB_CLK_DISABLE();
 
-    // The HAL has ways to turn off all the core clocking and the clock security
-    // system
-    HAL_RCC_DisableLSECSS();
-    HAL_RCC_DeInit();
+    const uint32_t disconnect_start = HAL_GetTick();
+    while ((HAL_GetTick() - disconnect_start) < 50U) {
+    }
 
-    // systick should be off at boot
+    // This programs option bytes and resets into system-memory DFU. It does
+    // not return on success. After a successful firmware update the app restores
+    // main-flash boot via system_hardware_handle_bootloader_request().
+    boot_system_memory_via_option_bytes();
+
+    // If option-byte programming failed, fall back to a direct sysmem jump.
+    // This path is known-unreliable for USB DFU on this board but is better
+    // than hanging forever.
+    __disable_irq();
     SysTick->CTRL = 0;
     SysTick->LOAD = 0;
     SysTick->VAL = 0;
-
-    /* Clear Interrupt Enable Register & Interrupt Pending Register */
     for (int i = 0; i < 8; i++) {
         NVIC->ICER[i] = 0xFFFFFFFF;
         NVIC->ICPR[i] = 0xFFFFFFFF;
     }
-
-    // We have to make sure that the processor is mapping the system memory
-    // region to address 0, which the bootloader expects
+    SCB->VTOR = 0;
+    __HAL_RCC_SYSCFG_CLK_ENABLE();
     __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH();
-    // and now we're ready to set the system up to start executing system flash.
-    // arm cortex initialization means that
-    // address 0 in the bootable region is the address where the processor
-    // should start its stack which we have to do as late as possible because as
-    // soon as we do this the c and c++ runtime environment is no longer valid
-    __set_MSP(*((uint32_t *)SYSMEM_START));
-
-    // finally, jump to the bootloader. we do this in inline asm because we need
-    // this to be a naked call (no caller-side prep like stacking return
-    // addresses) and to have a naked function you need to define it as a
-    // function, not a function pointer, and we don't statically know the
-    // address here since it is whatever's contained in that second word of the
-    // bsystem memory region.
-    asm volatile("bx %0"
-                 :  // no outputs
-                 : "r"(*sysmem_boot_loc)
-                 : "memory");
+    __enable_irq();
+    asm volatile(
+        "ldr r0, =%0\n"
+        "ldr r1, [r0]\n"
+        "msr msp, r1\n"
+        "ldr r0, [r0, #4]\n"
+        "bx  r0\n"
+        :
+        : "i"(SYSMEM_START)
+        : "r0", "r1", "memory");
+    __builtin_unreachable();
 }
 
 /**

--- a/stm32-modules/vacuum-module/firmware/system/system_stm32g4xx.c
+++ b/stm32-modules/vacuum-module/firmware/system/system_stm32g4xx.c
@@ -76,6 +76,7 @@
  * @{
  */
 
+#include "firmware/system_hardware.h"
 #include "firmware/system_stm32g4xx.h"
 #include "main.h"
 #include "stm32g4xx.h"
@@ -348,6 +349,9 @@ static void led_init(void) {
 
 void HardwareInit(void) {
     HAL_Init();
+    // If DFU entry left nSWBOOT0 cleared (boot from system memory), restore
+    // main-flash boot before USB comes up. May reset once via OB launch.
+    system_hardware_handle_bootloader_request();
     SystemClock_Config();
     SystemCoreClockUpdate();
     led_init();


### PR DESCRIPTION
## Summary

The vacuum module was not actually getting into DFU after a `dfu` gcode, so host updates could not find it with `dfu-util`. Jumping straight into the system bootloader from the running app does not bring up USB DFU on this board.

This change enters DFU by programming the boot option bytes and resetting into the system bootloader instead. On the next app boot we put the option bytes back so normal flash boot still works. Also fixed the `dfu OK` path so the response can go out before USB is disconnected.

Verified on hardware with ST-Link and with `update_module_fw.py` on a Flex.

## Test plan

- [x] Flash full image, send `dfu`, confirm `0483:df11` with `dfu-util -l`
- [x] Leave DFU / reboot app, confirm normal boot option bytes restored
- [x] Full Flex update via `update_module_fw.py --module vacuum-module --force`