### PR TITLE
fix(vacuum-module): stabilize pressure hold regulation

### DIFF
--- a/stm32-modules/include/vacuum-module/firmware/pressure_controller.hpp
+++ b/stm32-modules/include/vacuum-module/firmware/pressure_controller.hpp
@@ -27,6 +27,8 @@ static constexpr const double OVERSHOOT_DEPTH_PCT = 0.02F;
 static constexpr const double MAX_OVERSHOOT_MBAR = 20.0F;
 // Feed-forward tapers to zero within this band above the slewed trajectory.
 static constexpr const double APPROACH_BAND_MBAR = 80.0F;
+static constexpr const double MIN_APPROACH_BAND_MBAR = 1.0F;
+static constexpr const double MAX_APPROACH_BAND_MBAR = 500.0F;
 static constexpr const double ATM_PRESSURE_MBAR = 1013.25;
 
 // Slew tunning
@@ -34,7 +36,9 @@ static constexpr const double MIN_RAMP_RATE = 0.20F;
 static constexpr const double MAX_RAMP_RATE = 400.0F;
 static constexpr const double DEFAULT_RAMP_RATE = 50;
 // Slow the pressure slew within this fraction of total vacuum depth.
-static constexpr const double ADAPTIVE_SLEW_END_FRACTION = 0.30F;
+static constexpr const double SLEW_END_FRACTION = 0.30F;
+static constexpr const double MIN_SLEW_END_FRACTION = 0.05F;
+static constexpr const double MAX_SLEW_END_FRACTION = 0.9F;
 
 struct ConfigState {
     double ramp_rate = DEFAULT_RAMP_RATE;
@@ -42,6 +46,7 @@ struct ConfigState {
     double k_holding = K_HOLDING;
     double overshoot = OVERSHOOT_ERROR;
     double approach_band = APPROACH_BAND_MBAR;
+    double slew_end_fraction = SLEW_END_FRACTION;
     double kp = KP;
     double ki = KI;
     double kd = KD;
@@ -72,6 +77,14 @@ class PressureController {
         _pid.set_tunings(kp, ki, kd, reset);
     }
 
+    auto configure_bands(double approach_band, double slew_end_fraction)
+        -> void {
+        state.approach_band = std::clamp(approach_band, MIN_APPROACH_BAND_MBAR,
+                                         MAX_APPROACH_BAND_MBAR);
+        state.slew_end_fraction = std::clamp(
+            slew_end_fraction, MIN_SLEW_END_FRACTION, MAX_SLEW_END_FRACTION);
+    }
+
     auto update(double dt_seconds, double current_abs_mbar,
                 double target_abs_mbar) -> double {
         // Keep trajectory rate and PID sample time well-defined.
@@ -84,10 +97,9 @@ class PressureController {
             auto remaining = std::max(0.0, current_abs_mbar - target_abs_mbar);
             auto depth_fraction = remaining / vacuum_depth;
             auto rate_scale = 1.0;
-            if (depth_fraction < ADAPTIVE_SLEW_END_FRACTION) {
-                rate_scale =
-                    std::max(MIN_RAMP_RATE / state.ramp_rate,
-                             depth_fraction / ADAPTIVE_SLEW_END_FRACTION);
+            if (depth_fraction < state.slew_end_fraction) {
+                rate_scale = std::max(MIN_RAMP_RATE / state.ramp_rate,
+                                      depth_fraction / state.slew_end_fraction);
             }
             _slew.set_rate_limit(state.ramp_rate * rate_scale);
         } else {

--- a/stm32-modules/include/vacuum-module/firmware/pressure_controller.hpp
+++ b/stm32-modules/include/vacuum-module/firmware/pressure_controller.hpp
@@ -34,7 +34,7 @@ static constexpr const double MIN_RAMP_RATE = 0.20F;
 static constexpr const double MAX_RAMP_RATE = 400.0F;
 static constexpr const double DEFAULT_RAMP_RATE = 50;
 // Slow the pressure slew within this fraction of total vacuum depth.
-static constexpr const double ADAPTIVE_SLEW_END_FRACTION = 0.15F;
+static constexpr const double ADAPTIVE_SLEW_END_FRACTION = 0.30F;
 
 struct ConfigState {
     double ramp_rate = DEFAULT_RAMP_RATE;

--- a/stm32-modules/include/vacuum-module/firmware/pressure_controller.hpp
+++ b/stm32-modules/include/vacuum-module/firmware/pressure_controller.hpp
@@ -125,12 +125,12 @@ class PressureController {
             total_ff_rpm = (ff_velocity + ff_holding) * approach_scale;
         }
 
-        // Bleed integral windup as the trajectory is reached to limit
-        // overshoot.
-        if (error > 0.0) {
-            _pid.arm_integrator_reset(error, std::abs(effective_overshoot));
-        } else if (is_overshot) {
-            // Do not let integral keep driving the pump past the trajectory.
+        // Integral anti-windup: only clear when past the trajectory / final
+        // target. Do not arm a reset while still short of the final setpoint —
+        // that wiped I inside the ~2% overshoot band and left a steady ~8-10
+        // mbar shallow hold (e.g. -390 vs -400).
+        if (is_overshot ||
+            current_abs_mbar < target_abs_mbar + effective_overshoot) {
             _pid.clear_integrator();
         }
 
@@ -140,7 +140,6 @@ class PressureController {
 
         // Brake when actual pressure drops below the final target setpoint.
         if (current_abs_mbar < target_abs_mbar + effective_overshoot) {
-            _pid.clear_integrator();
             target_rpm = 0.0;
         }
         return target_rpm;

--- a/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
@@ -591,6 +591,8 @@ struct SetPressurePID {
     std::optional<double> k_velocity;
     std::optional<double> k_holding;
     std::optional<double> rel_tol_pct;
+    std::optional<double> approach_band;
+    std::optional<double> slew_end_fraction;
     bool reset = false;
 
     using ParseResult = std::optional<SetPressurePID>;
@@ -604,6 +606,8 @@ struct SetPressurePID {
     using V = Arg<float, 'V'>;
     using H = Arg<float, 'H'>;
     using T = Arg<float, 'T'>;
+    using A = Arg<float, 'A'>;
+    using S = Arg<float, 'S'>;
     using R = Arg<uint8_t, 'R'>;
 
     template <typename InputIt, typename Limit>
@@ -611,8 +615,9 @@ struct SetPressurePID {
         std::sized_sentinel_for<Limit, InputIt>
     static auto parse(const InputIt& input, Limit limit)
         -> std::pair<ParseResult, InputIt> {
-        auto res = gcode::SingleParser<P, I, D, O, V, H, T, R>::parse_gcode(
-            input, limit, prefix);
+        auto res =
+            gcode::SingleParser<P, I, D, O, V, H, T, A, S, R>::parse_gcode(
+                input, limit, prefix);
         if (!res.first.has_value()) {
             return std::make_pair(ParseResult(), input);
         }
@@ -647,8 +652,20 @@ struct SetPressurePID {
         }
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if (std::get<7>(arguments).present) {
+            ret.approach_band =
+                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+                static_cast<double>(std::get<7>(arguments).value);
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        if (std::get<8>(arguments).present) {
+            ret.slew_end_fraction =
+                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+                static_cast<double>(std::get<8>(arguments).value);
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        if (std::get<9>(arguments).present) {
             // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-            ret.reset = static_cast<bool>(std::get<7>(arguments).value);
+            ret.reset = static_cast<bool>(std::get<9>(arguments).value);
         }
         return std::make_pair(ret, res.second);
     }
@@ -674,12 +691,14 @@ struct GetPressurePID {
     static auto write_response_into(InputIt buf, InLimit limit, double kp,
                                     double ki, double kd, double overshoot,
                                     double k_velocity, double k_holding,
-                                    double rel_tol_pct) -> InputIt {
+                                    double rel_tol_pct, double approach_band,
+                                    double slew_end_fraction) -> InputIt {
         int res = 0;
-        res = snprintf(
-            &*buf, (limit - buf),
-            "M126 P:%.1f I:%.1f D:%.1f O:%.1f V:%.1f H:%.1f T:%.2f OK\n", kp,
-            ki, kd, overshoot, k_velocity, k_holding, rel_tol_pct);
+        res = snprintf(&*buf, (limit - buf),
+                       "M126 P:%.1f I:%.1f D:%.1f O:%.1f V:%.1f H:%.1f T:%.2f "
+                       "A:%.1f S:%.2f OK\n",
+                       kp, ki, kd, overshoot, k_velocity, k_holding,
+                       rel_tol_pct, approach_band, slew_end_fraction);
         if (res <= 0) {
             return buf;
         }

--- a/stm32-modules/include/vacuum-module/vacuum-module/host_comms_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/host_comms_task.hpp
@@ -360,7 +360,8 @@ class HostCommsTask {
                     return cache_element.write_response_into(
                         tx_into, tx_limit, response.kp, response.ki,
                         response.kd, response.overshoot, response.k_velocity,
-                        response.k_holding, response.rel_tol_pct);
+                        response.k_holding, response.rel_tol_pct,
+                        response.approach_band, response.slew_end_fraction);
                 }
             },
             cache_entry);
@@ -712,6 +713,8 @@ class HostCommsTask {
             .k_velocity = gcode.k_velocity,
             .k_holding = gcode.k_holding,
             .rel_tol_pct = gcode.rel_tol_pct,
+            .approach_band = gcode.approach_band,
+            .slew_end_fraction = gcode.slew_end_fraction,
             .reset = gcode.reset,
         };
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {

--- a/stm32-modules/include/vacuum-module/vacuum-module/messages.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/messages.hpp
@@ -199,6 +199,8 @@ struct SetPressurePIDMessage {
     std::optional<double> k_velocity = std::nullopt;
     std::optional<double> k_holding = std::nullopt;
     std::optional<double> rel_tol_pct = std::nullopt;
+    std::optional<double> approach_band = std::nullopt;
+    std::optional<double> slew_end_fraction = std::nullopt;
     bool reset = false;
 };
 
@@ -215,6 +217,8 @@ struct GetPressurePIDResponseMessage {
     double k_velocity;
     double k_holding;
     double rel_tol_pct;
+    double approach_band;
+    double slew_end_fraction;
 };
 
 struct SetWasteDetectionConfigMessage {

--- a/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
@@ -491,6 +491,9 @@ class PressureTask {
         auto k_holding = m.k_holding.value_or(cs.k_holding);
         _controller.configure_pid(kp, ki, kd, k_velocity, k_holding, overshoot,
                                   m.reset);
+        _controller.configure_bands(
+            m.approach_band.value_or(cs.approach_band),
+            m.slew_end_fraction.value_or(cs.slew_end_fraction));
 
         send_ack_message(m.id);
     }
@@ -508,7 +511,9 @@ class PressureTask {
             .overshoot = cs.overshoot,
             .k_velocity = cs.k_velocity,
             .k_holding = cs.k_holding,
-            .rel_tol_pct = _control_state.rel_tol_pct};
+            .rel_tol_pct = _control_state.rel_tol_pct,
+            .approach_band = cs.approach_band,
+            .slew_end_fraction = cs.slew_end_fraction};
         static_cast<void>(
             _task_registry->send_to_address(msg, Queues::HostCommsAddress));
     }

--- a/stm32-modules/vacuum-module/tests/test_pressure_controller.cpp
+++ b/stm32-modules/vacuum-module/tests/test_pressure_controller.cpp
@@ -35,6 +35,17 @@ TEST_CASE("PressureController - Basic Configuration", "[controller]") {
         REQUIRE(state.k_holding == Approx(50.0));
         REQUIRE(state.overshoot == Approx(-3.0));
     }
+
+    SECTION("configure_bands updates and clamps") {
+        ctrl.configure_bands(100.0, SLEW_END_FRACTION);
+        auto state = ctrl.get_state();
+        REQUIRE(state.approach_band == Approx(100.0));
+        REQUIRE(state.slew_end_fraction == Approx(SLEW_END_FRACTION));
+        ctrl.configure_bands(0.0, 1.5);
+        state = ctrl.get_state();
+        REQUIRE(state.approach_band == Approx(MIN_APPROACH_BAND_MBAR));
+        REQUIRE(state.slew_end_fraction == Approx(MAX_SLEW_END_FRACTION));
+    }
 }
 
 TEST_CASE("PressureController - Update Logic", "[controller]") {
@@ -119,7 +130,8 @@ TEST_CASE("PressureController - Update Logic", "[controller]") {
     }
 
     SECTION("Small residual short of final target still builds integral") {
-        // Pure I, no FF: a few mbar short of final must not zero the integrator.
+        // Pure I, no FF: a few mbar short of final must not zero the
+        // integrator.
         ctrl.configure_pid(0.0, 10.0, 0.0, 0.0, 0.0, -2.0, true);
         // Trajectory already at final target (no slew motion).
         ctrl.configure_slew(610.0, DEFAULT_RAMP_RATE);

--- a/stm32-modules/vacuum-module/tests/test_pressure_controller.cpp
+++ b/stm32-modules/vacuum-module/tests/test_pressure_controller.cpp
@@ -117,6 +117,24 @@ TEST_CASE("PressureController - Update Logic", "[controller]") {
         auto rpm_during_overshoot = ctrl.update(0.04, 420.0, 200.0);
         REQUIRE(rpm_during_overshoot == Approx(0.0));
     }
+
+    SECTION("Small residual short of final target still builds integral") {
+        // Pure I, no FF: a few mbar short of final must not zero the integrator.
+        ctrl.configure_pid(0.0, 10.0, 0.0, 0.0, 0.0, -2.0, true);
+        // Trajectory already at final target (no slew motion).
+        ctrl.configure_slew(610.0, DEFAULT_RAMP_RATE);
+        double rpm_early = 0.0;
+        double rpm_late = 0.0;
+        for (int i = 0; i < 20; ++i) {
+            // Final target 600 abs; current 608 => ~8 mbar shallow residual.
+            rpm_late = ctrl.update(0.04, 608.0, 600.0);
+            if (i == 0) {
+                rpm_early = rpm_late;
+            }
+        }
+        REQUIRE(rpm_late > rpm_early);
+        REQUIRE(rpm_late > 0.0);
+    }
 }
 
 TEST_CASE("PressureController - Reset", "[controller]") {


### PR DESCRIPTION
## Summary

- Keep integral active while still short of the final vacuum target so hold no longer sits several mbar shallow
- Soft-land the pressure slew near the target (`slew_end_fraction` default 0.30) to cut deep overshoot/ripple at -600…-800
- Expose approach band (`A`) and slew end fraction (`S`) on M125/M126 for runtime tuning

## Test plan

- [x] Bench hold sweep -100…-800 mbar (60s/90s) on water, 3×0.2 mm fixture
- [x] Confirm M126 reports `A`/`S` and M125 can set them
