### PR TITLE
fix(vacuum-module): detect waste-full as sealed deadhead, not ramp timing

### DIFF
--- a/stm32-modules/include/vacuum-module/firmware/waste_detector.hpp
+++ b/stm32-modules/include/vacuum-module/firmware/waste_detector.hpp
@@ -1,103 +1,56 @@
 #pragma once
-#include <array>
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 
-#include "systemwide.h"
-
 namespace waste_detector {
+
+// Waste-full is inferred, not measured. Sensors A and B sit in series
+// inside the module, downstream of the waste-jug floater, so |A-B| is
+// orifice flow after the jug.
+//
+// Full: tiny sealed volume. Hold is a deadhead (low conductance, no
+// orifice flow). Empty leaky: higher RPM/depth in hold.
 
 enum class WasteFullError : uint8_t {
     NO_ERROR = 0,
-    MAX_DELTA_TIC_ERROR = 1,
-    OVER_TARGET_ERROR = 2,
-    RISE_TOO_FAST_ERROR = 3,
-    FAST_BASELINE_ERROR = 4,
-    FIRST_RUN_SLOW_ERROR = 5,
-    SUDDEN_BLOCKED_ERROR = 6,
-    CUMMULATIVE_BLOCKED_ERROR = 7,
-    FLOW_STABLE_FULL_ERROR = 8,
+    FLOW_STABLE_FULL_ERROR = 1,
 };
 
-// Window thresholds: Measure from p1 depth to p2 depth
-static constexpr const double WASTE_WINDOW_START_PCT = 0.10F;
-static constexpr const double WASTE_WINDOW_END_PCT = 0.95F;
-// Resets the baseline if the new target pressure is this percent difference
-static constexpr const double BASELINE_DEPTH_RESET = 0.30F;
-// Compare to the learned baseline. Faster than this factor is full.
-static constexpr const double BASELINE_FAST_FACTOR = 0.50F;
-// Hold-phase vacuum increase per tick that flags a slam-shut.
-static constexpr const double MAX_RISE_PER_TICK = 30.0;
-// Total allowed rise before flag for slow build up case
-static constexpr const double MAX_CUMULATIVE_RISE = 70.0;
-// Looser hold-rise gates below this depth (empty water-on-plate hunting).
-static constexpr double SHALLOW_HOLD_RISE_DEPTH_MBAR = 300.0;
-static constexpr double SHALLOW_MAX_RISE_PER_TICK = 45.0;
-static constexpr double SHALLOW_MAX_CUMULATIVE_RISE = 90.0;
-// Decay cumulative rise on toward-vacuum ticks (hunting oscillation).
-static constexpr double CUMULATIVE_RISE_DECAY = 0.5;
-// Pressure offset from target to be considered in "hold" state
+static constexpr const uint32_t CONTROL_PERIOD_HZ = 25;
+static constexpr const uint32_t CONTROL_PERIOD_MS = 1000 / CONTROL_PERIOD_HZ;
+static constexpr double MAX_DT_MS = static_cast<double>(CONTROL_PERIOD_MS * 4);
+static constexpr const uint32_t NEAR_TARGET_MS = 2000;
 static constexpr const double PRESSURE_TOLERANCE = 20.0F;
-// Large negative = draining (air rush) - ignore
-static constexpr const double MAX_DRAIN_RISE_PER_TICK = -150.0;
-static constexpr const double MAX_DELTA_PER_TICK = 250.0;
-// Additional EMI smoothing for waste detection
 static constexpr const double SENSOR_ALPHA = 0.5F;
-// The baseline the system starts with, this is measured by how fast the floater
-// closes the pump hose hole when the waste is full.
-static constexpr const uint32_t DEFAULT_BASELINE = 600;
-// Hard Minimum: If it reaches p2 vacuum in <  this many ms, it's full.
-static constexpr const uint32_t MIN_ALLOWABLE_WINDOW_TIME_MS = 700;
-// Upper bound for first-run baseline learning. Slower than this is leaky
-// empty, not full — do not raise a waste-full error.
-static constexpr const uint32_t MAX_ALLOWABLE_WINDOW_TIME_MS = 20000;
-// Number of tics we need to be around the target pressure to enter hold phase
-static constexpr const uint32_t NEAR_TARGET_TICS = 50;  // ~2s at 25Hz
 
-// ~800ms window for pressure std at 25Hz
-static constexpr uint8_t PRESSURE_WINDOW_SIZE = 20;
-static constexpr double PRESSURE_OSCILLATION_MIN_STD = 7.5;
-// Max pressure std to count a shallow hold as quiet.
-static constexpr double PRESSURE_STABLE_MAX_STD = 1.0;
-static constexpr uint8_t STABLE_HOLD_TICKS = 150;       // ~6s at 25Hz
-static constexpr uint8_t STABLE_HOLD_TICKS_DEEP = 250;  // ~10s at 25Hz
-// Commanded RPM below this counts as unloaded (shallow).
-static constexpr double PUMP_UNLOADED_MAX_RPM = 50.0;
-static constexpr double PUMP_UNLOADED_MAX_RPM_DEEP = 800.0;
-// Depth at/above this uses the deep RPM cap and 10s hold.
+static constexpr double STABLE_HOLD_MS = 6000.0;
+static constexpr double STABLE_HOLD_DEEP_MS = 10000.0;
 static constexpr double DEEP_VACUUM_DEPTH_MBAR = 800.0;
-// Hold-trip setpoint band (tighter than PRESSURE_TOLERANCE hold entry).
-static constexpr double HOLD_SETPOINT_MAX_ERROR_MBAR = 8.0;
-// |A-B| above this is orifice flow; not sealed.
 static constexpr double FLOWING_DP_MBAR = 8.0;
-// Sealed-hold trip only at/above this vacuum depth. Shallower targets rely on
-// ramp baseline and rise limits (empty water-on-plate mimics sealed hold).
-static constexpr double SEALED_HOLD_MIN_DEPTH_MBAR = 300.0;
+static constexpr double MIN_WASTE_DEPTH_MBAR = 20.0;
+// Commanded RPM per mbar of current vacuum.
+static constexpr double G_SEALED_MAX = 0.50;
 
-// Hose diam_m 0.0760m; ORIFICE_AREA = PI * (diam_m / 2.0) * (diam_m / 2.0)
-static constexpr const double ORIFICE_AREA = 0.00004536;  // m²
+static constexpr const double ORIFICE_AREA = 0.00004536;  // m², 7.6 mm ID
 static constexpr const double DISCHARGE_COEFF = 0.85;
 static constexpr const double AIR_DENSITY = 1.2;  // kg/m³
-// Flow rate EMI smoothing
 static constexpr const double FLOW_RATE_ALPHA = 0.1F;
 static constexpr const double FLOW_RATE_FACTOR = 1e6;
 static constexpr const double MIN_DELTA_ALPHA = 0.1F;
 
 struct WasteConfig {
     bool enable_waste_full = true;
-    double p_window_start = WASTE_WINDOW_START_PCT;
-    double p_window_end = WASTE_WINDOW_END_PCT;
-    double baseline_fast_factor = BASELINE_FAST_FACTOR;
-    double max_delta_per_tick = MAX_DELTA_PER_TICK;
-    double max_rise_per_tick = MAX_RISE_PER_TICK;
-    double max_cummulative_rise = MAX_CUMULATIVE_RISE;
     double p_filter_alpha = SENSOR_ALPHA;
-    double min_window_time = MIN_ALLOWABLE_WINDOW_TIME_MS;
-    double max_window_time = MAX_ALLOWABLE_WINDOW_TIME_MS;
+    double g_sealed_max = G_SEALED_MAX;
+    double flowing_dp_mbar = FLOWING_DP_MBAR;
+    double stable_hold_ms = STABLE_HOLD_MS;
+    double stable_hold_deep_ms = STABLE_HOLD_DEEP_MS;
+    double min_waste_depth_mbar = MIN_WASTE_DEPTH_MBAR;
 };
 
 auto inline calculate_flow_per_second(double pressure_a, double pressure_b,
-                                      double smoothed_delta_p) -> double {
+                                      double& smoothed_delta_p) -> double {
     auto delta_p_pa = std::abs(pressure_a - pressure_b) * 100.0;
     if (smoothed_delta_p == 0.0) {
         smoothed_delta_p = delta_p_pa;
@@ -106,38 +59,11 @@ auto inline calculate_flow_per_second(double pressure_a, double pressure_b,
                            ((1.0 - FLOW_RATE_ALPHA) * smoothed_delta_p);
     }
 
-    // Prevent negative or tiny values
     if (smoothed_delta_p > MIN_DELTA_ALPHA) {
-        // Bernoulli velocity
         const auto velocity = std::sqrt(2 * smoothed_delta_p / AIR_DENSITY);
-
-        // Volumetric flow rate in ml/s
         return DISCHARGE_COEFF * ORIFICE_AREA * velocity * FLOW_RATE_FACTOR;
     }
     return 0.0;
-}
-
-// Helper: Calculate standard deviation of the fixed flow window
-template <size_t N>
-auto calculate_std_dev(const std::array<double, N>& buf, bool is_full,
-                       uint8_t cur_idx) -> double {
-    const uint8_t count = is_full ? N : cur_idx;
-    if (count < 2) {
-        return 0.0;
-    };
-
-    double mean = 0.0;
-    for (uint8_t i = 0; i < count; ++i) {
-        mean += buf.at(i);
-    }
-    mean /= count;
-
-    double sum_sq_diff = 0.0;
-    for (uint8_t i = 0; i < count; ++i) {
-        const double diff = buf.at(i) - mean;
-        sum_sq_diff += diff * diff;
-    }
-    return std::sqrt(sum_sq_diff / (count - 1));
 }
 
 class WasteDetector {
@@ -145,34 +71,10 @@ class WasteDetector {
     WasteDetector() = default;
 
     auto configure(WasteConfig c) -> void {
-        config.enable_waste_full = c.enable_waste_full;
-        if (c.p_window_start > 0) {
-            config.p_window_start = c.p_window_start;
-        }
-        if (c.p_window_end > 0) {
-            config.p_window_end = c.p_window_end;
-        }
-        if (c.baseline_fast_factor > 0) {
-            config.baseline_fast_factor = c.baseline_fast_factor;
-        };
-        if (c.max_delta_per_tick > 0) {
-            config.max_delta_per_tick = c.max_delta_per_tick;
-        }
-        if (c.max_rise_per_tick > 0) {
-            config.max_rise_per_tick = c.max_rise_per_tick;
-        }
-        if (c.max_cummulative_rise > 0) {
-            config.max_cummulative_rise = c.max_cummulative_rise;
-        }
-        if (c.p_filter_alpha > 0) {
-            config.p_filter_alpha = c.p_filter_alpha;
-        }
-        if (c.min_window_time > 0) {
-            config.min_window_time = c.min_window_time;
-        }
-        if (c.max_window_time > 0) {
-            config.max_window_time = c.max_window_time;
-        }
+        config = c;
+        config.p_filter_alpha = (c.p_filter_alpha <= 0.0)
+                                    ? SENSOR_ALPHA
+                                    : std::min(c.p_filter_alpha, 1.0);
     }
 
     auto check(uint32_t timestamp, double pressure_abs_a, double pressure_abs_b,
@@ -184,240 +86,126 @@ class WasteDetector {
         if (waste_full_) {
             return error;
         }
-        // Calculate flow rate
+        if ((p_atm - target_abs_mbar) < config.min_waste_depth_mbar) {
+            return WasteFullError::NO_ERROR;
+        }
+
         flow_ml_per_s = calculate_flow_per_second(
             pressure_abs_a, pressure_abs_b, smoothed_delta_p);
         error = WasteFullError::NO_ERROR;
-        auto total_vacuum_range = p_atm - target_abs_mbar;
-        auto last_p = smoothed_p_;
-        // EMA smoothing
-        if (smoothed_p_ == 0) {
+
+        if (smoothed_p_ == 0.0) {
             smoothed_p_ = pressure_abs_b;
         } else {
             smoothed_p_ = (config.p_filter_alpha * pressure_abs_b) +
-                          ((1.0F - config.p_filter_alpha) * smoothed_p_);
+                          ((1.0 - config.p_filter_alpha) * smoothed_p_);
         }
-        auto current_p = smoothed_p_;
+        const double current_p = smoothed_p_;
+        const double vacuum_depth = p_atm - target_abs_mbar;
+        const double current_vacuum = p_atm - current_p;
+        const double orifice_dp = std::abs(pressure_abs_a - pressure_abs_b);
+        const double g = conductance(pump_rpm, current_vacuum);
 
-        // Continuous delta_p for full-run spike/stall (positive = drop)
-        auto delta_p = last_p - current_p;
-        if (delta_p > config.max_delta_per_tick) {
-            waste_full_ = true;
-            error = WasteFullError::MAX_DELTA_TIC_ERROR;
-            return error;
-        }
+        const double dt_ms = sample_dt_ms(timestamp);
 
-        // Phase detection: Switch to hold if near target for a bit
-        if (std::abs(current_p - target_abs_mbar) < PRESSURE_TOLERANCE) {
-            near_target_ticks_++;
-            if (near_target_ticks_ > NEAR_TARGET_TICS) {  // ~1s at 25Hz
-                in_ramp_phase_ = false;                   // Enter hold mode
-            }
-        } else {
-            // Re-enter ramp if we drift too far from the target
-            near_target_ticks_ = 0;
-            in_ramp_phase_ = true;
-            stable_hold_ticks_ = 0;
+        const bool near_or_overshot =
+            (std::abs(current_p - target_abs_mbar) < PRESSURE_TOLERANCE) ||
+            (current_p < target_abs_mbar);
+        if (!near_or_overshot) {
+            near_target_ms_ = 0.0;
+            sealed_hold_ms_ = 0.0;
+            return WasteFullError::NO_ERROR;
         }
 
-        // Ramp phase: Pressure Window + stall timeout
-        if (in_ramp_phase_) {
-            auto p_window_start =
-                p_atm - (total_vacuum_range * config.p_window_start);
-            auto p_window_end =
-                p_atm - (total_vacuum_range * config.p_window_end);
-
-            if (current_p < p_window_start && ramp_start_ms_ == 0) {
-                if (current_p <= p_window_end) {
-                    waste_full_ = true;
-                    error = WasteFullError::OVER_TARGET_ERROR;
-                    return error;
-                }
-                ramp_start_ms_ = timestamp;
-            }
-
-            if (current_p <= p_window_end && ramp_start_ms_ != 0) {
-                auto measured_time = timestamp - ramp_start_ms_;
-                if (measured_time < config.min_window_time) {
-                    waste_full_ = true;
-                    error = WasteFullError::RISE_TOO_FAST_ERROR;
-                } else if (baseline_captured_) {
-                    if (measured_time < (baseline_rise_time_ms_ *
-                                         config.baseline_fast_factor)) {
-                        waste_full_ = true;
-                        error = WasteFullError::FAST_BASELINE_ERROR;
-                        return error;
-                    }
-                    return WasteFullError::NO_ERROR;
-                } else {
-                    // First run: learn any window slower than "too fast" and
-                    // faster than a 20s stall. A slow empty ramp is not full.
-                    if (measured_time >= config.min_window_time &&
-                        measured_time < config.max_window_time) {
-                        baseline_rise_time_ms_ = measured_time;
-                        baseline_captured_ = true;
-                    }
-                    return WasteFullError::NO_ERROR;
-                }
-                if (waste_full_) {
-                    return error;
-                };
-                ramp_start_ms_ = 0;
-            }
-        } else {  // Hold phase: Detect waste full (blocked flow)
-
-            // Ignore sudden inrush of air
-            if (delta_p < MAX_DRAIN_RISE_PER_TICK) {
-                cumulative_rise_ = 0.0;
-                return WasteFullError::NO_ERROR;
-            }
-
-            // Add pressure to circular buffer
-            pressure_window.at(pressure_window_index) = current_p;
-            pressure_window_index =
-                (pressure_window_index + 1) % PRESSURE_WINDOW_SIZE;
-            if (pressure_window_index == 0) {
-                pressure_window_full = true;
-            }
-
-            if (pressure_window_full) {
-                const double vacuum_depth = total_vacuum_range;
-                const bool deep_target =
-                    vacuum_depth >= DEEP_VACUUM_DEPTH_MBAR;
-                const bool sealed_hold_allowed =
-                    vacuum_depth >= SEALED_HOLD_MIN_DEPTH_MBAR;
-
-                if (sealed_hold_allowed) {
-                    auto pressure_std = calculate_std_dev(
-                        pressure_window, pressure_window_full,
-                        pressure_window_index);
-                    auto orifice_dp =
-                        std::abs(pressure_abs_a - pressure_abs_b);
-                    // Shallow: quiet + no flow + on setpoint + low RPM for 6s.
-                    // Deep: no flow + on setpoint + RPM < 800 for 10s (no quiet).
-                    const bool quiet = pressure_std < PRESSURE_STABLE_MAX_STD;
-                    const bool no_flow = orifice_dp < FLOWING_DP_MBAR;
-                    const bool at_setpoint =
-                        std::abs(current_p - target_abs_mbar) <
-                        HOLD_SETPOINT_MAX_ERROR_MBAR;
-                    const double rpm_cap = deep_target
-                                               ? PUMP_UNLOADED_MAX_RPM_DEEP
-                                               : PUMP_UNLOADED_MAX_RPM;
-                    const bool pump_unloaded = pump_rpm < rpm_cap;
-                    const bool hold_ok = no_flow && pump_unloaded &&
-                                         at_setpoint &&
-                                         (deep_target || quiet);
-                    if (hold_ok) {
-                        if (stable_hold_ticks_ < 255) {
-                            stable_hold_ticks_++;
-                        }
-                        const uint8_t needed_ticks =
-                            deep_target ? STABLE_HOLD_TICKS_DEEP
-                                        : STABLE_HOLD_TICKS;
-                        if (stable_hold_ticks_ >= needed_ticks) {
-                            waste_full_ = true;
-                            error = WasteFullError::FLOW_STABLE_FULL_ERROR;
-                            return error;
-                        }
-                    } else {
-                        stable_hold_ticks_ = 0;
-                    }
-                } else {
-                    stable_hold_ticks_ = 0;
-                }
-
-                const double rise_cap =
-                    vacuum_depth < SHALLOW_HOLD_RISE_DEPTH_MBAR
-                        ? SHALLOW_MAX_RISE_PER_TICK
-                        : config.max_rise_per_tick;
-                const double cumulative_cap =
-                    vacuum_depth < SHALLOW_HOLD_RISE_DEPTH_MBAR
-                        ? SHALLOW_MAX_CUMULATIVE_RISE
-                        : config.max_cummulative_rise;
-
-                // Smaller rise = potential full waste (blocked flow)
-                if (delta_p < -rise_cap) {
-                    waste_full_ = true;
-                    error = WasteFullError::SUDDEN_BLOCKED_ERROR;
-                    return error;
-                }
-
-                // Cumulative rise over time (slow blocked-flow back-pressure)
-                if (delta_p < 0) {
-                    cumulative_rise_ -= delta_p;
-                    if (cumulative_rise_ > cumulative_cap) {
-                        waste_full_ = true;
-                        error = WasteFullError::CUMMULATIVE_BLOCKED_ERROR;
-                    }
-                } else if (delta_p > 0) {
-                    cumulative_rise_ *= CUMULATIVE_RISE_DECAY;
-                }
-            }
+        near_target_ms_ += dt_ms;
+        if (near_target_ms_ < NEAR_TARGET_MS) {
+            return WasteFullError::NO_ERROR;
         }
-        return error;
+        return check_hold(dt_ms, vacuum_depth, orifice_dp, g);
     }
 
     auto reset() -> void {
         waste_full_ = false;
-        ramp_start_ms_ = 0;
-        near_target_ticks_ = 0;
-        cumulative_rise_ = 0.0;
-        in_ramp_phase_ = true;
+        near_target_ms_ = 0.0;
         smoothed_p_ = 0.0;
         error = WasteFullError::NO_ERROR;
-        pressure_window.fill(0);
-        pressure_window_index = 0;
-        pressure_window_full = false;
-        stable_hold_ticks_ = 0;
+        sealed_hold_ms_ = 0.0;
+        last_sample_ms_ = 0;
+        have_sample_ = false;
         smoothed_delta_p = 0.0;
         flow_ml_per_s = 0.0;
     }
 
-    auto reset_baseline() -> void {
-        baseline_captured_ = false;
-        baseline_rise_time_ms_ = 0;
-    }
-
     auto reset_config() -> void {
         config.enable_waste_full = true;
-        config.p_window_start = WASTE_WINDOW_START_PCT;
-        config.p_window_end = WASTE_WINDOW_END_PCT;
-        config.baseline_fast_factor = BASELINE_FAST_FACTOR;
-        config.max_delta_per_tick = MAX_DELTA_PER_TICK;
-        config.max_rise_per_tick = MAX_RISE_PER_TICK;
-        config.max_cummulative_rise = MAX_CUMULATIVE_RISE;
         config.p_filter_alpha = SENSOR_ALPHA;
-        config.min_window_time = MIN_ALLOWABLE_WINDOW_TIME_MS;
-        config.max_window_time = MAX_ALLOWABLE_WINDOW_TIME_MS;
+        config.g_sealed_max = G_SEALED_MAX;
+        config.flowing_dp_mbar = FLOWING_DP_MBAR;
+        config.stable_hold_ms = STABLE_HOLD_MS;
+        config.stable_hold_deep_ms = STABLE_HOLD_DEEP_MS;
+        config.min_waste_depth_mbar = MIN_WASTE_DEPTH_MBAR;
     }
 
-    [[nodiscard]] auto get_error() -> WasteFullError { return error; }
+    [[nodiscard]] auto get_error() const -> WasteFullError { return error; }
     [[nodiscard]] auto get_flow_rate() const -> double { return flow_ml_per_s; }
-    [[nodiscard]] auto baseline_captured() const -> bool {
-        return baseline_captured_;
-    }
-
-    auto get_config() -> WasteConfig { return config; }
+    [[nodiscard]] auto get_config() const -> WasteConfig { return config; }
 
   private:
-    bool waste_full_ = false;
-    uint32_t ramp_start_ms_ = 0;
-    uint32_t baseline_rise_time_ms_ = DEFAULT_BASELINE;
-    bool baseline_captured_ = false;
-    bool in_ramp_phase_ = true;
-    uint32_t near_target_ticks_ = 0;
-    double cumulative_rise_ = 0.0;
-    double smoothed_p_ = 0.0;
-    WasteFullError error = WasteFullError::NO_ERROR;
-    WasteConfig config;
+    static auto conductance(double rpm, double vacuum_mbar) -> double {
+        if (vacuum_mbar < 1.0) {
+            return 0.0;
+        }
+        return rpm / vacuum_mbar;
+    }
 
-    // standard deviation
-    std::array<double, PRESSURE_WINDOW_SIZE> pressure_window = {0.0};
-    uint8_t pressure_window_index = 0;
-    bool pressure_window_full = false;
-    uint8_t stable_hold_ticks_ = 0;
+    auto sample_dt_ms(uint32_t timestamp) -> double {
+        double dt_ms = 0.0;
+        if (have_sample_) {
+            dt_ms = std::min(static_cast<double>(timestamp - last_sample_ms_),
+                             MAX_DT_MS);
+        }
+        have_sample_ = true;
+        last_sample_ms_ = timestamp;
+        return dt_ms;
+    }
+
+    auto trip(WasteFullError e) -> WasteFullError {
+        waste_full_ = true;
+        error = e;
+        return error;
+    }
+
+    auto check_hold(double dt_ms, double vacuum_depth, double orifice_dp,
+                    double g) -> WasteFullError {
+        const bool sealed =
+            (orifice_dp < config.flowing_dp_mbar) && (g < config.g_sealed_max);
+        if (sealed) {
+            sealed_hold_ms_ += dt_ms;
+        } else if (sealed_hold_ms_ > dt_ms) {
+            sealed_hold_ms_ -= dt_ms;
+        } else {
+            sealed_hold_ms_ = 0.0;
+        }
+
+        const double needed_ms = vacuum_depth >= DEEP_VACUUM_DEPTH_MBAR
+                                     ? config.stable_hold_deep_ms
+                                     : config.stable_hold_ms;
+        if (sealed && sealed_hold_ms_ >= needed_ms) {
+            return trip(WasteFullError::FLOW_STABLE_FULL_ERROR);
+        }
+        return WasteFullError::NO_ERROR;
+    }
+
+    bool waste_full_ = false;
+    double smoothed_p_ = 0.0;
+    uint32_t last_sample_ms_ = 0;
+    double near_target_ms_ = 0.0;
+    double sealed_hold_ms_ = 0.0;
+    bool have_sample_ = false;
     double smoothed_delta_p = 0.0;
     double flow_ml_per_s = 0.0;
+    WasteConfig config;
+    WasteFullError error = WasteFullError::NO_ERROR;
 };
 
 }  // namespace waste_detector

--- a/stm32-modules/include/vacuum-module/firmware/waste_detector.hpp
+++ b/stm32-modules/include/vacuum-module/firmware/waste_detector.hpp
@@ -27,9 +27,15 @@ static constexpr const double BASELINE_DEPTH_RESET = 0.30F;
 // Compare to the learned baseline. Faster than this factor is full.
 static constexpr const double BASELINE_FAST_FACTOR = 0.50F;
 // Hold-phase vacuum increase per tick that flags a slam-shut.
-static constexpr const double MAX_RISE_PER_TICK = 12.0;
+static constexpr const double MAX_RISE_PER_TICK = 30.0;
 // Total allowed rise before flag for slow build up case
-static constexpr const double MAX_CUMULATIVE_RISE = 40.0;
+static constexpr const double MAX_CUMULATIVE_RISE = 70.0;
+// Looser hold-rise gates below this depth (empty water-on-plate hunting).
+static constexpr double SHALLOW_HOLD_RISE_DEPTH_MBAR = 300.0;
+static constexpr double SHALLOW_MAX_RISE_PER_TICK = 45.0;
+static constexpr double SHALLOW_MAX_CUMULATIVE_RISE = 90.0;
+// Decay cumulative rise on toward-vacuum ticks (hunting oscillation).
+static constexpr double CUMULATIVE_RISE_DECAY = 0.5;
 // Pressure offset from target to be considered in "hold" state
 static constexpr const double PRESSURE_TOLERANCE = 20.0F;
 // Large negative = draining (air rush) - ignore
@@ -55,8 +61,8 @@ static constexpr double PRESSURE_OSCILLATION_MIN_STD = 7.5;
 static constexpr double PRESSURE_STABLE_MAX_STD = 1.0;
 static constexpr uint8_t STABLE_HOLD_TICKS = 150;       // ~6s at 25Hz
 static constexpr uint8_t STABLE_HOLD_TICKS_DEEP = 250;  // ~10s at 25Hz
-// Commanded RPM below this counts as unloaded.
-static constexpr double PUMP_UNLOADED_MAX_RPM = 100.0;
+// Commanded RPM below this counts as unloaded (shallow).
+static constexpr double PUMP_UNLOADED_MAX_RPM = 50.0;
 static constexpr double PUMP_UNLOADED_MAX_RPM_DEEP = 800.0;
 // Depth at/above this uses the deep RPM cap and 10s hold.
 static constexpr double DEEP_VACUUM_DEPTH_MBAR = 800.0;
@@ -64,6 +70,9 @@ static constexpr double DEEP_VACUUM_DEPTH_MBAR = 800.0;
 static constexpr double HOLD_SETPOINT_MAX_ERROR_MBAR = 8.0;
 // |A-B| above this is orifice flow; not sealed.
 static constexpr double FLOWING_DP_MBAR = 8.0;
+// Sealed-hold trip only at/above this vacuum depth. Shallower targets rely on
+// ramp baseline and rise limits (empty water-on-plate mimics sealed hold).
+static constexpr double SEALED_HOLD_MIN_DEPTH_MBAR = 300.0;
 
 // Hose diam_m 0.0760m; ORIFICE_AREA = PI * (diam_m / 2.0) * (diam_m / 2.0)
 static constexpr const double ORIFICE_AREA = 0.00004536;  // m²
@@ -272,44 +281,62 @@ class WasteDetector {
             }
 
             if (pressure_window_full) {
-                auto pressure_std = calculate_std_dev(
-                    pressure_window, pressure_window_full,
-                    pressure_window_index);
-                auto orifice_dp =
-                    std::abs(pressure_abs_a - pressure_abs_b);
-                // Shallow: quiet + no flow + on setpoint + RPM < 100 for 6s.
-                // Deep: no flow + on setpoint + RPM < 800 for 10s (no quiet).
-                const bool quiet = pressure_std < PRESSURE_STABLE_MAX_STD;
-                const bool no_flow = orifice_dp < FLOWING_DP_MBAR;
-                const bool at_setpoint =
-                    std::abs(current_p - target_abs_mbar) <
-                    HOLD_SETPOINT_MAX_ERROR_MBAR;
+                const double vacuum_depth = total_vacuum_range;
                 const bool deep_target =
-                    (p_atm - target_abs_mbar) >= DEEP_VACUUM_DEPTH_MBAR;
-                const double rpm_cap = deep_target
-                                           ? PUMP_UNLOADED_MAX_RPM_DEEP
-                                           : PUMP_UNLOADED_MAX_RPM;
-                const bool pump_unloaded = pump_rpm < rpm_cap;
-                const bool hold_ok = no_flow && pump_unloaded &&
-                                     at_setpoint && (deep_target || quiet);
-                if (hold_ok) {
-                    if (stable_hold_ticks_ < 255) {
-                        stable_hold_ticks_++;
-                    }
-                    const uint8_t needed_ticks =
-                        deep_target ? STABLE_HOLD_TICKS_DEEP
-                                    : STABLE_HOLD_TICKS;
-                    if (stable_hold_ticks_ >= needed_ticks) {
-                        waste_full_ = true;
-                        error = WasteFullError::FLOW_STABLE_FULL_ERROR;
-                        return error;
+                    vacuum_depth >= DEEP_VACUUM_DEPTH_MBAR;
+                const bool sealed_hold_allowed =
+                    vacuum_depth >= SEALED_HOLD_MIN_DEPTH_MBAR;
+
+                if (sealed_hold_allowed) {
+                    auto pressure_std = calculate_std_dev(
+                        pressure_window, pressure_window_full,
+                        pressure_window_index);
+                    auto orifice_dp =
+                        std::abs(pressure_abs_a - pressure_abs_b);
+                    // Shallow: quiet + no flow + on setpoint + low RPM for 6s.
+                    // Deep: no flow + on setpoint + RPM < 800 for 10s (no quiet).
+                    const bool quiet = pressure_std < PRESSURE_STABLE_MAX_STD;
+                    const bool no_flow = orifice_dp < FLOWING_DP_MBAR;
+                    const bool at_setpoint =
+                        std::abs(current_p - target_abs_mbar) <
+                        HOLD_SETPOINT_MAX_ERROR_MBAR;
+                    const double rpm_cap = deep_target
+                                               ? PUMP_UNLOADED_MAX_RPM_DEEP
+                                               : PUMP_UNLOADED_MAX_RPM;
+                    const bool pump_unloaded = pump_rpm < rpm_cap;
+                    const bool hold_ok = no_flow && pump_unloaded &&
+                                         at_setpoint &&
+                                         (deep_target || quiet);
+                    if (hold_ok) {
+                        if (stable_hold_ticks_ < 255) {
+                            stable_hold_ticks_++;
+                        }
+                        const uint8_t needed_ticks =
+                            deep_target ? STABLE_HOLD_TICKS_DEEP
+                                        : STABLE_HOLD_TICKS;
+                        if (stable_hold_ticks_ >= needed_ticks) {
+                            waste_full_ = true;
+                            error = WasteFullError::FLOW_STABLE_FULL_ERROR;
+                            return error;
+                        }
+                    } else {
+                        stable_hold_ticks_ = 0;
                     }
                 } else {
                     stable_hold_ticks_ = 0;
                 }
 
+                const double rise_cap =
+                    vacuum_depth < SHALLOW_HOLD_RISE_DEPTH_MBAR
+                        ? SHALLOW_MAX_RISE_PER_TICK
+                        : config.max_rise_per_tick;
+                const double cumulative_cap =
+                    vacuum_depth < SHALLOW_HOLD_RISE_DEPTH_MBAR
+                        ? SHALLOW_MAX_CUMULATIVE_RISE
+                        : config.max_cummulative_rise;
+
                 // Smaller rise = potential full waste (blocked flow)
-                if (delta_p < -config.max_rise_per_tick) {
+                if (delta_p < -rise_cap) {
                     waste_full_ = true;
                     error = WasteFullError::SUDDEN_BLOCKED_ERROR;
                     return error;
@@ -318,13 +345,12 @@ class WasteDetector {
                 // Cumulative rise over time (slow blocked-flow back-pressure)
                 if (delta_p < 0) {
                     cumulative_rise_ -= delta_p;
-                    if (cumulative_rise_ > config.max_cummulative_rise) {
+                    if (cumulative_rise_ > cumulative_cap) {
                         waste_full_ = true;
                         error = WasteFullError::CUMMULATIVE_BLOCKED_ERROR;
                     }
-                } else {
-                    // Reset cumulative if drop due to normal fluctuations
-                    cumulative_rise_ = 0.0;
+                } else if (delta_p > 0) {
+                    cumulative_rise_ *= CUMULATIVE_RISE_DECAY;
                 }
             }
         }

--- a/stm32-modules/include/vacuum-module/firmware/waste_detector.hpp
+++ b/stm32-modules/include/vacuum-module/firmware/waste_detector.hpp
@@ -24,12 +24,12 @@ static constexpr const double WASTE_WINDOW_START_PCT = 0.10F;
 static constexpr const double WASTE_WINDOW_END_PCT = 0.95F;
 // Resets the baseline if the new target pressure is this percent difference
 static constexpr const double BASELINE_DEPTH_RESET = 0.30F;
-// Compare to the learned baseline. If it is N x faster than empty, it's full.
-static constexpr const double BASELINE_FAST_FACTOR = 0.75F;
-// Allowed upward drift per tick while in hold phase
-static constexpr const double MAX_RISE_PER_TICK = 3.5;
+// Compare to the learned baseline. Faster than this factor is full.
+static constexpr const double BASELINE_FAST_FACTOR = 0.50F;
+// Hold-phase vacuum increase per tick that flags a slam-shut.
+static constexpr const double MAX_RISE_PER_TICK = 12.0;
 // Total allowed rise before flag for slow build up case
-static constexpr const double MAX_CUMULATIVE_RISE = 11.5;
+static constexpr const double MAX_CUMULATIVE_RISE = 40.0;
 // Pressure offset from target to be considered in "hold" state
 static constexpr const double PRESSURE_TOLERANCE = 20.0F;
 // Large negative = draining (air rush) - ignore
@@ -42,16 +42,28 @@ static constexpr const double SENSOR_ALPHA = 0.5F;
 static constexpr const uint32_t DEFAULT_BASELINE = 600;
 // Hard Minimum: If it reaches p2 vacuum in <  this many ms, it's full.
 static constexpr const uint32_t MIN_ALLOWABLE_WINDOW_TIME_MS = 700;
-// If the ramp takes longer than this, we flag it as a stall or leak.
+// Upper bound for first-run baseline learning. Slower than this is leaky
+// empty, not full — do not raise a waste-full error.
 static constexpr const uint32_t MAX_ALLOWABLE_WINDOW_TIME_MS = 20000;
 // Number of tics we need to be around the target pressure to enter hold phase
 static constexpr const uint32_t NEAR_TARGET_TICS = 50;  // ~2s at 25Hz
 
-// Standard Deviation
-// ~800ms window for pressure std
+// ~800ms window for pressure std at 25Hz
 static constexpr uint8_t PRESSURE_WINDOW_SIZE = 20;
-// Oscillations above this means there is no air flow because the waste is full.
 static constexpr double PRESSURE_OSCILLATION_MIN_STD = 7.5;
+// Max pressure std to count a shallow hold as quiet.
+static constexpr double PRESSURE_STABLE_MAX_STD = 1.0;
+static constexpr uint8_t STABLE_HOLD_TICKS = 150;       // ~6s at 25Hz
+static constexpr uint8_t STABLE_HOLD_TICKS_DEEP = 250;  // ~10s at 25Hz
+// Commanded RPM below this counts as unloaded.
+static constexpr double PUMP_UNLOADED_MAX_RPM = 100.0;
+static constexpr double PUMP_UNLOADED_MAX_RPM_DEEP = 800.0;
+// Depth at/above this uses the deep RPM cap and 10s hold.
+static constexpr double DEEP_VACUUM_DEPTH_MBAR = 800.0;
+// Hold-trip setpoint band (tighter than PRESSURE_TOLERANCE hold entry).
+static constexpr double HOLD_SETPOINT_MAX_ERROR_MBAR = 8.0;
+// |A-B| above this is orifice flow; not sealed.
+static constexpr double FLOWING_DP_MBAR = 8.0;
 
 // Hose diam_m 0.0760m; ORIFICE_AREA = PI * (diam_m / 2.0) * (diam_m / 2.0)
 static constexpr const double ORIFICE_AREA = 0.00004536;  // m²
@@ -155,7 +167,8 @@ class WasteDetector {
     }
 
     auto check(uint32_t timestamp, double pressure_abs_a, double pressure_abs_b,
-               double target_abs_mbar, double p_atm) -> WasteFullError {
+               double target_abs_mbar, double p_atm, double pump_rpm = 0.0)
+        -> WasteFullError {
         if (!config.enable_waste_full) {
             return WasteFullError::NO_ERROR;
         }
@@ -195,6 +208,7 @@ class WasteDetector {
             // Re-enter ramp if we drift too far from the target
             near_target_ticks_ = 0;
             in_ramp_phase_ = true;
+            stable_hold_ticks_ = 0;
         }
 
         // Ramp phase: Pressure Window + stall timeout
@@ -227,16 +241,14 @@ class WasteDetector {
                     }
                     return WasteFullError::NO_ERROR;
                 } else {
-                    // Only learn if time is reasonable when empty
-                    if (measured_time > config.min_window_time * 2 &&
-                        measured_time < config.max_window_time / 2) {
+                    // First run: learn any window slower than "too fast" and
+                    // faster than a 20s stall. A slow empty ramp is not full.
+                    if (measured_time >= config.min_window_time &&
+                        measured_time < config.max_window_time) {
                         baseline_rise_time_ms_ = measured_time;
                         baseline_captured_ = true;
-                        return WasteFullError::NO_ERROR;
                     }
-                    // First run was too slow, flag as full
-                    waste_full_ = true;
-                    error = WasteFullError::FIRST_RUN_SLOW_ERROR;
+                    return WasteFullError::NO_ERROR;
                 }
                 if (waste_full_) {
                     return error;
@@ -259,16 +271,41 @@ class WasteDetector {
                 pressure_window_full = true;
             }
 
-            // Check if we are osocilating more than we should, this
-            // indicates no air-flow because the waste is full.
             if (pressure_window_full) {
-                auto pressure_std =
-                    calculate_std_dev(pressure_window, pressure_window_full,
-                                      pressure_window_index);
-                if (pressure_std > PRESSURE_OSCILLATION_MIN_STD) {
-                    waste_full_ = true;
-                    error = WasteFullError::FLOW_STABLE_FULL_ERROR;
-                    return error;
+                auto pressure_std = calculate_std_dev(
+                    pressure_window, pressure_window_full,
+                    pressure_window_index);
+                auto orifice_dp =
+                    std::abs(pressure_abs_a - pressure_abs_b);
+                // Shallow: quiet + no flow + on setpoint + RPM < 100 for 6s.
+                // Deep: no flow + on setpoint + RPM < 800 for 10s (no quiet).
+                const bool quiet = pressure_std < PRESSURE_STABLE_MAX_STD;
+                const bool no_flow = orifice_dp < FLOWING_DP_MBAR;
+                const bool at_setpoint =
+                    std::abs(current_p - target_abs_mbar) <
+                    HOLD_SETPOINT_MAX_ERROR_MBAR;
+                const bool deep_target =
+                    (p_atm - target_abs_mbar) >= DEEP_VACUUM_DEPTH_MBAR;
+                const double rpm_cap = deep_target
+                                           ? PUMP_UNLOADED_MAX_RPM_DEEP
+                                           : PUMP_UNLOADED_MAX_RPM;
+                const bool pump_unloaded = pump_rpm < rpm_cap;
+                const bool hold_ok = no_flow && pump_unloaded &&
+                                     at_setpoint && (deep_target || quiet);
+                if (hold_ok) {
+                    if (stable_hold_ticks_ < 255) {
+                        stable_hold_ticks_++;
+                    }
+                    const uint8_t needed_ticks =
+                        deep_target ? STABLE_HOLD_TICKS_DEEP
+                                    : STABLE_HOLD_TICKS;
+                    if (stable_hold_ticks_ >= needed_ticks) {
+                        waste_full_ = true;
+                        error = WasteFullError::FLOW_STABLE_FULL_ERROR;
+                        return error;
+                    }
+                } else {
+                    stable_hold_ticks_ = 0;
                 }
 
                 // Smaller rise = potential full waste (blocked flow)
@@ -305,6 +342,7 @@ class WasteDetector {
         pressure_window.fill(0);
         pressure_window_index = 0;
         pressure_window_full = false;
+        stable_hold_ticks_ = 0;
         smoothed_delta_p = 0.0;
         flow_ml_per_s = 0.0;
     }
@@ -351,6 +389,7 @@ class WasteDetector {
     std::array<double, PRESSURE_WINDOW_SIZE> pressure_window = {0.0};
     uint8_t pressure_window_index = 0;
     bool pressure_window_full = false;
+    uint8_t stable_hold_ticks_ = 0;
     double smoothed_delta_p = 0.0;
     double flow_ml_per_s = 0.0;
 };

--- a/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/gcodes.hpp
@@ -722,32 +722,28 @@ struct GetPressurePID {
 
 struct SetWasteDetectionConfig {
     /*
-     * M127- SetWasteDetectionConfig configure the waste full detection feature
+     * M127- SetWasteDetectionConfig
+     * A filter alpha, G sealed conductance cap, H flowing |A-B| mbar,
+     * T/U sealed-hold ms (normal/deep), N min vacuum depth mbar, E enable.
      * */
-    std::optional<double> p_window_start = std::nullopt;
-    std::optional<double> p_window_end = std::nullopt;
-    std::optional<double> baseline_fast_factor = std::nullopt;
-    std::optional<double> max_delta_per_tick = std::nullopt;
-    std::optional<double> max_rise_per_tick = std::nullopt;
-    std::optional<double> max_cummulative_rise = std::nullopt;
     std::optional<double> p_filter_alpha = std::nullopt;
-    std::optional<double> min_window_time = std::nullopt;
-    std::optional<double> max_window_time = std::nullopt;
+    std::optional<double> g_sealed_max = std::nullopt;
+    std::optional<double> flowing_dp_mbar = std::nullopt;
+    std::optional<double> stable_hold_ms = std::nullopt;
+    std::optional<double> stable_hold_deep_ms = std::nullopt;
+    std::optional<double> min_waste_depth_mbar = std::nullopt;
     bool enable_waste_full = true;
 
     using ParseResult = std::optional<SetWasteDetectionConfig>;
     static constexpr auto prefix = std::array{'M', '1', '2', '7', ' '};
     static constexpr const char* response = "M127 OK\n";
 
-    using S = Arg<float, 'S'>;
-    using P = Arg<float, 'P'>;
-    using F = Arg<float, 'F'>;
-    using D = Arg<float, 'D'>;
-    using R = Arg<float, 'R'>;
-    using C = Arg<float, 'C'>;
     using A = Arg<float, 'A'>;
-    using M = Arg<float, 'M'>;
-    using X = Arg<float, 'X'>;
+    using G = Arg<float, 'G'>;
+    using H = Arg<float, 'H'>;
+    using T = Arg<float, 'T'>;
+    using U = Arg<float, 'U'>;
+    using N = Arg<float, 'N'>;
     using E = Arg<uint8_t, 'E'>;
 
     template <typename InputIt, typename Limit>
@@ -755,9 +751,8 @@ struct SetWasteDetectionConfig {
         std::sized_sentinel_for<Limit, InputIt>
     static auto parse(const InputIt& input, Limit limit)
         -> std::pair<ParseResult, InputIt> {
-        auto res =
-            gcode::SingleParser<S, P, F, D, R, C, A, M, X, E>::parse_gcode(
-                input, limit, prefix);
+        auto res = gcode::SingleParser<A, G, H, T, U, N, E>::parse_gcode(
+            input, limit, prefix);
         if (!res.first.has_value()) {
             return std::make_pair(ParseResult(), input);
         }
@@ -766,56 +761,38 @@ struct SetWasteDetectionConfig {
 
         auto arguments = res.first.value();
         if (std::get<0>(arguments).present) {
-            ret.p_window_start =
+            ret.p_filter_alpha =
                 static_cast<double>(std::get<0>(arguments).value);
         }
         if (std::get<1>(arguments).present) {
-            ret.p_window_end =
+            ret.g_sealed_max =
                 static_cast<double>(std::get<1>(arguments).value);
         }
         if (std::get<2>(arguments).present) {
-            ret.baseline_fast_factor =
+            ret.flowing_dp_mbar =
                 static_cast<double>(std::get<2>(arguments).value);
         }
         if (std::get<3>(arguments).present) {
-            ret.max_delta_per_tick =
+            ret.stable_hold_ms =
                 static_cast<double>(std::get<3>(arguments).value);
         }
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if (std::get<4>(arguments).present) {
-            ret.max_rise_per_tick =
+            ret.stable_hold_deep_ms =
                 // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
                 static_cast<double>(std::get<4>(arguments).value);
         }
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if (std::get<5>(arguments).present) {
-            ret.max_cummulative_rise =
+            ret.min_waste_depth_mbar =
                 // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
                 static_cast<double>(std::get<5>(arguments).value);
         }
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if (std::get<6>(arguments).present) {
-            ret.p_filter_alpha =
-                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-                static_cast<double>(std::get<6>(arguments).value);
-        }
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-        if (std::get<7>(arguments).present) {
-            ret.min_window_time =
-                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-                static_cast<double>(std::get<7>(arguments).value);
-        }
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-        if (std::get<8>(arguments).present) {
-            ret.max_window_time =
-                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-                static_cast<double>(std::get<8>(arguments).value);
-        }
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-        if (std::get<9>(arguments).present) {
             ret.enable_waste_full =
                 // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-                static_cast<bool>(std::get<9>(arguments).value);
+                static_cast<bool>(std::get<6>(arguments).value);
         }
         return std::make_pair(ret, res.second);
     }
@@ -838,19 +815,19 @@ struct GetWasteDetectionConfig {
     template <typename InputIt, typename InLimit>
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputIt, InLimit>
-    static auto write_response_into(
-        InputIt buf, InLimit limit, bool enabled, double p1, double p2,
-        double baseline_factor, double max_delta_per_tick,
-        double max_rise_per_tick, double max_cummulative_rise,
-        double p_filter_alpha, double min_window_time, double max_window_time)
-        -> InputIt {
+    static auto write_response_into(InputIt buf, InLimit limit, bool enabled,
+                                    double p_filter_alpha, double g_sealed_max,
+                                    double flowing_dp_mbar,
+                                    double stable_hold_ms,
+                                    double stable_hold_deep_ms,
+                                    double min_waste_depth_mbar) -> InputIt {
         int res = 0;
-        res = snprintf(&*buf, (limit - buf),
-                       "M128 E:%d S:%.1f P:%.1f F:%.1f D:%.1f R:%.1f C:%.1f "
-                       "A:%.1f M:%.1f X:%.1f OK\n",
-                       enabled, p1, p2, baseline_factor, max_delta_per_tick,
-                       max_rise_per_tick, max_cummulative_rise, p_filter_alpha,
-                       min_window_time, max_window_time);
+        res =
+            snprintf(&*buf, (limit - buf),
+                     "M128 E:%d A:%.1f G:%.2f H:%.1f T:%.0f U:%.0f N:%.1f "
+                     "OK\n",
+                     enabled, p_filter_alpha, g_sealed_max, flowing_dp_mbar,
+                     stable_hold_ms, stable_hold_deep_ms, min_waste_depth_mbar);
         if (res <= 0) {
             return buf;
         }

--- a/stm32-modules/include/vacuum-module/vacuum-module/host_comms_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/host_comms_task.hpp
@@ -385,11 +385,10 @@ class HostCommsTask {
                 } else {
                     return cache_element.write_response_into(
                         tx_into, tx_limit, response.enable_waste_full,
-                        response.p_window_start, response.p_window_end,
-                        response.baseline_fast_factor,
-                        response.max_delta_per_tick, response.max_rise_per_tick,
-                        response.max_cummulative_rise, response.p_filter_alpha,
-                        response.min_window_time, response.max_window_time);
+                        response.p_filter_alpha, response.g_sealed_max,
+                        response.flowing_dp_mbar, response.stable_hold_ms,
+                        response.stable_hold_deep_ms,
+                        response.min_waste_depth_mbar);
                 }
             },
             cache_entry);
@@ -741,15 +740,12 @@ class HostCommsTask {
         auto message = messages::SetWasteDetectionConfigMessage{
             .id = id,
             .enable_waste_full = gcode.enable_waste_full,
-            .p_window_start = gcode.p_window_start,
-            .p_window_end = gcode.p_window_end,
-            .baseline_fast_factor = gcode.baseline_fast_factor,
-            .max_delta_per_tick = gcode.max_delta_per_tick,
-            .max_rise_per_tick = gcode.max_rise_per_tick,
-            .max_cummulative_rise = gcode.max_cummulative_rise,
             .p_filter_alpha = gcode.p_filter_alpha,
-            .min_window_time = gcode.min_window_time,
-            .max_window_time = gcode.max_window_time};
+            .g_sealed_max = gcode.g_sealed_max,
+            .flowing_dp_mbar = gcode.flowing_dp_mbar,
+            .stable_hold_ms = gcode.stable_hold_ms,
+            .stable_hold_deep_ms = gcode.stable_hold_deep_ms,
+            .min_waste_depth_mbar = gcode.min_waste_depth_mbar};
         if (!task_registry->send(message, TICKS_TO_WAIT_ON_SEND)) {
             auto wrote_to = errors::write_into(
                 tx_into, tx_limit, errors::ErrorCode::INTERNAL_QUEUE_FULL);

--- a/stm32-modules/include/vacuum-module/vacuum-module/messages.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/messages.hpp
@@ -224,15 +224,12 @@ struct GetPressurePIDResponseMessage {
 struct SetWasteDetectionConfigMessage {
     uint32_t id = 0;
     bool enable_waste_full = true;
-    std::optional<double> p_window_start = std::nullopt;
-    std::optional<double> p_window_end = std::nullopt;
-    std::optional<double> baseline_fast_factor = std::nullopt;
-    std::optional<double> max_delta_per_tick = std::nullopt;
-    std::optional<double> max_rise_per_tick = std::nullopt;
-    std::optional<double> max_cummulative_rise = std::nullopt;
     std::optional<double> p_filter_alpha = std::nullopt;
-    std::optional<double> min_window_time = std::nullopt;
-    std::optional<double> max_window_time = std::nullopt;
+    std::optional<double> g_sealed_max = std::nullopt;
+    std::optional<double> flowing_dp_mbar = std::nullopt;
+    std::optional<double> stable_hold_ms = std::nullopt;
+    std::optional<double> stable_hold_deep_ms = std::nullopt;
+    std::optional<double> min_waste_depth_mbar = std::nullopt;
 };
 
 struct GetWasteDetectionConfigMessage {
@@ -242,15 +239,12 @@ struct GetWasteDetectionConfigMessage {
 struct GetWasteDetectionConfigResponse {
     uint32_t responding_to_id;
     bool enable_waste_full;
-    double p_window_start;
-    double p_window_end;
-    double baseline_fast_factor;
-    double max_delta_per_tick;
-    double max_rise_per_tick;
-    double max_cummulative_rise;
     double p_filter_alpha;
-    double min_window_time;
-    double max_window_time;
+    double g_sealed_max;
+    double flowing_dp_mbar;
+    double stable_hold_ms;
+    double stable_hold_deep_ms;
+    double min_waste_depth_mbar;
 };
 
 using HostCommsMessage =

--- a/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
@@ -308,23 +308,24 @@ class PressureTask {
         }
         monitor_target_pressure();
 
-        // Handle waste detection
-        auto res =
-            // NOLINTNEXTLINE(readability-suspicious-call-argument)
-            _detector.check(timestamp, current_pressure_a, current_pressure_b,
-                            target_pressure, pressure_atm);
-        if (res != waste_detector::WasteFullError::NO_ERROR) {
-            stop_vacuum();
-            set_vent_state(VentState::OPENED);
-            send_error_message(Error::WASTE_FULL_ERROR);
-            return;
-        }
-
         if (_control_state.control_pump) {
             auto rpm =
                 _controller.update(dt, current_pressure_b, target_pressure);
             _control_state.target_rpm = rpm;
             set_pump_state(true, rpm);
+        }
+
+        // Waste check uses commanded RPM.
+        auto res =
+            // NOLINTNEXTLINE(readability-suspicious-call-argument)
+            _detector.check(timestamp, current_pressure_a, current_pressure_b,
+                            target_pressure, pressure_atm,
+                            _control_state.target_rpm);
+        if (res != waste_detector::WasteFullError::NO_ERROR) {
+            stop_vacuum();
+            set_vent_state(VentState::OPENED);
+            send_error_message(Error::WASTE_FULL_ERROR);
+            return;
         }
     }
 

--- a/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
+++ b/stm32-modules/include/vacuum-module/vacuum-module/pressure_task.hpp
@@ -339,19 +339,7 @@ class PressureTask {
             std::clamp<double>(m.pressure_setpoint, ATM_PRESSURE_MBAR * -1, 0);
         auto target_pressure = guage_pressure + p_atm;
 
-        // Check for Significant Target Change (> 10% of the vacuum range)
         auto current_pressure = _control_state.pressure_abs_b;
-        auto current_target = _control_state.target_pressure;
-        auto vacuum_depth = std::abs(p_atm - target_pressure);
-        auto change_delta = std::abs(target_pressure - current_target);
-
-        // If the target moves by more than N % of the intended depth,
-        // the previous baseline is no longer physically representative.
-        if (_detector.baseline_captured() &&
-            (change_delta >
-             (vacuum_depth * waste_detector::BASELINE_DEPTH_RESET))) {
-            _detector.reset_baseline();
-        }
 
         _control_state.target_pressure = target_pressure;
         _control_state.duration_s = m.duration_s;
@@ -525,19 +513,14 @@ class PressureTask {
         static_cast<void>(policy);
         auto dc = _detector.get_config();
         dc.enable_waste_full = m.enable_waste_full;
-        dc.p_window_start = m.p_window_start.value_or(dc.p_window_start);
-        dc.p_window_end = m.p_window_end.value_or(dc.p_window_end);
-        dc.baseline_fast_factor =
-            m.baseline_fast_factor.value_or(dc.baseline_fast_factor);
-        dc.max_delta_per_tick =
-            m.max_delta_per_tick.value_or(dc.max_delta_per_tick);
-        dc.max_rise_per_tick =
-            m.max_rise_per_tick.value_or(dc.max_rise_per_tick);
-        dc.max_cummulative_rise =
-            m.max_cummulative_rise.value_or(dc.max_cummulative_rise);
         dc.p_filter_alpha = m.p_filter_alpha.value_or(dc.p_filter_alpha);
-        dc.min_window_time = m.min_window_time.value_or(dc.min_window_time);
-        dc.max_window_time = m.max_window_time.value_or(dc.max_window_time);
+        dc.g_sealed_max = m.g_sealed_max.value_or(dc.g_sealed_max);
+        dc.flowing_dp_mbar = m.flowing_dp_mbar.value_or(dc.flowing_dp_mbar);
+        dc.stable_hold_ms = m.stable_hold_ms.value_or(dc.stable_hold_ms);
+        dc.stable_hold_deep_ms =
+            m.stable_hold_deep_ms.value_or(dc.stable_hold_deep_ms);
+        dc.min_waste_depth_mbar =
+            m.min_waste_depth_mbar.value_or(dc.min_waste_depth_mbar);
         _detector.configure(dc);
         send_ack_message(m.id);
     }
@@ -550,15 +533,12 @@ class PressureTask {
         auto msg = messages::GetWasteDetectionConfigResponse{
             .responding_to_id = m.id,
             .enable_waste_full = dc.enable_waste_full,
-            .p_window_start = dc.p_window_start,
-            .p_window_end = dc.p_window_end,
-            .baseline_fast_factor = dc.baseline_fast_factor,
-            .max_delta_per_tick = dc.max_delta_per_tick,
-            .max_rise_per_tick = dc.max_rise_per_tick,
-            .max_cummulative_rise = dc.max_cummulative_rise,
             .p_filter_alpha = dc.p_filter_alpha,
-            .min_window_time = dc.min_window_time,
-            .max_window_time = dc.max_window_time};
+            .g_sealed_max = dc.g_sealed_max,
+            .flowing_dp_mbar = dc.flowing_dp_mbar,
+            .stable_hold_ms = dc.stable_hold_ms,
+            .stable_hold_deep_ms = dc.stable_hold_deep_ms,
+            .min_waste_depth_mbar = dc.min_waste_depth_mbar};
         static_cast<void>(
             _task_registry->send_to_address(msg, Queues::HostCommsAddress));
     }

--- a/stm32-modules/vacuum-module/tests/CMakeLists.txt
+++ b/stm32-modules/vacuum-module/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(${TARGET_MODULE_NAME}
         test_mprll0025pa00001a.cpp
         test_pressure_controller.cpp
         test_waste_detector.cpp
+        test_m127.cpp
     )
 
 target_include_directories(${TARGET_MODULE_NAME}

--- a/stm32-modules/vacuum-module/tests/test_m127.cpp
+++ b/stm32-modules/vacuum-module/tests/test_m127.cpp
@@ -1,0 +1,38 @@
+#include <catch2/catch.hpp>
+#include <string>
+
+#include "vacuum-module/gcodes.hpp"
+
+TEST_CASE("M127 parses waste knobs", "[gcode][m127]") {
+    std::string cmd = "M127 A0.5 G0.5 H8 T6000 U10000 N20 E1\n";
+    auto parsed =
+        gcode::SetWasteDetectionConfig::parse(cmd.cbegin(), cmd.cend());
+    REQUIRE(parsed.first.has_value());
+    auto g = parsed.first.value();
+    REQUIRE(g.enable_waste_full);
+    REQUIRE(*g.p_filter_alpha == Approx(0.5));
+    REQUIRE(*g.g_sealed_max == Approx(0.5));
+    REQUIRE(*g.flowing_dp_mbar == Approx(8.0));
+    REQUIRE(*g.stable_hold_ms == Approx(6000.0));
+    REQUIRE(*g.stable_hold_deep_ms == Approx(10000.0));
+    REQUIRE(*g.min_waste_depth_mbar == Approx(20.0));
+}
+
+TEST_CASE("M127 E0 disables waste detection", "[gcode][m127]") {
+    std::string cmd = "M127 E0\n";
+    auto parsed =
+        gcode::SetWasteDetectionConfig::parse(cmd.cbegin(), cmd.cend());
+    REQUIRE(parsed.first.has_value());
+    REQUIRE_FALSE(parsed.first.value().enable_waste_full);
+    REQUIRE_FALSE(parsed.first.value().g_sealed_max.has_value());
+}
+
+TEST_CASE("M128 writes waste knobs", "[gcode][m128]") {
+    std::string buffer(256, 'c');
+    auto written = gcode::GetWasteDetectionConfig::write_response_into(
+        buffer.begin(), buffer.end(), true, 0.5, 0.5, 8.0, 6000.0, 10000.0,
+        20.0);
+    REQUIRE(written != buffer.begin());
+    auto text = std::string(buffer.begin(), written);
+    REQUIRE(text == "M128 E:1 A:0.5 G:0.50 H:8.0 T:6000 U:10000 N:20.0 OK\n");
+}

--- a/stm32-modules/vacuum-module/tests/test_waste_detector.cpp
+++ b/stm32-modules/vacuum-module/tests/test_waste_detector.cpp
@@ -4,707 +4,301 @@
 
 namespace waste_detector {
 
+namespace {
+
+auto samples_for(double ms) -> int {
+    return static_cast<int>(ms / CONTROL_PERIOD_MS);
+}
+
+auto run_ramp(WasteDetector& detector, double atm, double target,
+              double start_p, double step, uint32_t dt_ms, int ticks,
+              double orifice_dp, double rpm) -> WasteFullError {
+    auto err = WasteFullError::NO_ERROR;
+    double p = start_p;
+    uint32_t t = 0;
+    for (int i = 0; i < ticks; ++i) {
+        t += dt_ms;
+        p += step;
+        err = detector.check(t, p + orifice_dp, p, target, atm, rpm);
+        if (err != WasteFullError::NO_ERROR) {
+            return err;
+        }
+    }
+    return err;
+}
+
+auto enter_hold(WasteDetector& detector, double atm, double target,
+                double orifice_dp, double rpm) -> void {
+    double p = target + 3.0;
+    uint32_t t = 20000;
+    const uint32_t samples = (NEAR_TARGET_MS / CONTROL_PERIOD_MS) + 5;
+    for (uint32_t i = 0; i < samples; ++i) {
+        t += 40;
+        detector.check(t, p + orifice_dp, p, target, atm, rpm);
+    }
+}
+
+auto hold_for(WasteDetector& detector, double atm, double target, int ticks,
+              double orifice_dp, double rpm, double offset = 3.0)
+    -> WasteFullError {
+    auto err = WasteFullError::NO_ERROR;
+    const double p = target + offset;
+    uint32_t t = 40000;
+    for (int i = 0; i < ticks; ++i) {
+        t += 40;
+        err = detector.check(t, p + orifice_dp, p, target, atm, rpm);
+        if (err != WasteFullError::NO_ERROR) {
+            return err;
+        }
+    }
+    return err;
+}
+
+}  // namespace
+
 TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
     WasteDetector detector;
 
     SECTION("Default state after construction") {
         REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-        REQUIRE_FALSE(detector.baseline_captured());
         REQUIRE(detector.check(0, 1013.0, 1013.0, 200.0, 1013.0) ==
                 WasteFullError::NO_ERROR);
     }
 
-    SECTION("reset() clears all state") {
-        detector.check(1000, 500.0, 505.0, 200.0, 1013.0);  // force some state
+    SECTION("Zero vacuum depth is ignored") {
+        auto err = WasteFullError::NO_ERROR;
+        for (int i = 0; i < 80; ++i) {
+            err = detector.check(static_cast<uint32_t>(i * 40), 1011.0, 1010.0,
+                                 1013.0, 1013.0, 0.0);
+            REQUIRE(err == WasteFullError::NO_ERROR);
+        }
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Disabled detector never trips") {
+        auto cfg = detector.get_config();
+        cfg.enable_waste_full = false;
+        detector.configure(cfg);
+        auto err =
+            run_ramp(detector, 1013.0, 500.0, 1010.0, -40.0, 10, 40, 2.0, 0.0);
+        REQUIRE(err == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("reset() clears a hold trip") {
+        const double target = 500.0;
+        run_ramp(detector, 1013.0, target, 1010.0, -5.0, 80, 120, 2.0, 0.0);
+        enter_hold(detector, 1013.0, target, 2.0, 20.0);
+        auto err = hold_for(detector, 1013.0, target,
+                            samples_for(STABLE_HOLD_MS) + 5, 2.0, 20.0);
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
         detector.reset();
         REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-        REQUIRE_FALSE(detector.baseline_captured());
-        REQUIRE(detector.check(0, 1013.0, 1013.0, 200.0, 1013.0) ==
+        REQUIRE(detector.check(0, 1013.0, 1013.0, target, 1013.0) ==
                 WasteFullError::NO_ERROR);
     }
 
-    SECTION("Fast spike during ramp triggers RISE_TOO_FAST_ERROR") {
-        auto err = WasteFullError::NO_ERROR;
-        auto atm_pressure = 1013.0F;
-        auto t_pressure = 500;
-        auto c_pressure = 1010.0F;
-        auto tics = 0.0F;
-
-        detector.reset();
-        for (uint32_t i = 0; i <= 30; i++) {
-            tics += i * 2;
-            c_pressure -= 20;  // rise too quickly
-            err = detector.check(tics, c_pressure, c_pressure + 2, t_pressure,
-                                 atm_pressure);
-        }
-        REQUIRE(err == WasteFullError::RISE_TOO_FAST_ERROR);
-        REQUIRE(detector.get_error() == WasteFullError::RISE_TOO_FAST_ERROR);
-    }
-
-    SECTION("Normal empty run learns baseline correctly") {
-        auto err = WasteFullError::NO_ERROR;
-        auto atm_pressure = 1013.0F;
-        auto t_pressure = 500;
-        auto c_pressure = 1010.0F;
-        auto tics = 0.0F;
-
-        detector.reset();
-        for (uint32_t i = 0; i <= 100; i++) {
-            tics += i * 2;
-            c_pressure -= 5;  // learn normal baseline
-            err = detector.check(tics, c_pressure, c_pressure + 2, t_pressure,
-                                 atm_pressure);
-        }
-
-        REQUIRE(err == WasteFullError::NO_ERROR);
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-        REQUIRE(detector.baseline_captured());
-    }
-
-    SECTION("Second run faster than baseline triggers FAST_BASELINE_ERROR") {
-        detector.reset();
-        auto err = WasteFullError::NO_ERROR;
-        auto atm_pressure = 1013.0F;
-        auto t_pressure = 500;
-        auto c_pressure = 1010.0F;
-        auto tics = 0.0F;
-        detector.reset();
-        for (uint32_t i = 0; i <= 100; i++) {
-            tics += i * 2;
-            c_pressure -= 5;  // learn normal baseline
-            err = detector.check(tics, c_pressure, c_pressure + 2, t_pressure,
-                                 atm_pressure);
-        }
-
-        c_pressure = 1010.0;
-        detector.reset();
-        for (uint32_t i = 0; i <= 40; i++) {
-            tics += i * 2;
-            c_pressure -= 15;  // fast baseline
-            err = detector.check(tics, c_pressure, c_pressure + 2, t_pressure,
-                                 atm_pressure);
-        }
-
-        REQUIRE(err == WasteFullError::FAST_BASELINE_ERROR);
-    }
-
-    SECTION("Slow first run is empty, not full — learns if under max window") {
-        auto err = WasteFullError::NO_ERROR;
-        auto atm_pressure = 1013.0F;
-        auto t_pressure = 500;
-        auto c_pressure = 1010.0F;
-        auto tics = 0.0F;
-        detector.reset();
-        for (uint32_t i = 0; i <= 100; i++) {
-            tics += i * 3;  // slow empty ramp
-            c_pressure -= 5;
-            err = detector.check(tics, c_pressure, c_pressure + 2, t_pressure,
-                                 atm_pressure);
-        }
-
-        REQUIRE(err == WasteFullError::NO_ERROR);
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION("Hold phase - sudden blocked flow triggers SUDDEN_BLOCKED_ERROR") {
-        // Get to hold phase
-        auto c_pressure = 190.0F;
-        auto tics = 3000.0F;
-        detector.reset();
-        detector.check(1000, 500.0, 505.0, 200.0, 1013.0);
-        detector.check(3000, 210, 215, 200.0, 1013.0);
-        for (uint32_t i = 0; i <= NEAR_TARGET_TICS + 5; i++) {
-            tics += i;
-            detector.check(tics, c_pressure, c_pressure + 2, 200.0,
-                           1013.0);  // ramp finished
-        }
-
-        // fill window
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE; ++i) {
-            detector.check(tics, c_pressure, c_pressure + 3, 200.0, 1013.0);
-        }
-
-        // Repeated slam while remaining inside the 20 mbar hold band
-        auto err = WasteFullError::NO_ERROR;
-        for (int i = 0; i < 4; ++i) {
-            tics += 1;
-            c_pressure += SHALLOW_MAX_RISE_PER_TICK + 5;
-            err = detector.check(tics, c_pressure, c_pressure + 2, 200.0,
-                                 1013.0);
-            if (err == WasteFullError::SUDDEN_BLOCKED_ERROR) {
-                break;
-            }
-        }
-        REQUIRE(err == WasteFullError::SUDDEN_BLOCKED_ERROR);
-    }
-
-    SECTION("Hold phase - shallow sudden rise below shallow cap is not full") {
-        auto c_pressure = 813.0F;
-        auto tics = 3000.0F;
-        detector.reset();
-        detector.check(1000, 500.0, 505.0, 813.0, 1013.0);
-        detector.check(3000, 810, 815, 813.0, 1013.0);
-        for (uint32_t i = 0; i <= NEAR_TARGET_TICS; i++) {
-            tics += i;
-            detector.check(tics, c_pressure + 2, c_pressure, 813.0, 1013.0);
-        }
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE; ++i) {
-            detector.check(tics, c_pressure, c_pressure + 3, 813.0, 1013.0);
-        }
-        for (int i = 0; i < 6; ++i) {
-            tics += 1;
-            c_pressure += 6.0;
-            detector.check(tics, c_pressure, c_pressure + 2, 813.0, 1013.0);
-        }
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION("Hold phase - cumulative rise triggers CUMMULATIVE_BLOCKED_ERROR") {
-        auto c_pressure = 190.0F;
-        auto tics = 3000.0F;
-        detector.reset();
-        detector.check(1000, 498.0, 500.0, 200.0, 1013.0);
-        detector.check(3000, 210, 215, 200.0, 1013.0);
-        for (uint32_t i = 0; i <= NEAR_TARGET_TICS; i++) {
-            tics += i;
-            detector.check(tics, c_pressure + 2, c_pressure, 200.0,
-                           1013.0);  // ramp finished
-        }
-
-        // fill window
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE; ++i) {
-            detector.check(tics, c_pressure, c_pressure + 3, 200.0, 1013.0);
-        }
-
-        // ~15 mbar slow rise stays inside hold and below the 90 mbar
-        // cumulative gate (empty plate hunting is ~10 mbar).
-        for (int i = 0; i < 25; ++i) {
-            tics += 1;
-            c_pressure += 0.6;
-            detector.check(tics, c_pressure, c_pressure + 2, 200.0, 1013.0);
-        }
-
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION("Draining air rush is correctly ignored") {
-        detector.reset();
-        detector.check(1000, 502.0, 500.0, 200.0, 1013.0);
-        detector.check(3000, 246.0, 244.0, 200.0, 1013.0);
-
-        // Big negative delta (air rush while draining)
-        auto err = detector.check(3100, 302.0, 300.0, 200.0, 1013.0);
-        // delta_p = -61 (but we simulate big negative)
-        // In real usage you'd pass the real delta, but the test confirms it
-        // doesn't trigger
-        REQUIRE(err == WasteFullError::NO_ERROR);
-    }
-
-    SECTION(
-        "Hold phase - pressure oscillation does NOT trigger "
-        "FLOW_STABLE_FULL_ERROR") {
-        detector.reset();
-
-        const double atm = 1013.0;
-        const double target = 500.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 200; i++) {
-            tics += i * 2;
-            current_p -= 5;  // learn normal baseline
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        REQUIRE(detector.baseline_captured());
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            detector.check(tics, current_p + 5, current_p + 3, target, atm);
-            current_p = target + 8.0;
-        }
-
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + 5; ++i) {
-            tics += 40;
-            current_p = target + ((i % 12) * 2.0) - 20;
-            auto err =
-                detector.check(tics, current_p + 5, current_p + 3, target, atm);
-            REQUIRE(err == WasteFullError::NO_ERROR);
-        }
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION(
-        "Hold phase - quiet sealed hold eventually triggers "
-        "FLOW_STABLE_FULL_ERROR") {
-        detector.reset();
-
-        const double atm = 1013.0;
-        const double target = 500.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 96; i++) {
-            tics += i * 2;
-            current_p -= 5;  // learn normal baseline
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        REQUIRE(detector.baseline_captured());
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            detector.check(tics, current_p + 2, current_p, target, atm);
-        }
-
-        auto err = WasteFullError::NO_ERROR;
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS + 5;
-             ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            err = detector.check(tics, current_p + 2, current_p, target, atm,
-                                 0.0);
-            if (err == WasteFullError::FLOW_STABLE_FULL_ERROR) {
-                break;
-            }
-        }
-        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
-        REQUIRE(detector.get_error() == WasteFullError::FLOW_STABLE_FULL_ERROR);
-    }
-
-    SECTION("Hold phase - quiet with pump loaded is not full") {
-        detector.reset();
-
-        const double atm = 1013.0;
-        const double target = 713.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 96; i++) {
-            tics += i * 2;
-            current_p -= 5;
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            detector.check(tics, current_p + 2, current_p, target, atm, 0.0);
-        }
-
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS + 5;
-             ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            auto err = detector.check(tics, current_p + 2, current_p, target,
-                                      atm, 200.0);
-            REQUIRE(err == WasteFullError::NO_ERROR);
-        }
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION("Hold phase - mid-depth leak RPM is not full") {
-        detector.reset();
-
-        // Depth 700 mbar: shallow RPM cap, 250 RPM must not trip.
-        const double atm = 1013.0;
-        const double target = 313.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 96; i++) {
-            tics += i * 2;
-            current_p -= 5;
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            detector.check(tics, current_p + 2, current_p, target, atm, 250.0);
-        }
-
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS_DEEP + 5;
-             ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            auto err = detector.check(tics, current_p + 2, current_p, target,
-                                      atm, 250.0);
-            REQUIRE(err == WasteFullError::NO_ERROR);
-        }
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION("Hold phase - mid-depth quiet unloaded is full") {
-        detector.reset();
-
-        const double atm = 1013.0;
-        const double target = 313.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 96; i++) {
-            tics += i * 2;
-            current_p -= 5;
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            detector.check(tics, current_p + 2, current_p, target, atm, 0.0);
-        }
-
-        auto err = WasteFullError::NO_ERROR;
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS + 5;
-             ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            err = detector.check(tics, current_p + 2, current_p, target, atm,
-                                 0.0);
-            if (err == WasteFullError::FLOW_STABLE_FULL_ERROR) {
-                break;
-            }
-        }
-        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
-        REQUIRE(detector.get_error() == WasteFullError::FLOW_STABLE_FULL_ERROR);
-    }
-
-    SECTION("Hold phase - deep target quiet hold allows higher RPM") {
-        detector.reset();
-
-        // Depth 800 mbar: 250 RPM is under the deep cap and must trip.
-        const double atm = 1013.0;
-        const double target = 213.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 96; i++) {
-            tics += i * 2;
-            current_p -= 5;
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            detector.check(tics, current_p + 2, current_p, target, atm, 250.0);
-        }
-
-        auto err = WasteFullError::NO_ERROR;
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS_DEEP + 5;
-             ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            err = detector.check(tics, current_p + 2, current_p, target, atm,
-                                 250.0);
-            if (err == WasteFullError::FLOW_STABLE_FULL_ERROR) {
-                break;
-            }
-        }
-        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
-        REQUIRE(detector.get_error() == WasteFullError::FLOW_STABLE_FULL_ERROR);
-    }
-
-    SECTION("Hold phase - deep quiet with leak RPM is not full") {
-        detector.reset();
-
-        // Deep leak RPM must not trip.
-        const double atm = 1013.0;
-        const double target = 213.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 96; i++) {
-            tics += i * 2;
-            current_p -= 5;
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            detector.check(tics, current_p + 2, current_p, target, atm,
-                           1100.0);
-        }
-
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS_DEEP + 5;
-             ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            auto err = detector.check(tics, current_p + 2, current_p, target,
-                                      atm, 1100.0);
-            REQUIRE(err == WasteFullError::NO_ERROR);
-        }
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION("Hold phase - deep quiet 15 mbar shallow is not full") {
-        detector.reset();
-
-        // 15 mbar off target must not trip.
-        const double atm = 1013.0;
-        const double target = 213.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 96; i++) {
-            tics += i * 2;
-            current_p -= 5;
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            current_p = target + 15.0;
-            detector.check(tics, current_p + 2, current_p, target, atm, 250.0);
-        }
-
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS_DEEP + 5;
-             ++i) {
-            tics += 40;
-            current_p = target + 15.0;
-            auto err = detector.check(tics, current_p + 2, current_p, target,
-                                      atm, 250.0);
-            REQUIRE(err == WasteFullError::NO_ERROR);
-        }
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION("Hold phase - deep quiet 6s on setpoint is not yet full") {
-        detector.reset();
-
-        const double atm = 1013.0;
-        const double target = 213.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 96; i++) {
-            tics += i * 2;
-            current_p -= 5;
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            detector.check(tics, current_p + 2, current_p, target, atm, 250.0);
-        }
-
-        // 6s is not enough at a deep target.
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            auto err = detector.check(tics, current_p + 2, current_p, target,
-                                      atm, 250.0);
-            REQUIRE(err == WasteFullError::NO_ERROR);
-        }
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION("Hold phase - deep noisy pressure with unloaded RPM is full") {
-        detector.reset();
-
-        // Deep hold must trip even when pressure std > 1.0.
-        const double atm = 1013.0;
-        const double target = 213.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 96; i++) {
-            tics += i * 2;
-            current_p -= 5;
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            detector.check(tics, current_p + 2, current_p, target, atm, 200.0);
-        }
-
-        auto err = WasteFullError::NO_ERROR;
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS_DEEP + 5;
-             ++i) {
-            tics += 40;
-            current_p = target + ((i % 2) ? 4.0 : 0.0);
-            err = detector.check(tics, current_p + 2, current_p, target, atm,
-                                 200.0);
-            if (err == WasteFullError::FLOW_STABLE_FULL_ERROR) {
-                break;
-            }
-        }
-        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
-        REQUIRE(detector.get_error() == WasteFullError::FLOW_STABLE_FULL_ERROR);
-    }
-
-    SECTION("Hold phase - deep unloaded 5s then leak RPM is not full") {
-        detector.reset();
-
-        // 5s unloaded then leak RPM must not trip.
-        const double atm = 1013.0;
-        const double target = 213.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 96; i++) {
-            tics += i * 2;
-            current_p -= 5;
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            detector.check(tics, current_p + 2, current_p, target, atm, 200.0);
-        }
-
-        const int dip_ticks = PRESSURE_WINDOW_SIZE + 125;  // ~5s after window
-        for (int i = 0; i < dip_ticks; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            auto err = detector.check(tics, current_p + 2, current_p, target,
-                                      atm, 200.0);
-            REQUIRE(err == WasteFullError::NO_ERROR);
-        }
-        for (int i = 0; i < STABLE_HOLD_TICKS_DEEP + 5; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            auto err = detector.check(tics, current_p + 2, current_p, target,
-                                      atm, 1100.0);
-            REQUIRE(err == WasteFullError::NO_ERROR);
-        }
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION("Hold phase - quiet with orifice flow is not full") {
-        detector.reset();
-
-        const double atm = 1013.0;
-        const double target = 500.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 96; i++) {
-            tics += i * 2;
-            current_p -= 5;
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            detector.check(tics, current_p + 2, current_p, target, atm, 0.0);
-        }
-
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS + 5;
-             ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            auto err = detector.check(tics, current_p + 15, current_p, target,
-                                      atm, 0.0);
-            REQUIRE(err == WasteFullError::NO_ERROR);
-        }
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION(
-        "Hold phase - shallow quiet unloaded hold is not sealed full") {
-        detector.reset();
-
-        // Depth 200 mbar: empty water-on-plate can look sealed at -100/-200.
-        const double atm = 1013.0;
-        const double target = 813.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
-
-        for (uint32_t i = 0; i <= 96; i++) {
-            tics += i * 2;
-            current_p -= 5;
-            detector.check(tics, current_p, current_p + 2, target, atm);
-        }
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            detector.check(tics, current_p + 2, current_p, target, atm, 0.0);
-        }
-
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS + 20;
-             ++i) {
-            tics += 40;
-            current_p = target + 3.0;
-            auto err = detector.check(tics, current_p + 2, current_p, target,
-                                      atm, 0.0);
-            REQUIRE(err == WasteFullError::NO_ERROR);
-        }
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION("Hold phase - water hunting rise stays below hold gates") {
-        auto c_pressure = 813.0F;
-        auto tics = 3000.0F;
-        detector.reset();
-        detector.check(1000, 500.0, 505.0, 813.0, 1013.0);
-        detector.check(3000, 810, 815, 813.0, 1013.0);
-        for (uint32_t i = 0; i <= NEAR_TARGET_TICS; i++) {
-            tics += i;
-            detector.check(tics, c_pressure + 2, c_pressure, 813.0, 1013.0);
-        }
-
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE; ++i) {
-            detector.check(tics, c_pressure, c_pressure + 3, 813.0, 1013.0);
-        }
-
-        // ~20 mbar toward atmosphere over several ticks (r4 -100 FP pattern).
-        for (int i = 0; i < 8; ++i) {
-            tics += 1;
-            c_pressure += 2.5;
-            detector.check(tics, c_pressure, c_pressure + 2, 813.0, 1013.0);
-        }
-
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
-    }
-
-    SECTION("Hold phase - shallow cumulative hunting decays without trip") {
-        auto c_pressure = 813.0F;
-        auto tics = 3000.0F;
-        detector.reset();
-        detector.check(1000, 500.0, 505.0, 813.0, 1013.0);
-        detector.check(3000, 810, 815, 813.0, 1013.0);
-        for (uint32_t i = 0; i <= NEAR_TARGET_TICS; i++) {
-            tics += i;
-            detector.check(tics, c_pressure + 2, c_pressure, 813.0, 1013.0);
-        }
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE; ++i) {
-            detector.check(tics, c_pressure, c_pressure + 3, 813.0, 1013.0);
-        }
+    SECTION("Hold hunting toward atmosphere is not full") {
+        run_ramp(detector, 1013.0, 813.0, 1010.0, -3.0, 80, 120, 12.0, 400.0);
+        enter_hold(detector, 1013.0, 813.0, 3.0, 250.0);
+
+        double p = 813.0;
+        uint32_t t = 50000;
         for (int i = 0; i < 30; ++i) {
-            tics += 1;
-            c_pressure += (i % 2) ? 3.0 : -2.0;
-            detector.check(tics, c_pressure, c_pressure + 2, 813.0, 1013.0);
+            t += 40;
+            p += (i % 2) ? 3.0 : -2.0;
+            auto err = detector.check(t, p + 3.0, p, 813.0, 1013.0, 250.0);
+            REQUIRE(err == WasteFullError::NO_ERROR);
         }
         REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
     }
 
-    SECTION("Hold phase - oscillation after window fill is still not full") {
-        detector.reset();
+    SECTION("Shallow leaky hold is not full") {
+        run_ramp(detector, 1013.0, 813.0, 1010.0, -3.0, 80, 120, 2.0, 250.0);
+        enter_hold(detector, 1013.0, 813.0, 2.0, 250.0);
+        auto err = hold_for(detector, 1013.0, 813.0,
+                            samples_for(STABLE_HOLD_MS) + 20, 2.0, 250.0);
+        REQUIRE(err == WasteFullError::NO_ERROR);
+    }
 
+    SECTION("Shallow overshoot deadhead is full") {
+        const double target = 813.0;  // 200 mbar
+        run_ramp(detector, 1013.0, target, 1010.0, -3.0, 80, 120, 2.0, 0.0);
+        enter_hold(detector, 1013.0, target, 2.0, 0.0);
+        auto err = hold_for(detector, 1013.0, target,
+                            samples_for(STABLE_HOLD_MS) + 5, 2.0, 0.0, -15.0);
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
+    }
+
+    SECTION("Sealed credit waits for near-target debounce") {
+        const double target = 500.0;
+        auto err = hold_for(detector, 1013.0, target,
+                            samples_for(STABLE_HOLD_MS), 2.0, 20.0);
+        REQUIRE(err == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Mid-depth sealed deadhead is full") {
+        const double target = 500.0;
+        run_ramp(detector, 1013.0, target, 1010.0, -5.0, 80, 120, 2.0, 0.0);
+        enter_hold(detector, 1013.0, target, 2.0, 20.0);
+        auto err = hold_for(detector, 1013.0, target,
+                            samples_for(STABLE_HOLD_MS) + 5, 2.0, 20.0);
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
+    }
+
+    SECTION("Mid-depth sealed hold survives periodic RPM blips") {
         const double atm = 1013.0;
         const double target = 500.0;
-        double current_p = 1000.0;
-        uint32_t tics = 1000;
+        run_ramp(detector, atm, target, 1010.0, -5.0, 80, 120, 2.0, 20.0);
+        enter_hold(detector, atm, target, 2.0, 20.0);
 
-        for (uint32_t i = 0; i <= 100; i++) {
-            tics += i * 2;
-            current_p -= 5;  // learn normal baseline
-            detector.check(tics, current_p, current_p + 2, target, atm);
+        auto err = WasteFullError::NO_ERROR;
+        uint32_t t = 40000;
+        const double p = target + 3.0;
+        for (int i = 0; i < samples_for(STABLE_HOLD_MS) + 60; ++i) {
+            t += 40;
+            const double rpm = ((i % 10) == 0) ? 400.0 : 20.0;
+            err = detector.check(t, p + 2.0, p, target, atm, rpm);
+            if (err == WasteFullError::FLOW_STABLE_FULL_ERROR) {
+                break;
+            }
         }
-        REQUIRE(detector.baseline_captured());
-        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
+    }
 
-        for (uint32_t i = 0; i < NEAR_TARGET_TICS; ++i) {
-            tics += 40;
-            detector.check(tics, current_p + 2, current_p, target, atm);
-        }
+    SECTION("Mid-depth leak RPM is not full") {
+        const double target = 313.0;  // 700 mbar depth
+        run_ramp(detector, 1013.0, target, 1010.0, -8.0, 80, 140, 2.0, 800.0);
+        enter_hold(detector, 1013.0, target, 2.0, 800.0);
+        auto err = hold_for(detector, 1013.0, target,
+                            samples_for(STABLE_HOLD_MS) + 5, 2.0, 800.0);
+        REQUIRE(err == WasteFullError::NO_ERROR);
+    }
 
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + 5; ++i) {
-            tics += 40;
-            current_p = target + ((i % 10) * 12.0) - 20.0;
-            auto err =
-                detector.check(tics, current_p + 2, current_p, target, atm);
+    SECTION("Hold with orifice flow is not full") {
+        const double target = 500.0;
+        run_ramp(detector, 1013.0, target, 1010.0, -5.0, 80, 120, 2.0, 0.0);
+        enter_hold(detector, 1013.0, target, 15.0, 0.0);
+        auto err = hold_for(detector, 1013.0, target,
+                            samples_for(STABLE_HOLD_MS) + 5, 15.0, 0.0);
+        REQUIRE(err == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Deep sealed deadhead trips after 10s") {
+        const double target = 213.0;  // 800 mbar
+        run_ramp(detector, 1013.0, target, 1010.0, -8.0, 80, 140, 2.0, 40.0);
+        enter_hold(detector, 1013.0, target, 2.0, 40.0);
+        auto err = hold_for(detector, 1013.0, target,
+                            samples_for(STABLE_HOLD_MS), 2.0, 40.0);
+        REQUIRE(err == WasteFullError::NO_ERROR);
+        err = hold_for(detector, 1013.0, target,
+                       samples_for(STABLE_HOLD_DEEP_MS) + 5, 2.0, 40.0);
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
+    }
+
+    SECTION("Deep hold 180 RPM (full-like G) is full") {
+        const double target = 213.0;
+        run_ramp(detector, 1013.0, target, 1010.0, -8.0, 80, 140, 2.0, 180.0);
+        enter_hold(detector, 1013.0, target, 2.0, 180.0);
+        auto err = hold_for(detector, 1013.0, target,
+                            samples_for(STABLE_HOLD_DEEP_MS) + 5, 2.0, 180.0);
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
+    }
+
+    SECTION("Deep leak conductance is not full") {
+        const double target = 213.0;
+        run_ramp(detector, 1013.0, target, 1010.0, -8.0, 80, 140, 2.0, 1100.0);
+        enter_hold(detector, 1013.0, target, 2.0, 1100.0);
+        auto err = hold_for(detector, 1013.0, target,
+                            samples_for(STABLE_HOLD_DEEP_MS) + 5, 2.0, 1100.0);
+        REQUIRE(err == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Deep hold 15 mbar overshoot deadhead is full") {
+        const double target = 213.0;
+        run_ramp(detector, 1013.0, target, 1010.0, -8.0, 80, 140, 2.0, 40.0);
+        enter_hold(detector, 1013.0, target, 2.0, 40.0);
+        auto err =
+            hold_for(detector, 1013.0, target,
+                     samples_for(STABLE_HOLD_DEEP_MS) + 5, 2.0, 40.0, -15.0);
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
+    }
+
+    SECTION("Mid-depth 11 mbar overshoot deadhead is full") {
+        const double target = 713.0;  // 300 mbar
+        run_ramp(detector, 1013.0, target, 1010.0, -5.0, 80, 120, 2.0, 0.0);
+        enter_hold(detector, 1013.0, target, 2.0, 0.0);
+        auto err = hold_for(detector, 1013.0, target,
+                            samples_for(STABLE_HOLD_MS) + 5, 2.0, 0.0, -11.0);
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
+    }
+
+    SECTION("configure() applies zero values") {
+        auto cfg = detector.get_config();
+        cfg.min_waste_depth_mbar = 0.0;
+        cfg.g_sealed_max = 0.0;
+        cfg.stable_hold_ms = 0.0;
+        detector.configure(cfg);
+        auto got = detector.get_config();
+        REQUIRE(got.min_waste_depth_mbar == Approx(0.0));
+        REQUIRE(got.g_sealed_max == Approx(0.0));
+        REQUIRE(got.stable_hold_ms == Approx(0.0));
+    }
+
+    SECTION("configure() clamps p_filter_alpha to (0, 1]") {
+        auto cfg = detector.get_config();
+        cfg.p_filter_alpha = 2.0;
+        detector.configure(cfg);
+        REQUIRE(detector.get_config().p_filter_alpha == Approx(1.0));
+
+        cfg = detector.get_config();
+        cfg.p_filter_alpha = 0.0;
+        detector.configure(cfg);
+        REQUIRE(detector.get_config().p_filter_alpha == Approx(SENSOR_ALPHA));
+
+        cfg = detector.get_config();
+        cfg.p_filter_alpha = 0.25;
+        detector.configure(cfg);
+        REQUIRE(detector.get_config().p_filter_alpha == Approx(0.25));
+    }
+
+    SECTION("Configured G cap is used in hold") {
+        auto cfg = detector.get_config();
+        cfg.g_sealed_max = 2.0;
+        detector.configure(cfg);
+
+        const double target = 313.0;  // 700 mbar
+        run_ramp(detector, 1013.0, target, 1010.0, -8.0, 80, 140, 2.0, 800.0);
+        enter_hold(detector, 1013.0, target, 2.0, 800.0);
+        auto err = hold_for(detector, 1013.0, target,
+                            samples_for(STABLE_HOLD_MS) + 5, 2.0, 800.0);
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
+    }
+
+    SECTION("Configured hold time delays trip") {
+        auto cfg = detector.get_config();
+        cfg.stable_hold_ms = 20000.0;
+        cfg.stable_hold_deep_ms = 20000.0;
+        detector.configure(cfg);
+
+        const double target = 500.0;
+        run_ramp(detector, 1013.0, target, 1010.0, -5.0, 80, 120, 2.0, 20.0);
+        enter_hold(detector, 1013.0, target, 2.0, 20.0);
+        auto err = hold_for(detector, 1013.0, target,
+                            samples_for(STABLE_HOLD_MS) + 5, 2.0, 20.0);
+        REQUIRE(err == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Pressure oscillation in hold is not full") {
+        const double atm = 1013.0;
+        const double target = 500.0;
+        run_ramp(detector, atm, target, 1010.0, -5.0, 80, 120, 12.0, 400.0);
+        enter_hold(detector, atm, target, 5.0, 200.0);
+
+        uint32_t t = 50000;
+        for (int i = 0; i < samples_for(STABLE_HOLD_MS) + 5; ++i) {
+            t += 40;
+            const double p = target + ((i % 12) * 2.0) - 20.0;
+            auto err = detector.check(t, p + 5.0, p, target, atm, 400.0);
             REQUIRE(err == WasteFullError::NO_ERROR);
         }
         REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);

--- a/stm32-modules/vacuum-module/tests/test_waste_detector.cpp
+++ b/stm32-modules/vacuum-module/tests/test_waste_detector.cpp
@@ -88,7 +88,7 @@ TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
         REQUIRE(err == WasteFullError::FAST_BASELINE_ERROR);
     }
 
-    SECTION("First run too slow triggers FIRST_RUN_SLOW_ERROR") {
+    SECTION("Slow first run is empty, not full — learns if under max window") {
         auto err = WasteFullError::NO_ERROR;
         auto atm_pressure = 1013.0F;
         auto t_pressure = 500;
@@ -96,13 +96,14 @@ TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
         auto tics = 0.0F;
         detector.reset();
         for (uint32_t i = 0; i <= 100; i++) {
-            tics += i * 3;  // slow baseline
+            tics += i * 3;  // slow empty ramp
             c_pressure -= 5;
             err = detector.check(tics, c_pressure, c_pressure + 2, t_pressure,
                                  atm_pressure);
         }
 
-        REQUIRE(err == WasteFullError::FIRST_RUN_SLOW_ERROR);
+        REQUIRE(err == WasteFullError::NO_ERROR);
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
     }
 
     SECTION("Hold phase - sudden blocked flow triggers SUDDEN_BLOCKED_ERROR") {
@@ -123,11 +124,17 @@ TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
             detector.check(tics, c_pressure, c_pressure + 3, 200.0, 1013.0);
         }
 
-        // Now in hold - sudden rise
-        tics += 1;
-        c_pressure += MAX_RISE_PER_TICK + 5;
-        auto err =
-            detector.check(tics, c_pressure, c_pressure + 2, 200.0, 1013.0);
+        // Repeated slam while remaining inside the 20 mbar hold band
+        auto err = WasteFullError::NO_ERROR;
+        for (int i = 0; i < 4; ++i) {
+            tics += 1;
+            c_pressure += MAX_RISE_PER_TICK + 8;
+            err = detector.check(tics, c_pressure, c_pressure + 2, 200.0,
+                                 1013.0);
+            if (err == WasteFullError::SUDDEN_BLOCKED_ERROR) {
+                break;
+            }
+        }
         REQUIRE(err == WasteFullError::SUDDEN_BLOCKED_ERROR);
     }
 
@@ -148,15 +155,15 @@ TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
             detector.check(tics, c_pressure, c_pressure + 3, 200.0, 1013.0);
         }
 
-        // Slow gradual rise over many ticks
+        // ~15 mbar slow rise stays inside hold and below the 40 mbar
+        // cumulative gate (empty plate hunting is ~10 mbar).
         for (int i = 0; i < 25; ++i) {
-            tics += i;
+            tics += 1;
             c_pressure += 0.6;
             detector.check(tics, c_pressure, c_pressure + 2, 200.0, 1013.0);
         }
 
-        REQUIRE(detector.get_error() ==
-                WasteFullError::CUMMULATIVE_BLOCKED_ERROR);
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
     }
 
     SECTION("Draining air rush is correctly ignored") {
@@ -173,7 +180,8 @@ TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
     }
 
     SECTION(
-        "Hold phase - pressure oscillation triggers FLOW_STABLE_FULL_ERROR") {
+        "Hold phase - pressure oscillation does NOT trigger "
+        "FLOW_STABLE_FULL_ERROR") {
         detector.reset();
 
         const double atm = 1013.0;
@@ -189,34 +197,26 @@ TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
         REQUIRE(detector.baseline_captured());
         REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
 
-        // 1. Get into hold phase first
         for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
             tics += 40;
             detector.check(tics, current_p + 5, current_p + 3, target, atm);
-            current_p = target + 8.0;  // stay near target
+            current_p = target + 8.0;
         }
 
         REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
 
-        // 2. Simulate sawtooth oscillation (high std dev) while in hold
         for (int i = 0; i < PRESSURE_WINDOW_SIZE + 5; ++i) {
             tics += 40;
-            // Create sawtooth: oscillating between ~target-20 and target+20
             current_p = target + ((i % 12) * 2.0) - 20;
             auto err =
                 detector.check(tics, current_p + 5, current_p + 3, target, atm);
-
-            if (i >= PRESSURE_WINDOW_SIZE - 1) {
-                REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
-                REQUIRE(detector.get_error() ==
-                        WasteFullError::FLOW_STABLE_FULL_ERROR);
-                break;
-            }
+            REQUIRE(err == WasteFullError::NO_ERROR);
         }
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
     }
 
     SECTION(
-        "Hold phase - low oscillation does NOT trigger "
+        "Hold phase - quiet sealed hold eventually triggers "
         "FLOW_STABLE_FULL_ERROR") {
         detector.reset();
 
@@ -233,23 +233,354 @@ TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
         REQUIRE(detector.baseline_captured());
         REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
 
-        detector.check(tics, current_p + 2, current_p, target, atm);
-        detector.check(tics + 100, current_p + 2, current_p, target, atm);
-
-        // Simulate very stable pressure (low std dev)
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE + 10; ++i) {
+        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
             tics += 40;
-            current_p = target + 3.0;  // almost flat
-            auto err =
-                detector.check(tics, current_p + 2, current_p, target, atm);
-
-            REQUIRE(err == WasteFullError::NO_ERROR);
+            current_p = target + 3.0;
+            detector.check(tics, current_p + 2, current_p, target, atm);
         }
 
+        auto err = WasteFullError::NO_ERROR;
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS + 5;
+             ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            err = detector.check(tics, current_p + 2, current_p, target, atm,
+                                 0.0);
+            if (err == WasteFullError::FLOW_STABLE_FULL_ERROR) {
+                break;
+            }
+        }
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
+        REQUIRE(detector.get_error() == WasteFullError::FLOW_STABLE_FULL_ERROR);
+    }
+
+    SECTION("Hold phase - quiet with pump loaded is not full") {
+        detector.reset();
+
+        const double atm = 1013.0;
+        const double target = 713.0;
+        double current_p = 1000.0;
+        uint32_t tics = 1000;
+
+        for (uint32_t i = 0; i <= 96; i++) {
+            tics += i * 2;
+            current_p -= 5;
+            detector.check(tics, current_p, current_p + 2, target, atm);
+        }
+        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            detector.check(tics, current_p + 2, current_p, target, atm, 0.0);
+        }
+
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS + 5;
+             ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            auto err = detector.check(tics, current_p + 2, current_p, target,
+                                      atm, 200.0);
+            REQUIRE(err == WasteFullError::NO_ERROR);
+        }
         REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
     }
 
-    SECTION("Hold phase - oscillation only triggers after window is full") {
+    SECTION("Hold phase - mid-depth leak RPM is not full") {
+        detector.reset();
+
+        // Depth 700 mbar: shallow RPM cap, 250 RPM must not trip.
+        const double atm = 1013.0;
+        const double target = 313.0;
+        double current_p = 1000.0;
+        uint32_t tics = 1000;
+
+        for (uint32_t i = 0; i <= 96; i++) {
+            tics += i * 2;
+            current_p -= 5;
+            detector.check(tics, current_p, current_p + 2, target, atm);
+        }
+        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            detector.check(tics, current_p + 2, current_p, target, atm, 250.0);
+        }
+
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS_DEEP + 5;
+             ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            auto err = detector.check(tics, current_p + 2, current_p, target,
+                                      atm, 250.0);
+            REQUIRE(err == WasteFullError::NO_ERROR);
+        }
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Hold phase - mid-depth quiet unloaded is full") {
+        detector.reset();
+
+        const double atm = 1013.0;
+        const double target = 313.0;
+        double current_p = 1000.0;
+        uint32_t tics = 1000;
+
+        for (uint32_t i = 0; i <= 96; i++) {
+            tics += i * 2;
+            current_p -= 5;
+            detector.check(tics, current_p, current_p + 2, target, atm);
+        }
+        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            detector.check(tics, current_p + 2, current_p, target, atm, 0.0);
+        }
+
+        auto err = WasteFullError::NO_ERROR;
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS + 5;
+             ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            err = detector.check(tics, current_p + 2, current_p, target, atm,
+                                 0.0);
+            if (err == WasteFullError::FLOW_STABLE_FULL_ERROR) {
+                break;
+            }
+        }
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
+        REQUIRE(detector.get_error() == WasteFullError::FLOW_STABLE_FULL_ERROR);
+    }
+
+    SECTION("Hold phase - deep target quiet hold allows higher RPM") {
+        detector.reset();
+
+        // Depth 800 mbar: 250 RPM is under the deep cap and must trip.
+        const double atm = 1013.0;
+        const double target = 213.0;
+        double current_p = 1000.0;
+        uint32_t tics = 1000;
+
+        for (uint32_t i = 0; i <= 96; i++) {
+            tics += i * 2;
+            current_p -= 5;
+            detector.check(tics, current_p, current_p + 2, target, atm);
+        }
+        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            detector.check(tics, current_p + 2, current_p, target, atm, 250.0);
+        }
+
+        auto err = WasteFullError::NO_ERROR;
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS_DEEP + 5;
+             ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            err = detector.check(tics, current_p + 2, current_p, target, atm,
+                                 250.0);
+            if (err == WasteFullError::FLOW_STABLE_FULL_ERROR) {
+                break;
+            }
+        }
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
+        REQUIRE(detector.get_error() == WasteFullError::FLOW_STABLE_FULL_ERROR);
+    }
+
+    SECTION("Hold phase - deep quiet with leak RPM is not full") {
+        detector.reset();
+
+        // Deep leak RPM must not trip.
+        const double atm = 1013.0;
+        const double target = 213.0;
+        double current_p = 1000.0;
+        uint32_t tics = 1000;
+
+        for (uint32_t i = 0; i <= 96; i++) {
+            tics += i * 2;
+            current_p -= 5;
+            detector.check(tics, current_p, current_p + 2, target, atm);
+        }
+        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            detector.check(tics, current_p + 2, current_p, target, atm,
+                           1100.0);
+        }
+
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS_DEEP + 5;
+             ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            auto err = detector.check(tics, current_p + 2, current_p, target,
+                                      atm, 1100.0);
+            REQUIRE(err == WasteFullError::NO_ERROR);
+        }
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Hold phase - deep quiet 15 mbar shallow is not full") {
+        detector.reset();
+
+        // 15 mbar off target must not trip.
+        const double atm = 1013.0;
+        const double target = 213.0;
+        double current_p = 1000.0;
+        uint32_t tics = 1000;
+
+        for (uint32_t i = 0; i <= 96; i++) {
+            tics += i * 2;
+            current_p -= 5;
+            detector.check(tics, current_p, current_p + 2, target, atm);
+        }
+        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
+            tics += 40;
+            current_p = target + 15.0;
+            detector.check(tics, current_p + 2, current_p, target, atm, 250.0);
+        }
+
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS_DEEP + 5;
+             ++i) {
+            tics += 40;
+            current_p = target + 15.0;
+            auto err = detector.check(tics, current_p + 2, current_p, target,
+                                      atm, 250.0);
+            REQUIRE(err == WasteFullError::NO_ERROR);
+        }
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Hold phase - deep quiet 6s on setpoint is not yet full") {
+        detector.reset();
+
+        const double atm = 1013.0;
+        const double target = 213.0;
+        double current_p = 1000.0;
+        uint32_t tics = 1000;
+
+        for (uint32_t i = 0; i <= 96; i++) {
+            tics += i * 2;
+            current_p -= 5;
+            detector.check(tics, current_p, current_p + 2, target, atm);
+        }
+        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            detector.check(tics, current_p + 2, current_p, target, atm, 250.0);
+        }
+
+        // 6s is not enough at a deep target.
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            auto err = detector.check(tics, current_p + 2, current_p, target,
+                                      atm, 250.0);
+            REQUIRE(err == WasteFullError::NO_ERROR);
+        }
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Hold phase - deep noisy pressure with unloaded RPM is full") {
+        detector.reset();
+
+        // Deep hold must trip even when pressure std > 1.0.
+        const double atm = 1013.0;
+        const double target = 213.0;
+        double current_p = 1000.0;
+        uint32_t tics = 1000;
+
+        for (uint32_t i = 0; i <= 96; i++) {
+            tics += i * 2;
+            current_p -= 5;
+            detector.check(tics, current_p, current_p + 2, target, atm);
+        }
+        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            detector.check(tics, current_p + 2, current_p, target, atm, 200.0);
+        }
+
+        auto err = WasteFullError::NO_ERROR;
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS_DEEP + 5;
+             ++i) {
+            tics += 40;
+            current_p = target + ((i % 2) ? 4.0 : 0.0);
+            err = detector.check(tics, current_p + 2, current_p, target, atm,
+                                 200.0);
+            if (err == WasteFullError::FLOW_STABLE_FULL_ERROR) {
+                break;
+            }
+        }
+        REQUIRE(err == WasteFullError::FLOW_STABLE_FULL_ERROR);
+        REQUIRE(detector.get_error() == WasteFullError::FLOW_STABLE_FULL_ERROR);
+    }
+
+    SECTION("Hold phase - deep unloaded 5s then leak RPM is not full") {
+        detector.reset();
+
+        // 5s unloaded then leak RPM must not trip.
+        const double atm = 1013.0;
+        const double target = 213.0;
+        double current_p = 1000.0;
+        uint32_t tics = 1000;
+
+        for (uint32_t i = 0; i <= 96; i++) {
+            tics += i * 2;
+            current_p -= 5;
+            detector.check(tics, current_p, current_p + 2, target, atm);
+        }
+        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            detector.check(tics, current_p + 2, current_p, target, atm, 200.0);
+        }
+
+        const int dip_ticks = PRESSURE_WINDOW_SIZE + 125;  // ~5s after window
+        for (int i = 0; i < dip_ticks; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            auto err = detector.check(tics, current_p + 2, current_p, target,
+                                      atm, 200.0);
+            REQUIRE(err == WasteFullError::NO_ERROR);
+        }
+        for (int i = 0; i < STABLE_HOLD_TICKS_DEEP + 5; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            auto err = detector.check(tics, current_p + 2, current_p, target,
+                                      atm, 1100.0);
+            REQUIRE(err == WasteFullError::NO_ERROR);
+        }
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Hold phase - quiet with orifice flow is not full") {
+        detector.reset();
+
+        const double atm = 1013.0;
+        const double target = 500.0;
+        double current_p = 1000.0;
+        uint32_t tics = 1000;
+
+        for (uint32_t i = 0; i <= 96; i++) {
+            tics += i * 2;
+            current_p -= 5;
+            detector.check(tics, current_p, current_p + 2, target, atm);
+        }
+        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            detector.check(tics, current_p + 2, current_p, target, atm, 0.0);
+        }
+
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS + 5;
+             ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            auto err = detector.check(tics, current_p + 15, current_p, target,
+                                      atm, 0.0);
+            REQUIRE(err == WasteFullError::NO_ERROR);
+        }
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Hold phase - oscillation after window fill is still not full") {
         detector.reset();
 
         const double atm = 1013.0;
@@ -265,33 +596,19 @@ TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
         REQUIRE(detector.baseline_captured());
         REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
 
-        // Enter hold
         for (uint32_t i = 0; i < NEAR_TARGET_TICS; ++i) {
             tics += 40;
             detector.check(tics, current_p + 2, current_p, target, atm);
         }
 
-        // First few samples - should NOT trigger yet
-        for (int i = 0; i < PRESSURE_WINDOW_SIZE - 5; ++i) {
-            tics += 40;
-            current_p = target + ((i % 10) * 4.0) - 15.0;
-            auto err =
-                detector.check(tics, current_p + 2, current_p, target, atm);
-            REQUIRE(err == WasteFullError::NO_ERROR);
-        }
-
-        // After window fills - should trigger
-        for (int i = 0; i < 5; ++i) {
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE + 5; ++i) {
             tics += 40;
             current_p = target + ((i % 10) * 12.0) - 20.0;
             auto err =
                 detector.check(tics, current_p + 2, current_p, target, atm);
-            if (err == WasteFullError::FLOW_STABLE_FULL_ERROR) {
-                break;
-            }
+            REQUIRE(err == WasteFullError::NO_ERROR);
         }
-
-        REQUIRE(detector.get_error() == WasteFullError::FLOW_STABLE_FULL_ERROR);
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
     }
 }
 

--- a/stm32-modules/vacuum-module/tests/test_waste_detector.cpp
+++ b/stm32-modules/vacuum-module/tests/test_waste_detector.cpp
@@ -128,7 +128,7 @@ TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
         auto err = WasteFullError::NO_ERROR;
         for (int i = 0; i < 4; ++i) {
             tics += 1;
-            c_pressure += MAX_RISE_PER_TICK + 8;
+            c_pressure += SHALLOW_MAX_RISE_PER_TICK + 5;
             err = detector.check(tics, c_pressure, c_pressure + 2, 200.0,
                                  1013.0);
             if (err == WasteFullError::SUDDEN_BLOCKED_ERROR) {
@@ -136,6 +136,27 @@ TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
             }
         }
         REQUIRE(err == WasteFullError::SUDDEN_BLOCKED_ERROR);
+    }
+
+    SECTION("Hold phase - shallow sudden rise below shallow cap is not full") {
+        auto c_pressure = 813.0F;
+        auto tics = 3000.0F;
+        detector.reset();
+        detector.check(1000, 500.0, 505.0, 813.0, 1013.0);
+        detector.check(3000, 810, 815, 813.0, 1013.0);
+        for (uint32_t i = 0; i <= NEAR_TARGET_TICS; i++) {
+            tics += i;
+            detector.check(tics, c_pressure + 2, c_pressure, 813.0, 1013.0);
+        }
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE; ++i) {
+            detector.check(tics, c_pressure, c_pressure + 3, 813.0, 1013.0);
+        }
+        for (int i = 0; i < 6; ++i) {
+            tics += 1;
+            c_pressure += 6.0;
+            detector.check(tics, c_pressure, c_pressure + 2, 813.0, 1013.0);
+        }
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
     }
 
     SECTION("Hold phase - cumulative rise triggers CUMMULATIVE_BLOCKED_ERROR") {
@@ -155,7 +176,7 @@ TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
             detector.check(tics, c_pressure, c_pressure + 3, 200.0, 1013.0);
         }
 
-        // ~15 mbar slow rise stays inside hold and below the 40 mbar
+        // ~15 mbar slow rise stays inside hold and below the 90 mbar
         // cumulative gate (empty plate hunting is ~10 mbar).
         for (int i = 0; i < 25; ++i) {
             tics += 1;
@@ -576,6 +597,84 @@ TEST_CASE("WasteDetector - Core Behavior", "[waste][detector]") {
             auto err = detector.check(tics, current_p + 15, current_p, target,
                                       atm, 0.0);
             REQUIRE(err == WasteFullError::NO_ERROR);
+        }
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
+    }
+
+    SECTION(
+        "Hold phase - shallow quiet unloaded hold is not sealed full") {
+        detector.reset();
+
+        // Depth 200 mbar: empty water-on-plate can look sealed at -100/-200.
+        const double atm = 1013.0;
+        const double target = 813.0;
+        double current_p = 1000.0;
+        uint32_t tics = 1000;
+
+        for (uint32_t i = 0; i <= 96; i++) {
+            tics += i * 2;
+            current_p -= 5;
+            detector.check(tics, current_p, current_p + 2, target, atm);
+        }
+        for (uint32_t i = 0; i < NEAR_TARGET_TICS + 10; ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            detector.check(tics, current_p + 2, current_p, target, atm, 0.0);
+        }
+
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE + STABLE_HOLD_TICKS + 20;
+             ++i) {
+            tics += 40;
+            current_p = target + 3.0;
+            auto err = detector.check(tics, current_p + 2, current_p, target,
+                                      atm, 0.0);
+            REQUIRE(err == WasteFullError::NO_ERROR);
+        }
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Hold phase - water hunting rise stays below hold gates") {
+        auto c_pressure = 813.0F;
+        auto tics = 3000.0F;
+        detector.reset();
+        detector.check(1000, 500.0, 505.0, 813.0, 1013.0);
+        detector.check(3000, 810, 815, 813.0, 1013.0);
+        for (uint32_t i = 0; i <= NEAR_TARGET_TICS; i++) {
+            tics += i;
+            detector.check(tics, c_pressure + 2, c_pressure, 813.0, 1013.0);
+        }
+
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE; ++i) {
+            detector.check(tics, c_pressure, c_pressure + 3, 813.0, 1013.0);
+        }
+
+        // ~20 mbar toward atmosphere over several ticks (r4 -100 FP pattern).
+        for (int i = 0; i < 8; ++i) {
+            tics += 1;
+            c_pressure += 2.5;
+            detector.check(tics, c_pressure, c_pressure + 2, 813.0, 1013.0);
+        }
+
+        REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
+    }
+
+    SECTION("Hold phase - shallow cumulative hunting decays without trip") {
+        auto c_pressure = 813.0F;
+        auto tics = 3000.0F;
+        detector.reset();
+        detector.check(1000, 500.0, 505.0, 813.0, 1013.0);
+        detector.check(3000, 810, 815, 813.0, 1013.0);
+        for (uint32_t i = 0; i <= NEAR_TARGET_TICS; i++) {
+            tics += i;
+            detector.check(tics, c_pressure + 2, c_pressure, 813.0, 1013.0);
+        }
+        for (int i = 0; i < PRESSURE_WINDOW_SIZE; ++i) {
+            detector.check(tics, c_pressure, c_pressure + 3, 813.0, 1013.0);
+        }
+        for (int i = 0; i < 30; ++i) {
+            tics += 1;
+            c_pressure += (i % 2) ? 3.0 : -2.0;
+            detector.check(tics, c_pressure, c_pressure + 2, 813.0, 1013.0);
         }
         REQUIRE(detector.get_error() == WasteFullError::NO_ERROR);
     }


### PR DESCRIPTION
## Summary

The Waste-full detector checks if we are in a sealed deadhead for long enough. This means we are near the target, but the pump needs to do relatively little work to hold the required vacuum.

Companion host PR: https://github.com/Opentrons/opentrons/pull/22401

### How does this work

When waste-full detection is enabled, every tick we check:

1. Are we near target?: `|current − target| < PRESSURE_TOLERANCE` mbar
    - `current` is the EMA-smoothed pressure of B
    If false, Reset `near_target_ms_` and `sealed_hold_ms_`
2. Debounce: Stay near target for `NEAR_TARGET_MS`
    If false, don't add or subtract from `sealed_hold_ms_`
3. Sealed?: All the following conditions must be true to be a sealed deadhead
    - Commanded RPM ≥ 1 - Pump is actually being asked to run
    - |A−B| < H mbar    - Veto for large leaks; this is mostly sensor-to-sensor offset, but when there is a wide-open path, the sensors show different pressures. Not the main discriminator; that's G below.
    - (G = RPMcmd / vacuum) < Gcap - The work the pump is doing relative to the current vacuum.

        A lower G means a full deadhead; a higher G means empty or leaky. Gcap is our tuning knob; lowering it decreases sensitivity, making it easier to avoid false positives but harder to trip when actually full. Raising the value increases the sensitivity, so it makes it easier to trip when full, but increases the chances of false positives when empty.

    If false, the sealed clock decays by the same dt. This way 1-tick PID blips don't reset the whole thing. We subtract dt from `sealed_hold_ms_`, AND we don't do the trip check on this tick.
4. Hold time: Sealed clock ≥ `stable_hold_ms`; have we stayed "sealed" for N
    seconds?
    - If false, keep watching.
    - If true, trip the system and return Waste-Full error. This stays latched until a reset or a new vacuum command comes in.


## Test plan

- [ ] Have the hardware testing team validate the new algorithm
